### PR TITLE
Implement diagnostic SA1300 ElementMustBeginWithUpperCaseLetter

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
@@ -412,22 +412,8 @@ readonly string test;
 public string test;
 }";
 
-            var expected = new[]
-            {
-                new DiagnosticResult
-                {
-                    Id = DiagnosticId,
-                    Message = string.Format(Message, "test"),
-                    Severity = DiagnosticSeverity.Warning,
-                    Locations =
-                    new []
-                    {
-                        new DiagnosticResultLocation("Test0.cs", 3, 15)
-                    }
-                }
-            };
-
-            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            // Handled by SA1307
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
 
         [TestMethod]
@@ -438,22 +424,8 @@ public string test;
 internal string test;
 }";
 
-            var expected = new[]
-            {
-                new DiagnosticResult
-                {
-                    Id = DiagnosticId,
-                    Message = string.Format(Message, "test"),
-                    Severity = DiagnosticSeverity.Warning,
-                    Locations =
-                    new []
-                    {
-                        new DiagnosticResultLocation("Test0.cs", 3, 17)
-                    }
-                }
-            };
-
-            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            // Handled by SA1307
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
 
         [TestMethod]
@@ -464,22 +436,8 @@ internal string test;
 const string test;
 }";
 
-            var expected = new[]
-            {
-                new DiagnosticResult
-                {
-                    Id = DiagnosticId,
-                    Message = string.Format(Message, "test"),
-                    Severity = DiagnosticSeverity.Warning,
-                    Locations =
-                    new []
-                    {
-                        new DiagnosticResultLocation("Test0.cs", 3, 14)
-                    }
-                }
-            };
-
-            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            // Reported as SA1303
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
 
         [TestMethod]
@@ -501,22 +459,8 @@ public string test;
 protected readonly string test;
 }";
 
-            var expected = new[]
-            {
-                new DiagnosticResult
-                {
-                    Id = DiagnosticId,
-                    Message = string.Format(Message, "test"),
-                    Severity = DiagnosticSeverity.Warning,
-                    Locations =
-                    new []
-                    {
-                        new DiagnosticResultLocation("Test0.cs", 3, 27)
-                    }
-                }
-            };
-
-            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            // Handled by SA1304
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
@@ -283,6 +283,58 @@ public delegate void test();
 
             await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
         }
+
+        [TestMethod]
+        public async Task TestUpperCaseEventField()
+        {
+            var testCode = @"public class TestClass
+{
+    public delegate void Test();
+    public event Test TestEvent;
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestLowerCaseEventField()
+        {
+            var testCode = @"public class TestClass
+{
+    public delegate void Test();
+    public event Test testEvent;
+}";
+
+            var expected = new[]
+            {
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId,
+                    Message = string.Format(Message, "testEvent"),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                    new []
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 4, 23)
+                    }
+                },
+                // Workaround because the diagnostic is called twice for the SyntaxNode
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId,
+                    Message = string.Format(Message, "testEvent"),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                    new []
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 4, 23)
+                    }
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
         [TestMethod]
         public async Task TestUpperCaseMethod()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
@@ -90,6 +90,29 @@
         }
 
         [TestMethod]
+        public async Task TestUpperCaseInterface()
+        {
+            var testCode = @"public interface Test
+{
+
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestLowerCaseInterface()
+        {
+            var testCode = @"public interface test
+{
+
+}";
+
+            // Reported as SA1302
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
         public async Task TestUpperCaseStruct()
         {
             var testCode = @"public struct Test 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
@@ -1,0 +1,527 @@
+﻿namespace StyleCop.Analyzers.Test.NamingRules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using StyleCop.Analyzers.NamingRules;
+    using TestHelper;
+
+    [TestClass]
+    public class SA1300UnitTests : CodeFixVerifier
+    {
+        private const string DiagnosticId = SA1300ElementMustBeginWithUpperCaseLetter.DiagnosticId;
+        private const string Message = "Element '{0}' must begin with an uppercase letter";
+        protected static readonly DiagnosticResult[] EmptyDiagnosticResults = { };
+
+        [TestMethod]
+        public async Task TestUpperCaseNamespace()
+        {
+            var testCode = @"public namespace Test 
+{ 
+
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestLowerCaseNamespace()
+        {
+            var testCode = @"public namespace test 
+{ 
+
+}";
+
+            var expected = new[]
+            {
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId,
+                    Message = string.Format(Message, "test"),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                    new []
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 1, 18)
+                    }
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestUpperCaseClass()
+        {
+            var testCode = @"public class Test 
+{ 
+
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestLowerCaseClass()
+        {
+            var testCode = @"public class test 
+{ 
+
+}";
+
+            var expected = new[]
+            {
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId,
+                    Message = string.Format(Message, "test"),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                    new []
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 1, 14)
+                    }
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestUpperCaseStruct()
+        {
+            var testCode = @"public struct Test 
+{ 
+
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestLowerCaseStruct()
+        {
+            var testCode = @"public struct test 
+{ 
+
+}";
+
+            var expected = new[]
+            {
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId,
+                    Message = string.Format(Message, "test"),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                    new []
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 1, 15)
+                    }
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestUpperCaseEnum()
+        {
+            var testCode = @"public enum Test 
+{ 
+
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestLowerCaseEnum()
+        {
+            var testCode = @"public enum test 
+{ 
+
+}";
+
+            var expected = new[]
+            {
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId,
+                    Message = string.Format(Message, "test"),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                    new []
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 1, 13)
+                    }
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestUpperCaseDelegate()
+        {
+            var testCode = @"public class TestClass
+{ 
+public delegate void Test();
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestLowerCaseDelegate()
+        {
+            var testCode = @"public class TestClass
+{ 
+public delegate void test();
+}";
+
+            var expected = new[]
+            {
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId,
+                    Message = string.Format(Message, "test"),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                    new []
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 3, 22)
+                    }
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestUpperCaseEvent()
+        {
+            var testCode = @"public class TestClass
+{
+    public delegate void Test();
+    Test _testEvent;
+    public event Test TestEvent
+    {
+        add
+        {
+            _testEvent += value;
+        }
+        remove
+        {
+            _testEvent -= value;
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestLowerCaseEvent()
+        {
+            var testCode = @"public class TestClass
+{
+    public delegate void Test();
+    Test _testEvent;
+    public event Test testEvent
+    {
+        add
+        {
+            _testEvent += value;
+        }
+        remove
+        {
+            _testEvent -= value;
+        }
+    }
+}";
+
+            var expected = new[]
+            {
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId,
+                    Message = string.Format(Message, "testEvent"),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                    new []
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 5, 23)
+                    }
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+        [TestMethod]
+        public async Task TestUpperCaseMethod()
+        {
+            var testCode = @"public class TestClass
+{
+public void Test()
+{
+
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestLowerCaseMethod()
+        {
+            var testCode = @"public class TestClass
+{
+public void test()
+{
+
+}";
+
+            var expected = new[]
+            {
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId,
+                    Message = string.Format(Message, "test"),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                    new []
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 3, 13)
+                    }
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestUpperCaseProperty()
+        {
+            var testCode = @"public class TestClass
+{
+public string Test { get; set; }
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestLowerCaseProperty()
+        {
+            var testCode = @"public class TestClass
+{
+public string test { get; set; }
+}";
+
+            var expected = new[]
+            {
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId,
+                    Message = string.Format(Message, "test"),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                    new []
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 3, 15)
+                    }
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestUpperCasePublicField()
+        {
+            var testCode = @"public class TestClass
+{
+public string Test;
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestUpperCaseInternalField()
+        {
+            var testCode = @"public class TestClass
+{
+internal string Test;
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestUpperCaseConstField()
+        {
+            var testCode = @"public class TestClass
+{
+const string Test;
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestUpperCaseProtectedReadOnlyField()
+        {
+            var testCode = @"public class TestClass
+{
+protected readonly string Test;
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestLowerCaseProtectedField()
+        {
+            var testCode = @"public class TestClass
+{
+protected string Test;
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestLowerCaseReadOnlyField()
+        {
+            var testCode = @"public class TestClass
+{
+readonly string test;
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestLowerCasePublicField()
+        {
+            var testCode = @"public class TestClass
+{
+public string test;
+}";
+
+            var expected = new[]
+            {
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId,
+                    Message = string.Format(Message, "test"),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                    new []
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 3, 15)
+                    }
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestLowerCaseInternalField()
+        {
+            var testCode = @"public class TestClass
+{
+internal string test;
+}";
+
+            var expected = new[]
+            {
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId,
+                    Message = string.Format(Message, "test"),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                    new []
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 3, 17)
+                    }
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestLowerCaseConstField()
+        {
+            var testCode = @"public class TestClass
+{
+const string test;
+}";
+
+            var expected = new[]
+            {
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId,
+                    Message = string.Format(Message, "test"),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                    new []
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 3, 14)
+                    }
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestNativeMethodsException()
+        {
+            var testCode = @"public class TestNativeMethods
+{
+public string test;
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestLowerCaseProtectedReadOnlyField()
+        {
+            var testCode = @"public class TestClass
+{
+protected readonly string test;
+}";
+
+            var expected = new[]
+            {
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId,
+                    Message = string.Format(Message, "test"),
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                    new []
+                    {
+                        new DiagnosticResultLocation("Test0.cs", 3, 27)
+                    }
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new SA1300ElementMustBeginWithUpperCaseLetter();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -119,6 +119,7 @@
     <Compile Include="MaintainabilityRules\SA1408UnitTests.cs" />
     <Compile Include="MaintainabilityRules\SA1410UnitTests.cs" />
     <Compile Include="MaintainabilityRules\SA1411UnitTests.cs" />
+    <Compile Include="NamingRules\SA1300UnitTests.cs" />
     <Compile Include="NamingRules\SA1302UnitTests.cs" />
     <Compile Include="NamingRules\SA1303UnitTests.cs" />
     <Compile Include="NamingRules\SA1304UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
@@ -53,6 +53,7 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
+            // Note: Interfaces are handled by SA1302
             // Note: Fields are handled by SA1303 through SA1311
 
             context.RegisterSyntaxNodeAction(HandleNamespaceDeclarationSyntax, SyntaxKind.NamespaceDeclaration);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
@@ -53,6 +53,8 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
+            // Note: Fields are handled by SA1303 through SA1311
+
             context.RegisterSyntaxNodeAction(HandleNamespaceDeclarationSyntax, SyntaxKind.NamespaceDeclaration);
             context.RegisterSyntaxNodeAction(HandleClassDeclarationSyntax, SyntaxKind.ClassDeclaration);
             context.RegisterSyntaxNodeAction(HandleEnumDeclarationSyntax, SyntaxKind.EnumDeclaration);
@@ -61,7 +63,6 @@
             context.RegisterSyntaxNodeAction(HandleEventDeclarationSyntax, SyntaxKind.EventDeclaration);
             context.RegisterSyntaxNodeAction(HandleMethodDeclarationSyntax, SyntaxKind.MethodDeclaration);
             context.RegisterSyntaxNodeAction(HandlePropertyDeclarationSyntax, SyntaxKind.PropertyDeclaration);
-            context.RegisterSyntaxNodeAction(HandleFieldDeclarationSyntax, SyntaxKind.FieldDeclaration);
         }
 
         private void HandleNamespaceDeclarationSyntax(SyntaxNodeAnalysisContext context)
@@ -126,45 +127,6 @@
         private void HandlePropertyDeclarationSyntax(SyntaxNodeAnalysisContext context)
         {
             CheckElementNameToken(context, ((PropertyDeclarationSyntax)context.Node).Identifier);
-        }
-
-        private void HandleFieldDeclarationSyntax(SyntaxNodeAnalysisContext context)
-        {
-            FieldDeclarationSyntax fieldDeclarationSyntax = (FieldDeclarationSyntax)context.Node;
-            VariableDeclarationSyntax variableDeclarationSyntax = fieldDeclarationSyntax.Declaration;
-            if (variableDeclarationSyntax == null || variableDeclarationSyntax.IsMissing)
-                return;
-
-            bool? checkName = null;
-            if (fieldDeclarationSyntax.Modifiers.Any(SyntaxKind.PublicKeyword)
-                || fieldDeclarationSyntax.Modifiers.Any(SyntaxKind.ConstKeyword))
-            {
-                checkName = true;
-            }
-
-            if (!checkName.HasValue)
-            {
-                if (fieldDeclarationSyntax.Modifiers.Any(SyntaxKind.ProtectedKeyword))
-                {
-                    if (fieldDeclarationSyntax.Modifiers.Any(SyntaxKind.ReadOnlyKeyword))
-                        checkName = true;
-                }
-                else if (fieldDeclarationSyntax.Modifiers.Any(SyntaxKind.InternalKeyword))
-                {
-                    checkName = true;
-                }
-            }
-
-            if (!(checkName ?? false))
-                return;
-
-            foreach (var declarator in variableDeclarationSyntax.Variables)
-            {
-                if (declarator == null || declarator.IsMissing)
-                    continue;
-
-                CheckElementNameToken(context, declarator.Identifier);
-            }
         }
 
         private void CheckElementNameToken(SyntaxNodeAnalysisContext context, SyntaxToken identifier)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
@@ -1,6 +1,5 @@
 ﻿namespace StyleCop.Analyzers.NamingRules
 {
-    using System;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
@@ -152,16 +151,22 @@
             if (identifier.IsMissing)
                 return;
 
-            if (string.IsNullOrEmpty(identifier.Text))
+            if (string.IsNullOrEmpty(identifier.ValueText))
                 return;
 
-            if (char.IsUpper(identifier.Text[0]))
+            // This code uses char.IsLower(...) instead of !char.IsUpper(...) for all of the following reasons:
+            //  1. Foreign languages may not have upper case variants for certain characters
+            //  2. This diagnostic appears targeted for "English" identifiers.
+            //
+            // See DotNetAnalyzers/StyleCopAnalyzers#369 for additional information:
+            // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/369
+            if (!char.IsLower(identifier.ValueText[0]) && identifier.ValueText[0] != '_')
                 return;
 
             if (NamedTypeHelpers.IsContainedInNativeMethodsClass(context.Node))
                 return;
 
-            context.ReportDiagnostic(Diagnostic.Create(Descriptor, identifier.GetLocation(), identifier.Text));
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, identifier.GetLocation(), identifier.ValueText));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
@@ -6,6 +6,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// The name of a C# element does not begin with an upper-case letter.
@@ -177,25 +178,10 @@
             if (char.IsUpper(identifier.Text[0]))
                 return;
 
-            if (IsIgnored(context.Node))
+            if (NamedTypeHelpers.IsContainedInNativeMethodsClass(context.Node))
                 return;
 
             context.ReportDiagnostic(Diagnostic.Create(Descriptor, identifier.GetLocation(), identifier.Text));
-        }
-
-        private bool IsIgnored(SyntaxNode node)
-        {
-            ClassDeclarationSyntax containingClass = node.Parent.FirstAncestorOrSelf<ClassDeclarationSyntax>();
-            if (containingClass == null)
-                return false;
-
-            if (containingClass.Identifier.IsMissing)
-                return IsIgnored(containingClass);
-
-            if (containingClass.Identifier.Text.EndsWith("NativeMethods", StringComparison.Ordinal))
-                return true;
-
-            return IsIgnored(containingClass);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
@@ -35,7 +35,7 @@
         internal const string HelpLink = "http://www.stylecop.com/docs/SA1300.html";
 
         public static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledNoTests, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true, Description, HelpLink);
 
         private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
             ImmutableArray.Create(Descriptor);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
@@ -1,7 +1,10 @@
 ﻿namespace StyleCop.Analyzers.NamingRules
 {
+    using System;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
 
     /// <summary>
@@ -26,7 +29,7 @@
     {
         public const string DiagnosticId = "SA1300";
         internal const string Title = "Element must begin with upper-case letter";
-        internal const string MessageFormat = "TODO: Message format";
+        internal const string MessageFormat = "Element '{0}' must begin with an uppercase letter";
         internal const string Category = "StyleCop.CSharp.NamingRules";
         internal const string Description = "The name of a C# element does not begin with an upper-case letter.";
         internal const string HelpLink = "http://www.stylecop.com/docs/SA1300.html";
@@ -49,7 +52,150 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            // TODO: Implement analysis
+            context.RegisterSyntaxNodeAction(HandleNamespaceDeclarationSyntax, SyntaxKind.NamespaceDeclaration);
+            context.RegisterSyntaxNodeAction(HandleClassDeclarationSyntax, SyntaxKind.ClassDeclaration);
+            context.RegisterSyntaxNodeAction(HandleEnumDeclarationSyntax, SyntaxKind.EnumDeclaration);
+            context.RegisterSyntaxNodeAction(HandleStructDeclarationSyntax, SyntaxKind.StructDeclaration);
+            context.RegisterSyntaxNodeAction(HandleDelegateDeclarationSyntax, SyntaxKind.DelegateDeclaration);
+            context.RegisterSyntaxNodeAction(HandleEventDeclarationSyntax, SyntaxKind.EventDeclaration);
+            context.RegisterSyntaxNodeAction(HandleMethodDeclarationSyntax, SyntaxKind.MethodDeclaration);
+            context.RegisterSyntaxNodeAction(HandlePropertyDeclarationSyntax, SyntaxKind.PropertyDeclaration);
+            context.RegisterSyntaxNodeAction(HandleFieldDeclarationSyntax, SyntaxKind.FieldDeclaration);
+        }
+
+        private void HandleNamespaceDeclarationSyntax(SyntaxNodeAnalysisContext context)
+        {
+            NameSyntax nameSyntax = ((NamespaceDeclarationSyntax)context.Node).Name;
+            CheckNameSyntax(context, nameSyntax);
+        }
+
+        private void CheckNameSyntax(SyntaxNodeAnalysisContext context, NameSyntax nameSyntax)
+        {
+            if (nameSyntax == null || nameSyntax.IsMissing)
+                return;
+
+            QualifiedNameSyntax qualifiedNameSyntax = nameSyntax as QualifiedNameSyntax;
+            if (qualifiedNameSyntax != null)
+            {
+                CheckNameSyntax(context, qualifiedNameSyntax.Left);
+                CheckNameSyntax(context, qualifiedNameSyntax.Right);
+                return;
+            }
+
+            SimpleNameSyntax simpleNameSyntax = nameSyntax as SimpleNameSyntax;
+            if (simpleNameSyntax != null)
+            {
+                CheckElementNameToken(context, simpleNameSyntax.Identifier);
+                return;
+            }
+
+            // TODO: any other cases?
+        }
+
+        private void HandleClassDeclarationSyntax(SyntaxNodeAnalysisContext context)
+        {
+            CheckElementNameToken(context, ((ClassDeclarationSyntax)context.Node).Identifier);
+        }
+
+        private void HandleEnumDeclarationSyntax(SyntaxNodeAnalysisContext context)
+        {
+            CheckElementNameToken(context, ((EnumDeclarationSyntax)context.Node).Identifier);
+        }
+
+        private void HandleStructDeclarationSyntax(SyntaxNodeAnalysisContext context)
+        {
+            CheckElementNameToken(context, ((StructDeclarationSyntax)context.Node).Identifier);
+        }
+
+        private void HandleDelegateDeclarationSyntax(SyntaxNodeAnalysisContext context)
+        {
+            CheckElementNameToken(context, ((DelegateDeclarationSyntax)context.Node).Identifier);
+        }
+
+        private void HandleEventDeclarationSyntax(SyntaxNodeAnalysisContext context)
+        {
+            CheckElementNameToken(context, ((EventDeclarationSyntax)context.Node).Identifier);
+        }
+
+        private void HandleMethodDeclarationSyntax(SyntaxNodeAnalysisContext context)
+        {
+            CheckElementNameToken(context, ((MethodDeclarationSyntax)context.Node).Identifier);
+        }
+
+        private void HandlePropertyDeclarationSyntax(SyntaxNodeAnalysisContext context)
+        {
+            CheckElementNameToken(context, ((PropertyDeclarationSyntax)context.Node).Identifier);
+        }
+
+        private void HandleFieldDeclarationSyntax(SyntaxNodeAnalysisContext context)
+        {
+            FieldDeclarationSyntax fieldDeclarationSyntax = (FieldDeclarationSyntax)context.Node;
+            VariableDeclarationSyntax variableDeclarationSyntax = fieldDeclarationSyntax.Declaration;
+            if (variableDeclarationSyntax == null || variableDeclarationSyntax.IsMissing)
+                return;
+
+            bool? checkName = null;
+            if (fieldDeclarationSyntax.Modifiers.Any(SyntaxKind.PublicKeyword)
+                || fieldDeclarationSyntax.Modifiers.Any(SyntaxKind.ConstKeyword))
+            {
+                checkName = true;
+            }
+
+            if (!checkName.HasValue)
+            {
+                if (fieldDeclarationSyntax.Modifiers.Any(SyntaxKind.ProtectedKeyword))
+                {
+                    if (fieldDeclarationSyntax.Modifiers.Any(SyntaxKind.ReadOnlyKeyword))
+                        checkName = true;
+                }
+                else if (fieldDeclarationSyntax.Modifiers.Any(SyntaxKind.InternalKeyword))
+                {
+                    checkName = true;
+                }
+            }
+
+            if (!(checkName ?? false))
+                return;
+
+            foreach (var declarator in variableDeclarationSyntax.Variables)
+            {
+                if (declarator == null || declarator.IsMissing)
+                    continue;
+
+                CheckElementNameToken(context, declarator.Identifier);
+            }
+        }
+
+        private void CheckElementNameToken(SyntaxNodeAnalysisContext context, SyntaxToken identifier)
+        {
+            if (identifier.IsMissing)
+                return;
+
+            if (string.IsNullOrEmpty(identifier.Text))
+                return;
+
+            if (char.IsUpper(identifier.Text[0]))
+                return;
+
+            if (IsIgnored(context.Node))
+                return;
+
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, identifier.GetLocation(), identifier.Text));
+        }
+
+        private bool IsIgnored(SyntaxNode node)
+        {
+            ClassDeclarationSyntax containingClass = node.Parent.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+            if (containingClass == null)
+                return false;
+
+            if (containingClass.Identifier.IsMissing)
+                return IsIgnored(containingClass);
+
+            if (containingClass.Identifier.Text.EndsWith("NativeMethods", StringComparison.Ordinal))
+                return true;
+
+            return IsIgnored(containingClass);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
@@ -62,6 +62,7 @@
             context.RegisterSyntaxNodeAction(HandleStructDeclarationSyntax, SyntaxKind.StructDeclaration);
             context.RegisterSyntaxNodeAction(HandleDelegateDeclarationSyntax, SyntaxKind.DelegateDeclaration);
             context.RegisterSyntaxNodeAction(HandleEventDeclarationSyntax, SyntaxKind.EventDeclaration);
+            context.RegisterSyntaxNodeAction(HandleEventFieldDeclarationSyntax, SyntaxKind.EventFieldDeclaration);
             context.RegisterSyntaxNodeAction(HandleMethodDeclarationSyntax, SyntaxKind.MethodDeclaration);
             context.RegisterSyntaxNodeAction(HandlePropertyDeclarationSyntax, SyntaxKind.PropertyDeclaration);
         }
@@ -118,6 +119,22 @@
         private void HandleEventDeclarationSyntax(SyntaxNodeAnalysisContext context)
         {
             CheckElementNameToken(context, ((EventDeclarationSyntax)context.Node).Identifier);
+        }
+
+        private void HandleEventFieldDeclarationSyntax(SyntaxNodeAnalysisContext context)
+        {
+            EventFieldDeclarationSyntax eventFieldDeclarationSyntax = (EventFieldDeclarationSyntax)context.Node;
+            VariableDeclarationSyntax variableDeclarationSyntax = eventFieldDeclarationSyntax.Declaration;
+            if (variableDeclarationSyntax == null || variableDeclarationSyntax.IsMissing)
+                return;
+
+            foreach (var declarator in variableDeclarationSyntax.Variables)
+            {
+                if (declarator == null || declarator.IsMissing)
+                    continue;
+
+                CheckElementNameToken(context, declarator.Identifier);
+            }
         }
 
         private void HandleMethodDeclarationSyntax(SyntaxNodeAnalysisContext context)


### PR DESCRIPTION
Fixes #76

It's hard to tell if the rules used by this implementation are an exact match to the original StyleCop rule. In particular, the following are open questions.

1. :question: What about a class named `fooNativeMethods`? Current behavior: warning unless `fooNativeMethods` is inside a containing `NativeMethods` class.
2. :question: Are private methods included or excluded from analysis? Current behavior: included.
3. :question: ~~How does the `protected internal` accessibility apply to analysis of fields? Current behavior: not considered "internal", and not considered "private".~~ Update: Fields are handled by SA1303-SA1311.