### PR TITLE
Generate XML documentation file during the build

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/CodeFixProvider.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿#pragma warning disable 1591 // will be removing this file
+
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Composition;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DiagnosticAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DiagnosticAnalyzer.cs
@@ -1,3 +1,5 @@
+#pragma warning disable 1591 // will be removing this file
+
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
@@ -31,6 +31,7 @@
         private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
             ImmutableArray.Create(Descriptor);
 
+        /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
         {
             get
@@ -39,6 +40,7 @@
             }
         }
 
+        /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
             // TODO: Implement analysis

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1500CurlyBracketsForMultiLineStatementsMustNotShareLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1500CurlyBracketsForMultiLineStatementsMustNotShareLine.cs
@@ -61,6 +61,7 @@
         private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
             ImmutableArray.Create(Descriptor);
 
+        /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
         {
             get
@@ -69,6 +70,7 @@
             }
         }
 
+        /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
             // TODO: Implement analysis

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400AccessModifierMustBeDeclared.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400AccessModifierMustBeDeclared.cs
@@ -28,6 +28,7 @@
         private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
             ImmutableArray.Create(Descriptor);
 
+        /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
         {
             get
@@ -36,6 +37,7 @@
             }
         }
 
+        /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
             // TODO: Implement analysis

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
@@ -36,6 +36,7 @@
         private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
             ImmutableArray.Create(Descriptor);
 
+        /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
         {
             get
@@ -44,6 +45,7 @@
             }
         }
 
+        /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
             // TODO: Implement analysis

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1200UsingDirectivesMustBePlacedWithinNamespace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1200UsingDirectivesMustBePlacedWithinNamespace.cs
@@ -160,6 +160,7 @@
         private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
             ImmutableArray.Create(Descriptor);
 
+        /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
         {
             get
@@ -168,6 +169,7 @@
             }
         }
 
+        /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
             // TODO: Implement analysis

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists.cs
@@ -59,6 +59,7 @@
         private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
             ImmutableArray.Create(Descriptor);
 
+        /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
         {
             get
@@ -67,6 +68,7 @@
             }
         }
 
+        /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
             // TODO: Implement analysis

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
@@ -38,6 +38,7 @@
         private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
             ImmutableArray.Create(Descriptor);
 
+        /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
         {
             get
@@ -46,6 +47,7 @@
             }
         }
 
+        /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
             // TODO: Implement analysis

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -22,6 +22,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Debug\StyleCop.Analyzers.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -30,6 +31,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\Release\StyleCop.Analyzers.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CodeFixProvider.cs" />


### PR DESCRIPTION
- Generate XML documentation file (also causes the .NET Compiler Platform to validate `cref` XML attributes in documentation comments)
- Fix a few, but not all, build warnings resulting from missing documentation
