### PR TITLE
Implement diagnostic SA1123 DoNotPlaceRegionsWithinElements

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1123DoNotPlaceRegionsWithinElements.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1123DoNotPlaceRegionsWithinElements.cs
@@ -1,0 +1,77 @@
+﻿namespace StyleCop.Analyzers.ReadabilityRules
+{
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    /// <summary>
+    /// The C# code contains a region within the body of a code element.
+    /// </summary>
+    /// <remarks>
+    /// <para>A violation of this rule occurs whenever a region is placed within the body of a code element. In many
+    /// editors, including Visual Studio, the region will appear collapsed by default, hiding the code within the
+    /// region. It is generally a bad practice to hide code within the body of an element, as this can lead to bad
+    /// decisions as the code is maintained over time.</para>
+    /// </remarks>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class SA1123DoNotPlaceRegionsWithinElements : DiagnosticAnalyzer
+    {
+        public const string DiagnosticId = "SA1123";
+        internal const string Title = "Do Not Place Regions Within Elements";
+        internal const string MessageFormat = "Region must not be located within a code element.";
+        internal const string Category = "StyleCop.CSharp.Readability";
+        internal const string Description = "The C# code contains a region within the body of a code element.";
+        internal const string HelpLink = "http://www.stylecop.com/docs/SA1123.html";
+
+        public static readonly DiagnosticDescriptor Descriptor =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledNoTests, Description, HelpLink);
+
+        private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
+            ImmutableArray.Create(Descriptor);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        {
+            get
+            {
+                return _supportedDiagnostics;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxTreeAction(HandleSyntaxTree);
+        }
+
+        private void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
+        {
+            SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
+            foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
+            {
+                switch (trivia.CSharpKind())
+                {
+                case SyntaxKind.RegionDirectiveTrivia:
+                    HandleRegionDirectiveTrivia(context, trivia);
+                    break;
+
+                default:
+                    break;
+                }
+            }
+        }
+
+        private void HandleRegionDirectiveTrivia(SyntaxTreeAnalysisContext context, SyntaxTrivia trivia)
+        {
+            BlockSyntax blockSyntax = trivia.Token.Parent.AncestorsAndSelf().OfType<BlockSyntax>().FirstOrDefault();
+            if (blockSyntax == null)
+                return;
+
+            // Region must not be located within a code element.
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, trivia.GetLocation()));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -44,6 +44,7 @@
     <Compile Include="OrderingRules\SA1200UsingDirectivesMustBePlacedWithinNamespace.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReadabilityRules\SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists.cs" />
+    <Compile Include="ReadabilityRules\SA1123DoNotPlaceRegionsWithinElements.cs" />
     <Compile Include="SpacingRules\SA1000KeywordsMustBeSpacedCorrectly.cs" />
     <Compile Include="SpacingRules\SA1001CommasMustBeSpacedCorrectly.cs" />
     <Compile Include="SpacingRules\SA1002SemicolonsMustBeSpacedCorrectly.cs" />


### PR DESCRIPTION
Fixes #56.

Does not include tests (see #246), but was run manually on a project with good results.
