### PR TITLE
Implemented SA1626 SingleLineCommentsMustNotUseDocumentationStyleSlashes

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1626UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1626UnitTests.cs
@@ -1,0 +1,118 @@
+﻿namespace StyleCop.Analyzers.Test.DocumentationRules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using StyleCop.Analyzers.MaintainabilityRules;
+    using TestHelper;
+    using StyleCop.Analyzers.DocumentationRules;
+
+    [TestClass]
+    public class SA1626UnitTests : CodeFixVerifier
+    { 
+            private const string DiagnosticId = SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes.DiagnosticId;
+            protected static readonly DiagnosticResult[] EmptyDiagnosticResults = { };
+
+            [TestMethod]
+            public async Task TestEmptySource()
+            {
+                var testCode = @"";
+                await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            }
+
+            [TestMethod]
+            public async Task TestClassWithXmlComment()
+            {
+                var testCode = @"/// <summary>
+/// Xml Documentation
+/// </summary>
+public class Foo
+{
+    public void Bar()
+    {
+    }
+}
+";
+                await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestMethodWithComment()
+        {
+            var testCode = @"public class Foo
+{
+    public void Bar()
+    {
+        // This is a comment
+    }
+}
+";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestMethodWithOneLineThreeSlashComment()
+        {
+            var testCode = @"public class Foo
+{
+    public void Bar()
+    {
+        /// This is a comment
+    }
+}
+";
+            var expected = new[]
+            {
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId,
+                    Message = "Single-line comments must not use documentation style slashes",
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                        new[]
+                        {
+                            new DiagnosticResultLocation("Test0.cs", 5, 9)
+                        }
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestMethodWithMultiLineThreeSlashComment()
+        {
+            var testCode = @"public class Foo
+{
+    public void Bar()
+    {
+        /// This is
+        /// a comment
+    }
+}
+";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+            public async Task TestMethodWithCodeComments()
+        {
+            var testCode = @"public class Foo
+{
+    public void Bar()
+    {
+        //// System.Console.WriteLine(""Bar"")
+    }
+}
+";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+            protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+            {
+                return new SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes();
+            }
+        }
+    }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1626UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1626UnitTests.cs
@@ -4,28 +4,25 @@
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Diagnostics;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using StyleCop.Analyzers.MaintainabilityRules;
     using TestHelper;
     using StyleCop.Analyzers.DocumentationRules;
+    using Xunit;
 
-    [TestClass]
     public class SA1626UnitTests : CodeFixVerifier
-    { 
-            private const string DiagnosticId = SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes.DiagnosticId;
-            protected static readonly DiagnosticResult[] EmptyDiagnosticResults = { };
+    {
+        private const string DiagnosticId = SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes.DiagnosticId;
 
-            [TestMethod]
-            public async Task TestEmptySource()
-            {
-                var testCode = @"";
-                await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
-            }
+        [Fact]
+        public async Task TestEmptySource()
+        {
+            var testCode = string.Empty;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
 
-            [TestMethod]
-            public async Task TestClassWithXmlComment()
-            {
-                var testCode = @"/// <summary>
+        [Fact]
+        public async Task TestClassWithXmlComment()
+        {
+            var testCode = @"/// <summary>
 /// Xml Documentation
 /// </summary>
 public class Foo
@@ -35,10 +32,10 @@ public class Foo
     }
 }
 ";
-                await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestMethodWithComment()
         {
             var testCode = @"public class Foo
@@ -49,10 +46,10 @@ public class Foo
     }
 }
 ";
-            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestMethodWithOneLineThreeSlashComment()
         {
             var testCode = @"public class Foo
@@ -65,23 +62,13 @@ public class Foo
 ";
             var expected = new[]
             {
-                new DiagnosticResult
-                {
-                    Id = DiagnosticId,
-                    Message = "Single-line comments must not use documentation style slashes",
-                    Severity = DiagnosticSeverity.Warning,
-                    Locations =
-                        new[]
-                        {
-                            new DiagnosticResultLocation("Test0.cs", 5, 9)
-                        }
-                }
+                this.CSharpDiagnostic().WithLocation(5, 9)
             };
 
-            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestMethodWithMultiLineThreeSlashComment()
         {
             var testCode = @"public class Foo
@@ -93,11 +80,16 @@ public class Foo
     }
 }
 ";
-            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            var expected = new[]
+            {
+                this.CSharpDiagnostic().WithLocation(5, 9)
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
         }
 
-        [TestMethod]
-            public async Task TestMethodWithCodeComments()
+        [Fact]
+        public async Task TestMethodWithCodeComments()
         {
             var testCode = @"public class Foo
 {
@@ -107,12 +99,26 @@ public class Foo
     }
 }
 ";
-            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
 
-            protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-            {
-                return new SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes();
-            }
+        [Fact]
+        public async Task TestMethodWithSingeLineDocumentation()
+        {
+            var testCode = @"public class Foo
+{
+    /// <summary>Summary text</summary>
+    public void Bar()
+    {
+    }
+}
+";
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes();
         }
     }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -131,6 +131,7 @@
     <Compile Include="DocumentationRules\SA1608UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1609UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1610UnitTests.cs" />
+    <Compile Include="DocumentationRules\SA1626UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1642UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1643UnitTests.cs" />
     <Compile Include="Helpers\CodeFixVerifier.Helper.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes.cs
@@ -58,7 +58,7 @@
         private const string HelpLink = "http://www.stylecop.com/docs/SA1626.html";
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledNoTests, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true, Description, HelpLink);
 
         private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
             ImmutableArray.Create(Descriptor);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes.cs
@@ -3,6 +3,12 @@
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Text;
+
+
+
 
     /// <summary>
     /// The C# code contains a single-line comment which begins with three forward slashes in a row.
@@ -46,7 +52,7 @@
         /// </summary>
         public const string DiagnosticId = "SA1626";
         private const string Title = "Single-line comments must not use documentation style slashes";
-        private const string MessageFormat = "TODO: Message format";
+        private const string MessageFormat = "Single-line comments must not use documentation style slashes";
         private const string Category = "StyleCop.CSharp.DocumentationRules";
         private const string Description = "The C# code contains a single-line comment which begins with three forward slashes in a row.";
         private const string HelpLink = "http://www.stylecop.com/docs/SA1626.html";
@@ -69,7 +75,22 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            // TODO: Implement analysis
+            context.RegisterSyntaxNodeAction(this.HandleSingleLineDocumentationTrivia, SyntaxKind.SingleLineDocumentationCommentTrivia);
+        }
+
+        private void HandleSingleLineDocumentationTrivia(SyntaxNodeAnalysisContext context)
+        {
+            var node = context.Node as DocumentationCommentTriviaSyntax;
+            if (node == null)
+                return;
+            // Check if the comment is not multi line
+            if (!node.Content.ToString().Trim().Contains("\n"))
+            {
+                //Add a diagnostic on '///'
+                var trivia = context.Node.GetLeadingTrivia().First();
+
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, trivia.GetLocation()));
+            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes.cs
@@ -1,14 +1,11 @@
 ﻿namespace StyleCop.Analyzers.DocumentationRules
 {
     using System.Collections.Immutable;
+    using System.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Diagnostics;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
-    using Microsoft.CodeAnalysis.Text;
-
-
-
 
     /// <summary>
     /// The C# code contains a single-line comment which begins with three forward slashes in a row.
@@ -83,8 +80,9 @@
             var node = context.Node as DocumentationCommentTriviaSyntax;
             if (node == null)
                 return;
+
             // Check if the comment is not multi line
-            if (!node.Content.ToString().Trim().Contains("\n"))
+            if (node.Content.All(x => x.IsKind(SyntaxKind.XmlText)))
             {
                 //Add a diagnostic on '///'
                 var trivia = context.Node.GetLeadingTrivia().First();


### PR DESCRIPTION
One thing which is a little bit odd in my opinion is, that this is allowed:

```csharp
public class Foo
{
    public void Bar()
    {
        /// This is
        /// a comment
    }
}
```

I might add a code fixer later. Fixes #146.