### PR TITLE
Include WellKnownDiagnosticTags.Unnecessary in the SA1121 diagnostic

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121UseBuiltInTypeAlias.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121UseBuiltInTypeAlias.cs
@@ -127,7 +127,7 @@
         internal const string HelpLink = "http://www.stylecop.com/docs/SA1121.html";
 
         public static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true, Description, HelpLink, WellKnownDiagnosticTags.Unnecessary);
 
         private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
             ImmutableArray.Create(Descriptor);


### PR DESCRIPTION
Normally this flag is not needed because the Simplify Type Name diagnostic provided by Visual Studio includes the tag and marks the same span. However, The Simplify Type Name diagnostic is not reported for references to a using alias directive, so adding the flag to SA1121 ensures the UI is correct for all cases where this diagnostic might be reported.