### PR TITLE
Fix SA1408 is reporting for wrong Binary Expressions

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1408UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1408UnitTests.cs
@@ -138,6 +138,33 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         }
 
         [TestMethod]
+        public async Task TestOrAndEqualsParenthesized()
+        {
+            var testCode = @"public class Foo
+{
+    public void Bar()
+    {
+        bool x = true || (false == true);
+    }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestAndAndEquals()
+        {
+            var testCode = @"public class Foo
+{
+    public void Bar()
+    {
+        bool x = true && false == true;
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
         public async Task TesAndAndOrParenthesized()
         {
             var testCode = @"public class Foo

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1408ConditionalExpressionsMustDeclarePrecedence.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1408ConditionalExpressionsMustDeclarePrecedence.cs
@@ -91,18 +91,23 @@
                     // Check if the operations are of the same kind
 
                     var left = (BinaryExpressionSyntax)binSyntax.Left;
+                    if (left.OperatorToken.IsKind(SyntaxKind.AmpersandAmpersandToken) || left.OperatorToken.IsKind(SyntaxKind.BarBarToken))
+                    {
 
-                    if (!IsSameFamily(binSyntax.OperatorToken, left.OperatorToken))
-                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, left.GetLocation()));
+                        if (!IsSameFamily(binSyntax.OperatorToken, left.OperatorToken))
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptor, left.GetLocation()));
+                    }
                 }
                 if (binSyntax.Right is BinaryExpressionSyntax)
                 {
                     // Check if the operations are of the same kind
 
                     var right = (BinaryExpressionSyntax)binSyntax.Right;
-
-                    if (!IsSameFamily(binSyntax.OperatorToken, right.OperatorToken))
-                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, right.GetLocation()));
+                    if (right.OperatorToken.IsKind(SyntaxKind.AmpersandAmpersandToken) || right.OperatorToken.IsKind(SyntaxKind.BarBarToken))
+                    {
+                        if (!IsSameFamily(binSyntax.OperatorToken, right.OperatorToken))
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptor, right.GetLocation()));
+                    }
                 }
             }
         }


### PR DESCRIPTION
```csharp
bool b = true || 1 == 2;
```
was reporting SA1408