### PR TITLE
Enhance SA1303 ConstFieldNamesMustBeginWithUpperCaseLetter

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1303UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1303UnitTests.cs
@@ -174,6 +174,17 @@ namespace Test
         }
 
         [TestMethod]
+        public async Task TestConstFieldStatingWithUnderscore()
+        {
+            var testCode = @"public class Foo
+{
+    public const string _Bar = ""baz"";
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
         public async Task TestFieldWhichIsNotConstStatingWithLowerCase()
         {
             var testCode = @"public class Foo

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1303ConstFieldNamesMustBeginWithUpperCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1303ConstFieldNamesMustBeginWithUpperCaseLetter.cs
@@ -32,7 +32,7 @@
         private NamedTypeHelpers namedTypeHelpers = new NamedTypeHelpers();
 
         public static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledNoTests, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true, Description, HelpLink);
 
         private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
             ImmutableArray.Create(Descriptor);


### PR DESCRIPTION
Fixes #369.
As we discussed, we keep the old behaviour. Additionally I added a test to make sure we don't report SA1303 for fields starting with `_`.
The diagnostic is now enabled by default.