### PR TITLE
Trivia extensions

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
@@ -57,12 +57,8 @@
                 BinaryExpressionSyntax syntax = node as BinaryExpressionSyntax;
                 if (syntax != null)
                 {
-                    var leadingTrivia = syntax.GetLeadingTrivia();
-                    var trailingTrivia = syntax.GetTrailingTrivia();
-
                     var newNode = SyntaxFactory.ParenthesizedExpression(syntax.WithoutLeadingTrivia().WithoutTrailingTrivia())
-                        .WithLeadingTrivia(leadingTrivia)
-                        .WithTrailingTrivia(trailingTrivia)
+                        .WithTriviaFrom(syntax)
                         .WithoutFormatting();
 
                     var syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
@@ -57,7 +57,7 @@
                 BinaryExpressionSyntax syntax = node as BinaryExpressionSyntax;
                 if (syntax != null)
                 {
-                    var newNode = SyntaxFactory.ParenthesizedExpression(syntax.WithoutLeadingTrivia().WithoutTrailingTrivia())
+                    var newNode = SyntaxFactory.ParenthesizedExpression(syntax.WithoutTrivia())
                         .WithTriviaFrom(syntax)
                         .WithoutFormatting();
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists.cs
@@ -89,9 +89,8 @@
             var tree = context.Node.SyntaxTree;
             var root = tree.GetRoot(context.CancellationToken);
 
-            var testThisToken = SyntaxFactory.Token(baseExpressionSyntax.Token.LeadingTrivia, SyntaxKind.ThisKeyword, baseExpressionSyntax.Token.TrailingTrivia);
-            var testExpression = SyntaxFactory.ThisExpression(testThisToken).WithLeadingTrivia(baseExpressionSyntax.GetLeadingTrivia()).WithTrailingTrivia(baseExpressionSyntax.GetTrailingTrivia());
-            var testTree = tree.WithRootAndOptions(root.ReplaceNode(baseExpressionSyntax, testExpression.WithoutFormatting()), tree.Options);
+            var testExpression = SyntaxFactory.ThisExpression().WithTriviaFrom(baseExpressionSyntax).WithoutFormatting();
+            var testTree = tree.WithRootAndOptions(root.ReplaceNode(baseExpressionSyntax, testExpression), tree.Options);
             var testCompilation = context.SemanticModel.Compilation.ReplaceSyntaxTree(tree, testTree);
 
             var testSemanticModel = testCompilation.GetSemanticModel(testTree);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
@@ -74,8 +74,7 @@
                 {
                     SpecialType specialType = typeInfo.Value.Type.SpecialType;
                     var newNode = SyntaxFactory.PredefinedType(SyntaxFactory.Token(_predefinedSpecialTypes[specialType]))
-                        .WithLeadingTrivia(node.GetLeadingTrivia())
-                        .WithTrailingTrivia(node.GetTrailingTrivia())
+                        .WithTriviaFrom(node)
                         .WithoutFormatting();
                     var newRoot = root.ReplaceNode(node, newNode);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SpacingExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SpacingExtensions.cs
@@ -44,6 +44,32 @@
         }
 
         /// <summary>
+        /// Removes the leading and trailing trivia associated with a syntax node.
+        /// </summary>
+        /// <typeparam name="TNode">The type of syntax node to remove trivia from.</typeparam>
+        /// <param name="node">The syntax node to remove trivia from.</param>
+        /// <returns>A copy of the input syntax node with leading and trailing trivia removed.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="node"/> is <see langword="null"/>.</exception>
+        public static TNode WithoutTrivia<TNode>(this TNode node)
+            where TNode : SyntaxNode
+        {
+            if (node == null)
+                throw new ArgumentNullException(nameof(node));
+
+            return node.WithoutLeadingTrivia().WithoutTrailingTrivia();
+        }
+
+        /// <summary>
+        /// Removes the leading and trailing trivia associated with a syntax token.
+        /// </summary>
+        /// <param name="token">The syntax token to remove trivia from.</param>
+        /// <returns>A copy of the input syntax token with leading and trailing trivia removed.</returns>
+        public static SyntaxToken WithoutTrivia(this SyntaxToken token)
+        {
+            return token.WithLeadingTrivia(default(SyntaxTriviaList)).WithTrailingTrivia(default(SyntaxTriviaList));
+        }
+
+        /// <summary>
         /// Replaces the leading and trailing trivia associated with <paramref name="targetNode"/> with the trivia from
         /// <paramref name="node"/>.
         /// </summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SpacingExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SpacingExtensions.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.SpacingRules
 {
+    using System;
     using System.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeActions;
@@ -40,6 +41,48 @@
                 trivia = trivia.Where(i => !i.IsKind(SyntaxKind.EndOfLineTrivia));
 
             return SyntaxFactory.TriviaList(trivia);
+        }
+
+        /// <summary>
+        /// Replaces the leading and trailing trivia associated with <paramref name="targetNode"/> with the trivia from
+        /// <paramref name="node"/>.
+        /// </summary>
+        /// <typeparam name="TNode">The type of syntax node to apply the trivia to.</typeparam>
+        /// <param name="targetNode">The syntax node to update.</param>
+        /// <param name="node">The syntax node with the desired leading and trailing trivia.</param>
+        /// <returns>A copy of <paramref name="targetNode"/> with the leading and trailing trivia replaced with the
+        /// trivia from <paramref name="node"/>.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// <para>If <paramref name="targetNode"/> is <see langword="null"/>.</para>
+        /// <para>-or-</para>
+        /// <para>If <paramref name="node"/> is <see langword="null"/>.</para>
+        /// </exception>
+        public static TNode WithTriviaFrom<TNode>(this TNode targetNode, SyntaxNode node)
+            where TNode : SyntaxNode
+        {
+            if (targetNode == null)
+                throw new ArgumentNullException(nameof(targetNode));
+            if (node == null)
+                throw new ArgumentNullException(nameof(node));
+
+            return targetNode
+                .WithLeadingTrivia(node.GetLeadingTrivia())
+                .WithTrailingTrivia(node.GetTrailingTrivia());
+        }
+
+        /// <summary>
+        /// Replaces the leading and trailing trivia associated with <paramref name="targetToken"/> with the trivia from
+        /// <paramref name="token"/>.
+        /// </summary>
+        /// <param name="targetToken">The syntax token to update.</param>
+        /// <param name="token">The syntax token with the desired leading and trailing trivia.</param>
+        /// <returns>A copy of <paramref name="targetToken"/> with the leading and trailing trivia replaced with the
+        /// trivia from <paramref name="token"/>.</returns>
+        public static SyntaxToken WithTriviaFrom(this SyntaxToken targetToken, SyntaxToken token)
+        {
+            return targetToken
+                .WithLeadingTrivia(token.LeadingTrivia)
+                .WithTrailingTrivia(token.TrailingTrivia);
         }
 
         /// <summary>


### PR DESCRIPTION
* `WithTriviaFrom`: Copy leading and trailing trivia from one `SyntaxNode` or `SyntaxToken` to another.
* `WithoutTrivia`: Remove the leading and trailing trivia from a `SyntaxNode` or `SyntaxToken`.