### PR TITLE
In tests only check distinct diagnostics

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
@@ -364,18 +364,6 @@ public interface InterfaceName
                             {
                                 new DiagnosticResultLocation("Test0.cs", 8, 25)
                             }
-                    },
-                    // Workaround because the diagnostic is called twice for the SyntaxNode
-                    new DiagnosticResult
-                    {
-                        Id = DiagnosticId,
-                        Message = "Elements must be documented",
-                        Severity = DiagnosticSeverity.Warning,
-                        Locations =
-                            new[]
-                            {
-                                new DiagnosticResultLocation("Test0.cs", 8, 25)
-                            }
                     }
                 };
 
@@ -707,17 +695,6 @@ public class OuterClass
                             {
                                 new DiagnosticResultLocation("Test0.cs", 8, 19)
                             }
-                    },
-                    new DiagnosticResult
-                    {
-                        Id = DiagnosticId,
-                        Message = "Elements must be documented",
-                        Severity = DiagnosticSeverity.Warning,
-                        Locations =
-                            new[]
-                            {
-                                new DiagnosticResultLocation("Test0.cs", 8, 19)
-                            }
                     }
                 };
 
@@ -750,17 +727,6 @@ public class OuterClass
             expected =
                 new[]
                 {
-                    new DiagnosticResult
-                    {
-                        Id = DiagnosticId,
-                        Message = "Elements must be documented",
-                        Severity = DiagnosticSeverity.Warning,
-                        Locations =
-                            new[]
-                            {
-                                new DiagnosticResultLocation("Test0.cs", 8, 19)
-                            }
-                    },
                     new DiagnosticResult
                     {
                         Id = DiagnosticId,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1604UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1604UnitTests.cs
@@ -710,17 +710,6 @@ public class ClassName
                             {
                                 new DiagnosticResultLocation("Test0.cs", 8, 22)
                             }
-                    },
-                    new DiagnosticResult
-                    {
-                        Id = DiagnosticId,
-                        Message = "Element documentation must have summary",
-                        Severity = DiagnosticSeverity.Warning,
-                        Locations =
-                            new[]
-                            {
-                                new DiagnosticResultLocation("Test0.cs", 8, 22)
-                            }
                     }
                 };
             await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
@@ -790,17 +779,6 @@ public class ClassName
             expected =
                 new[]
                 {
-                    new DiagnosticResult
-                    {
-                        Id = DiagnosticId,
-                        Message = "Element documentation must have summary",
-                        Severity = DiagnosticSeverity.Warning,
-                        Locations =
-                            new[]
-                            {
-                                new DiagnosticResultLocation("Test0.cs", 8, 32)
-                            }
-                    },
                     new DiagnosticResult
                     {
                         Id = DiagnosticId,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1606UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1606UnitTests.cs
@@ -726,17 +726,6 @@ public class ClassName
                             {
                                 new DiagnosticResultLocation("Test0.cs", 10, 22)
                             }
-                    },
-                    new DiagnosticResult
-                    {
-                        Id = DiagnosticId,
-                        Message = "Element documentation must have summary text",
-                        Severity = DiagnosticSeverity.Warning,
-                        Locations =
-                            new[]
-                            {
-                                new DiagnosticResultLocation("Test0.cs", 10, 22)
-                            }
                     }
                 };
             await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
@@ -808,17 +797,6 @@ public class ClassName
             expected =
                 new[]
                 {
-                    new DiagnosticResult
-                    {
-                        Id = DiagnosticId,
-                        Message = "Element documentation must have summary text",
-                        Severity = DiagnosticSeverity.Warning,
-                        Locations =
-                            new[]
-                            {
-                                new DiagnosticResultLocation("Test0.cs", 10, 32)
-                            }
-                    },
                     new DiagnosticResult
                     {
                         Id = DiagnosticId,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1304UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1304UnitTests.cs
@@ -41,18 +41,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
                         {
                             new DiagnosticResultLocation("Test0.cs", 3, 28)
                         }
-                },
-                // Workaround because the diagnostic is called twice for the SyntaxNode
-                new DiagnosticResult
-                {
-                    Id = DiagnosticId,
-                    Message = "Non-private readonly fields must begin with upper-case letter",
-                    Severity = DiagnosticSeverity.Warning,
-                    Locations =
-                        new[]
-                        {
-                            new DiagnosticResultLocation("Test0.cs", 3, 28)
-                        }
                 }
             };
 
@@ -90,18 +78,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
                         {
                             new DiagnosticResultLocation("Test0.cs", 3, 31)
                         }
-                },
-                // Workaround because the diagnostic is called twice for the SyntaxNode
-                new DiagnosticResult
-                {
-                    Id = DiagnosticId,
-                    Message = "Non-private readonly fields must begin with upper-case letter",
-                    Severity = DiagnosticSeverity.Warning,
-                    Locations =
-                        new[]
-                        {
-                            new DiagnosticResultLocation("Test0.cs", 3, 31)
-                        }
                 }
             };
 
@@ -129,18 +105,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
 
             var expected = new[]
             {
-                new DiagnosticResult
-                {
-                    Id = DiagnosticId,
-                    Message = "Non-private readonly fields must begin with upper-case letter",
-                    Severity = DiagnosticSeverity.Warning,
-                    Locations =
-                        new[]
-                        {
-                            new DiagnosticResultLocation("Test0.cs", 3, 30)
-                        }
-                },
-                // Workaround because the diagnostic is called twice for the SyntaxNode
                 new DiagnosticResult
                 {
                     Id = DiagnosticId,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1121UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1121UnitTests.cs
@@ -945,18 +945,6 @@ public class Foo
                             {
                                 new DiagnosticResultLocation("Test0.cs", 6, 5)
                             }
-                    },
-                // Workaround because the diagnostic is called twice for the SyntaxNode
-                new DiagnosticResult
-                    {
-                        Id = DiagnosticId,
-                        Message = "Use built-in type alias",
-                        Severity = DiagnosticSeverity.Warning,
-                        Locations =
-                            new[]
-                            {
-                                new DiagnosticResultLocation("Test0.cs", 6, 5)
-                            }
                     }
                 };
 
@@ -1006,18 +994,6 @@ public class Foo
                 new[]
                 {
                     new DiagnosticResult
-                    {
-                        Id = DiagnosticId,
-                        Message = "Use built-in type alias",
-                        Severity = DiagnosticSeverity.Warning,
-                        Locations =
-                            new[]
-                            {
-                                new DiagnosticResultLocation("Test0.cs", 6, 5)
-                            }
-                    },
-                // Workaround because the diagnostic is called twice for the SyntaxNode
-                new DiagnosticResult
                     {
                         Id = DiagnosticId,
                         Message = "Use built-in type alias",


### PR DESCRIPTION
Fixes #366.
I actually found a bug in Roslyn while fixing this. https://github.com/dotnet/roslyn/issues/57
So I implemented a minor work around until this is fixed.