### PR TITLE
Allow the default text for non private constructors to be used on private constructors

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
@@ -150,9 +150,22 @@
         }
 
         [TestMethod]
+        public async Task TestPrivateConstructorCorrectDocumentationSimpleVariation()
+        {
+            await TestConstructorCorrectDocumentationSimple("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false);
+        }
+
+        [TestMethod]
         public async Task TestPrivateConstructorCorrectDocumentationCustomized()
         {
             await TestConstructorCorrectDocumentationCustomized("private", PrivateConstructorStandardText[0], PrivateConstructorStandardText[1], false);
+        }
+
+
+        [TestMethod]
+        public async Task TestPrivateConstructorCorrectDocumentationCustomizedVariation()
+        {
+            await TestConstructorCorrectDocumentationCustomized("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false);
         }
 
         [TestMethod]
@@ -162,9 +175,21 @@
         }
 
         [TestMethod]
+        public async Task TestPrivateConstructorCorrectDocumentationGenericSimpleVariation()
+        {
+            await TestConstructorCorrectDocumentationSimple("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true);
+        }
+
+        [TestMethod]
         public async Task TestPrivateConstructorCorrectDocumentationGenericCustomized()
         {
             await TestConstructorCorrectDocumentationCustomized("private", PrivateConstructorStandardText[0], PrivateConstructorStandardText[1], true);
+        }
+
+        [TestMethod]
+        public async Task TestPrivateConstructorCorrectDocumentationGenericCustomizedVariation()
+        {
+            await TestConstructorCorrectDocumentationCustomized("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true);
         }
 
         [TestMethod]

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -132,19 +132,20 @@
 
             if (constructorDeclarationSyntax.Modifiers.Any(SyntaxKind.StaticKeyword))
             {
-                HandleConstructorDeclaration(context, StaticConstructorStandardText[0], StaticConstructorStandardText[1]);
+                HandleConstructorDeclaration(context, StaticConstructorStandardText);
             }
             else if (constructorDeclarationSyntax.Modifiers.Any(SyntaxKind.PrivateKeyword))
             {
-                HandleConstructorDeclaration(context, PrivateConstructorStandardText[0], PrivateConstructorStandardText[1]);
+                // Allow both the default text for private and non-private constructors to be allowed here
+                HandleConstructorDeclaration(context, PrivateConstructorStandardText, NonPrivateConstructorStandardText);
             }
             else
             {
-                HandleConstructorDeclaration(context, NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1]);
+                HandleConstructorDeclaration(context, NonPrivateConstructorStandardText);
             }
         }
 
-        private void HandleConstructorDeclaration(SyntaxNodeAnalysisContext context, string firstTextPart, string secondTextPart)
+        private void HandleConstructorDeclaration(SyntaxNodeAnalysisContext context, params ImmutableArray<string>[] allowedTextParts)
         {
             var constructorDeclarationSyntax = context.Node as ConstructorDeclarationSyntax;
 
@@ -172,7 +173,7 @@
                                 var firstText = XmlCommentHelper.GetText(firstTextPartSyntax);
                                 var secondText = XmlCommentHelper.GetText(secondTextParSyntaxt);
 
-                                if (TextPartsMatch(firstTextPart, secondTextPart, firstTextPartSyntax, secondTextParSyntaxt)
+                                if (allowedTextParts.Any(textParts => TextPartsMatch(textParts[0], textParts[1], firstTextPartSyntax, secondTextParSyntaxt))
                                 && SeeTagIsCorrect(classReferencePart, constructorDeclarationSyntax))
                                 {
                                     // We found a correct standard text


### PR DESCRIPTION
Fixes #413 