### PR TITLE
Tweak FixAllProvider for SA1407 and SA1408

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408FixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408FixAllProvider.cs
@@ -16,7 +16,7 @@
             switch (fixAllContext.Scope)
             {
             case FixAllScope.Document:
-                var newRoot = await FixAllInDocument(fixAllContext, fixAllContext.Document);
+                var newRoot = await FixAllInDocumentAsync(fixAllContext, fixAllContext.Document);
                 return CodeAction.Create("Add parenthesis", fixAllContext.Document.WithSyntaxRoot(newRoot));
 
             case FixAllScope.Project:
@@ -45,7 +45,7 @@
             List<Task<SyntaxNode>> newDocuments = new List<Task<SyntaxNode>>(oldDocuments.Length);
             foreach (var document in oldDocuments)
             {
-                newDocuments.Add(FixAllInDocument(fixAllContext, document));
+                newDocuments.Add(FixAllInDocumentAsync(fixAllContext, document));
             }
             for (int i = 0; i < oldDocuments.Length; i++)
             {
@@ -56,7 +56,7 @@
             return solution;
         }
 
-        private async Task<SyntaxNode> FixAllInDocument(FixAllContext fixAllContext, Document document)
+        private async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
         {
             var diagnostics = await fixAllContext.GetDiagnosticsAsync(document);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408FixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408FixAllProvider.cs
@@ -11,6 +11,8 @@
 
     internal sealed class SA1407SA1408FixAllProvider : FixAllProvider
     {
+        private static readonly SyntaxAnnotation NeedsParenthesisAnnotation = new SyntaxAnnotation("StyleCop.NeedsParenthesis");
+
         public override async Task<CodeAction> GetFixAsync(FixAllContext fixAllContext)
         {
             switch (fixAllContext.Scope)
@@ -73,7 +75,7 @@
                 if (node.IsMissing)
                     continue;
 
-                root = root.ReplaceNode(node, node.WithAdditionalAnnotations(new SyntaxAnnotation("StyleCop.NeedsParenthesis")));
+                root = root.ReplaceNode(node, node.WithAdditionalAnnotations(NeedsParenthesisAnnotation));
             }
 
             // Add parenthesis
@@ -88,9 +90,9 @@
 
             node = node.ReplaceNodes(node.ChildNodes(), (a, b) => AddParenthesisRecursive(b));
 
-            if (node.HasAnnotations("StyleCop.NeedsParenthesis"))
+            if (node.HasAnnotations(NeedsParenthesisAnnotation.Kind))
             {
-                BinaryExpressionSyntax syntax = node.WithoutAnnotations("StyleCop.NeedsParenthesis") as BinaryExpressionSyntax;
+                BinaryExpressionSyntax syntax = node.WithoutAnnotations(NeedsParenthesisAnnotation.Kind) as BinaryExpressionSyntax;
                 if (syntax != null)
                 {
                     var newNode = SyntaxFactory.ParenthesizedExpression(syntax.WithoutTrivia())


### PR DESCRIPTION
This change simplifies the process of applying parentheses to all annotated nodes in a `Document`.

@pdelvo I'm assigning this to you for review since you are the original author of this `FixAllProvider` :+1: 