### PR TITLE
Rewrite SA1100 analysis using the speculative semantic model

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
@@ -17,11 +17,19 @@
         private static readonly ImmutableArray<string> _fixableDiagnostics =
             ImmutableArray.Create(SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists.DiagnosticId);
 
+        /// <inheritdoc/>
         public override ImmutableArray<string> GetFixableDiagnosticIds()
         {
             return _fixableDiagnostics;
         }
 
+        /// <inheritdoc/>
+        public override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        /// <inheritdoc/>
         public override async Task ComputeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
@@ -52,7 +52,7 @@
                 var newSyntaxRoot = root.ReplaceNode(node, thisExpressionSyntax);
 
                 context.RegisterFix(
-                    CodeAction.Create("Replace with this", context.Document.WithSyntaxRoot(newSyntaxRoot)), diagnostic);
+                    CodeAction.Create("Replace 'base.' with 'this.'", context.Document.WithSyntaxRoot(newSyntaxRoot)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
@@ -15,7 +15,7 @@
     public class SA1100CodeFixProvider : CodeFixProvider
     {
         private static readonly ImmutableArray<string> _fixableDiagnostics =
-    ImmutableArray.Create(SA1110OpeningParenthesisMustBeOnDeclarationLine.DiagnosticId);
+            ImmutableArray.Create(SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists.DiagnosticId);
 
         public override ImmutableArray<string> GetFixableDiagnosticIds()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists.cs
@@ -85,26 +85,18 @@
             if (targetSymbol.Symbol == null)
                 return;
 
-            // Replace the 'base.' with 'this.' and analyze the symbol again
-            var tree = context.Node.SyntaxTree;
-            var root = tree.GetRoot(context.CancellationToken);
-
-            var testExpression = SyntaxFactory.ThisExpression().WithTriviaFrom(baseExpressionSyntax).WithoutFormatting();
-            var testTree = tree.WithRootAndOptions(root.ReplaceNode(baseExpressionSyntax, testExpression), tree.Options);
-            var testCompilation = context.SemanticModel.Compilation.ReplaceSyntaxTree(tree, testTree);
-
-            var testSemanticModel = testCompilation.GetSemanticModel(testTree);
-            var testRoot = testSemanticModel.SyntaxTree.GetRoot(context.CancellationToken);
-            var testToken = testRoot.FindToken(context.Node.GetLocation().SourceSpan.Start);
-            var testNode = testToken.Parent;
-            var testSymbol = testSemanticModel.GetSymbolInfo(testNode.Parent, context.CancellationToken);
-            if (testSymbol.Symbol == null)
+            var memberAccessExpression = baseExpressionSyntax.Parent as MemberAccessExpressionSyntax;
+            if (memberAccessExpression == null)
                 return;
 
-            // If 'this.' caused the expression to resolve to a different symbol, then 'base.' is required
-            string baseContainerName = targetSymbol.Symbol.ContainingType?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-            string thisContainerName = testSymbol.Symbol.ContainingType?.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat);
-            if (baseContainerName != thisContainerName)
+            // make sure to evaluate the complete invocation expression if this is a call, or overload resolution will fail
+            ExpressionSyntax speculativeExpression = memberAccessExpression.WithExpression(SyntaxFactory.ThisExpression());
+            InvocationExpressionSyntax invocationExpression = memberAccessExpression.Parent as InvocationExpressionSyntax;
+            if (invocationExpression != null)
+                speculativeExpression = invocationExpression.WithExpression(speculativeExpression);
+
+            var speculativeSymbol = context.SemanticModel.GetSpeculativeSymbolInfo(memberAccessExpression.SpanStart, speculativeExpression, SpeculativeBindingOption.BindAsExpression);
+            if (speculativeSymbol.Symbol != targetSymbol.Symbol)
                 return;
 
             // Do not prefix calls with base unless local implementation exists


### PR DESCRIPTION
Following feedback in dotnet/roslyn#200, this pull request updates SA1100 to use the speculative semantic model instead of creating new `Compilation` instances.