### PR TITLE
Implement diagnostic and code fix for SA1101 PrefixLocalCallsWithThis

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1101UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1101UnitTests.cs
@@ -1,0 +1,287 @@
+﻿namespace StyleCop.Analyzers.Test.ReadabilityRules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using StyleCop.Analyzers.ReadabilityRules;
+    using TestHelper;
+
+    [TestClass]
+    public class SA1101UnitTests : CodeFixVerifier
+    {
+        private const string DiagnosticId = SA1101PrefixLocalCallsWithThis.DiagnosticId;
+
+        private const string ReferenceCode = @"
+        public class BaseTypeName
+        {
+            public static int BaseStaticFieldName;
+            public int BaseInstanceFieldName;
+
+            public static event EventHandler BaseStaticEventName;
+            public virtual event EventHandler BaseInstanceEventName;
+
+            public static int BaseStaticPropertyName
+            {
+                get;
+            }
+
+            public virtual int BaseInstancePropertyName
+            {
+                get;
+                set;
+            }
+
+            public static void BaseStaticMethodName()
+            {
+            }
+
+            public virtual void BaseInstanceMethodName()
+            {
+            }
+
+            public static void BaseMethodGroupName(int x)
+            {
+            }
+
+            public virtual void BaseMethodGroupName(string y)
+            {
+            }
+        }
+
+        [Obsolete(nameof(BaseInstanceFieldName))]
+        public class TypeName : BaseTypeName
+        {
+            /// <seealso cref='BaseStaticFieldName'/>
+            /// <seealso cref='BaseInstanceFieldName'/>
+            [Obsolete(nameof(BaseStaticFieldName))]
+            public static int N1;
+            [Obsolete(nameof(BaseInstanceFieldName))]
+            public int N2;
+
+            [Obsolete(nameof(BaseStaticEventName))]
+            public static int N3;
+            [Obsolete(nameof(BaseInstanceEventName))]
+            public static int N4;
+
+            [Obsolete(nameof(BaseStaticPropertyName))]
+            public static int N5;
+            [Obsolete(nameof(BaseInstancePropertyName))]
+            public static int N6;
+
+            [Obsolete(nameof(BaseStaticMethodName))]
+            public static int N7;
+            [Obsolete(nameof(BaseInstanceMethodName))]
+            public static int N8;
+
+            [Obsolete(nameof(N1))]
+            public static int N9;
+            [Obsolete(nameof(N2))]
+            public static int N10;
+
+            public static void StaticMethodName(int ParameterName)
+            {
+                string LocalName;
+                LocalName = nameof(N1);
+                LocalName = nameof(N2);
+                LocalName = nameof(ParameterName);
+                LocalName = nameof(LocalName);
+                LocalName = nameof(BaseStaticFieldName);
+                LocalName = nameof(BaseInstanceFieldName);
+                LocalName = nameof(BaseStaticEventName);
+                LocalName = nameof(BaseInstanceEventName);
+                LocalName = nameof(BaseStaticPropertyName);
+                LocalName = nameof(BaseInstancePropertyName);
+                LocalName = nameof(BaseStaticMethodName);
+                LocalName = nameof(BaseInstanceMethodName);
+                LocalName = nameof(BaseMethodGroupName);
+            }
+
+            public void InstanceMethodName(int ParameterName)
+            {
+                string LocalName;
+                LocalName = nameof(N1);
+                LocalName = nameof(N2);
+                LocalName = nameof(ParameterName);
+                LocalName = nameof(LocalName);
+                LocalName = nameof(BaseStaticFieldName);
+                LocalName = nameof(BaseInstanceFieldName);
+                LocalName = nameof(BaseStaticEventName);
+                LocalName = nameof(BaseInstanceEventName);
+                LocalName = nameof(BaseStaticPropertyName);
+                LocalName = nameof(BaseInstancePropertyName);
+                LocalName = nameof(BaseStaticMethodName);
+                LocalName = nameof(BaseInstanceMethodName);
+                LocalName = nameof(BaseMethodGroupName);
+
+                var obj = new BaseTypeName
+                {
+                    BaseInstanceFieldName = BaseInstanceFieldName,
+                    BaseInstancePropertyName = BaseInstancePropertyName,
+                }
+            }
+        }
+        ";
+
+        private static string FixedCode = @"
+        public class BaseTypeName
+        {
+            public static int BaseStaticFieldName;
+            public int BaseInstanceFieldName;
+
+            public static event EventHandler BaseStaticEventName;
+            public virtual event EventHandler BaseInstanceEventName;
+
+            public static int BaseStaticPropertyName
+            {
+                get;
+            }
+
+            public virtual int BaseInstancePropertyName
+            {
+                get;
+                set;
+            }
+
+            public static void BaseStaticMethodName()
+            {
+            }
+
+            public virtual void BaseInstanceMethodName()
+            {
+            }
+
+            public static void BaseMethodGroupName(int x)
+            {
+            }
+
+            public virtual void BaseMethodGroupName(string y)
+            {
+            }
+        }
+
+        [Obsolete(nameof(BaseInstanceFieldName))]
+        public class TypeName : BaseTypeName
+        {
+            /// <seealso cref='BaseStaticFieldName'/>
+            /// <seealso cref='BaseInstanceFieldName'/>
+            [Obsolete(nameof(BaseStaticFieldName))]
+            public static int N1;
+            [Obsolete(nameof(BaseInstanceFieldName))]
+            public int N2;
+
+            [Obsolete(nameof(BaseStaticEventName))]
+            public static int N3;
+            [Obsolete(nameof(BaseInstanceEventName))]
+            public static int N4;
+
+            [Obsolete(nameof(BaseStaticPropertyName))]
+            public static int N5;
+            [Obsolete(nameof(BaseInstancePropertyName))]
+            public static int N6;
+
+            [Obsolete(nameof(BaseStaticMethodName))]
+            public static int N7;
+            [Obsolete(nameof(BaseInstanceMethodName))]
+            public static int N8;
+
+            [Obsolete(nameof(N1))]
+            public static int N9;
+            [Obsolete(nameof(N2))]
+            public static int N10;
+
+            public static void StaticMethodName(int ParameterName)
+            {
+                string LocalName;
+                LocalName = nameof(N1);
+                LocalName = nameof(N2);
+                LocalName = nameof(ParameterName);
+                LocalName = nameof(LocalName);
+                LocalName = nameof(BaseStaticFieldName);
+                LocalName = nameof(BaseInstanceFieldName);
+                LocalName = nameof(BaseStaticEventName);
+                LocalName = nameof(BaseInstanceEventName);
+                LocalName = nameof(BaseStaticPropertyName);
+                LocalName = nameof(BaseInstancePropertyName);
+                LocalName = nameof(BaseStaticMethodName);
+                LocalName = nameof(BaseInstanceMethodName);
+                LocalName = nameof(BaseMethodGroupName);
+            }
+
+            public void InstanceMethodName(int ParameterName)
+            {
+                string LocalName;
+                LocalName = nameof(N1);
+                LocalName = nameof(this.N2);
+                LocalName = nameof(ParameterName);
+                LocalName = nameof(LocalName);
+                LocalName = nameof(BaseStaticFieldName);
+                LocalName = nameof(this.BaseInstanceFieldName);
+                LocalName = nameof(BaseStaticEventName);
+                LocalName = nameof(this.BaseInstanceEventName);
+                LocalName = nameof(BaseStaticPropertyName);
+                LocalName = nameof(this.BaseInstancePropertyName);
+                LocalName = nameof(BaseStaticMethodName);
+                LocalName = nameof(this.BaseInstanceMethodName);
+                LocalName = nameof(BaseMethodGroupName);
+
+                var obj = new BaseTypeName
+                {
+                    BaseInstanceFieldName = this.BaseInstanceFieldName,
+                    BaseInstancePropertyName = this.BaseInstancePropertyName,
+                }
+            }
+        }
+        ";
+
+        private DiagnosticResult CreateDiagnosticResult(int line, int column)
+        {
+            return new DiagnosticResult
+            {
+                Id = DiagnosticId,
+                Message = "Prefix local calls with this",
+                Severity = DiagnosticSeverity.Warning,
+                Locations =
+                    new[]
+                    {
+                        new DiagnosticResultLocation("Test0.cs", line, column)
+                    }
+            };
+        }
+
+        [TestMethod]
+        public async Task TestPrefixLocalCallsWithThisDiagnostics()
+        {
+            var expected = new[]
+            {
+                CreateDiagnosticResult(90, 36),
+                CreateDiagnosticResult(94, 36),
+                CreateDiagnosticResult(96, 36),
+                CreateDiagnosticResult(98, 36),
+                CreateDiagnosticResult(100, 36),
+                CreateDiagnosticResult(105, 45),
+                CreateDiagnosticResult(106, 48),
+            };
+
+            await VerifyCSharpDiagnosticAsync(ReferenceCode, expected, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestPrefixLocalCallsWithThisCodeFix()
+        {
+            await VerifyCSharpFixAsync(ReferenceCode, FixedCode, cancellationToken: CancellationToken.None);
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new SA1101PrefixLocalCallsWithThis();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new SA1101CodeFixProvider();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -139,6 +139,7 @@
     <Compile Include="NamingRules\SA1311UnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReadabilityRules\SA1100UnitTests.cs" />
+    <Compile Include="ReadabilityRules\SA1101UnitTests.cs" />
     <Compile Include="ReadabilityRules\SA1106UnitTests.cs" />
     <Compile Include="ReadabilityRules\SA1111UnitTests.cs" />
     <Compile Include="ReadabilityRules\SA1112UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
@@ -109,26 +109,26 @@ namespace TestHelper
                 document = await ApplyFixAsync(document, actions.ElementAt(0), cancellationToken).ConfigureAwait(false);
                 analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzer, new[] { document }, cancellationToken);
 
-                var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false));
-
-                //check if applying the code fix introduced any new compiler diagnostics
-                if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
-                {
-                    // Format and get the compiler diagnostics again so that the locations make sense in the output
-                    document = await Formatter.FormatAsync(document, Formatter.Annotation, cancellationToken: cancellationToken);
-                    newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false));
-
-                    Assert.IsTrue(false,
-                        string.Format("Fix introduced new compiler diagnostics:\r\n{0}\r\n\r\nNew document:\r\n{1}\r\n",
-                            string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString())),
-                            (await document.GetSyntaxRootAsync().ConfigureAwait(false)).ToFullString()));
-                }
-
                 //check if there are analyzer diagnostics left after the code fix
                 if (!analyzerDiagnostics.Any())
                 {
                     break;
                 }
+            }
+
+            var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false));
+
+            //check if applying the code fix introduced any new compiler diagnostics
+            if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
+            {
+                // Format and get the compiler diagnostics again so that the locations make sense in the output
+                document = await Formatter.FormatAsync(document, Formatter.Annotation, cancellationToken: cancellationToken);
+                newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false));
+
+                Assert.IsTrue(false,
+                    string.Format("Fix introduced new compiler diagnostics:\r\n{0}\r\n\r\nNew document:\r\n{1}\r\n",
+                        string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString())),
+                        (await document.GetSyntaxRootAsync().ConfigureAwait(false)).ToFullString()));
             }
 
             //after applying all of the code fixes, compare the resulting string to the inputted one

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
@@ -1,0 +1,58 @@
+﻿namespace StyleCop.Analyzers.ReadabilityRules
+{
+    using System.Collections.Immutable;
+    using System.Composition;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using SpacingRules;
+
+    [ExportCodeFixProvider(nameof(SA1101PrefixLocalCallsWithThis), LanguageNames.CSharp)]
+    [Shared]
+    public class SA1101CodeFixProvider : CodeFixProvider
+    {
+        private static readonly ImmutableArray<string> _fixableDiagnostics =
+            ImmutableArray.Create(SA1101PrefixLocalCallsWithThis.DiagnosticId);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<string> GetFixableDiagnosticIds()
+        {
+            return _fixableDiagnostics;
+        }
+
+        /// <inheritdoc/>
+        public override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        /// <inheritdoc/>
+        public override async Task ComputeFixesAsync(CodeFixContext context)
+        {
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                if (!diagnostic.Id.Equals(SA1101PrefixLocalCallsWithThis.DiagnosticId))
+                    continue;
+
+                var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
+                var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true) as SimpleNameSyntax;
+                if (node == null)
+                    return;
+
+                var qualifiedExpression =
+                    SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.ThisExpression(), node.WithoutTrivia().WithoutFormatting())
+                    .WithTriviaFrom(node)
+                    .WithoutFormatting();
+
+                var newSyntaxRoot = root.ReplaceNode(node, qualifiedExpression);
+
+                context.RegisterFix(
+                    CodeAction.Create("Prefix reference with 'this.'", context.Document.WithSyntaxRoot(newSyntaxRoot)), diagnostic);
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101PrefixLocalCallsWithThis.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101PrefixLocalCallsWithThis.cs
@@ -37,7 +37,7 @@
         private const string HelpLink = "http://www.stylecop.com/docs/SA1101.html";
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledNoTests, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true, Description, HelpLink);
 
         private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
             ImmutableArray.Create(Descriptor);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ReadabilityRules\SA1100CodeFixProvider.cs" />
     <Compile Include="ReadabilityRules\SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists.cs" />
+    <Compile Include="ReadabilityRules\SA1101CodeFixProvider.cs" />
     <Compile Include="ReadabilityRules\SA1101PrefixLocalCallsWithThis.cs" />
     <Compile Include="ReadabilityRules\SA1102QueryClauseMustFollowPreviousClause.cs" />
     <Compile Include="ReadabilityRules\SA1103QueryClausesMustBeOnSeparateLinesOrAllOnOneLine.cs" />


### PR DESCRIPTION
Fixes #35

The number of test cases is large to say the least. Basically I need to choose one item from each of the categories below and build a test for that set of conditions.

* Element type
  * Type
  * Method
  * Property
  * Field
  * Event
  * Parameter
  * Local
* Inheritance
  * New element
  * Override
  * Interface implementation
  * *Explicit* interface implementation
  * Hides static base element
  * Hides instance base element
* Is Static
  * True
  * False
* Expression type
  * Assignment to element
  * Read from (simple, e.g. `var x = this.Property;`)
    * For methods this is a reference to the method group
  * Read from (qualified, e.g. `var x = this.Property.GetHashCode();`)
  * `nameof` expression
* Expression location
  * Attribute value
  * In static member
  * In instance member
  * Field initializer for static field
  * Field initializer for instance field
  * String interpolation
  * Documentation comment
* Receiver
  * Current instance (or the containing type if Is Static is true)
  * Another instance

This gives a maximum of 4704 tests for complete coverage, although some combinations do not make since (e.g. you cannot assign to an element within a documentation comment or `nameof` expression).