### PR TITLE
Fix potential spacing problems when removing parentheses

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1119UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1119UnitTests.cs
@@ -1854,6 +1854,89 @@
             await VerifyCSharpFixAsync(testCode, fixedCode);
         }
 
+        [TestMethod]
+        public async Task TestNoLeadingTrivia()
+        {
+            var testCode = @"public class Foo
+{
+    public string Bar()
+    {
+        string foo = """";
+        return(foo);
+    }
+}";
+            var expected = new[]
+            {
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId,
+                    Message = "Statement must not use unnecessary parenthesis",
+                    Severity = DiagnosticSeverity.Warning,
+                    Locations =
+                        new[]
+                        {
+                            new DiagnosticResultLocation("Test0.cs", 6, 15)
+                        }
+                },
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId + "_p",
+                    Message = "Statement must not use unnecessary parenthesis",
+                    Severity = DiagnosticSeverity.Hidden,
+                    Locations =
+                        new[]
+                        {
+                            new DiagnosticResultLocation("Test0.cs", 6, 15)
+                        }
+                },
+                new DiagnosticResult
+                {
+                    Id = DiagnosticId + "_p",
+                    Message = "Statement must not use unnecessary parenthesis",
+                    Severity = DiagnosticSeverity.Hidden,
+                    Locations =
+                        new[]
+                        {
+                            new DiagnosticResultLocation("Test0.cs", 6, 19)
+                        }
+                }
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+
+            var fixedCode = @"public class Foo
+{
+    public string Bar()
+    {
+        string foo = """";
+        return foo;
+    }
+}";
+            await VerifyCSharpFixAsync(testCode, fixedCode);
+        }
+
+        [TestMethod]
+        public async Task TestCodeFixDoesNotRemoveSpaces()
+        {
+            var testCode = @"public class Foo
+{
+    public string Bar()
+    {
+        string foo = """";
+        return     (     foo     )     ;
+    }
+}";
+            var fixedCode = @"public class Foo
+{
+    public string Bar()
+    {
+        string foo = """";
+        return          foo          ;
+    }
+}";
+            await VerifyCSharpFixAsync(testCode, fixedCode);
+        }
+
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new SA1119StatementMustNotUseUnnecessaryParenthesis();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
@@ -8,6 +8,7 @@
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeActions;
     using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Formatting;
     using StyleCop.Analyzers.SpacingRules;
@@ -71,6 +72,11 @@
                     .WithoutFormatting();
 
                 var newSyntaxRoot = syntaxRoot.ReplaceNode(syntax, newNode);
+                if (!newSyntaxRoot.SyntaxTree.IsEquivalentTo(SyntaxFactory.ParseSyntaxTree(newSyntaxRoot.ToFullString())))
+                {
+                    newNode = newNode.WithLeadingTrivia(newNode.GetLeadingTrivia().Add(SyntaxFactory.Whitespace(" ", false)));
+                    newSyntaxRoot = syntaxRoot.ReplaceNode(syntax, newNode);
+                }
 
                 var changedDocument = context.Document.WithSyntaxRoot(newSyntaxRoot);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
@@ -3,6 +3,7 @@
     using System.Collections.Immutable;
     using System.Composition;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeActions;
@@ -37,36 +38,47 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override Task ComputeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1119StatementMustNotUseUnnecessaryParenthesis.DiagnosticId))
                     continue;
 
-                var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-                SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true, findInsideTrivia: true);
-                if (node.IsMissing)
-                    continue;
-                ParenthesizedExpressionSyntax syntax = node as ParenthesizedExpressionSyntax;
-                if (syntax != null)
-                {
-                    var syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken);
-                    var leadingTrivia = syntax.OpenParenToken.GetAllTrivia().Concat(syntax.Expression.GetLeadingTrivia());
-                    var trailingTrivia = syntax.Expression.GetTrailingTrivia().Concat(syntax.CloseParenToken.GetAllTrivia());
-
-                    var newNode = syntax.Expression
-                        .WithLeadingTrivia(leadingTrivia)
-                        .WithTrailingTrivia(trailingTrivia)
-                        .WithoutFormatting();
-
-                    var newSyntaxRoot = syntaxRoot.ReplaceNode(syntax, newNode);
-
-                    var changedDocument = context.Document.WithSyntaxRoot(newSyntaxRoot);
-
-                    context.RegisterFix(CodeAction.Create("Remove parenthesis", changedDocument), diagnostic);
-                }
+                context.RegisterFix(CodeAction.Create("Remove parenthesis", cancellationToken => ComputeChangedDocumentAsync(context, diagnostic, cancellationToken)), diagnostic);
             }
+
+            return Task.FromResult(default(object));
+        }
+
+        private async Task<Document> ComputeChangedDocumentAsync(CodeFixContext context, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var root = await context.Document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true, findInsideTrivia: true);
+            if (node.IsMissing)
+                return context.Document;
+
+            ParenthesizedExpressionSyntax syntax = node as ParenthesizedExpressionSyntax;
+            if (syntax != null)
+            {
+                var syntaxRoot = await context.Document.GetSyntaxRootAsync(cancellationToken);
+                var leadingTrivia = syntax.OpenParenToken.GetAllTrivia().Concat(syntax.Expression.GetLeadingTrivia());
+                var trailingTrivia = syntax.Expression.GetTrailingTrivia().Concat(syntax.CloseParenToken.GetAllTrivia());
+
+                var newNode = syntax.Expression
+                    .WithLeadingTrivia(leadingTrivia)
+                    .WithTrailingTrivia(trailingTrivia)
+                    .WithoutFormatting();
+
+                var newSyntaxRoot = syntaxRoot.ReplaceNode(syntax, newNode);
+
+                var changedDocument = context.Document.WithSyntaxRoot(newSyntaxRoot);
+
+                return changedDocument;
+            }
+
+            // no changes were made
+            return context.Document;
         }
     }
 }


### PR DESCRIPTION
This is an alternative solution to #449. It reuses the tests originally provided in #450.

The new implementation detects a spacing error by writing the new syntax root to a string, and then parsing it to verify that the parsed version is the same as expected. If these trees are not considered equivalent (for any reason), the algorithm assumes a spacing error resulted in the combination of one or more nodes and a space is added where the opening parentheses once was.