### PR TITLE
Fix removing trivia in SA1001CodeFixProvider

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
@@ -76,7 +76,7 @@
                     SyntaxToken precedingToken = token.GetPreviousToken();
                     if (precedingToken.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
                     {
-                        SyntaxToken corrected = precedingToken.WithoutLeadingWhitespace().WithoutFormatting();
+                        SyntaxToken corrected = precedingToken.WithoutTrailingWhitespace().WithoutFormatting();
                         replacements[precedingToken] = corrected;
                     }
                 }


### PR DESCRIPTION
Realized this when writing the tests.

The referred CodeFixProvider is checking the token preceding the comma for trailing trivia at:
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/ccbeeb757ecbe26bc7f85a1cc7273efe52a2609c/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs#L77

but then, removing leading trivia. It should remove the trailing one, so, this function call:
```f(a , b);```
correctly becomes:
```f(a, b);```