### PR TITLE
SA1001 tests

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.Test.SpacingRules
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -87,6 +88,33 @@
         }
 
         [TestMethod]
+        public async Task TestSpaceBeforeCommaAtEndOfLine()
+        {
+            string spaceBeforeComma = $"f(a ,{Environment.NewLine}b);";
+            string spaceOnlyAfterComma = $"f(a,{Environment.NewLine}b);";
+
+            DiagnosticResult[] expected;
+
+            expected =
+                new[]
+                {
+                    new DiagnosticResult
+                    {
+                        Id = DiagnosticId,
+                        Message = "Commas must not be preceded by a space.",
+                        Severity = DiagnosticSeverity.Warning,
+                        Locations =
+                            new[]
+                            {
+                                new DiagnosticResultLocation("Test0.cs", 7, 17)
+                            }
+                    },
+                };
+
+            await TestCommaInStatementOrDecl(spaceBeforeComma, expected, spaceOnlyAfterComma);
+        }
+
+        [TestMethod]
         public async Task TestLastCommaInLine()
         {
             string statement = @"f(a,
@@ -95,10 +123,78 @@
         }
 
         [TestMethod]
+        public async Task TestFirstCommaInLine()
+        {
+            string statement = $"f(a{Environment.NewLine}, b);";
+            await TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement);
+        }
+
+        [TestMethod]
+        public async Task TestCommentBeforeFirstCommaInLine()
+        {
+            string statement = $"f(a // comment{Environment.NewLine}, b);";
+            await TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement);
+        }
+
+        [TestMethod]
+        public async Task TestSpaceBeforeCommaFollowedByAngleBracketInFuncType()
+        {
+            string statement = @"var a = typeof(System.Func< ,>);";
+            string fixedStatement = @"var a = typeof(System.Func<,>);";
+
+            DiagnosticResult[] expected;
+
+            expected =
+                new[]
+                {
+                    new DiagnosticResult
+                    {
+                        Id = DiagnosticId,
+                        Message = "Commas must not be preceded by a space.",
+                        Severity = DiagnosticSeverity.Warning,
+                        Locations =
+                            new[]
+                            {
+                                new DiagnosticResultLocation("Test0.cs", 7, 41)
+                            }
+                    },
+                };
+
+            await TestCommaInStatementOrDecl(statement, expected, fixedStatement);
+        }
+
+        [TestMethod]
         public async Task TestCommaFollowedByAngleBracketInFuncType()
         {
             string statement = @"var a = typeof(System.Func<,>);";
             await TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement);
+        }
+
+        [TestMethod]
+        public async Task TestSpaceBeforeCommaFollowedByCommaInFuncType()
+        {
+            string statement = @"var a = typeof(System.Func< ,,>);";
+            string fixedStatement = @"var a = typeof(System.Func<,,>);";
+
+            DiagnosticResult[] expected;
+
+            expected =
+                new[]
+                {
+                    new DiagnosticResult
+                    {
+                        Id = DiagnosticId,
+                        Message = "Commas must not be preceded by a space.",
+                        Severity = DiagnosticSeverity.Warning,
+                        Locations =
+                            new[]
+                            {
+                                new DiagnosticResultLocation("Test0.cs", 7, 41)
+                            }
+                    },
+                };
+
+            await TestCommaInStatementOrDecl(statement, expected, fixedStatement);
         }
 
         [TestMethod]

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CommasMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CommasMustBeSpacedCorrectly.cs
@@ -87,9 +87,8 @@
             }
 
             bool hasPrecedingSpace = false;
-            if (!token.HasLeadingTrivia)
+            if (!token.IsFirstTokenOnLine(context.CancellationToken))
             {
-                // only the first token on the line has leading trivia, and those are ignored
                 SyntaxToken precedingToken = token.GetPreviousToken();
                 if (precedingToken.HasTrailingTrivia)
                     hasPrecedingSpace = true;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CommasMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CommasMustBeSpacedCorrectly.cs
@@ -25,7 +25,7 @@
         private const string HelpLink = "http://www.stylecop.com/docs/SA1001.html";
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledNoTests, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true, Description, HelpLink);
 
         private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
             ImmutableArray.Create(Descriptor);


### PR DESCRIPTION
* Additional tests to cover cases identified during review of #457 
* Fix handling of commas at the beginning of a line (#257)
* Enable SA1001 by default now that tests are in place