### PR TITLE
Add simple test for no diagnostics on correct space after identifiers. Better implementation of TestLastCommaInLine

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
@@ -30,6 +30,13 @@
         }
 
         [TestMethod]
+        public async Task TestSpaceAfterComma()
+        {
+            string statement = "f(a, b);";
+            await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement);
+        }
+
+        [TestMethod]
         public async Task TestNoSpaceAfterComma()
         {
             string statementWithoutSpace = @"f(a,b);";
@@ -117,8 +124,7 @@
         [TestMethod]
         public async Task TestLastCommaInLine()
         {
-            string statement = @"f(a,
-              b);";
+            string statement = $"f(a,{Environment.NewLine}b);";
             await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
@@ -210,6 +210,32 @@
             await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement);
         }
 
+        [TestMethod]
+        public async Task TestCommaFollowedBySpaceFollowedByCommaInFuncType()
+        {
+            string statement = @"var a = typeof(System.Func<, ,>);";
+            string fixedStatement = @"var a = typeof(System.Func<,,>);";
+            DiagnosticResult[] expected;
+
+            expected =
+                new[]
+                {
+                    new DiagnosticResult
+                    {
+                        Id = this.DiagnosticId,
+                        Message = "Commas must not be preceded by a space.",
+                        Severity = DiagnosticSeverity.Warning,
+                        Locations =
+                            new[]
+                            {
+                                new DiagnosticResultLocation("Test0.cs", 7, 42)
+                            }
+                    },
+                };
+
+            await this.TestCommaInStatementOrDecl(statement, expected, fixedStatement);
+        }
+
         private async Task TestCommaInStatementOrDecl(string originalStatement, DiagnosticResult[] expected, string fixedStatement)
         {
             string template = @"namespace Foo

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
@@ -177,6 +177,14 @@
         }
 
         [TestMethod]
+        public async Task TestCommaFollowedBySpaceFollowedByAngleBracketInFuncType()
+        {
+            // This is correct by SA1001, and reported as an error by SA1015
+            string statement = @"var a = typeof(System.Func<, >);";
+            await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement);
+        }
+
+        [TestMethod]
         public async Task TestSpaceBeforeCommaFollowedByCommaInFuncType()
         {
             string statement = @"var a = typeof(System.Func< ,,>);";


### PR DESCRIPTION
@sharwell I missed the single, correct case of empty diagnostics with `f(a, b);` (which is also being checked by `TestSpaceBeforeComma`, but I prefer to be explicit :sunglasses:).
This pull request includes a change for `TestLastCommaInLine`, now using `{Environment.NewLine}` and looking better.

Besides that, tests look complete!

According to SA1001 things like `System.Func<, >` aren't errors, so diagnostics behave correctly in that case too.

The wording of StyleCop rules can be confusing, as for example: *"comma should always be followed by a single space, unless it is the last character on the line"* can be understood as "when a comma is the last character on the line, it should not be followed by a single space", but really means "when a comma is the last character of the line, **rule doesn't apply**".

So, I'm taking into account that bit of possible ambiguity to continue implementing more rules :-)