### PR TITLE
Implemened Code fix: SA1304NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1304UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1304UnitTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using StyleCop.Analyzers.NamingRules;
@@ -44,6 +45,13 @@ namespace StyleCop.Analyzers.Test.NamingRules
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+
+            var fixedCode = @"public class Foo
+{
+    public readonly string Bar = ""baz"";
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedCode);
         }
 
         [TestMethod]
@@ -81,6 +89,12 @@ namespace StyleCop.Analyzers.Test.NamingRules
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+
+            var fixedCode = @"public class Foo
+{
+    protected readonly string Bar = ""baz"";
+}";
+            await this.VerifyCSharpFixAsync(testCode, fixedCode);
         }
 
         [TestMethod]
@@ -118,6 +132,12 @@ namespace StyleCop.Analyzers.Test.NamingRules
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+
+            var fixedCode = @"public class Foo
+{
+    internal readonly string Bar = ""baz"";
+}";
+            await this.VerifyCSharpFixAsync(testCode, fixedCode);
         }
 
         [TestMethod]
@@ -167,6 +187,11 @@ namespace StyleCop.Analyzers.Test.NamingRules
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {
             return new SA1304NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new SA1304SA1311CodeFixProvider();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1311UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1311UnitTests.cs
@@ -170,7 +170,7 @@
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
-            return new SA1311CodeFixProvider();
+            return new SA1304SA1311CodeFixProvider();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1304SA1311CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1304SA1311CodeFixProvider.cs
@@ -1,4 +1,6 @@
-﻿namespace StyleCop.Analyzers.NamingRules
+﻿using System.Linq;
+
+namespace StyleCop.Analyzers.NamingRules
 {
     using System.Collections.Immutable;
     using System.Composition;
@@ -11,12 +13,13 @@
     /// <summary>
     /// Implements a code fix for <see cref="SA1311StaticReadonlyFieldsMustBeginWithUpperCaseLetter"/>
     /// </summary>
-    [ExportCodeFixProvider(nameof(SA1311CodeFixProvider), LanguageNames.CSharp)]
+    [ExportCodeFixProvider(nameof(SA1304SA1311CodeFixProvider), LanguageNames.CSharp)]
     [Shared]
-    public class SA1311CodeFixProvider : CodeFixProvider
+    public class SA1304SA1311CodeFixProvider : CodeFixProvider
     {
         private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1311StaticReadonlyFieldsMustBeginWithUpperCaseLetter.DiagnosticId);
+            ImmutableArray.Create(SA1311StaticReadonlyFieldsMustBeginWithUpperCaseLetter.DiagnosticId,
+                                  SA1304NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter.DiagnosticId);
 
         /// <inheritdoc/>
         public override ImmutableArray<string> GetFixableDiagnosticIds()
@@ -29,7 +32,7 @@
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1311StaticReadonlyFieldsMustBeginWithUpperCaseLetter.DiagnosticId))
+                if (!FixableDiagnostics.Any(d => diagnostic.Id.Equals(d)))
                     continue;
 
                 var document = context.Document;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -153,7 +153,7 @@
     <Compile Include="NamingRules\SA1309CodeFixProvider.cs" />
     <Compile Include="NamingRules\SA1309FieldNamesMustNotBeginWithUnderscore.cs" />
     <Compile Include="NamingRules\SA1310FieldNamesMustNotContainUnderscore.cs" />
-    <Compile Include="NamingRules\SA1311CodeFixProvider.cs" />
+    <Compile Include="NamingRules\SA1304SA1311CodeFixProvider.cs" />
     <Compile Include="NamingRules\SA1311StaticReadonlyFieldsMustBeginWithUpperCaseLetter.cs" />
     <Compile Include="OrderingRules\SA1200UsingDirectivesMustBePlacedWithinNamespace.cs" />
     <Compile Include="OrderingRules\SA1201ElementsMustAppearInTheCorrectOrder.cs" />


### PR DESCRIPTION
Fixes #430.
StyleCop mentions 3 ways of solving this:
* change the name of the readonly field so that it begins with an upper-case letter
* make the field private
*  place the item within a NativeMethods class

This codefix solves this issue using the first option. In my opinion, we shouldn't try to implement remaining 2 options (I even guess that the second option is provided by VS).