### PR TITLE
Finish SA1123

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1123UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1123UnitTests.cs
@@ -5,27 +5,26 @@
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using StyleCop.Analyzers.ReadabilityRules;
+    using Analyzers.ReadabilityRules;
     using TestHelper;
+    using Xunit;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1123DoNotPlaceRegionsWithinElements"/> and
     /// <see cref="RemoveRegionCodeFixProvider"/>.
     /// </summary>
-    [TestClass]
     public class SA1123UnitTests : CodeFixVerifier
     {
         public string DiagnosticId { get; } = SA1123DoNotPlaceRegionsWithinElements.DiagnosticId;
 
-        [TestMethod]
+        [Fact]
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestRegionInMethod()
         {
             var testCode = @"public class Foo
@@ -43,17 +42,7 @@
             expected =
                 new[]
                 {
-                    new DiagnosticResult
-                    {
-                        Id = this.DiagnosticId,
-                        Message = "Region must not be located within a code element.",
-                        Severity = DiagnosticSeverity.Warning,
-                        Locations =
-                            new[]
-                            {
-                                new DiagnosticResultLocation("Test0.cs", 5, 1)
-                            }
-                    }
+                    this.CSharpDiagnostic().WithLocation(5, 1)
                 };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
@@ -69,7 +58,7 @@
             await this.VerifyCSharpFixAsync(testCode, fixedCode);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestRegionPartialyInMethod()
         {
             var testCode = @"public class Foo
@@ -85,7 +74,7 @@
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestRegionPartialyInMethod2()
         {
             var testCode = @"public class Foo
@@ -100,7 +89,7 @@
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestRegionPartialyMultipleMethods()
         {
             var testCode = @"public class Foo
@@ -119,7 +108,7 @@
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestEndRegionInMethod()
         {
             var testCode = @"public class Foo
@@ -135,7 +124,7 @@
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestRegionOutsideMethod()
         {
             var testCode = @"public class Foo
@@ -151,7 +140,7 @@
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
 
-        [TestMethod]
+        [Fact]
         public async Task TestRegionOutsideMethod2()
         {
             var testCode = @"public class Foo

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1123UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1123UnitTests.cs
@@ -1,0 +1,180 @@
+﻿namespace StyleCop.Analyzers.Test.ReadabilityRules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using StyleCop.Analyzers.ReadabilityRules;
+    using TestHelper;
+
+    /// <summary>
+    /// This class contains unit tests for <see cref="SA1123DoNotPlaceRegionsWithinElements"/> and
+    /// <see cref="RemoveRegionCodeFixProvider"/>.
+    /// </summary>
+    [TestClass]
+    public class SA1123UnitTests : CodeFixVerifier
+    {
+        public string DiagnosticId { get; } = SA1123DoNotPlaceRegionsWithinElements.DiagnosticId;
+
+        [TestMethod]
+        public async Task TestEmptySource()
+        {
+            var testCode = string.Empty;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestRegionInMethod()
+        {
+            var testCode = @"public class Foo
+{
+    public void Bar()
+    {
+#region Foo
+        string test = """";
+#endregion
+    }
+}";
+
+            DiagnosticResult[] expected;
+
+            expected =
+                new[]
+                {
+                    new DiagnosticResult
+                    {
+                        Id = this.DiagnosticId,
+                        Message = "Region must not be located within a code element.",
+                        Severity = DiagnosticSeverity.Warning,
+                        Locations =
+                            new[]
+                            {
+                                new DiagnosticResultLocation("Test0.cs", 5, 1)
+                            }
+                    }
+                };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+
+            string fixedCode = @"public class Foo
+{
+    public void Bar()
+    {
+        string test = """";
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+        }
+
+        [TestMethod]
+        public async Task TestRegionPartialyInMethod()
+        {
+            var testCode = @"public class Foo
+{
+    public void Bar()
+    {
+#region Foo
+        string test = """";
+    }
+#endregion
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestRegionPartialyInMethod2()
+        {
+            var testCode = @"public class Foo
+{
+    public void Bar()
+#region Foo
+    {
+        string test = """";
+    }
+#endregion
+}";
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestRegionPartialyMultipleMethods()
+        {
+            var testCode = @"public class Foo
+{
+    public void Bar()
+    {
+#region Foo
+        string test = """";
+    }
+    public void FooBar()
+    {
+        string test = """";
+#endregion
+    }
+}";
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestEndRegionInMethod()
+        {
+            var testCode = @"public class Foo
+{
+#region Foo
+    public void Bar()
+    {
+        string test = """";
+#endregion
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestRegionOutsideMethod()
+        {
+            var testCode = @"public class Foo
+{
+#region Foo
+#endregion
+    public void Bar()
+    {
+        string test = """";
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task TestRegionOutsideMethod2()
+        {
+            var testCode = @"public class Foo
+{
+#region Foo
+    public void Bar()
+    {
+        string test = """";
+    }
+#endregion
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new RemoveRegionCodeFixProvider();
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new SA1123DoNotPlaceRegionsWithinElements();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -178,6 +178,7 @@
     <Compile Include="ReadabilityRules\SA1113UnitTests.cs" />
     <Compile Include="ReadabilityRules\SA1114UnitTests.cs" />
     <Compile Include="ReadabilityRules\SA1121UnitTests.cs" />
+    <Compile Include="ReadabilityRules\SA1123UnitTests.cs" />
     <Compile Include="ReadabilityRules\SA1122UnitTests.cs" />
     <Compile Include="SpacingRules\NumberSignSpacingTestBase.cs" />
     <Compile Include="SpacingRules\SA1000UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionCodeFixProvider.cs
@@ -1,0 +1,58 @@
+﻿namespace StyleCop.Analyzers.ReadabilityRules
+{
+    using System.Collections.Immutable;
+    using System.Composition;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+    /// <summary>
+    /// Implements a code fix for <see cref="SA1123DoNotPlaceRegionsWithinElements"/> and <see cref="SA1124DoNotUseRegions"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>To fix a violation of this rule, remove the region.</para>
+    /// </remarks>
+    [ExportCodeFixProvider(nameof(RemoveRegionCodeFixProvider), LanguageNames.CSharp)]
+    [Shared]
+    public class RemoveRegionCodeFixProvider : CodeFixProvider
+    {
+        private static readonly ImmutableArray<string> FixableDiagnostics =
+            ImmutableArray.Create(SA1123DoNotPlaceRegionsWithinElements.DiagnosticId, SA1124DoNotUseRegions.DiagnosticId);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<string> GetFixableDiagnosticIds()
+        {
+            return FixableDiagnostics;
+        }
+
+        /// <inheritdoc/>
+        public override FixAllProvider GetFixAllProvider()
+        {
+            // The batch fixer does not do a very good job if regions are stacked in each other
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        /// <inheritdoc/>
+        public override async Task ComputeFixesAsync(CodeFixContext context)
+        {
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                if (!this.GetFixableDiagnosticIds().Contains(diagnostic.Id))
+                    continue;
+                var syntaxRoot = await context.Document.GetSyntaxRootAsync().ConfigureAwait(false);
+                var node = syntaxRoot?.FindNode(diagnostic.Location.SourceSpan, findInsideTrivia: true, getInnermostNodeForTie: true);
+                if (node != null && node.IsKind(SyntaxKind.RegionDirectiveTrivia))
+                {
+                    var regionDirective = node as RegionDirectiveTriviaSyntax;
+
+                    var newSyntaxRoot = syntaxRoot.RemoveNodes(regionDirective.GetRelatedDirectives(), SyntaxRemoveOptions.AddElasticMarker);
+
+                    context.RegisterFix(CodeAction.Create("Remove region", context.Document.WithSyntaxRoot(newSyntaxRoot)), diagnostic);
+                }
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -207,6 +207,7 @@
     <Compile Include="ReadabilityRules\SA1120CommentsMustContainText.cs" />
     <Compile Include="ReadabilityRules\SA1121CodeFixProvider.cs" />
     <Compile Include="ReadabilityRules\SA1121UseBuiltInTypeAlias.cs" />
+    <Compile Include="ReadabilityRules\RemoveRegionCodeFixProvider.cs" />
     <Compile Include="ReadabilityRules\SA1122CodeFixProvider.cs" />
     <Compile Include="ReadabilityRules\SA1122UseStringEmptyForEmptyStrings.cs" />
     <Compile Include="ReadabilityRules\SA1123DoNotPlaceRegionsWithinElements.cs" />


### PR DESCRIPTION
I changed the diagnostic to not report some uses of regions where SA1124 should be reported instead. I implemented a code fix that removes regions (for SA1123 and SA1124). and I implemented tests for SA1123.

The diagnostic now has a handy method which can be used by SA1124 to exclude cases where SA1123 should be reported instead of SA1124.
With that implementing SA1124 should be very easy.

Fixes #246. Fixes #247.