### PR TITLE
Upgrade code analysis to 1.0.0rc1

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -70,9 +70,8 @@ namespace TestHelper
             foreach (var project in projects)
             {
                 var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-                var driver = AnalyzerDriver.Create(compilation, ImmutableArray.Create(analyzer), null, out compilation, cancellationToken);
-                var discarded = compilation.GetDiagnostics(cancellationToken);
-                var diags = await driver.GetDiagnosticsAsync().ConfigureAwait(false);
+                var compilationWithAnalyzers = compilation.WithAnalyzers(ImmutableArray.Create(analyzer), null, cancellationToken);
+                var diags = await compilationWithAnalyzers.GetAllDiagnosticsAsync().ConfigureAwait(false);
                 foreach (var diag in diags)
                 {
                     if (diag.Location == Location.None || diag.Location.IsInMetadata)
@@ -170,7 +169,7 @@ namespace TestHelper
 
             var projectId = ProjectId.CreateNewId(debugName: TestProjectName);
 
-            var solution = new CustomWorkspace()
+            var solution = new AdhocWorkspace()
                 .CurrentSolution
                 .AddProject(projectId, TestProjectName, TestProjectName, language)
                 .AddMetadataReference(projectId, CorlibReference)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -105,7 +105,7 @@ namespace TestHelper
         /// <see cref="Diagnostic.Location"/>.</returns>
         private static Diagnostic[] SortDistinctDiagnostics(IEnumerable<Diagnostic> diagnostics)
         {
-            return diagnostics.OrderBy(d => d.Location.SourceSpan.Start).Distinct(default(DiagnosticEqualityComparer)).ToArray();
+            return diagnostics.OrderBy(d => d.Location.SourceSpan.Start).ToArray();
         }
 
         #endregion
@@ -189,42 +189,6 @@ namespace TestHelper
             return solution.GetProject(projectId);
         }
         #endregion
-
-        /// <summary>
-        /// A little helper to be able to use Enumerable.Distinct. Currently Roslyn does have a bug so that Diagnostic.GetHashCode()
-        /// is not implemented correctly. <see href="https://github.com/dotnet/roslyn/issues/57"/>.
-        /// </summary>
-        private struct DiagnosticEqualityComparer : IEqualityComparer<Diagnostic>
-        {
-            public bool Equals(Diagnostic x, Diagnostic y)
-            {
-                return (x == null && y == null)
-                    || x.Equals(y);
-            }
-
-            public int GetHashCode(Diagnostic obj)
-            {
-                return this.Combine(obj.Descriptor,
-                         this.Combine(obj.Location.GetHashCode(),
-                          this.Combine(obj.Severity.GetHashCode(), obj.WarningLevel)));
-            }
-
-            private int Combine<T>(T newKeyPart, int currentKey) where T : class
-            {
-                int hash = unchecked(currentKey * (int)0xA5555529);
-
-                if (newKeyPart != null)
-                {
-                    return unchecked(hash + newKeyPart.GetHashCode());
-                }
-
-                return hash;
-            }
-            private int Combine(int newKey, int currentKey)
-            {
-                return unchecked((currentKey * (int)0xA5555529) + newKey);
-            }
-        }
     }
 }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -71,7 +71,7 @@ namespace TestHelper
             {
                 var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
                 var compilationWithAnalyzers = compilation.WithAnalyzers(ImmutableArray.Create(analyzer), null, cancellationToken);
-                var diags = await compilationWithAnalyzers.GetAllDiagnosticsAsync().ConfigureAwait(false);
+                var diags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
                 foreach (var diag in diags)
                 {
                     if (diag.Location == Location.None || diag.Location.IsInMetadata)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/OpenIssueAttribute.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/OpenIssueAttribute.cs
@@ -1,0 +1,20 @@
+﻿namespace StyleCop.Analyzers.Test.Helpers
+{
+    /// <summary>
+    /// Indicates that a specific test is related to an open issue.
+    /// </summary>
+    [System.AttributeUsage(System.AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+    public sealed class OpenIssueAttribute : System.Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OpenIssueAttribute"/> class.
+        /// </summary>
+        /// <param name="issue">A link to the open issue.</param>
+        public OpenIssueAttribute(string issue)
+        {
+            this.Issue = issue;
+        }
+
+        public string Issue { get; }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1400UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1400UnitTests.cs
@@ -2,11 +2,12 @@
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Analyzers.MaintainabilityRules;
+    using Helpers;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using StyleCop.Analyzers.MaintainabilityRules;
     using TestHelper;
 
     [TestClass]
@@ -487,37 +488,37 @@
 
         #region EventFieldDeclarationSyntax
 
-        [TestMethod]
+        [TestMethod, Ignore, OpenIssue("https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestEventFieldDeclarationAsync()
         {
             await this.TestNestedDeclarationAsync("private", "MemberName", "event EventHandler MemberName", ", AnotherMemberName;");
         }
 
-        [TestMethod]
+        [TestMethod, Ignore, OpenIssue("https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestEventFieldDeclarationWithAttributesAsync()
         {
             await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "event EventHandler MemberName", ", AnotherMemberName;");
         }
 
-        [TestMethod]
+        [TestMethod, Ignore, OpenIssue("https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestEventFieldDeclarationWithDirectivesAsync()
         {
             await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "event EventHandler MemberName", ", AnotherMemberName;");
         }
 
-        [TestMethod]
+        [TestMethod, Ignore, OpenIssue("https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestStaticEventFieldDeclarationAsync()
         {
             await this.TestNestedDeclarationAsync("private", "MemberName", "static event EventHandler MemberName", ", AnotherMemberName;");
         }
 
-        [TestMethod]
+        [TestMethod, Ignore, OpenIssue("https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestStaticEventFieldDeclarationWithAttributesAsync()
         {
             await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "static event EventHandler MemberName", ", AnotherMemberName;");
         }
 
-        [TestMethod]
+        [TestMethod, Ignore, OpenIssue("https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestStaticEventFieldDeclarationWithDirectivesAsync()
         {
             await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "static event EventHandler MemberName", ", AnotherMemberName;");
@@ -545,37 +546,37 @@
 
         #region FieldDeclarationSyntax
 
-        [TestMethod]
+        [TestMethod, Ignore, OpenIssue("https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestFieldDeclarationAsync()
         {
             await this.TestNestedDeclarationAsync("private", "MemberName", "System.EventHandler MemberName", ", AnotherMemberName;");
         }
 
-        [TestMethod]
+        [TestMethod, Ignore, OpenIssue("https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestFieldDeclarationWithAttributesAsync()
         {
             await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "System.EventHandler MemberName", ", AnotherMemberName;");
         }
 
-        [TestMethod]
+        [TestMethod, Ignore, OpenIssue("https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestFieldDeclarationWithDirectivesAsync()
         {
             await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "System.EventHandler MemberName", ", AnotherMemberName;");
         }
 
-        [TestMethod]
+        [TestMethod, Ignore, OpenIssue("https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestStaticFieldDeclarationAsync()
         {
             await this.TestNestedDeclarationAsync("private", "MemberName", "static System.EventHandler MemberName", ", AnotherMemberName;");
         }
 
-        [TestMethod]
+        [TestMethod, Ignore, OpenIssue("https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestStaticFieldDeclarationWithAttributesAsync()
         {
             await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "static System.EventHandler MemberName", ", AnotherMemberName;");
         }
 
-        [TestMethod]
+        [TestMethod, Ignore, OpenIssue("https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestStaticFieldDeclarationWithDirectivesAsync()
         {
             await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "static System.EventHandler MemberName", ", AnotherMemberName;");

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -120,6 +120,7 @@
     <Compile Include="Helpers\CodeFixVerifier.Helper.cs" />
     <Compile Include="Helpers\DiagnosticResult.cs" />
     <Compile Include="Helpers\DiagnosticVerifier.Helper.cs" />
+    <Compile Include="Helpers\OpenIssueAttribute.cs" />
     <Compile Include="MaintainabilityRules\DebugMessagesUnitTestsBase.cs" />
     <Compile Include="MaintainabilityRules\FileMayOnlyContainTestBase.cs" />
     <Compile Include="MaintainabilityRules\SA1119UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -43,40 +43,40 @@
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Desktop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.CSharp.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.CSharp.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Desktop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0.0-beta2\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Collections.Immutable, Version=1.1.32.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>True</Private>
-      <HintPath>..\..\packages\System.Collections.Immutable.1.1.32-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Composition.AttributedModel">
       <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
@@ -94,8 +94,9 @@
       <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.0.17-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=1.0.18.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -169,6 +170,8 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc1\tools\analyzers\C#\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc1\tools\analyzers\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-alpha003\tools\analyzers\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
@@ -93,7 +93,7 @@ namespace TestHelper
             {
                 var actions = new List<CodeAction>();
                 var context = new CodeFixContext(document, analyzerDiagnostics[0], (a, d) => actions.Add(a), cancellationToken);
-                await codeFixProvider.ComputeFixesAsync(context).ConfigureAwait(false);
+                await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
 
                 if (!actions.Any())
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/packages.config
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/packages.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0.0-beta2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0.0-beta2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0.0-beta2" targetFramework="net45" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0.0-beta2" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0-rc1" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-rc1" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0-rc1" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-rc1" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-rc1" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.0-alpha003" targetFramework="net45" />
-  <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="net45" />
-  <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" />
 </packages>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -28,10 +28,7 @@
             ImmutableArray.Create(SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.DiagnosticId, SA1643DestructorSummaryDocumentationMustBeginWithStandardText.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -40,7 +37,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -89,7 +86,7 @@
                 var newRoot = root.ReplaceNode(node, newNode);
 
                 var newDocument = context.Document.WithSyntaxRoot(newRoot);
-                context.RegisterFix(CodeAction.Create("Add standard text.", newDocument), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Add standard text.", token => Task.FromResult(newDocument)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1500CurlyBracketsForMultiLineStatementsMustNotShareLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1500CurlyBracketsForMultiLineStatementsMustNotShareLine.cs
@@ -47,6 +47,7 @@
     /// }
     /// </code>
     /// </remarks>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class SA1500CurlyBracketsForMultiLineStatementsMustNotShareLine : DiagnosticAnalyzer
     {
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
@@ -25,10 +25,7 @@
             ImmutableArray.Create(SA1119StatementMustNotUseUnnecessaryParenthesis.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -37,7 +34,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -64,7 +61,7 @@
 
                     var changedDocument = context.Document.WithSyntaxRoot(newSyntaxRoot);
 
-                    context.RegisterFix(CodeAction.Create("Remove parenthesis", changedDocument), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Remove parenthesis", token => Task.FromResult(changedDocument)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400AccessModifierMustBeDeclared.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400AccessModifierMustBeDeclared.cs
@@ -169,7 +169,7 @@
 
             foreach (SyntaxToken token in modifiers)
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.PublicKeyword:
                 case SyntaxKind.ProtectedKeyword:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
@@ -25,10 +25,7 @@
             ImmutableArray.Create(SA1400AccessModifierMustBeDeclared.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -37,7 +34,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -54,7 +51,7 @@
                     continue;
 
                 SyntaxNode updatedDeclarationNode;
-                switch (declarationNode.CSharpKind())
+                switch (declarationNode.Kind())
                 {
                 case SyntaxKind.ClassDeclaration:
                     updatedDeclarationNode = this.HandleClassDeclaration((ClassDeclarationSyntax)declarationNode);
@@ -113,7 +110,7 @@
                     break;
 
                 default:
-                    throw new InvalidOperationException("Unhandled declaration kind: " + declarationNode.CSharpKind());
+                    throw new InvalidOperationException("Unhandled declaration kind: " + declarationNode.Kind());
                 }
 
                 if (updatedDeclarationNode != null)
@@ -121,7 +118,7 @@
                     var syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken);
                     var newSyntaxRoot = syntaxRoot.ReplaceNode(declarationNode, updatedDeclarationNode);
                     var newDocument = context.Document.WithSyntaxRoot(newSyntaxRoot);
-                    context.RegisterFix(CodeAction.Create("Declare accessibility", newDocument), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Declare accessibility", token => Task.FromResult(newDocument)), diagnostic);
                 }
             }
         }
@@ -379,7 +376,7 @@
         {
             while (node != null)
             {
-                switch (node.CSharpKind())
+                switch (node.Kind())
                 {
                 case SyntaxKind.ClassDeclaration:
                 case SyntaxKind.InterfaceDeclaration:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
@@ -24,10 +24,7 @@
             ImmutableArray.Create(SA1407ArithmeticExpressionsMustDeclarePrecedence.DiagnosticId, SA1408ConditionalExpressionsMustDeclarePrecedence.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -36,11 +33,11 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!this.GetFixableDiagnosticIds().Contains(diagnostic.Id))
+                if (!this.FixableDiagnosticIds.Contains(diagnostic.Id))
                     continue;
 
                 var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
@@ -60,7 +57,7 @@
 
                     var changedDocument = context.Document.WithSyntaxRoot(newSyntaxRoot);
 
-                    context.RegisterFix(CodeAction.Create("Add parenthesis", changedDocument), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Add parenthesis", token => Task.FromResult(changedDocument)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1410SA1411CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1410SA1411CodeFixProvider.cs
@@ -26,10 +26,7 @@
                 SA1411AttributeConstructorMustNotUseUnnecessaryParenthesis.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -38,11 +35,11 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!this.GetFixableDiagnosticIds().Contains(diagnostic.Id))
+                if (!this.FixableDiagnosticIds.Contains(diagnostic.Id))
                     continue;
 
                 var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
@@ -61,7 +58,7 @@
 
                     var changedDocument = context.Document.WithSyntaxRoot(newSyntaxRoot);
 
-                    context.RegisterFix(CodeAction.Create("Remove parenthesis", changedDocument), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Remove parenthesis", token => Task.FromResult(changedDocument)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1302CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1302CodeFixProvider.cs
@@ -23,13 +23,10 @@
             ImmutableArray.Create(SA1302InterfaceNamesMustBeginWithI.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -43,7 +40,7 @@
                     continue;
 
                 var newName = "I" + token.ValueText;
-                context.RegisterFix(CodeAction.Create($"Rename interface to '{newName}'", cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create($"Rename interface to '{newName}'", cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1309CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1309CodeFixProvider.cs
@@ -23,10 +23,7 @@
           ImmutableArray.Create(SA1309FieldNamesMustNotBeginWithUnderscore.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -35,7 +32,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -51,7 +48,7 @@
                 if (!string.IsNullOrEmpty(token.ValueText))
                 {
                     var newName = token.ValueText.Substring(1);
-                    context.RegisterFix(CodeAction.Create($"Rename field to '{newName}'", cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create($"Rename field to '{newName}'", cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1311CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1311CodeFixProvider.cs
@@ -23,13 +23,10 @@
             ImmutableArray.Create(SA1311StaticReadonlyFieldsMustBeginWithUpperCaseLetter.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -43,7 +40,7 @@
                     continue;
 
                 var newName = char.ToUpper(token.ValueText[0]) + token.ValueText.Substring(1);
-                context.RegisterFix(CodeAction.Create($"Rename field to '{newName}'", cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create($"Rename field to '{newName}'", cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1200UsingDirectivesMustBePlacedWithinNamespace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1200UsingDirectivesMustBePlacedWithinNamespace.cs
@@ -188,7 +188,7 @@
             List<SyntaxNode> usingDirectives = new List<SyntaxNode>();
             foreach (SyntaxNode child in syntax.ChildNodes())
             {
-                switch (child.CSharpKind())
+                switch (child.Kind())
                 {
                 case SyntaxKind.ClassDeclaration:
                 case SyntaxKind.InterfaceDeclaration:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1212PropertyAccessorsMustFollowOrder.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1212PropertyAccessorsMustFollowOrder.cs
@@ -91,8 +91,8 @@
                 return;
             }
 
-            if (accessors[0].CSharpKind() == SyntaxKind.SetAccessorDeclaration &&
-                accessors[1].CSharpKind() == SyntaxKind.GetAccessorDeclaration)
+            if (accessors[0].Kind() == SyntaxKind.SetAccessorDeclaration &&
+                accessors[1].Kind() == SyntaxKind.GetAccessorDeclaration)
             {
                 context.ReportDiagnostic(Diagnostic.Create(Descriptor, accessors[0].GetLocation()));
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
@@ -24,10 +24,7 @@
             ImmutableArray.Create(SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -36,7 +33,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -57,8 +54,7 @@
 
                 var newSyntaxRoot = root.ReplaceNode(node, thisExpressionSyntax);
 
-                context.RegisterFix(
-                    CodeAction.Create("Replace 'base.' with 'this.'", context.Document.WithSyntaxRoot(newSyntaxRoot)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Replace 'base.' with 'this.'", token => Task.FromResult(context.Document.WithSyntaxRoot(newSyntaxRoot))), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
@@ -25,10 +25,7 @@
             ImmutableArray.Create(SA1101PrefixLocalCallsWithThis.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -37,7 +34,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -57,8 +54,7 @@
 
                 var newSyntaxRoot = root.ReplaceNode(node, qualifiedExpression);
 
-                context.RegisterFix(
-                    CodeAction.Create("Prefix reference with 'this.'", context.Document.WithSyntaxRoot(newSyntaxRoot)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Prefix reference with 'this.'", token => Task.FromResult(context.Document.WithSyntaxRoot(newSyntaxRoot))), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101PrefixLocalCallsWithThis.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101PrefixLocalCallsWithThis.cs
@@ -74,7 +74,7 @@
 
         private void HandleIdentifierName(SyntaxNodeAnalysisContext context)
         {
-            switch (context.Node?.Parent?.CSharpKind() ?? SyntaxKind.None)
+            switch (context.Node?.Parent?.Kind() ?? SyntaxKind.None)
             {
             case SyntaxKind.SimpleMemberAccessExpression:
                 // this is handled separately
@@ -104,7 +104,7 @@
                 if (((NameEqualsSyntax)context.Node.Parent).Name != context.Node)
                     break;
 
-                switch (context.Node?.Parent?.Parent?.CSharpKind() ?? SyntaxKind.None)
+                switch (context.Node?.Parent?.Parent?.Kind() ?? SyntaxKind.None)
                 {
                 case SyntaxKind.AttributeArgument:
                 case SyntaxKind.AnonymousObjectMemberDeclarator:
@@ -178,7 +178,7 @@
         {
             for (; node != null; node = node.Parent)
             {
-                switch (node.CSharpKind())
+                switch (node.Kind())
                 {
                 case SyntaxKind.ClassDeclaration:
                 case SyntaxKind.InterfaceDeclaration:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
@@ -43,10 +43,7 @@
             ImmutableArray.Create(SA1121UseBuiltInTypeAlias.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -55,7 +52,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -78,7 +75,7 @@
                         .WithoutFormatting();
                     var newRoot = root.ReplaceNode(node, newNode);
 
-                    context.RegisterFix(CodeAction.Create("Replace with built-in type", context.Document.WithSyntaxRoot(newRoot)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Replace with built-in type", token => Task.FromResult(context.Document.WithSyntaxRoot(newRoot))), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
@@ -25,10 +25,7 @@
             ImmutableArray.Create(SA1122UseStringEmptyForEmptyStrings.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -37,7 +34,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -54,7 +51,7 @@
 
                     var newSyntaxRoot = syntaxRoot.ReplaceNode(node, newNode);
 
-                    context.RegisterFix(CodeAction.Create($"Replace with {newNode}", context.Document.WithSyntaxRoot(newSyntaxRoot)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create($"Replace with {newNode}", token => Task.FromResult(context.Document.WithSyntaxRoot(newSyntaxRoot))), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1123DoNotPlaceRegionsWithinElements.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1123DoNotPlaceRegionsWithinElements.cs
@@ -55,7 +55,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
             {
-                switch (trivia.CSharpKind())
+                switch (trivia.Kind())
                 {
                 case SyntaxKind.RegionDirectiveTrivia:
                     this.HandleRegionDirectiveTrivia(context, trivia);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000CodeFixProvider.cs
@@ -23,10 +23,7 @@
             ImmutableArray.Create(SA1000KeywordsMustBeSpacedCorrectly.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -35,7 +32,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -48,7 +45,7 @@
                     continue;
 
                 bool isAddingSpace = true;
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.NewKeyword:
                     {
@@ -99,7 +96,7 @@
                     SyntaxTrivia whitespace = SyntaxFactory.Whitespace(" ").WithoutFormatting();
                     SyntaxToken corrected = token.WithTrailingTrivia(token.TrailingTrivia.Insert(0, whitespace));
                     Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceToken(token, corrected));
-                    context.RegisterFix(CodeAction.Create("Fix spacing", updatedDocument), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
                 }
                 else
                 {
@@ -108,7 +105,7 @@
 
                     SyntaxToken corrected = token.WithoutTrailingWhitespace().WithoutFormatting();
                     Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceToken(token, corrected));
-                    context.RegisterFix(CodeAction.Create("Fix spacing", updatedDocument), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
@@ -68,7 +68,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.AwaitKeyword:
                 case SyntaxKind.CaseKeyword:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
@@ -25,10 +25,7 @@
             ImmutableArray.Create(SA1001CommasMustBeSpacedCorrectly.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -37,7 +34,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -93,7 +90,7 @@
 
                 var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
                 Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterFix(CodeAction.Create("Fix spacing", updatedDocument), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CommasMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CommasMustBeSpacedCorrectly.cs
@@ -53,7 +53,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.CommaToken:
                     this.HandleCommaToken(context, token);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002CodeFixProvider.cs
@@ -24,10 +24,7 @@
             ImmutableArray.Create(SA1002SemicolonsMustBeSpacedCorrectly.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -36,7 +33,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -83,7 +80,7 @@
 
                 var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
                 Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterFix(CodeAction.Create("Fix spacing", updatedDocument), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002SemicolonsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002SemicolonsMustBeSpacedCorrectly.cs
@@ -53,7 +53,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.SemicolonToken:
                     this.HandleSemicolonToken(context, token);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
@@ -26,10 +26,7 @@
             ImmutableArray.Create(SA1003SymbolsMustBeSpacedCorrectly.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -38,7 +35,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -58,7 +55,7 @@
                 {
                     SyntaxToken precedingToken = token.GetPreviousToken();
                     SyntaxToken correctedPrecedingNoSpace = precedingToken.WithoutTrailingWhitespace();
-                    switch (precedingToken.CSharpKind())
+                    switch (precedingToken.Kind())
                     {
                     case SyntaxKind.OpenParenToken:
                     case SyntaxKind.CloseParenToken:
@@ -103,7 +100,7 @@
 
                 var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
                 Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterFix(CodeAction.Create("Fix spacing", updatedDocument), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003SymbolsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003SymbolsMustBeSpacedCorrectly.cs
@@ -75,11 +75,11 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                if (SyntaxFacts.IsBinaryExpressionOperatorToken(token.CSharpKind()) && token.Parent is BinaryExpressionSyntax)
+                if (SyntaxFacts.IsBinaryExpressionOperatorToken(token.Kind()) && token.Parent is BinaryExpressionSyntax)
                 {
                     this.HandleBinaryExpressionOperatorToken(context, token);
                 }
-                else if (SyntaxFacts.IsPrefixUnaryExpressionOperatorToken(token.CSharpKind()) && token.Parent is PrefixUnaryExpressionSyntax)
+                else if (SyntaxFacts.IsPrefixUnaryExpressionOperatorToken(token.Kind()) && token.Parent is PrefixUnaryExpressionSyntax)
                 {
                     this.HandlePrefixUnaryExpressionOperatorToken(context, token);
                 }
@@ -121,7 +121,7 @@
             else
             {
                 SyntaxToken precedingToken = token.GetPreviousToken();
-                switch (precedingToken.CSharpKind())
+                switch (precedingToken.Kind())
                 {
                 case SyntaxKind.OpenParenToken:
                 case SyntaxKind.CloseParenToken:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1004DocumentationLinesMustBeginWithSingleSpace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1004DocumentationLinesMustBeginWithSingleSpace.cs
@@ -76,7 +76,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
             {
-                switch (trivia.CSharpKind())
+                switch (trivia.Kind())
                 {
                 case SyntaxKind.DocumentationCommentExteriorTrivia:
                     this.HandleDocumentationCommentExteriorTrivia(context, trivia);
@@ -94,7 +94,7 @@
             if (token.IsMissing)
                 return;
 
-            switch (token.CSharpKind())
+            switch (token.Kind())
             {
             case SyntaxKind.EqualsToken:
             case SyntaxKind.DoubleQuoteToken:
@@ -112,7 +112,7 @@
                     break;
 
                 SyntaxTrivia lastLeadingTrivia = token.LeadingTrivia.Last();
-                switch (lastLeadingTrivia.CSharpKind())
+                switch (lastLeadingTrivia.Kind())
                 {
                 case SyntaxKind.WhitespaceTrivia:
                     if (lastLeadingTrivia.ToFullString().StartsWith(" "))

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
@@ -24,10 +24,7 @@
             ImmutableArray.Create(SA1005SingleLineCommentsMustBeginWithSingleSpace.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -36,7 +33,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -55,7 +52,7 @@
                 string correctedText = "// " + text.Substring(2);
                 SyntaxTrivia corrected = SyntaxFactory.Comment(correctedText).WithoutFormatting();
                 Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceTrivia(trivia, corrected));
-                context.RegisterFix(CodeAction.Create("Insert space", updatedDocument), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Insert space", t => Task.FromResult(updatedDocument)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005SingleLineCommentsMustBeginWithSingleSpace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005SingleLineCommentsMustBeginWithSingleSpace.cs
@@ -82,7 +82,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var trivia in root.DescendantTrivia())
             {
-                switch (trivia.CSharpKind())
+                switch (trivia.Kind())
                 {
                 case SyntaxKind.SingleLineCommentTrivia:
                     this.HandleSingleLineCommentTrivia(context, trivia);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1006CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1006CodeFixProvider.cs
@@ -23,10 +23,7 @@
             ImmutableArray.Create(SA1006PreprocessorKeywordsMustNotBePrecededBySpace.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -35,7 +32,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -53,7 +50,7 @@
 
                 SyntaxToken corrected = hashToken.WithoutTrailingWhitespace().WithoutFormatting();
                 Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceToken(hashToken, corrected));
-                context.RegisterFix(CodeAction.Create("Remove space", updatedDocument), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove space", t => Task.FromResult(updatedDocument)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1006PreprocessorKeywordsMustNotBePrecededBySpace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1006PreprocessorKeywordsMustNotBePrecededBySpace.cs
@@ -62,7 +62,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens(descendIntoTrivia: true))
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.HashToken:
                     this.HandleHashToken(context, token);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1007CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1007CodeFixProvider.cs
@@ -22,10 +22,7 @@
             ImmutableArray.Create(SA1007OperatorKeywordMustBeFollowedBySpace.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -34,7 +31,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -52,7 +49,7 @@
                 SyntaxTrivia whitespace = SyntaxFactory.Whitespace(" ");
                 SyntaxToken corrected = token.WithTrailingTrivia(token.TrailingTrivia.Insert(0, whitespace)).WithoutFormatting();
                 Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceToken(token, corrected));
-                context.RegisterFix(CodeAction.Create("Insert space", updatedDocument), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Insert space", t => Task.FromResult(updatedDocument)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1007OperatorKeywordMustBeFollowedBySpace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1007OperatorKeywordMustBeFollowedBySpace.cs
@@ -58,7 +58,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.OperatorKeyword:
                     this.HandleRequiredSpaceToken(context, token);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
@@ -57,7 +57,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.OpenParenToken:
                     this.HandleOpenParenToken(context, token);
@@ -95,7 +95,7 @@
             {
                 SyntaxToken precedingToken = token.GetPreviousToken();
                 precededBySpace = precedingToken.HasTrailingTrivia;
-                switch (precedingToken.CSharpKind())
+                switch (precedingToken.Kind())
                 {
                 case SyntaxKind.AwaitKeyword:
                 case SyntaxKind.CaseKeyword:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
@@ -59,7 +59,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.CloseParenToken:
                     this.HandleCloseParenToken(context, token);
@@ -99,7 +99,7 @@
             bool suppressFollowingSpaceError = false;
 
             SyntaxToken nextToken = token.GetNextToken();
-            switch (nextToken.CSharpKind())
+            switch (nextToken.Kind())
             {
             case SyntaxKind.OpenParenToken:
             case SyntaxKind.CloseParenToken:
@@ -155,7 +155,7 @@
                 break;
             }
 
-            switch (token.Parent.CSharpKind())
+            switch (token.Parent.Kind())
             {
             case SyntaxKind.CastExpression:
                 precedesStickyCharacter = true;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010CodeFixProvider.cs
@@ -24,10 +24,7 @@
             ImmutableArray.Create(SA1010OpeningSquareBracketsMustBeSpacedCorrectly.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -36,7 +33,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -72,7 +69,7 @@
 
                 var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
                 Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterFix(CodeAction.Create("Fix spacing", updatedDocument), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010OpeningSquareBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010OpeningSquareBracketsMustBeSpacedCorrectly.cs
@@ -56,7 +56,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.OpenBracketToken:
                     this.HandleOpenBracketToken(context, token);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011ClosingSquareBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011ClosingSquareBracketsMustBeSpacedCorrectly.cs
@@ -58,7 +58,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.CloseBracketToken:
                     this.HandleCloseBracketToken(context, token);
@@ -102,7 +102,7 @@
             if (!followedBySpace && !lastInLine)
             {
                 SyntaxToken nextToken = token.GetNextToken();
-                switch (nextToken.CSharpKind())
+                switch (nextToken.Kind())
                 {
                 case SyntaxKind.CloseBracketToken:
                 case SyntaxKind.OpenParenToken:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
@@ -24,10 +24,7 @@
             ImmutableArray.Create(SA1011ClosingSquareBracketsMustBeSpacedCorrectly.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -36,7 +33,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -65,7 +62,7 @@
                 {
                     bool ignoreTrailingWhitespace;
                     SyntaxToken nextToken = token.GetNextToken();
-                    switch (nextToken.CSharpKind())
+                    switch (nextToken.Kind())
                     {
                     case SyntaxKind.CloseBracketToken:
                     case SyntaxKind.OpenParenToken:
@@ -103,7 +100,7 @@
 
                 var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
                 Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterFix(CodeAction.Create("Fix spacing", updatedDocument), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1012OpeningCurlyBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1012OpeningCurlyBracketsMustBeSpacedCorrectly.cs
@@ -58,7 +58,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.OpenBraceToken:
                     this.HandleOpenBraceToken(context, token);
@@ -94,7 +94,7 @@
             {
                 SyntaxToken precedingToken = token.GetPreviousToken();
                 precededBySpace = precedingToken.HasTrailingTrivia;
-                switch (precedingToken.CSharpKind())
+                switch (precedingToken.Kind())
                 {
                 case SyntaxKind.OpenParenToken:
                     allowLeadingNoSpace = true;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1013ClosingCurlyBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1013ClosingCurlyBracketsMustBeSpacedCorrectly.cs
@@ -57,7 +57,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.CloseBraceToken:
                     this.HandleCloseBraceToken(context, token);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1014OpeningGenericBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1014OpeningGenericBracketsMustBeSpacedCorrectly.cs
@@ -54,7 +54,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.LessThanToken:
                     this.HandleLessThanToken(context, token);
@@ -71,7 +71,7 @@
             if (token.IsMissing)
                 return;
 
-            switch (token.Parent.CSharpKind())
+            switch (token.Parent.Kind())
             {
             case SyntaxKind.TypeArgumentList:
             case SyntaxKind.TypeParameterList:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1015ClosingGenericBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1015ClosingGenericBracketsMustBeSpacedCorrectly.cs
@@ -56,7 +56,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.GreaterThanToken:
                     this.HandleGreaterThanToken(context, token);
@@ -73,7 +73,7 @@
             if (token.IsMissing)
                 return;
 
-            switch (token.Parent.CSharpKind())
+            switch (token.Parent.Kind())
             {
             case SyntaxKind.TypeArgumentList:
             case SyntaxKind.TypeParameterList:
@@ -108,7 +108,7 @@
             if (!lastInLine)
             {
                 SyntaxToken nextToken = token.GetNextToken();
-                switch (nextToken.CSharpKind())
+                switch (nextToken.Kind())
                 {
                 case SyntaxKind.OpenParenToken:
                 // DotToken isn't listed above, but it's required for reasonable member access formatting

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016CodeFixProvider.cs
@@ -23,10 +23,7 @@
             ImmutableArray.Create(SA1016OpeningAttributeBracketsMustBeSpacedCorrectly.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -35,7 +32,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -56,7 +53,7 @@
                 SyntaxToken corrected = token.WithoutTrailingWhitespace().WithoutFormatting();
                 SyntaxNode transformed = root.ReplaceToken(token, corrected);
                 Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterFix(CodeAction.Create("Fix spacing", updatedDocument), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016OpeningAttributeBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016OpeningAttributeBracketsMustBeSpacedCorrectly.cs
@@ -55,7 +55,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.OpenBracketToken:
                     this.HandleOpenBracketToken(context, token);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017ClosingAttributeBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017ClosingAttributeBracketsMustBeSpacedCorrectly.cs
@@ -54,7 +54,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.CloseBracketToken:
                     this.HandleCloseBracketToken(context, token);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017CodeFixProvider.cs
@@ -23,10 +23,7 @@
             ImmutableArray.Create(SA1017ClosingAttributeBracketsMustBeSpacedCorrectly.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -35,7 +32,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -58,7 +55,7 @@
                 SyntaxToken corrected = precedingToken.WithoutTrailingWhitespace().WithoutFormatting();
                 SyntaxNode transformed = root.ReplaceToken(precedingToken, corrected);
                 Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterFix(CodeAction.Create("Fix spacing", updatedDocument), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
@@ -23,10 +23,7 @@
             ImmutableArray.Create(SA1018NullableTypeSymbolsMustNotBePrecededBySpace.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -35,7 +32,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -57,7 +54,7 @@
 
                 SyntaxToken corrected = previousToken.WithoutTrailingWhitespace().WithoutFormatting();
                 Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceToken(previousToken, corrected));
-                context.RegisterFix(CodeAction.Create("Remove space", updatedDocument), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove space", t => Task.FromResult(updatedDocument)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018NullableTypeSymbolsMustNotBePrecededBySpace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018NullableTypeSymbolsMustNotBePrecededBySpace.cs
@@ -54,7 +54,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.QuestionToken:
                     this.HandleQuestionToken(context, token);
@@ -71,7 +71,7 @@
             if (token.IsMissing)
                 return;
 
-            if (token.Parent.CSharpKind() != SyntaxKind.NullableType)
+            if (token.Parent.Kind() != SyntaxKind.NullableType)
                 return;
 
             if (token.IsFirstTokenOnLine(context.CancellationToken))

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1019MemberAccessSymbolsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1019MemberAccessSymbolsMustBeSpacedCorrectly.cs
@@ -52,7 +52,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.DotToken:
                     this.HandleDotToken(context, token);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1020IncrementDecrementSymbolsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1020IncrementDecrementSymbolsMustBeSpacedCorrectly.cs
@@ -55,7 +55,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.MinusMinusToken:
                 case SyntaxKind.PlusPlusToken:
@@ -73,7 +73,7 @@
             if (token.IsMissing)
                 return;
 
-            switch (token.Parent.CSharpKind())
+            switch (token.Parent.Kind())
             {
             case SyntaxKind.PreIncrementExpression:
             case SyntaxKind.PreDecrementExpression:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021CodeFixProvider.cs
@@ -25,10 +25,7 @@
             ImmutableArray.Create(SA1021NegativeSignsMustBeSpacedCorrectly.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -37,7 +34,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -91,7 +88,7 @@
 
                 var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
                 Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterFix(CodeAction.Create("Fix spacing", updatedDocument), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021NegativeSignsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021NegativeSignsMustBeSpacedCorrectly.cs
@@ -56,7 +56,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.MinusToken:
                     this.HandleMinusToken(context, token);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022CodeFixProvider.cs
@@ -25,10 +25,7 @@
             ImmutableArray.Create(SA1022PositiveSignsMustBeSpacedCorrectly.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -37,7 +34,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -91,7 +88,7 @@
 
                 var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
                 Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterFix(CodeAction.Create("Fix spacing", updatedDocument), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022PositiveSignsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022PositiveSignsMustBeSpacedCorrectly.cs
@@ -56,7 +56,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.PlusToken:
                     this.HandlePlusToken(context, token);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly.cs
@@ -72,7 +72,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.AsteriskToken:
                     this.HandleAsteriskToken(context, token);
@@ -95,7 +95,7 @@
             bool allowPrecedingNoSpace;
             bool allowTrailingSpace;
             bool allowTrailingNoSpace;
-            switch (token.Parent.CSharpKind())
+            switch (token.Parent.Kind())
             {
             case SyntaxKind.PointerType:
                 allowAtLineStart = false;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1024ColonsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1024ColonsMustBeSpacedCorrectly.cs
@@ -82,7 +82,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.ColonToken:
                     this.HandleColonToken(context, token);
@@ -100,7 +100,7 @@
                 return;
 
             bool requireBefore;
-            switch (token.Parent.CSharpKind())
+            switch (token.Parent.Kind())
             {
             case SyntaxKind.BaseList:
             case SyntaxKind.BaseConstructorInitializer:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1025CodeMustNotContainMultipleWhitespaceInARow.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1025CodeMustNotContainMultipleWhitespaceInARow.cs
@@ -54,7 +54,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var trivia in root.DescendantTrivia())
             {
-                switch (trivia.CSharpKind())
+                switch (trivia.Kind())
                 {
                 case SyntaxKind.WhitespaceTrivia:
                     this.HandleWhitespaceTrivia(context, trivia);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1026CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1026CodeFixProvider.cs
@@ -22,10 +22,7 @@
             ImmutableArray.Create(SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> GetFixableDiagnosticIds()
-        {
-            return FixableDiagnostics;
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -34,7 +31,7 @@
         }
 
         /// <inheritdoc/>
-        public override async Task ComputeFixesAsync(CodeFixContext context)
+        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (var diagnostic in context.Diagnostics)
             {
@@ -48,7 +45,7 @@
 
                 SyntaxToken corrected = token.WithoutTrailingWhitespace().WithoutFormatting();
                 Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceToken(token, corrected));
-                context.RegisterFix(CodeAction.Create("Remove space", updatedDocument), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove space", t => Task.FromResult(updatedDocument)), diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation.cs
@@ -57,7 +57,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
             {
-                switch (token.CSharpKind())
+                switch (token.Kind())
                 {
                 case SyntaxKind.NewKeyword:
                     this.HandleNewKeywordToken(context, token);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1027TabsMustNotBeUsed.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1027TabsMustNotBeUsed.cs
@@ -57,7 +57,7 @@
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
             {
-                switch (trivia.CSharpKind())
+                switch (trivia.Kind())
                 {
                 case SyntaxKind.WhitespaceTrivia:
                     this.HandleWhitespaceTrivia(context, trivia);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SpacingExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SpacingExtensions.cs
@@ -73,22 +73,6 @@
         }
 
         /// <summary>
-        /// Removes the leading and trailing trivia associated with a syntax node.
-        /// </summary>
-        /// <typeparam name="TNode">The type of syntax node to remove trivia from.</typeparam>
-        /// <param name="node">The syntax node to remove trivia from.</param>
-        /// <returns>A copy of the input syntax node with leading and trailing trivia removed.</returns>
-        /// <exception cref="ArgumentNullException">If <paramref name="node"/> is <see langword="null"/>.</exception>
-        public static TNode WithoutTrivia<TNode>(this TNode node)
-            where TNode : SyntaxNode
-        {
-            if (node == null)
-                throw new ArgumentNullException(nameof(node));
-
-            return node.WithoutLeadingTrivia().WithoutTrailingTrivia();
-        }
-
-        /// <summary>
         /// Removes the leading and trailing trivia associated with a syntax token.
         /// </summary>
         /// <param name="token">The syntax token to remove trivia from.</param>
@@ -96,48 +80,6 @@
         public static SyntaxToken WithoutTrivia(this SyntaxToken token)
         {
             return token.WithLeadingTrivia(default(SyntaxTriviaList)).WithTrailingTrivia(default(SyntaxTriviaList));
-        }
-
-        /// <summary>
-        /// Replaces the leading and trailing trivia associated with <paramref name="targetNode"/> with the trivia from
-        /// <paramref name="node"/>.
-        /// </summary>
-        /// <typeparam name="TNode">The type of syntax node to apply the trivia to.</typeparam>
-        /// <param name="targetNode">The syntax node to update.</param>
-        /// <param name="node">The syntax node with the desired leading and trailing trivia.</param>
-        /// <returns>A copy of <paramref name="targetNode"/> with the leading and trailing trivia replaced with the
-        /// trivia from <paramref name="node"/>.</returns>
-        /// <exception cref="ArgumentNullException">
-        /// <para>If <paramref name="targetNode"/> is <see langword="null"/>.</para>
-        /// <para>-or-</para>
-        /// <para>If <paramref name="node"/> is <see langword="null"/>.</para>
-        /// </exception>
-        public static TNode WithTriviaFrom<TNode>(this TNode targetNode, SyntaxNode node)
-            where TNode : SyntaxNode
-        {
-            if (targetNode == null)
-                throw new ArgumentNullException(nameof(targetNode));
-            if (node == null)
-                throw new ArgumentNullException(nameof(node));
-
-            return targetNode
-                .WithLeadingTrivia(node.GetLeadingTrivia())
-                .WithTrailingTrivia(node.GetTrailingTrivia());
-        }
-
-        /// <summary>
-        /// Replaces the leading and trailing trivia associated with <paramref name="targetToken"/> with the trivia from
-        /// <paramref name="token"/>.
-        /// </summary>
-        /// <param name="targetToken">The syntax token to update.</param>
-        /// <param name="token">The syntax token with the desired leading and trailing trivia.</param>
-        /// <returns>A copy of <paramref name="targetToken"/> with the leading and trailing trivia replaced with the
-        /// trivia from <paramref name="token"/>.</returns>
-        public static SyntaxToken WithTriviaFrom(this SyntaxToken targetToken, SyntaxToken token)
-        {
-            return targetToken
-                .WithLeadingTrivia(token.LeadingTrivia)
-                .WithTrailingTrivia(token.TrailingTrivia);
         }
 
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -273,20 +273,19 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0-rc1\lib\portable-net45+win8\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-rc1\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-rc1\lib\portable-net45+win8\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0.0-beta2\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-rc1\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\packages\System.Collections.Immutable.1.1.32-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Composition.AttributedModel">
       <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
@@ -309,11 +308,12 @@
       <Private>False</Private>
     </Reference>
     <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\..\packages\System.Reflection.Metadata.1.0.17-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc1\tools\analyzers\C#\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc1\tools\analyzers\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-alpha003\tools\analyzers\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/packages.config
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/packages.config
@@ -1,11 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0.0-beta2" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0-rc1" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-rc1" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0-rc1" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-rc1" targetFramework="portable-net45+win" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-rc1" targetFramework="portable-net45+win" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable-net45+win" />
   <package id="StyleCop.Analyzers" version="1.0.0-alpha003" targetFramework="portable-net45+win" />
-  <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="portable-net45+win" />
-  <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="portable-net45+win" />
+  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="portable-net45+win" />
+  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="portable-net45+win" />
 </packages>


### PR DESCRIPTION
Do not merge.

Currently all SA1400 tests that require a syntax node action of type EventFieldDeclaration or FieldDeclaration being called are failing.