### PR TITLE
Improve assertion messages

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticResult.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticResult.cs
@@ -91,5 +91,10 @@ namespace TestHelper
                 return this.Locations.Length > 0 ? this.Locations[0].Column : -1;
             }
         }
+
+        public override string ToString()
+        {
+            return $"{this.Path}({this.Line},{this.Column}): {this.Severity}: {this.Message}";
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/DiagnosticVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/DiagnosticVerifier.cs
@@ -1,12 +1,12 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
-using Xunit;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Xunit;
+using Xunit.Sdk;
 
 namespace TestHelper
 {
@@ -135,70 +135,141 @@ namespace TestHelper
         {
             int expectedCount = expectedResults.Count();
             int actualCount = actualResults.Count();
+                StringBuilder errorStringBuilder = new StringBuilder();
 
             if (expectedCount != actualCount)
             {
-                string diagnosticsOutput = actualResults.Any() ? FormatDiagnostics(analyzer, actualResults.ToArray()) : "    NONE.";
-
-                Assert.True(false,
-                    string.Format("Mismatch between number of diagnostics returned, expected \"{0}\" actual \"{1}\"\r\n\r\nDiagnostics:\r\n{2}\r\n", expectedCount, actualCount, diagnosticsOutput));
+                errorStringBuilder.AppendLine($"Mismatch between number of diagnostics returned, expected \"{expectedCount}\" actual \"{actualCount}\"");
             }
 
+            AppendMissmatchErrorText(actualResults, analyzer, expectedResults, errorStringBuilder);
+
+            string errorString = errorStringBuilder.ToString();
+            if (!string.IsNullOrEmpty(errorString))
+            {
+                Assert.True(false, errorString);
+            }
+
+            //The only thing that could still be wrong is that the duplicated entries in actualResult and expectedResults
+            // don't match. Example:
+            // Let a, b, c be diagnostics and
+            // actual: a, b, b, c
+            // expected: a, b, c, c
+            // Then every actual result was expected and every expected result was reported, but they still don't match.
+            // We shouldn't report multiple diagnostics for a single location so this should not happen, but for the sake
+            // of correctness of this method we should still check it.
             for (int i = 0; i < expectedResults.Length; i++)
             {
                 var actual = actualResults.ElementAt(i);
                 var expected = expectedResults[i];
 
-                if (expected.Line == -1 && expected.Column == -1)
+                AssertDiagnosticsMatch(analyzer, actual, expected);
+            }
+        }
+
+        private static void AppendMissmatchErrorText(IEnumerable<Diagnostic> actualResults, DiagnosticAnalyzer analyzer, DiagnosticResult[] expectedResults, StringBuilder errorStringBuilder)
+        {
+            foreach (var actual in actualResults)
+            {
+                bool success = false;
+                foreach (var expected in expectedResults)
                 {
-                    if (actual.Location != Location.None)
+                    try
                     {
-                        Assert.True(false,
-                            string.Format("Expected:\nA project diagnostic with No location\nActual:\n{0}",
-                            FormatDiagnostics(analyzer, actual)));
+                        AssertDiagnosticsMatch(analyzer, actual, expected);
+                        success = true;
+                        break;
+                    }
+                    catch (XunitException)
+                    {
+                        // If the diagnostic does not match any expected result we will get an Exception for all
+                        // expected diagnostics.
                     }
                 }
-                else
+                if (!success)
                 {
-                    VerifyDiagnosticLocation(analyzer, actual, actual.Location, expected.Locations.First());
-                    var additionalLocations = actual.AdditionalLocations.ToArray();
+                    errorStringBuilder.AppendLine("The diagnostic is reporting this diagnostic, but it is not expected:");
+                    errorStringBuilder.AppendLine(FormatDiagnostics(analyzer, actual));
+                }
+            }
 
-                    if (additionalLocations.Length != expected.Locations.Length - 1)
+            foreach (var expected in expectedResults)
+            {
+                bool success = false;
+                foreach (var actual in actualResults)
+                {
+                    try
                     {
-                        Assert.True(false,
-                            string.Format("Expected {0} additional locations but got {1} for Diagnostic:\r\n    {2}\r\n",
-                                expected.Locations.Length - 1, additionalLocations.Length,
-                                FormatDiagnostics(analyzer, actual)));
+                        AssertDiagnosticsMatch(analyzer, actual, expected);
+                        success = true;
+                        break;
                     }
-
-                    for (int j = 0; j < additionalLocations.Length; ++j)
+                    catch (XunitException)
                     {
-                        VerifyDiagnosticLocation(analyzer, actual, additionalLocations[j], expected.Locations[j + 1]);
+                        // If the expected result does not match any diagnostic we will get an Exception for all
+                        // diagnostics.
                     }
                 }
-
-                if (actual.Id != expected.Id)
+                if (!success)
                 {
-                    Assert.True(false,
-                        string.Format("Expected diagnostic id to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                            expected.Id, actual.Id, FormatDiagnostics(analyzer, actual)));
-                }
-
-                if (actual.Severity != expected.Severity)
-                {
-                    Assert.True(false,
-                        string.Format("Expected diagnostic severity to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                            expected.Severity, actual.Severity, FormatDiagnostics(analyzer, actual)));
-                }
-
-                if (actual.GetMessage() != expected.Message)
-                {
-                    Assert.True(false,
-                        string.Format("Expected diagnostic message to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                            expected.Message, actual.GetMessage(), FormatDiagnostics(analyzer, actual)));
+                    errorStringBuilder.AppendLine("The test is expecting this diagnostic, but it is not reported:");
+                    errorStringBuilder.AppendLine(FormatDiagnostics(analyzer, expected));
                 }
             }
         }
+
+        private static void AssertDiagnosticsMatch(DiagnosticAnalyzer analyzer, Diagnostic actual, DiagnosticResult expected)
+        {
+            if (expected.Line == -1 && expected.Column == -1)
+            {
+                if (actual.Location != Location.None)
+                {
+                    Assert.True(false,
+                        string.Format("Expected:\nA project diagnostic with No location\nActual:\n{0}",
+                        FormatDiagnostics(analyzer, actual)));
+                }
+            }
+            else
+            {
+                VerifyDiagnosticLocation(analyzer, actual, actual.Location, expected.Locations.First());
+                var additionalLocations = actual.AdditionalLocations.ToArray();
+
+                if (additionalLocations.Length != expected.Locations.Length - 1)
+                {
+                    Assert.True(false,
+                        string.Format("Expected {0} additional locations but got {1} for Diagnostic:\r\n    {2}\r\n",
+                            expected.Locations.Length - 1, additionalLocations.Length,
+                            FormatDiagnostics(analyzer, actual)));
+                }
+
+                for (int j = 0; j < additionalLocations.Length; ++j)
+                {
+                    VerifyDiagnosticLocation(analyzer, actual, additionalLocations[j], expected.Locations[j + 1]);
+                }
+            }
+
+            if (actual.Id != expected.Id)
+            {
+                Assert.True(false,
+                    string.Format("Expected diagnostic id to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                        expected.Id, actual.Id, FormatDiagnostics(analyzer, actual)));
+            }
+
+            if (actual.Severity != expected.Severity)
+            {
+                Assert.True(false,
+                    string.Format("Expected diagnostic severity to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                        expected.Severity, actual.Severity, FormatDiagnostics(analyzer, actual)));
+            }
+
+            if (actual.GetMessage() != expected.Message)
+            {
+                Assert.True(false,
+                    string.Format("Expected diagnostic message to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                        expected.Message, actual.GetMessage(), FormatDiagnostics(analyzer, actual)));
+            }
+        }
+
 
         /// <summary>
         /// Helper method to <see cref="VerifyDiagnosticResults"/> that checks the location of a
@@ -285,6 +356,50 @@ namespace TestHelper
                                 analyzerType.Name,
                                 rule.Id);
                         }
+
+                        if (i != diagnostics.Length - 1)
+                        {
+                            builder.Append(',');
+                        }
+
+                        builder.AppendLine();
+                        break;
+                    }
+                }
+            }
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Helper method to format a <see cref="Diagnostic"/> into an easily readable string.
+        /// </summary>
+        /// <param name="analyzer">The analyzer that this verifier tests.</param>
+        /// <param name="diagnostics">A collection of <see cref="Diagnostic"/>s to be formatted.</param>
+        /// <returns>The <paramref name="diagnostics"/> formatted as a string.</returns>
+        private static string FormatDiagnostics(DiagnosticAnalyzer analyzer, params DiagnosticResult[] diagnostics)
+        {
+            var builder = new StringBuilder();
+            for (int i = 0; i < diagnostics.Length; ++i)
+            {
+                builder.AppendLine("// " + diagnostics[i].ToString());
+
+                var analyzerType = analyzer.GetType();
+                var rules = analyzer.SupportedDiagnostics;
+
+                foreach (var rule in rules)
+                {
+                    if (rule != null && rule.Id == diagnostics[i].Id)
+                    {
+                        var location = diagnostics[i].Locations[0];
+
+                        string resultMethodName = "GetCSharpResultAt";
+
+                        builder.AppendFormat("{0}({1}, {2}, {3}.{4})",
+                            resultMethodName,
+                            location.Line,
+                            location.Column,
+                            analyzerType.Name,
+                            rule.Id);
 
                         if (i != diagnostics.Length - 1)
                         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/DiagnosticVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/DiagnosticVerifier.cs
@@ -142,13 +142,10 @@ namespace TestHelper
                 errorStringBuilder.AppendLine($"Mismatch between number of diagnostics returned, expected \"{expectedCount}\" actual \"{actualCount}\"");
             }
 
-            AppendMissmatchErrorText(actualResults, analyzer, expectedResults, errorStringBuilder);
+            AppendMismatchErrorText(actualResults, analyzer, expectedResults, errorStringBuilder);
 
             string errorString = errorStringBuilder.ToString();
-            if (!string.IsNullOrEmpty(errorString))
-            {
-                Assert.True(false, errorString);
-            }
+            Assert.True(string.IsNullOrEmpty(errorString), errorString);
 
             //The only thing that could still be wrong is that the duplicated entries in actualResult and expectedResults
             // don't match. Example:
@@ -167,7 +164,7 @@ namespace TestHelper
             }
         }
 
-        private static void AppendMissmatchErrorText(IEnumerable<Diagnostic> actualResults, DiagnosticAnalyzer analyzer, DiagnosticResult[] expectedResults, StringBuilder errorStringBuilder)
+        private static void AppendMismatchErrorText(IEnumerable<Diagnostic> actualResults, DiagnosticAnalyzer analyzer, DiagnosticResult[] expectedResults, StringBuilder errorStringBuilder)
         {
             foreach (var actual in actualResults)
             {
@@ -222,52 +219,33 @@ namespace TestHelper
         {
             if (expected.Line == -1 && expected.Column == -1)
             {
-                if (actual.Location != Location.None)
-                {
-                    Assert.True(false,
-                        string.Format("Expected:\nA project diagnostic with No location\nActual:\n{0}",
-                        FormatDiagnostics(analyzer, actual)));
-                }
+                Assert.True(actual.Location == Location.None,
+                    string.Format("Expected:\nA project diagnostic with No location\nActual:\n{0}",
+                    FormatDiagnostics(analyzer, actual)));
             }
             else
             {
                 VerifyDiagnosticLocation(analyzer, actual, actual.Location, expected.Locations.First());
                 var additionalLocations = actual.AdditionalLocations.ToArray();
-
-                if (additionalLocations.Length != expected.Locations.Length - 1)
-                {
-                    Assert.True(false,
-                        string.Format("Expected {0} additional locations but got {1} for Diagnostic:\r\n    {2}\r\n",
-                            expected.Locations.Length - 1, additionalLocations.Length,
-                            FormatDiagnostics(analyzer, actual)));
-                }
+                Assert.True(additionalLocations.Length == expected.Locations.Length - 1,
+                    string.Format("Expected {0} additional locations but got {1} for Diagnostic:\r\n    {2}\r\n",
+                        expected.Locations.Length - 1, additionalLocations.Length,
+                        FormatDiagnostics(analyzer, actual)));
 
                 for (int j = 0; j < additionalLocations.Length; ++j)
                 {
                     VerifyDiagnosticLocation(analyzer, actual, additionalLocations[j], expected.Locations[j + 1]);
                 }
             }
-
-            if (actual.Id != expected.Id)
-            {
-                Assert.True(false,
-                    string.Format("Expected diagnostic id to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                        expected.Id, actual.Id, FormatDiagnostics(analyzer, actual)));
-            }
-
-            if (actual.Severity != expected.Severity)
-            {
-                Assert.True(false,
-                    string.Format("Expected diagnostic severity to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                        expected.Severity, actual.Severity, FormatDiagnostics(analyzer, actual)));
-            }
-
-            if (actual.GetMessage() != expected.Message)
-            {
-                Assert.True(false,
-                    string.Format("Expected diagnostic message to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                        expected.Message, actual.GetMessage(), FormatDiagnostics(analyzer, actual)));
-            }
+            Assert.True(actual.Id == expected.Id,
+                string.Format("Expected diagnostic id to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                    expected.Id, actual.Id, FormatDiagnostics(analyzer, actual)));
+            Assert.True(actual.Severity == expected.Severity,
+                string.Format("Expected diagnostic severity to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                    expected.Severity, actual.Severity, FormatDiagnostics(analyzer, actual)));
+            Assert.True(actual.GetMessage() == expected.Message,
+                string.Format("Expected diagnostic message to be \"{0}\" was \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                    expected.Message, actual.GetMessage(), FormatDiagnostics(analyzer, actual)));
         }
 
 
@@ -292,26 +270,14 @@ namespace TestHelper
             var actualLinePosition = actualSpan.StartLinePosition;
 
             // Only check line position if there is an actual line in the real diagnostic
-            if (actualLinePosition.Line > 0)
-            {
-                if (actualLinePosition.Line + 1 != expected.Line)
-                {
-                    Assert.True(false,
-                        string.Format("Expected diagnostic to be on line \"{0}\" was actually on line \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                            expected.Line, actualLinePosition.Line + 1, FormatDiagnostics(analyzer, diagnostic)));
-                }
-            }
+            Assert.True(actualLinePosition.Line <= 0 || actualLinePosition.Line + 1 == expected.Line,
+                string.Format("Expected diagnostic to be on line \"{0}\" was actually on line \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                    expected.Line, actualLinePosition.Line + 1, FormatDiagnostics(analyzer, diagnostic)));
 
             // Only check column position if there is an actual column position in the real diagnostic
-            if (actualLinePosition.Character > 0)
-            {
-                if (actualLinePosition.Character + 1 != expected.Column)
-                {
-                    Assert.True(false,
-                        string.Format("Expected diagnostic to start at column \"{0}\" was actually at column \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
-                            expected.Column, actualLinePosition.Character + 1, FormatDiagnostics(analyzer, diagnostic)));
-                }
-            }
+            Assert.True(actualLinePosition.Character <= 0 || actualLinePosition.Character + 1 == expected.Column,
+                string.Format("Expected diagnostic to start at column \"{0}\" was actually at column \"{1}\"\r\n\r\nDiagnostic:\r\n    {2}\r\n",
+                    expected.Column, actualLinePosition.Character + 1, FormatDiagnostics(analyzer, diagnostic)));
         }
         #endregion
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/DiagnosticVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/DiagnosticVerifier.cs
@@ -371,10 +371,10 @@ namespace TestHelper
         }
 
         /// <summary>
-        /// Helper method to format a <see cref="Diagnostic"/> into an easily readable string.
+        /// Helper method to format a <see cref="DiagnosticResult"/> into an easily readable string.
         /// </summary>
         /// <param name="analyzer">The analyzer that this verifier tests.</param>
-        /// <param name="diagnostics">A collection of <see cref="Diagnostic"/>s to be formatted.</param>
+        /// <param name="diagnostics">A collection of <see cref="DiagnosticResult"/>s to be formatted.</param>
         /// <returns>The <paramref name="diagnostics"/> formatted as a string.</returns>
         private static string FormatDiagnostics(DiagnosticAnalyzer analyzer, params DiagnosticResult[] diagnostics)
         {


### PR DESCRIPTION
One thing that was annoying me when writing unit tests is that assertion messages where not really usefull. When your tests expects 20 diagnostics and your diagnostic only reports 19 it would only tell you that the number of diagnostics didnt match but it would not tell you which diagnostic was missing. So I was debugging the unit tests and diffing the expected and the actual results in the auto window myself which is really annoying. This change changes the way assertion messages are generated. With this change the VerifyDiagnosticResults will diff the expected results and the actual results of the diagnostic and it will include the changes in the assertion message. This makes writing tests a lot easier.

One drawback with this is that if the severity, the message or any other property of the diagnostic is wrong it will not print the specific assertion message defined in AssertDiagnosticsMatch but it will instead report that one diagnostic is missing, and that one was reported that was not expected. But these mistakes are easy to figure out anyway and they are not really the ones you run into very often.