### PR TITLE
Disable diagnostic IDE0003 (Remove 'this' qualification)

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.ruleset
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.ruleset
@@ -64,6 +64,9 @@
     <Rule Id="CA2241" Action="Warning" />
     <Rule Id="CA2242" Action="Warning" />
   </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
+    <Rule Id="IDE0003" Action="None" />
+  </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA1000" Action="Error" />
     <Rule Id="SA1021" Action="Error" />


### PR DESCRIPTION
This rule conflicts with SA1101, where the StyleCop rule is preferred for this project.

Fixes #530