### PR TITLE
Allow SA1610 to have a code fix

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1610PropertyDocumentationMustHaveValueText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1610PropertyDocumentationMustHaveValueText.cs
@@ -22,7 +22,6 @@
     /// <para>A violation of this rule occurs when the <c>&lt;value&gt;</c> tag for a property is empty.</para>
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    [NoCodeFix("Cannot generate documentation")]
     public class SA1610PropertyDocumentationMustHaveValueText : PropertyDocumentationSummaryBase
     {
         /// <summary>


### PR DESCRIPTION
As described in #534, I plan to implement a working code fix for SA1610. This pull request removes the `[NoCodeFix]` attribute from the SA1610 analyzer in preparation for that work.