### PR TITLE
Make code fixes lazy

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -51,11 +51,11 @@
                 if (node == null)
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Add standard text.", token => GetTransformedDocument(context, root, node)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Add standard text.", token => GetTransformedDocument(context.Document, root, node)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, XmlElementSyntax node)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, XmlElementSyntax node)
         {
             var classDeclaration = node.FirstAncestorOrSelf<ClassDeclarationSyntax>();
             var declarationSyntax = node.FirstAncestorOrSelf<BaseMethodDeclarationSyntax>();
@@ -94,7 +94,7 @@
 
             var newRoot = root.ReplaceNode(node, newNode);
 
-            var newDocument = context.Document.WithSyntaxRoot(newRoot);
+            var newDocument = document.WithSyntaxRoot(newRoot);
 
             return Task.FromResult(newDocument);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1517CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1517CodeFixProvider.cs
@@ -35,15 +35,15 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create("Remove blank lines at the start of the file", token => GetTransformedDocument(context, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove blank lines at the start of the file", token => GetTransformedDocument(context.Document, token)), diagnostic);
             }
 
             return Task.FromResult(true);
         }
 
-        private static async Task<Document> GetTransformedDocument(CodeFixContext context, CancellationToken token)
+        private static async Task<Document> GetTransformedDocument(Document document, CancellationToken token)
         {
-            var syntaxRoot = await context.Document.GetSyntaxRootAsync(token).ConfigureAwait(false);
+            var syntaxRoot = await document.GetSyntaxRootAsync(token).ConfigureAwait(false);
 
             var firstToken = syntaxRoot.GetFirstToken(includeZeroWidth: true);
             var leadingTrivia = firstToken.LeadingTrivia;
@@ -61,7 +61,7 @@
 
             var newFirstToken = firstToken.WithLeadingTrivia(newTriviaList);
             var newSyntaxRoot = syntaxRoot.ReplaceToken(firstToken, newFirstToken);
-            var newDocument = context.Document.WithSyntaxRoot(newSyntaxRoot);
+            var newDocument = document.WithSyntaxRoot(newSyntaxRoot);
 
             return newDocument;
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1517CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1517CodeFixProvider.cs
@@ -3,6 +3,7 @@
     using System.Collections.Immutable;
     using System.Composition;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeActions;
@@ -30,32 +31,39 @@
         }
 
         /// <inheritdoc/>
-        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                var syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
-                var firstToken = syntaxRoot.GetFirstToken(includeZeroWidth: true);
-                var leadingTrivia = firstToken.LeadingTrivia;
-
-                var newTriviaList = SyntaxFactory.TriviaList();
-
-                var firstNonBlankLineTriviaIndex = TriviaHelper.IndexOfFirstNonBlankLineTrivia(leadingTrivia);
-                if (firstNonBlankLineTriviaIndex != -1)
-                {
-                    for (var index = firstNonBlankLineTriviaIndex; index < leadingTrivia.Count; index++)
-                    {
-                        newTriviaList = newTriviaList.Add(leadingTrivia[index]);
-                    }
-                }
-
-                var newFirstToken = firstToken.WithLeadingTrivia(newTriviaList);
-                var newSyntaxRoot = syntaxRoot.ReplaceToken(firstToken, newFirstToken);
-                var newDocument = context.Document.WithSyntaxRoot(newSyntaxRoot);
-
-                context.RegisterCodeFix(CodeAction.Create("Remove blank lines at the start of the file", token => Task.FromResult(newDocument)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove blank lines at the start of the file", token => GetTransformedDocument(context, token)), diagnostic);
             }
+
+            return Task.FromResult(true);
+        }
+
+        private static async Task<Document> GetTransformedDocument(CodeFixContext context, CancellationToken token)
+        {
+            var syntaxRoot = await context.Document.GetSyntaxRootAsync(token).ConfigureAwait(false);
+
+            var firstToken = syntaxRoot.GetFirstToken(includeZeroWidth: true);
+            var leadingTrivia = firstToken.LeadingTrivia;
+            var newTriviaList = SyntaxFactory.TriviaList();
+
+            var firstNonBlankLineTriviaIndex = TriviaHelper.IndexOfFirstNonBlankLineTrivia(leadingTrivia);
+
+            if (firstNonBlankLineTriviaIndex != -1)
+            {
+                for (var index = firstNonBlankLineTriviaIndex; index < leadingTrivia.Count; index++)
+                {
+                    newTriviaList = newTriviaList.Add(leadingTrivia[index]);
+                }
+            }
+
+            var newFirstToken = firstToken.WithLeadingTrivia(newTriviaList);
+            var newSyntaxRoot = syntaxRoot.ReplaceToken(firstToken, newFirstToken);
+            var newDocument = context.Document.WithSyntaxRoot(newSyntaxRoot);
+
+            return newDocument;
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1518CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1518CodeFixProvider.cs
@@ -35,21 +35,21 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create("Remove blank lines at the end of the file", token => GetTransformedDocument(context, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove blank lines at the end of the file", token => GetTransformedDocument(context.Document, token)), diagnostic);
             }
 
             return Task.FromResult(true);
         }
 
-        private static async Task<Document> GetTransformedDocument(CodeFixContext context, CancellationToken token)
+        private static async Task<Document> GetTransformedDocument(Document document, CancellationToken token)
         {
-            var syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var syntaxRoot = await document.GetSyntaxRootAsync(token).ConfigureAwait(false);
 
             var lastToken = syntaxRoot.GetLastToken(includeZeroWidth: true);
 
             var newLastToken = StripViolatingWhitespace(lastToken);
             var newSyntaxRoot = syntaxRoot.ReplaceToken(lastToken, newLastToken);
-            var newDocument = context.Document.WithSyntaxRoot(newSyntaxRoot);
+            var newDocument = document.WithSyntaxRoot(newSyntaxRoot);
 
             return newDocument;
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
@@ -36,34 +36,40 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1119StatementMustNotUseUnnecessaryParenthesis.DiagnosticId))
                     continue;
 
-                var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
                 SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true, findInsideTrivia: true);
                 if (node.IsMissing)
                     continue;
                 ParenthesizedExpressionSyntax syntax = node as ParenthesizedExpressionSyntax;
+
                 if (syntax != null)
                 {
-                    var syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken);
-                    var leadingTrivia = syntax.OpenParenToken.GetAllTrivia().Concat(syntax.Expression.GetLeadingTrivia());
-                    var trailingTrivia = syntax.Expression.GetTrailingTrivia().Concat(syntax.CloseParenToken.GetAllTrivia());
-
-                    var newNode = syntax.Expression
-                        .WithLeadingTrivia(leadingTrivia)
-                        .WithTrailingTrivia(trailingTrivia)
-                        .WithoutFormatting();
-
-                    var newSyntaxRoot = syntaxRoot.ReplaceNode(syntax, newNode);
-
-                    var changedDocument = context.Document.WithSyntaxRoot(newSyntaxRoot);
-
-                    context.RegisterCodeFix(CodeAction.Create("Remove parenthesis", token => Task.FromResult(changedDocument)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Remove parenthesis", token => GetTransformedDocument(context, root, syntax)), diagnostic);
                 }
             }
+        }
+
+        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, ParenthesizedExpressionSyntax syntax)
+        {
+            var leadingTrivia = syntax.OpenParenToken.GetAllTrivia().Concat(syntax.Expression.GetLeadingTrivia());
+            var trailingTrivia = syntax.Expression.GetTrailingTrivia().Concat(syntax.CloseParenToken.GetAllTrivia());
+
+            var newNode = syntax.Expression
+                .WithLeadingTrivia(leadingTrivia)
+                .WithTrailingTrivia(trailingTrivia)
+                .WithoutFormatting();
+
+            var newSyntaxRoot = root.ReplaceNode(syntax, newNode);
+
+            var changedDocument = context.Document.WithSyntaxRoot(newSyntaxRoot);
+
+            return Task.FromResult(changedDocument);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
@@ -50,12 +50,12 @@
 
                 if (syntax != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create("Remove parenthesis", token => GetTransformedDocument(context, root, syntax)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Remove parenthesis", token => GetTransformedDocument(context.Document, root, syntax)), diagnostic);
                 }
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, ParenthesizedExpressionSyntax syntax)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, ParenthesizedExpressionSyntax syntax)
         {
             var leadingTrivia = syntax.OpenParenToken.GetAllTrivia().Concat(syntax.Expression.GetLeadingTrivia());
             var trailingTrivia = syntax.Expression.GetTrailingTrivia().Concat(syntax.CloseParenToken.GetAllTrivia());
@@ -67,7 +67,7 @@
 
             var newSyntaxRoot = root.ReplaceNode(syntax, newNode);
 
-            var changedDocument = context.Document.WithSyntaxRoot(newSyntaxRoot);
+            var changedDocument = document.WithSyntaxRoot(newSyntaxRoot);
 
             return Task.FromResult(changedDocument);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
@@ -115,15 +115,15 @@
 
                 if (updatedDeclarationNode != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create("Declare accessibility", token => GetTransformedDocument(context, root, declarationNode, updatedDeclarationNode)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Declare accessibility", token => GetTransformedDocument(context.Document, root, declarationNode, updatedDeclarationNode)), diagnostic);
                 }
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxNode declarationNode, SyntaxNode updatedDeclarationNode)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxNode declarationNode, SyntaxNode updatedDeclarationNode)
         {
             var newSyntaxRoot = root.ReplaceNode(declarationNode, updatedDeclarationNode);
-            return Task.FromResult(context.Document.WithSyntaxRoot(newSyntaxRoot));
+            return Task.FromResult(document.WithSyntaxRoot(newSyntaxRoot));
         }
 
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
@@ -50,78 +50,75 @@
                 if (declarationNode == null)
                     continue;
 
-                SyntaxNode updatedDeclarationNode;
-                switch (declarationNode.Kind())
-                {
-                case SyntaxKind.ClassDeclaration:
-                    updatedDeclarationNode = this.HandleClassDeclaration((ClassDeclarationSyntax)declarationNode);
-                    break;
-
-                case SyntaxKind.InterfaceDeclaration:
-                    updatedDeclarationNode = this.HandleInterfaceDeclaration((InterfaceDeclarationSyntax)declarationNode);
-                    break;
-
-                case SyntaxKind.EnumDeclaration:
-                    updatedDeclarationNode = this.HandleEnumDeclaration((EnumDeclarationSyntax)declarationNode);
-                    break;
-
-                case SyntaxKind.StructDeclaration:
-                    updatedDeclarationNode = this.HandleStructDeclaration((StructDeclarationSyntax)declarationNode);
-                    break;
-
-                case SyntaxKind.DelegateDeclaration:
-                    updatedDeclarationNode = this.HandleDelegateDeclaration((DelegateDeclarationSyntax)declarationNode);
-                    break;
-
-                case SyntaxKind.EventDeclaration:
-                    updatedDeclarationNode = this.HandleEventDeclaration((EventDeclarationSyntax)declarationNode);
-                    break;
-
-                case SyntaxKind.EventFieldDeclaration:
-                    updatedDeclarationNode = this.HandleEventFieldDeclaration((EventFieldDeclarationSyntax)declarationNode);
-                    break;
-
-                case SyntaxKind.MethodDeclaration:
-                    updatedDeclarationNode = this.HandleMethodDeclaration((MethodDeclarationSyntax)declarationNode);
-                    break;
-
-                case SyntaxKind.PropertyDeclaration:
-                    updatedDeclarationNode = this.HandlePropertyDeclaration((PropertyDeclarationSyntax)declarationNode);
-                    break;
-
-                case SyntaxKind.FieldDeclaration:
-                    updatedDeclarationNode = this.HandleFieldDeclaration((FieldDeclarationSyntax)declarationNode);
-                    break;
-
-                case SyntaxKind.OperatorDeclaration:
-                    updatedDeclarationNode = this.HandleOperatorDeclaration((OperatorDeclarationSyntax)declarationNode);
-                    break;
-
-                case SyntaxKind.ConversionOperatorDeclaration:
-                    updatedDeclarationNode = this.HandleConversionOperatorDeclaration((ConversionOperatorDeclarationSyntax)declarationNode);
-                    break;
-
-                case SyntaxKind.IndexerDeclaration:
-                    updatedDeclarationNode = this.HandleIndexerDeclaration((IndexerDeclarationSyntax)declarationNode);
-                    break;
-
-                case SyntaxKind.ConstructorDeclaration:
-                    updatedDeclarationNode = this.HandleConstructorDeclaration((ConstructorDeclarationSyntax)declarationNode);
-                    break;
-
-                default:
-                    throw new InvalidOperationException("Unhandled declaration kind: " + declarationNode.Kind());
-                }
-
-                if (updatedDeclarationNode != null)
-                {
-                    context.RegisterCodeFix(CodeAction.Create("Declare accessibility", token => GetTransformedDocument(context.Document, root, declarationNode, updatedDeclarationNode)), diagnostic);
-                }
+                context.RegisterCodeFix(CodeAction.Create("Declare accessibility", token => GetTransformedDocument(context.Document, root, declarationNode)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxNode declarationNode, SyntaxNode updatedDeclarationNode)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxNode declarationNode)
         {
+            SyntaxNode updatedDeclarationNode;
+            switch (declarationNode.Kind())
+            {
+            case SyntaxKind.ClassDeclaration:
+                updatedDeclarationNode = HandleClassDeclaration((ClassDeclarationSyntax)declarationNode);
+                break;
+
+            case SyntaxKind.InterfaceDeclaration:
+                updatedDeclarationNode = HandleInterfaceDeclaration((InterfaceDeclarationSyntax)declarationNode);
+                break;
+
+            case SyntaxKind.EnumDeclaration:
+                updatedDeclarationNode = HandleEnumDeclaration((EnumDeclarationSyntax)declarationNode);
+                break;
+
+            case SyntaxKind.StructDeclaration:
+                updatedDeclarationNode = HandleStructDeclaration((StructDeclarationSyntax)declarationNode);
+                break;
+
+            case SyntaxKind.DelegateDeclaration:
+                updatedDeclarationNode = HandleDelegateDeclaration((DelegateDeclarationSyntax)declarationNode);
+                break;
+
+            case SyntaxKind.EventDeclaration:
+                updatedDeclarationNode = HandleEventDeclaration((EventDeclarationSyntax)declarationNode);
+                break;
+
+            case SyntaxKind.EventFieldDeclaration:
+                updatedDeclarationNode = HandleEventFieldDeclaration((EventFieldDeclarationSyntax)declarationNode);
+                break;
+
+            case SyntaxKind.MethodDeclaration:
+                updatedDeclarationNode = HandleMethodDeclaration((MethodDeclarationSyntax)declarationNode);
+                break;
+
+            case SyntaxKind.PropertyDeclaration:
+                updatedDeclarationNode = HandlePropertyDeclaration((PropertyDeclarationSyntax)declarationNode);
+                break;
+
+            case SyntaxKind.FieldDeclaration:
+                updatedDeclarationNode = HandleFieldDeclaration((FieldDeclarationSyntax)declarationNode);
+                break;
+
+            case SyntaxKind.OperatorDeclaration:
+                updatedDeclarationNode = HandleOperatorDeclaration((OperatorDeclarationSyntax)declarationNode);
+                break;
+
+            case SyntaxKind.ConversionOperatorDeclaration:
+                updatedDeclarationNode = HandleConversionOperatorDeclaration((ConversionOperatorDeclarationSyntax)declarationNode);
+                break;
+
+            case SyntaxKind.IndexerDeclaration:
+                updatedDeclarationNode = HandleIndexerDeclaration((IndexerDeclarationSyntax)declarationNode);
+                break;
+
+            case SyntaxKind.ConstructorDeclaration:
+                updatedDeclarationNode = HandleConstructorDeclaration((ConstructorDeclarationSyntax)declarationNode);
+                break;
+
+            default:
+                throw new InvalidOperationException("Unhandled declaration kind: " + declarationNode.Kind());
+            }
+
             var newSyntaxRoot = root.ReplaceNode(declarationNode, updatedDeclarationNode);
             return Task.FromResult(document.WithSyntaxRoot(newSyntaxRoot));
         }
@@ -188,7 +185,7 @@
             return modifiers;
         }
 
-        private SyntaxNode HandleClassDeclaration(ClassDeclarationSyntax node)
+        private static SyntaxNode HandleClassDeclaration(ClassDeclarationSyntax node)
         {
             SyntaxToken triviaToken = node.Keyword;
             if (triviaToken.IsMissing)
@@ -202,7 +199,7 @@
                 .WithoutFormatting();
         }
 
-        private SyntaxNode HandleInterfaceDeclaration(InterfaceDeclarationSyntax node)
+        private static SyntaxNode HandleInterfaceDeclaration(InterfaceDeclarationSyntax node)
         {
             SyntaxToken triviaToken = node.Keyword;
             if (triviaToken.IsMissing)
@@ -216,7 +213,7 @@
                 .WithoutFormatting();
         }
 
-        private SyntaxNode HandleEnumDeclaration(EnumDeclarationSyntax node)
+        private static SyntaxNode HandleEnumDeclaration(EnumDeclarationSyntax node)
         {
             SyntaxToken triviaToken = node.EnumKeyword;
             if (triviaToken.IsMissing)
@@ -230,7 +227,7 @@
                 .WithoutFormatting();
         }
 
-        private SyntaxNode HandleStructDeclaration(StructDeclarationSyntax node)
+        private static SyntaxNode HandleStructDeclaration(StructDeclarationSyntax node)
         {
             SyntaxToken triviaToken = node.Keyword;
             if (triviaToken.IsMissing)
@@ -244,7 +241,7 @@
                 .WithoutFormatting();
         }
 
-        private SyntaxNode HandleDelegateDeclaration(DelegateDeclarationSyntax node)
+        private static SyntaxNode HandleDelegateDeclaration(DelegateDeclarationSyntax node)
         {
             SyntaxToken triviaToken = node.DelegateKeyword;
             if (triviaToken.IsMissing)
@@ -258,7 +255,7 @@
                 .WithoutFormatting();
         }
 
-        private SyntaxNode HandleEventDeclaration(EventDeclarationSyntax node)
+        private static SyntaxNode HandleEventDeclaration(EventDeclarationSyntax node)
         {
             SyntaxToken triviaToken = node.EventKeyword;
             if (triviaToken.IsMissing)
@@ -271,7 +268,7 @@
                 .WithoutFormatting();
         }
 
-        private SyntaxNode HandleEventFieldDeclaration(EventFieldDeclarationSyntax node)
+        private static SyntaxNode HandleEventFieldDeclaration(EventFieldDeclarationSyntax node)
         {
             SyntaxToken triviaToken = node.EventKeyword;
             if (triviaToken.IsMissing)
@@ -284,7 +281,7 @@
                 .WithoutFormatting();
         }
 
-        private SyntaxNode HandleMethodDeclaration(MethodDeclarationSyntax node)
+        private static SyntaxNode HandleMethodDeclaration(MethodDeclarationSyntax node)
         {
             TypeSyntax type = node.ReturnType;
             if (type == null || type.IsMissing)
@@ -297,7 +294,7 @@
                 .WithoutFormatting();
         }
 
-        private SyntaxNode HandlePropertyDeclaration(PropertyDeclarationSyntax node)
+        private static SyntaxNode HandlePropertyDeclaration(PropertyDeclarationSyntax node)
         {
             TypeSyntax type = node.Type;
             if (type == null || type.IsMissing)
@@ -310,7 +307,7 @@
                 .WithoutFormatting();
         }
 
-        private SyntaxNode HandleFieldDeclaration(FieldDeclarationSyntax node)
+        private static SyntaxNode HandleFieldDeclaration(FieldDeclarationSyntax node)
         {
             VariableDeclarationSyntax declaration = node.Declaration;
             if (declaration == null || declaration.IsMissing)
@@ -323,7 +320,7 @@
                 .WithoutFormatting();
         }
 
-        private SyntaxNode HandleOperatorDeclaration(OperatorDeclarationSyntax node)
+        private static SyntaxNode HandleOperatorDeclaration(OperatorDeclarationSyntax node)
         {
             TypeSyntax type = node.ReturnType;
             if (type == null || type.IsMissing)
@@ -336,7 +333,7 @@
                 .WithoutFormatting();
         }
 
-        private SyntaxNode HandleConversionOperatorDeclaration(ConversionOperatorDeclarationSyntax node)
+        private static SyntaxNode HandleConversionOperatorDeclaration(ConversionOperatorDeclarationSyntax node)
         {
             SyntaxToken triviaToken = node.ImplicitOrExplicitKeyword;
             if (triviaToken.IsMissing)
@@ -349,7 +346,7 @@
                 .WithoutFormatting();
         }
 
-        private SyntaxNode HandleIndexerDeclaration(IndexerDeclarationSyntax node)
+        private static SyntaxNode HandleIndexerDeclaration(IndexerDeclarationSyntax node)
         {
             TypeSyntax type = node.Type;
             if (type == null || type.IsMissing)
@@ -362,7 +359,7 @@
                 .WithoutFormatting();
         }
 
-        private SyntaxNode HandleConstructorDeclaration(ConstructorDeclarationSyntax node)
+        private static SyntaxNode HandleConstructorDeclaration(ConstructorDeclarationSyntax node)
         {
             SyntaxToken triviaToken = node.Identifier;
             if (triviaToken.IsMissing)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
@@ -48,12 +48,12 @@
                 BinaryExpressionSyntax syntax = node as BinaryExpressionSyntax;
                 if (syntax != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create("Add parenthesis", token => GetTransformedDocument(context, root, syntax)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Add parenthesis", token => GetTransformedDocument(context.Document, root, syntax)), diagnostic);
                 }
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, BinaryExpressionSyntax syntax)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, BinaryExpressionSyntax syntax)
         {
             var newNode = SyntaxFactory.ParenthesizedExpression(syntax.WithoutTrivia())
                 .WithTriviaFrom(syntax)
@@ -61,7 +61,7 @@
 
             var newSyntaxRoot = root.ReplaceNode(syntax, newNode);
 
-            return Task.FromResult(context.Document.WithSyntaxRoot(newSyntaxRoot));
+            return Task.FromResult(document.WithSyntaxRoot(newSyntaxRoot));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1410SA1411CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1410SA1411CodeFixProvider.cs
@@ -54,16 +54,16 @@
                 if (node != null)
                 {
 
-                    context.RegisterCodeFix(CodeAction.Create("Remove parenthesis", token => GetTransformedDocument(context, root, node)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Remove parenthesis", token => GetTransformedDocument(context.Document, root, node)), diagnostic);
                 }
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxNode node)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxNode node)
         {
             var newSyntaxRoot = root.RemoveNode(node, SyntaxRemoveOptions.KeepExteriorTrivia);
 
-            return Task.FromResult(context.Document.WithSyntaxRoot(newSyntaxRoot));
+            return Task.FromResult(document.WithSyntaxRoot(newSyntaxRoot));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1302CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1302CodeFixProvider.cs
@@ -28,13 +28,14 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var document = context.Document;
+            var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1302InterfaceNamesMustBeginWithI.DiagnosticId))
                     continue;
 
-                var document = context.Document;
-                var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (token.IsMissing)
                     continue;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1304SA1311CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1304SA1311CodeFixProvider.cs
@@ -30,13 +30,14 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var document = context.Document;
+            var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!FixableDiagnostics.Any(d => diagnostic.Id.Equals(d)))
                     continue;
 
-                var document = context.Document;
-                var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (token.IsMissing)
                     continue;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1306CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1306CodeFixProvider.cs
@@ -34,13 +34,14 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var document = context.Document;
+            var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1306FieldNamesMustBeginWithLowerCaseLetter.DiagnosticId))
                     continue;
 
-                var document = context.Document;
-                var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (token.IsMissing)
                     continue;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1309CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1309CodeFixProvider.cs
@@ -34,13 +34,14 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var document = context.Document;
+            var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1309FieldNamesMustNotBeginWithUnderscore.DiagnosticId))
                     continue;
 
-                var document = context.Document;
-                var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (token.IsMissing)
                     continue;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
@@ -48,18 +48,18 @@
                     return;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create("Replace 'base.' with 'this.'", token => GetTransformedDocument(context, root, node)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Replace 'base.' with 'this.'", token => GetTransformedDocument(context.Document, root, node)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxNode node)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxNode node)
         {
             var thisExpressionSyntax = SyntaxFactory.ThisExpression()
                 .WithTriviaFrom(node)
                 .WithoutFormatting();
 
             SyntaxNode newSyntaxRoot = root.ReplaceNode(node, thisExpressionSyntax);
-            return Task.FromResult(context.Document.WithSyntaxRoot(newSyntaxRoot));
+            return Task.FromResult(document.WithSyntaxRoot(newSyntaxRoot));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
@@ -47,11 +47,11 @@
                 if (node == null)
                     return;
 
-                context.RegisterCodeFix(CodeAction.Create("Prefix reference with 'this.'", token => GetTransformedDocument(context, root, diagnostic, node)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Prefix reference with 'this.'", token => GetTransformedDocument(context.Document, root, diagnostic, node)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, Diagnostic diagnostic, SimpleNameSyntax node)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, Diagnostic diagnostic, SimpleNameSyntax node)
         {
             var qualifiedExpression =
                 SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.ThisExpression(), node.WithoutTrivia().WithoutFormatting())
@@ -60,7 +60,7 @@
 
             var newSyntaxRoot = root.ReplaceNode(node, qualifiedExpression);
 
-            return Task.FromResult(context.Document.WithSyntaxRoot(newSyntaxRoot));
+            return Task.FromResult(document.WithSyntaxRoot(newSyntaxRoot));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
@@ -74,19 +74,19 @@
                 if (typeInfo.Type != null)
                 {
                     SpecialType specialType = typeInfo.Type.SpecialType;
-                    context.RegisterCodeFix(CodeAction.Create("Replace with built-in type", token => GetTransformedDocument(context, root, node, specialType)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Replace with built-in type", token => GetTransformedDocument(context.Document, root, node, specialType)), diagnostic);
                 }
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxNode node, SpecialType specialType)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxNode node, SpecialType specialType)
         {
             var newNode = SyntaxFactory.PredefinedType(SyntaxFactory.Token(PredefinedSpecialTypes[specialType]))
                 .WithTriviaFrom(node)
                 .WithoutFormatting();
             var newRoot = root.ReplaceNode(node, newNode);
 
-            return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
+            return Task.FromResult(document.WithSyntaxRoot(newRoot));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
@@ -54,30 +54,39 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+            var semanticModel = await context.Document.GetSemanticModelAsync();
+
+            if (semanticModel == null)
+            {
+                return;
+            }
+
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1121UseBuiltInTypeAlias.DiagnosticId))
                     continue;
 
-                var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-
                 var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
 
-                var semanticModel = await context.Document.GetSemanticModelAsync();
+                var typeInfo = semanticModel.GetTypeInfo(node);
 
-                var typeInfo = semanticModel?.GetTypeInfo(node);
-
-                if (typeInfo?.Type != null)
+                if (typeInfo.Type != null)
                 {
-                    SpecialType specialType = typeInfo.Value.Type.SpecialType;
-                    var newNode = SyntaxFactory.PredefinedType(SyntaxFactory.Token(PredefinedSpecialTypes[specialType]))
-                        .WithTriviaFrom(node)
-                        .WithoutFormatting();
-                    var newRoot = root.ReplaceNode(node, newNode);
-
-                    context.RegisterCodeFix(CodeAction.Create("Replace with built-in type", token => Task.FromResult(context.Document.WithSyntaxRoot(newRoot))), diagnostic);
+                    SpecialType specialType = typeInfo.Type.SpecialType;
+                    context.RegisterCodeFix(CodeAction.Create("Replace with built-in type", token => GetTransformedDocument(context, root, node, specialType)), diagnostic);
                 }
             }
+        }
+
+        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxNode node, SpecialType specialType)
+        {
+            var newNode = SyntaxFactory.PredefinedType(SyntaxFactory.Token(PredefinedSpecialTypes[specialType]))
+                .WithTriviaFrom(node)
+                .WithoutFormatting();
+            var newRoot = root.ReplaceNode(node, newNode);
+
+            return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
@@ -54,15 +54,15 @@
                 var node = root?.FindNode(diagnostic.Location.SourceSpan, findInsideTrivia: true, getInnermostNodeForTie: true);
                 if (node != null && node.IsKind(SyntaxKind.StringLiteralExpression))
                 {
-                    context.RegisterCodeFix(CodeAction.Create($"Replace with string.Empty", token => GetTransformedDocument(context, root, node)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create($"Replace with string.Empty", token => GetTransformedDocument(context.Document, root, node)), diagnostic);
                 }
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxNode node)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxNode node)
         {
             var newSyntaxRoot = root.ReplaceNode(node, StringEmptyExpression);
-            return Task.FromResult(context.Document.WithSyntaxRoot(newSyntaxRoot));
+            return Task.FromResult(document.WithSyntaxRoot(newSyntaxRoot));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
@@ -27,6 +27,16 @@
         /// <inheritdoc/>
         public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
+        private static readonly SyntaxNode StringEmptyExpression;
+        
+        static SA1122CodeFixProvider()
+        {
+            var identifierNameSyntax = SyntaxFactory.IdentifierName(nameof(String.Empty));
+            var stringKeyword = SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword));
+            StringEmptyExpression = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, stringKeyword, identifierNameSyntax)
+                .WithoutFormatting();
+        }
+
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
         {
@@ -36,24 +46,23 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var root = await context.Document.GetSyntaxRootAsync().ConfigureAwait(false);
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1122UseStringEmptyForEmptyStrings.DiagnosticId))
                     continue;
-                var syntaxRoot = await context.Document.GetSyntaxRootAsync().ConfigureAwait(false);
-                var node = syntaxRoot?.FindNode(diagnostic.Location.SourceSpan, findInsideTrivia: true, getInnermostNodeForTie: true);
+                var node = root?.FindNode(diagnostic.Location.SourceSpan, findInsideTrivia: true, getInnermostNodeForTie: true);
                 if (node != null && node.IsKind(SyntaxKind.StringLiteralExpression))
                 {
-                    var identifierNameSyntax = SyntaxFactory.IdentifierName(nameof(String.Empty));
-                    var stringKeyword = SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.StringKeyword));
-                    var newNode = SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, stringKeyword, identifierNameSyntax)
-                        .WithoutFormatting();
-
-                    var newSyntaxRoot = syntaxRoot.ReplaceNode(node, newNode);
-
-                    context.RegisterCodeFix(CodeAction.Create($"Replace with {newNode}", token => Task.FromResult(context.Document.WithSyntaxRoot(newSyntaxRoot))), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create($"Replace with string.Empty", token => GetTransformedDocument(context, root, node)), diagnostic);
                 }
             }
+        }
+
+        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxNode node)
+        {
+            var newSyntaxRoot = root.ReplaceNode(node, StringEmptyExpression);
+            return Task.FromResult(context.Document.WithSyntaxRoot(newSyntaxRoot));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000CodeFixProvider.cs
@@ -45,59 +45,61 @@
                 if (token.IsMissing)
                     continue;
 
-                bool isAddingSpace = true;
-                switch (token.Kind())
-                {
-                case SyntaxKind.NewKeyword:
-                    {
-                        SyntaxToken nextToken = token.GetNextToken();
-                        if (nextToken.IsKind(SyntaxKind.OpenBracketToken) || nextToken.IsKind(SyntaxKind.OpenParenToken))
-                            isAddingSpace = false;
-                    }
-
-                    break;
-
-                case SyntaxKind.ReturnKeyword:
-                case SyntaxKind.ThrowKeyword:
-                    {
-                        SyntaxToken nextToken = token.GetNextToken();
-                        if (nextToken.IsKind(SyntaxKind.SemicolonToken))
-                            isAddingSpace = false;
-                    }
-
-                    break;
-
-                case SyntaxKind.CheckedKeyword:
-                case SyntaxKind.DefaultKeyword:
-                case SyntaxKind.NameOfKeyword:
-                case SyntaxKind.SizeOfKeyword:
-                case SyntaxKind.TypeOfKeyword:
-                case SyntaxKind.UncheckedKeyword:
-                    isAddingSpace = false;
-                    break;
-
-                case SyntaxKind.IdentifierToken:
-                    if (token.Text == "nameof")
-                    {
-                        // SA1000 would only have been reported for a nameof expression. No need to verify.
-                        goto case SyntaxKind.NameOfKeyword;
-                    }
-
-                    continue;
-
-                default:
-                    break;
-                }
-
-                if (isAddingSpace == !token.HasTrailingTrivia)
-                {
-                    context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token, isAddingSpace)), diagnostic);
-                }
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token, isAddingSpace)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token, bool isAddingSpace)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
         {
+            bool isAddingSpace = true;
+            switch (token.Kind())
+            {
+            case SyntaxKind.NewKeyword:
+                {
+                    SyntaxToken nextToken = token.GetNextToken();
+                    if (nextToken.IsKind(SyntaxKind.OpenBracketToken) || nextToken.IsKind(SyntaxKind.OpenParenToken))
+                        isAddingSpace = false;
+                }
+
+                break;
+
+            case SyntaxKind.ReturnKeyword:
+            case SyntaxKind.ThrowKeyword:
+                {
+                    SyntaxToken nextToken = token.GetNextToken();
+                    if (nextToken.IsKind(SyntaxKind.SemicolonToken))
+                        isAddingSpace = false;
+                }
+
+                break;
+
+            case SyntaxKind.CheckedKeyword:
+            case SyntaxKind.DefaultKeyword:
+            case SyntaxKind.NameOfKeyword:
+            case SyntaxKind.SizeOfKeyword:
+            case SyntaxKind.TypeOfKeyword:
+            case SyntaxKind.UncheckedKeyword:
+                isAddingSpace = false;
+                break;
+
+            case SyntaxKind.IdentifierToken:
+                if (token.Text == "nameof")
+                {
+                    // SA1000 would only have been reported for a nameof expression. No need to verify.
+                    goto case SyntaxKind.NameOfKeyword;
+                }
+
+                return Task.FromResult(document);
+
+            default:
+                break;
+            }
+
+            if (isAddingSpace == !token.HasTrailingTrivia)
+            {
+                return Task.FromResult(document);
+            }
+
             if (isAddingSpace)
             {
                 SyntaxTrivia whitespace = SyntaxFactory.Whitespace(" ").WithoutFormatting();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000CodeFixProvider.cs
@@ -45,7 +45,7 @@
                 if (token.IsMissing)
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token, isAddingSpace)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
             }
         }
 
@@ -95,7 +95,7 @@
                 break;
             }
 
-            if (isAddingSpace == !token.HasTrailingTrivia)
+            if (isAddingSpace == token.HasTrailingTrivia)
             {
                 return Task.FromResult(document);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000CodeFixProvider.cs
@@ -91,24 +91,24 @@
 
                 if (isAddingSpace == !token.HasTrailingTrivia)
                 {
-                    context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, token, isAddingSpace)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token, isAddingSpace)), diagnostic);
                 }
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken token, bool isAddingSpace)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token, bool isAddingSpace)
         {
             if (isAddingSpace)
             {
                 SyntaxTrivia whitespace = SyntaxFactory.Whitespace(" ").WithoutFormatting();
                 SyntaxToken corrected = token.WithTrailingTrivia(token.TrailingTrivia.Insert(0, whitespace));
-                Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceToken(token, corrected));
+                Document updatedDocument = document.WithSyntaxRoot(root.ReplaceToken(token, corrected));
                 return Task.FromResult(updatedDocument);
             }
             else
             {
                 SyntaxToken corrected = token.WithoutTrailingWhitespace().WithoutFormatting();
-                Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceToken(token, corrected));
+                Document updatedDocument = document.WithSyntaxRoot(root.ReplaceToken(token, corrected));
                 return Task.FromResult(updatedDocument);
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
@@ -46,11 +46,11 @@
                 if (!token.IsKind(SyntaxKind.CommaToken))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
         {
             Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
 
@@ -95,7 +95,7 @@
             }
 
             var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
-            return Task.FromResult(context.Document.WithSyntaxRoot(transformed));
+            return Task.FromResult(document.WithSyntaxRoot(transformed));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
@@ -36,62 +36,66 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1001CommasMustBeSpacedCorrectly.DiagnosticId))
                     continue;
 
-                var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
                 SyntaxToken token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (!token.IsKind(SyntaxKind.CommaToken))
                     continue;
 
-                Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
-
-                // check for a following space
-                bool missingFollowingSpace = true;
-                if (token.HasTrailingTrivia)
-                {
-                    if (token.TrailingTrivia.First().IsKind(SyntaxKind.WhitespaceTrivia))
-                        missingFollowingSpace = false;
-                    else if (token.TrailingTrivia.First().IsKind(SyntaxKind.EndOfLineTrivia))
-                        missingFollowingSpace = false;
-                }
-                else
-                {
-                    SyntaxToken nextToken = token.GetNextToken();
-                    if (nextToken.IsKind(SyntaxKind.CommaToken) || nextToken.IsKind(SyntaxKind.GreaterThanToken))
-                    {
-                        // make an exception for things like typeof(Func<,>) and typeof(Func<,,>)
-                        missingFollowingSpace = false;
-                    }
-                }
-
-                bool firstInLine = token.HasLeadingTrivia || token.GetLocation()?.GetMappedLineSpan().StartLinePosition.Character == 0;
-                if (!firstInLine)
-                {
-                    SyntaxToken precedingToken = token.GetPreviousToken();
-                    if (precedingToken.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
-                    {
-                        SyntaxToken corrected = precedingToken.WithoutTrailingWhitespace().WithoutFormatting();
-                        replacements[precedingToken] = corrected;
-                    }
-                }
-
-                if (missingFollowingSpace)
-                {
-                    SyntaxToken intermediate = token.WithoutTrailingWhitespace();
-                    SyntaxToken corrected =
-                        intermediate
-                        .WithTrailingTrivia(intermediate.TrailingTrivia.Insert(0, SyntaxFactory.Whitespace(" ")))
-                        .WithoutFormatting();
-                    replacements[token] = corrected;
-                }
-
-                var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
-                Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, token)), diagnostic);
             }
+        }
+
+        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken token)
+        {
+            Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
+
+            // check for a following space
+            bool missingFollowingSpace = true;
+            if (token.HasTrailingTrivia)
+            {
+                if (token.TrailingTrivia.First().IsKind(SyntaxKind.WhitespaceTrivia))
+                    missingFollowingSpace = false;
+                else if (token.TrailingTrivia.First().IsKind(SyntaxKind.EndOfLineTrivia))
+                    missingFollowingSpace = false;
+            }
+            else
+            {
+                SyntaxToken nextToken = token.GetNextToken();
+                if (nextToken.IsKind(SyntaxKind.CommaToken) || nextToken.IsKind(SyntaxKind.GreaterThanToken))
+                {
+                    // make an exception for things like typeof(Func<,>) and typeof(Func<,,>)
+                    missingFollowingSpace = false;
+                }
+            }
+
+            bool firstInLine = token.HasLeadingTrivia || token.GetLocation()?.GetMappedLineSpan().StartLinePosition.Character == 0;
+            if (!firstInLine)
+            {
+                SyntaxToken precedingToken = token.GetPreviousToken();
+                if (precedingToken.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
+                {
+                    SyntaxToken corrected = precedingToken.WithoutTrailingWhitespace().WithoutFormatting();
+                    replacements[precedingToken] = corrected;
+                }
+            }
+
+            if (missingFollowingSpace)
+            {
+                SyntaxToken intermediate = token.WithoutTrailingWhitespace();
+                SyntaxToken corrected =
+                    intermediate
+                    .WithTrailingTrivia(intermediate.TrailingTrivia.Insert(0, SyntaxFactory.Whitespace(" ")))
+                    .WithoutFormatting();
+                replacements[token] = corrected;
+            }
+
+            var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
+            return Task.FromResult(context.Document.WithSyntaxRoot(transformed));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002CodeFixProvider.cs
@@ -35,53 +35,60 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1002SemicolonsMustBeSpacedCorrectly.DiagnosticId))
                     continue;
 
-                var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
                 SyntaxToken token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (!token.IsKind(SyntaxKind.SemicolonToken))
                     continue;
 
-                Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
-
-                // check for a following space
-                bool missingFollowingSpace = true;
-                if (token.HasTrailingTrivia)
-                {
-                    if (token.TrailingTrivia.First().IsKind(SyntaxKind.WhitespaceTrivia))
-                        missingFollowingSpace = false;
-                    else if (token.TrailingTrivia.First().IsKind(SyntaxKind.EndOfLineTrivia))
-                        missingFollowingSpace = false;
-                }
-
-                bool firstInLine = token.HasLeadingTrivia || token.GetLocation()?.GetMappedLineSpan().StartLinePosition.Character == 0;
-                if (!firstInLine)
-                {
-                    SyntaxToken precedingToken = token.GetPreviousToken();
-                    if (precedingToken.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
-                    {
-                        SyntaxToken corrected = precedingToken.WithoutLeadingWhitespace().WithoutFormatting();
-                        replacements[precedingToken] = corrected;
-                    }
-                }
-
-                if (missingFollowingSpace)
-                {
-                    SyntaxToken intermediate = token.WithoutTrailingWhitespace();
-                    SyntaxToken corrected =
-                        intermediate
-                        .WithTrailingTrivia(intermediate.TrailingTrivia.Insert(0, SyntaxFactory.Whitespace(" ")))
-                        .WithoutFormatting();
-                    replacements[token] = corrected;
-                }
-
-                var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
-                Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, token)), diagnostic);
             }
+        }
+
+        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken token)
+        {
+            Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
+
+            // check for a following space
+            bool missingFollowingSpace = true;
+            if (token.HasTrailingTrivia)
+            {
+                if (token.TrailingTrivia.First().IsKind(SyntaxKind.WhitespaceTrivia))
+                    missingFollowingSpace = false;
+                else if (token.TrailingTrivia.First().IsKind(SyntaxKind.EndOfLineTrivia))
+                    missingFollowingSpace = false;
+            }
+
+            bool firstInLine = token.HasLeadingTrivia || token.GetLocation()?.GetMappedLineSpan().StartLinePosition.Character == 0;
+            if (!firstInLine)
+            {
+                SyntaxToken precedingToken = token.GetPreviousToken();
+                if (precedingToken.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
+                {
+                    SyntaxToken corrected = precedingToken.WithoutLeadingWhitespace().WithoutFormatting();
+                    replacements[precedingToken] = corrected;
+                }
+            }
+
+            if (missingFollowingSpace)
+            {
+                SyntaxToken intermediate = token.WithoutTrailingWhitespace();
+                SyntaxToken corrected =
+                    intermediate
+                    .WithTrailingTrivia(intermediate.TrailingTrivia.Insert(0, SyntaxFactory.Whitespace(" ")))
+                    .WithoutFormatting();
+                replacements[token] = corrected;
+            }
+
+            var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
+            Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
+
+            return Task.FromResult(updatedDocument);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002CodeFixProvider.cs
@@ -46,11 +46,11 @@
                 if (!token.IsKind(SyntaxKind.SemicolonToken))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
         {
             Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
 
@@ -86,7 +86,7 @@
             }
 
             var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
-            Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
+            Document updatedDocument = document.WithSyntaxRoot(transformed);
 
             return Task.FromResult(updatedDocument);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
@@ -48,63 +48,59 @@
                 if (token.IsMissing)
                     continue;
 
-                Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
-
-                // always a space before unless at the beginning of a line or after certain tokens
-                bool firstInLine = token.HasLeadingTrivia || token.GetLocation()?.GetMappedLineSpan().StartLinePosition.Character == 0;
-                if (!firstInLine)
-                {
-                    SyntaxToken precedingToken = token.GetPreviousToken();
-                    SyntaxToken correctedPrecedingNoSpace = precedingToken.WithoutTrailingWhitespace();
-                    switch (precedingToken.Kind())
-                    {
-                    case SyntaxKind.OpenParenToken:
-                    case SyntaxKind.CloseParenToken:
-                    case SyntaxKind.OpenBracketToken:
-                    case SyntaxKind.CloseBracketToken:
-                        // remove any whitespace before
-                        replacements[precedingToken] = correctedPrecedingNoSpace;
-                        break;
-
-                    default:
-                        if (!precedingToken.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
-                        {
-                            SyntaxToken correctedPreceding = correctedPrecedingNoSpace.WithTrailingTrivia(correctedPrecedingNoSpace.TrailingTrivia.Insert(0, SyntaxFactory.Whitespace(" ")));
-                            replacements[precedingToken] = correctedPreceding;
-                        }
-                        break;
-                    }
-                }
-
-                if (token.Parent is BinaryExpressionSyntax)
-                {
-                    // include a space after unless last on line
-                    if (!token.TrailingTrivia.Any(SyntaxKind.EndOfLineTrivia))
-                    {
-                        SyntaxToken correctedOperatorNoSpace = token.WithoutTrailingWhitespace();
-                        SyntaxToken correctedOperator =
-                            correctedOperatorNoSpace
-                            .WithTrailingTrivia(correctedOperatorNoSpace.TrailingTrivia.Insert(0, SyntaxFactory.Whitespace(" ")))
-                            .WithoutFormatting();
-                        replacements[token] = correctedOperator;
-                    }
-                }
-                else if (token.Parent is PrefixUnaryExpressionSyntax)
-                {
-                    // do not include a space after (includes new line characters)
-                    SyntaxToken correctedOperatorNoSpace = token.WithoutTrailingWhitespace(removeEndOfLineTrivia: true).WithoutFormatting();
-                    replacements[token] = correctedOperatorNoSpace;
-                }
-
-                if (replacements.Count == 0)
-                    continue;
-
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, replacements)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, Dictionary<SyntaxToken, SyntaxToken> replacements)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
         {
+            Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
+
+            // always a space before unless at the beginning of a line or after certain tokens
+            bool firstInLine = token.HasLeadingTrivia || token.GetLocation()?.GetMappedLineSpan().StartLinePosition.Character == 0;
+            if (!firstInLine)
+            {
+                SyntaxToken precedingToken = token.GetPreviousToken();
+                SyntaxToken correctedPrecedingNoSpace = precedingToken.WithoutTrailingWhitespace();
+                switch (precedingToken.Kind())
+                {
+                case SyntaxKind.OpenParenToken:
+                case SyntaxKind.CloseParenToken:
+                case SyntaxKind.OpenBracketToken:
+                case SyntaxKind.CloseBracketToken:
+                    // remove any whitespace before
+                    replacements[precedingToken] = correctedPrecedingNoSpace;
+                    break;
+
+                default:
+                    if (!precedingToken.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
+                    {
+                        SyntaxToken correctedPreceding = correctedPrecedingNoSpace.WithTrailingTrivia(correctedPrecedingNoSpace.TrailingTrivia.Insert(0, SyntaxFactory.Whitespace(" ")));
+                        replacements[precedingToken] = correctedPreceding;
+                    }
+                    break;
+                }
+            }
+
+            if (token.Parent is BinaryExpressionSyntax)
+            {
+                // include a space after unless last on line
+                if (!token.TrailingTrivia.Any(SyntaxKind.EndOfLineTrivia))
+                {
+                    SyntaxToken correctedOperatorNoSpace = token.WithoutTrailingWhitespace();
+                    SyntaxToken correctedOperator =
+                        correctedOperatorNoSpace
+                        .WithTrailingTrivia(correctedOperatorNoSpace.TrailingTrivia.Insert(0, SyntaxFactory.Whitespace(" ")))
+                        .WithoutFormatting();
+                    replacements[token] = correctedOperator;
+                }
+            }
+            else if (token.Parent is PrefixUnaryExpressionSyntax)
+            {
+                // do not include a space after (includes new line characters)
+                SyntaxToken correctedOperatorNoSpace = token.WithoutTrailingWhitespace(removeEndOfLineTrivia: true).WithoutFormatting();
+                replacements[token] = correctedOperatorNoSpace;
+            }
             var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
             Document updatedDocument = document.WithSyntaxRoot(transformed);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
@@ -99,14 +99,14 @@
                 if (replacements.Count == 0)
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, replacements)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, replacements)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, Dictionary<SyntaxToken, SyntaxToken> replacements)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, Dictionary<SyntaxToken, SyntaxToken> replacements)
         {
             var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
-            Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
+            Document updatedDocument = document.WithSyntaxRoot(transformed);
 
             return Task.FromResult(updatedDocument);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
@@ -46,16 +46,15 @@
                 if (!trivia.IsKind(SyntaxKind.SingleLineCommentTrivia))
                     continue;
 
-                string text = trivia.ToFullString();
-                if (!text.StartsWith("//"))
-                    continue;
-
-                context.RegisterCodeFix(CodeAction.Create("Insert space", t => GetTransformedDocument(context.Document, root, trivia, text)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Insert space", t => GetTransformedDocument(context.Document, root, trivia)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxTrivia trivia, string text)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxTrivia trivia)
         {
+            string text = trivia.ToFullString();
+            if (!text.StartsWith("//"))
+                return Task.FromResult(document);
             string correctedText = "// " + text.Substring(2);
             SyntaxTrivia corrected = SyntaxFactory.Comment(correctedText).WithoutFormatting();
             Document updatedDocument = document.WithSyntaxRoot(root.ReplaceTrivia(trivia, corrected));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
@@ -50,15 +50,15 @@
                 if (!text.StartsWith("//"))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Insert space", t => GetTransformedDocument(context, root, trivia, text)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Insert space", t => GetTransformedDocument(context.Document, root, trivia, text)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxTrivia trivia, string text)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxTrivia trivia, string text)
         {
             string correctedText = "// " + text.Substring(2);
             SyntaxTrivia corrected = SyntaxFactory.Comment(correctedText).WithoutFormatting();
-            Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceTrivia(trivia, corrected));
+            Document updatedDocument = document.WithSyntaxRoot(root.ReplaceTrivia(trivia, corrected));
 
             return Task.FromResult(updatedDocument);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1006CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1006CodeFixProvider.cs
@@ -49,14 +49,14 @@
                 if (!hashToken.IsKind(SyntaxKind.HashToken))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Remove space", t => GetTransformedDocument(context, root, hashToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove space", t => GetTransformedDocument(context.Document, root, hashToken)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken hashToken)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken hashToken)
         {
             SyntaxToken corrected = hashToken.WithoutTrailingWhitespace().WithoutFormatting();
-            Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceToken(hashToken, corrected));
+            Document updatedDocument = document.WithSyntaxRoot(root.ReplaceToken(hashToken, corrected));
             return Task.FromResult(updatedDocument);
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1006CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1006CodeFixProvider.cs
@@ -45,16 +45,16 @@
                 if (keywordToken.IsMissing)
                     continue;
 
-                SyntaxToken hashToken = keywordToken.GetPreviousToken(includeDirectives: true);
-                if (!hashToken.IsKind(SyntaxKind.HashToken))
-                    continue;
-
-                context.RegisterCodeFix(CodeAction.Create("Remove space", t => GetTransformedDocument(context.Document, root, hashToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove space", t => GetTransformedDocument(context.Document, root, keywordToken)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken hashToken)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken keywordToken)
         {
+            SyntaxToken hashToken = keywordToken.GetPreviousToken(includeDirectives: true);
+            if (!hashToken.IsKind(SyntaxKind.HashToken))
+                return Task.FromResult(document);
+
             SyntaxToken corrected = hashToken.WithoutTrailingWhitespace().WithoutFormatting();
             Document updatedDocument = document.WithSyntaxRoot(root.ReplaceToken(hashToken, corrected));
             return Task.FromResult(updatedDocument);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1007CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1007CodeFixProvider.cs
@@ -47,15 +47,15 @@
                 if (token.HasTrailingTrivia && token.TrailingTrivia[0].IsKind(SyntaxKind.WhitespaceTrivia))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Insert space", t => GetTransformedDocument(context, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Insert space", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
         {
             SyntaxTrivia whitespace = SyntaxFactory.Whitespace(" ");
             SyntaxToken corrected = token.WithTrailingTrivia(token.TrailingTrivia.Insert(0, whitespace)).WithoutFormatting();
-            Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceToken(token, corrected));
+            Document updatedDocument = document.WithSyntaxRoot(root.ReplaceToken(token, corrected));
 
             return Task.FromResult(updatedDocument);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1007CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1007CodeFixProvider.cs
@@ -33,12 +33,13 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1007OperatorKeywordMustBeFollowedBySpace.DiagnosticId))
                     continue;
 
-                var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
                 SyntaxToken token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (token.IsMissing)
                     continue;
@@ -46,11 +47,17 @@
                 if (token.HasTrailingTrivia && token.TrailingTrivia[0].IsKind(SyntaxKind.WhitespaceTrivia))
                     continue;
 
-                SyntaxTrivia whitespace = SyntaxFactory.Whitespace(" ");
-                SyntaxToken corrected = token.WithTrailingTrivia(token.TrailingTrivia.Insert(0, whitespace)).WithoutFormatting();
-                Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceToken(token, corrected));
-                context.RegisterCodeFix(CodeAction.Create("Insert space", t => Task.FromResult(updatedDocument)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Insert space", t => GetTransformedDocument(context, root, token)), diagnostic);
             }
+        }
+
+        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken token)
+        {
+            SyntaxTrivia whitespace = SyntaxFactory.Whitespace(" ");
+            SyntaxToken corrected = token.WithTrailingTrivia(token.TrailingTrivia.Insert(0, whitespace)).WithoutFormatting();
+            Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceToken(token, corrected));
+
+            return Task.FromResult(updatedDocument);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010CodeFixProvider.cs
@@ -67,10 +67,15 @@
                 if (replacements.Count == 0)
                     continue;
 
-                var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
-                Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, replacements)), diagnostic);
             }
+        }
+        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, Dictionary<SyntaxToken, SyntaxToken> replacements)
+        {
+            var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
+            Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
+
+            return Task.FromResult(updatedDocument);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010CodeFixProvider.cs
@@ -67,13 +67,13 @@
                 if (replacements.Count == 0)
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, replacements)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, replacements)), diagnostic);
             }
         }
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, Dictionary<SyntaxToken, SyntaxToken> replacements)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, Dictionary<SyntaxToken, SyntaxToken> replacements)
         {
             var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
-            Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
+            Document updatedDocument = document.WithSyntaxRoot(transformed);
 
             return Task.FromResult(updatedDocument);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010CodeFixProvider.cs
@@ -35,12 +35,13 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1010OpeningSquareBracketsMustBeSpacedCorrectly.DiagnosticId))
                     continue;
 
-                var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
                 SyntaxToken token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (!token.IsKind(SyntaxKind.OpenBracketToken))
                     continue;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
@@ -35,12 +35,13 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1011ClosingSquareBracketsMustBeSpacedCorrectly.DiagnosticId))
                     continue;
 
-                var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
                 SyntaxToken token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (!token.IsKind(SyntaxKind.CloseBracketToken))
                     continue;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
@@ -46,65 +46,66 @@
                 if (!token.IsKind(SyntaxKind.CloseBracketToken))
                     continue;
 
-                Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
-
-                bool firstInLine = token.HasLeadingTrivia || token.GetLocation()?.GetMappedLineSpan().StartLinePosition.Character == 0;
-                if (!firstInLine)
-                {
-                    SyntaxToken precedingToken = token.GetPreviousToken();
-                    if (precedingToken.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
-                    {
-                        SyntaxToken corrected = precedingToken.WithoutTrailingWhitespace().WithoutFormatting();
-                        replacements[precedingToken] = corrected;
-                    }
-                }
-
-                if (!token.TrailingTrivia.Any(SyntaxKind.EndOfLineTrivia) && token.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
-                {
-                    bool ignoreTrailingWhitespace;
-                    SyntaxToken nextToken = token.GetNextToken();
-                    switch (nextToken.Kind())
-                    {
-                    case SyntaxKind.CloseBracketToken:
-                    case SyntaxKind.OpenParenToken:
-                    case SyntaxKind.CommaToken:
-                    case SyntaxKind.SemicolonToken:
-                    // TODO: "certain types of operator symbols"
-                    case SyntaxKind.DotToken:
-                    case SyntaxKind.OpenBracketToken:
-                    case SyntaxKind.CloseParenToken:
-                        ignoreTrailingWhitespace = true;
-                        break;
-
-                    case SyntaxKind.GreaterThanToken:
-                        ignoreTrailingWhitespace = nextToken.Parent.IsKind(SyntaxKind.TypeArgumentList);
-                        break;
-
-                    case SyntaxKind.QuestionToken:
-                        ignoreTrailingWhitespace = nextToken.Parent.IsKind(SyntaxKind.ConditionalAccessExpression);
-                        break;
-
-                    default:
-                        ignoreTrailingWhitespace = false;
-                        break;
-                    }
-
-                    if (!ignoreTrailingWhitespace)
-                    {
-                        SyntaxToken corrected = token.WithoutTrailingWhitespace().WithoutFormatting();
-                        replacements[token] = corrected;
-                    }
-                }
-
-                if (replacements.Count == 0)
-                    continue;
-
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, replacements)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, Dictionary<SyntaxToken, SyntaxToken> replacements)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
         {
+
+            Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
+
+            bool firstInLine = token.HasLeadingTrivia || token.GetLocation()?.GetMappedLineSpan().StartLinePosition.Character == 0;
+            if (!firstInLine)
+            {
+                SyntaxToken precedingToken = token.GetPreviousToken();
+                if (precedingToken.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
+                {
+                    SyntaxToken corrected = precedingToken.WithoutTrailingWhitespace().WithoutFormatting();
+                    replacements[precedingToken] = corrected;
+                }
+            }
+
+            if (!token.TrailingTrivia.Any(SyntaxKind.EndOfLineTrivia) && token.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
+            {
+                bool ignoreTrailingWhitespace;
+                SyntaxToken nextToken = token.GetNextToken();
+                switch (nextToken.Kind())
+                {
+                case SyntaxKind.CloseBracketToken:
+                case SyntaxKind.OpenParenToken:
+                case SyntaxKind.CommaToken:
+                case SyntaxKind.SemicolonToken:
+                // TODO: "certain types of operator symbols"
+                case SyntaxKind.DotToken:
+                case SyntaxKind.OpenBracketToken:
+                case SyntaxKind.CloseParenToken:
+                    ignoreTrailingWhitespace = true;
+                    break;
+
+                case SyntaxKind.GreaterThanToken:
+                    ignoreTrailingWhitespace = nextToken.Parent.IsKind(SyntaxKind.TypeArgumentList);
+                    break;
+
+                case SyntaxKind.QuestionToken:
+                    ignoreTrailingWhitespace = nextToken.Parent.IsKind(SyntaxKind.ConditionalAccessExpression);
+                    break;
+
+                default:
+                    ignoreTrailingWhitespace = false;
+                    break;
+                }
+
+                if (!ignoreTrailingWhitespace)
+                {
+                    SyntaxToken corrected = token.WithoutTrailingWhitespace().WithoutFormatting();
+                    replacements[token] = corrected;
+                }
+            }
+
+            if (replacements.Count == 0)
+                return Task.FromResult(document);
+
             var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
             Document updatedDocument = document.WithSyntaxRoot(transformed);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
@@ -98,14 +98,14 @@
                 if (replacements.Count == 0)
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, replacements)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, replacements)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, Dictionary<SyntaxToken, SyntaxToken> replacements)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, Dictionary<SyntaxToken, SyntaxToken> replacements)
         {
             var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
-            Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
+            Document updatedDocument = document.WithSyntaxRoot(transformed);
 
             return Task.FromResult(updatedDocument);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
@@ -98,10 +98,16 @@
                 if (replacements.Count == 0)
                     continue;
 
-                var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
-                Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, replacements)), diagnostic);
             }
+        }
+
+        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, Dictionary<SyntaxToken, SyntaxToken> replacements)
+        {
+            var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
+            Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
+
+            return Task.FromResult(updatedDocument);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016CodeFixProvider.cs
@@ -34,12 +34,13 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1016OpeningAttributeBracketsMustBeSpacedCorrectly.DiagnosticId))
                     continue;
 
-                var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
                 SyntaxToken token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (!token.IsKind(SyntaxKind.OpenBracketToken))
                     continue;
@@ -50,11 +51,17 @@
                 if (!token.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
                     continue;
 
-                SyntaxToken corrected = token.WithoutTrailingWhitespace().WithoutFormatting();
-                SyntaxNode transformed = root.ReplaceToken(token, corrected);
-                Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, token)), diagnostic);
             }
+        }
+
+        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken token)
+        {
+            SyntaxToken corrected = token.WithoutTrailingWhitespace().WithoutFormatting();
+            SyntaxNode transformed = root.ReplaceToken(token, corrected);
+            Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
+
+            return Task.FromResult(updatedDocument);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016CodeFixProvider.cs
@@ -51,15 +51,15 @@
                 if (!token.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
         {
             SyntaxToken corrected = token.WithoutTrailingWhitespace().WithoutFormatting();
             SyntaxNode transformed = root.ReplaceToken(token, corrected);
-            Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
+            Document updatedDocument = document.WithSyntaxRoot(transformed);
 
             return Task.FromResult(updatedDocument);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017CodeFixProvider.cs
@@ -53,15 +53,15 @@
                 if (!precedingToken.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, precedingToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, precedingToken)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken precedingToken)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken precedingToken)
         {
             SyntaxToken corrected = precedingToken.WithoutTrailingWhitespace().WithoutFormatting();
             SyntaxNode transformed = root.ReplaceToken(precedingToken, corrected);
-            Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
+            Document updatedDocument = document.WithSyntaxRoot(transformed);
 
             return Task.FromResult(updatedDocument);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017CodeFixProvider.cs
@@ -34,12 +34,13 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1017ClosingAttributeBracketsMustBeSpacedCorrectly.DiagnosticId))
                     continue;
 
-                var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
                 SyntaxToken token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (!token.IsKind(SyntaxKind.CloseBracketToken))
                     continue;
@@ -52,11 +53,17 @@
                 if (!precedingToken.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
                     continue;
 
-                SyntaxToken corrected = precedingToken.WithoutTrailingWhitespace().WithoutFormatting();
-                SyntaxNode transformed = root.ReplaceToken(precedingToken, corrected);
-                Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, precedingToken)), diagnostic);
             }
+        }
+
+        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken precedingToken)
+        {
+            SyntaxToken corrected = precedingToken.WithoutTrailingWhitespace().WithoutFormatting();
+            SyntaxNode transformed = root.ReplaceToken(precedingToken, corrected);
+            Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
+
+            return Task.FromResult(updatedDocument);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
@@ -53,14 +53,14 @@
                 if (!previousToken.HasTrailingTrivia)
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Remove space", t => GetTransformedDocument(context, root, previousToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove space", t => GetTransformedDocument(context.Document, root, previousToken)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken previousToken)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken previousToken)
         {
             SyntaxToken corrected = previousToken.WithoutTrailingWhitespace().WithoutFormatting();
-            Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceToken(previousToken, corrected));
+            Document updatedDocument = document.WithSyntaxRoot(root.ReplaceToken(previousToken, corrected));
 
             return Task.FromResult(updatedDocument);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
@@ -34,12 +34,13 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1018NullableTypeSymbolsMustNotBePrecededBySpace.DiagnosticId))
                     continue;
 
-                var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
                 SyntaxToken token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (!token.IsKind(SyntaxKind.QuestionToken))
                     continue;
@@ -52,10 +53,16 @@
                 if (!previousToken.HasTrailingTrivia)
                     continue;
 
-                SyntaxToken corrected = previousToken.WithoutTrailingWhitespace().WithoutFormatting();
-                Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceToken(previousToken, corrected));
-                context.RegisterCodeFix(CodeAction.Create("Remove space", t => Task.FromResult(updatedDocument)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove space", t => GetTransformedDocument(context, root, previousToken)), diagnostic);
             }
+        }
+
+        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken previousToken)
+        {
+            SyntaxToken corrected = previousToken.WithoutTrailingWhitespace().WithoutFormatting();
+            Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceToken(previousToken, corrected));
+
+            return Task.FromResult(updatedDocument);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021CodeFixProvider.cs
@@ -47,11 +47,11 @@
                 if (!token.IsKind(SyntaxKind.MinusToken))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
         {
             bool precededBySpace;
             bool firstInLine;
@@ -94,7 +94,7 @@
             }
 
             var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
-            Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
+            Document updatedDocument = document.WithSyntaxRoot(transformed);
 
             return Task.FromResult(updatedDocument);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021CodeFixProvider.cs
@@ -36,60 +36,67 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1021NegativeSignsMustBeSpacedCorrectly.DiagnosticId))
                     continue;
 
-                var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
                 SyntaxToken token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (!token.IsKind(SyntaxKind.MinusToken))
                     continue;
 
-                bool precededBySpace;
-                bool firstInLine;
-                bool followsSpecialCharacter;
-
-                Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
-
-                firstInLine = token.HasLeadingTrivia || token.GetLocation()?.GetMappedLineSpan().StartLinePosition.Character == 0;
-                if (!firstInLine)
-                {
-                    SyntaxToken precedingToken = token.GetPreviousToken();
-                    precededBySpace = precedingToken.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia);
-
-                    followsSpecialCharacter =
-                        precedingToken.IsKind(SyntaxKind.OpenBracketToken)
-                        || precedingToken.IsKind(SyntaxKind.OpenParenToken)
-                        || precedingToken.IsKind(SyntaxKind.CloseParenToken);
-
-                    if (followsSpecialCharacter && precededBySpace)
-                    {
-                        SyntaxToken correctedPreceding = precedingToken.WithoutTrailingWhitespace().WithoutFormatting();
-                        replacements.Add(precedingToken, correctedPreceding);
-                    }
-                    else if (!followsSpecialCharacter && !precededBySpace)
-                    {
-                        SyntaxToken correctedPreceding = precedingToken.WithoutTrailingWhitespace();
-                        SyntaxTrivia whitespace = SyntaxFactory.Whitespace(" ");
-                        correctedPreceding =
-                            correctedPreceding
-                            .WithTrailingTrivia(correctedPreceding.TrailingTrivia.Add(whitespace))
-                            .WithoutFormatting();
-                        replacements.Add(precedingToken, correctedPreceding);
-                    }
-                }
-
-                if (token.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia) || token.TrailingTrivia.Any(SyntaxKind.EndOfLineTrivia))
-                {
-                    SyntaxToken corrected = token.WithoutTrailingWhitespace(removeEndOfLineTrivia: true).WithoutFormatting();
-                    replacements.Add(token, corrected);
-                }
-
-                var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
-                Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, token)), diagnostic);
             }
+        }
+
+        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken token)
+        {
+            bool precededBySpace;
+            bool firstInLine;
+            bool followsSpecialCharacter;
+
+            Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
+
+            firstInLine = token.HasLeadingTrivia || token.GetLocation()?.GetMappedLineSpan().StartLinePosition.Character == 0;
+            if (!firstInLine)
+            {
+                SyntaxToken precedingToken = token.GetPreviousToken();
+                precededBySpace = precedingToken.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia);
+
+                followsSpecialCharacter =
+                    precedingToken.IsKind(SyntaxKind.OpenBracketToken)
+                    || precedingToken.IsKind(SyntaxKind.OpenParenToken)
+                    || precedingToken.IsKind(SyntaxKind.CloseParenToken);
+
+                if (followsSpecialCharacter && precededBySpace)
+                {
+                    SyntaxToken correctedPreceding = precedingToken.WithoutTrailingWhitespace().WithoutFormatting();
+                    replacements.Add(precedingToken, correctedPreceding);
+                }
+                else if (!followsSpecialCharacter && !precededBySpace)
+                {
+                    SyntaxToken correctedPreceding = precedingToken.WithoutTrailingWhitespace();
+                    SyntaxTrivia whitespace = SyntaxFactory.Whitespace(" ");
+                    correctedPreceding =
+                        correctedPreceding
+                        .WithTrailingTrivia(correctedPreceding.TrailingTrivia.Add(whitespace))
+                        .WithoutFormatting();
+                    replacements.Add(precedingToken, correctedPreceding);
+                }
+            }
+
+            if (token.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia) || token.TrailingTrivia.Any(SyntaxKind.EndOfLineTrivia))
+            {
+                SyntaxToken corrected = token.WithoutTrailingWhitespace(removeEndOfLineTrivia: true).WithoutFormatting();
+                replacements.Add(token, corrected);
+            }
+
+            var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
+            Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
+
+            return Task.FromResult(updatedDocument);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022CodeFixProvider.cs
@@ -36,60 +36,68 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1022PositiveSignsMustBeSpacedCorrectly.DiagnosticId))
                     continue;
 
-                var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
                 SyntaxToken token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (!token.IsKind(SyntaxKind.PlusToken))
                     continue;
 
-                bool precededBySpace;
-                bool firstInLine;
-                bool followsSpecialCharacter;
-
-                Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
-
-                firstInLine = token.HasLeadingTrivia || token.GetLocation()?.GetMappedLineSpan().StartLinePosition.Character == 0;
-                if (!firstInLine)
-                {
-                    SyntaxToken precedingToken = token.GetPreviousToken();
-                    precededBySpace = precedingToken.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia);
-
-                    followsSpecialCharacter =
-                        precedingToken.IsKind(SyntaxKind.OpenBracketToken)
-                        || precedingToken.IsKind(SyntaxKind.OpenParenToken)
-                        || precedingToken.IsKind(SyntaxKind.CloseParenToken);
-
-                    if (followsSpecialCharacter && precededBySpace)
-                    {
-                        SyntaxToken correctedPreceding = precedingToken.WithoutTrailingWhitespace().WithoutFormatting();
-                        replacements.Add(precedingToken, correctedPreceding);
-                    }
-                    else if (!followsSpecialCharacter && !precededBySpace)
-                    {
-                        SyntaxToken correctedPreceding = precedingToken.WithoutTrailingWhitespace();
-                        SyntaxTrivia whitespace = SyntaxFactory.Whitespace(" ");
-                        correctedPreceding =
-                            correctedPreceding
-                            .WithTrailingTrivia(correctedPreceding.TrailingTrivia.Add(whitespace))
-                            .WithoutFormatting();
-                        replacements.Add(precedingToken, correctedPreceding);
-                    }
-                }
-
-                if (token.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia) || token.TrailingTrivia.Any(SyntaxKind.EndOfLineTrivia))
-                {
-                    SyntaxToken corrected = token.WithoutTrailingWhitespace(removeEndOfLineTrivia: true).WithoutFormatting();
-                    replacements.Add(token, corrected);
-                }
-
-                var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
-                Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => Task.FromResult(updatedDocument)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, token)), diagnostic);
             }
+        }
+
+        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken token)
+        {
+
+            bool precededBySpace;
+            bool firstInLine;
+            bool followsSpecialCharacter;
+
+            Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
+
+            firstInLine = token.HasLeadingTrivia || token.GetLocation()?.GetMappedLineSpan().StartLinePosition.Character == 0;
+            if (!firstInLine)
+            {
+                SyntaxToken precedingToken = token.GetPreviousToken();
+                precededBySpace = precedingToken.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia);
+
+                followsSpecialCharacter =
+                    precedingToken.IsKind(SyntaxKind.OpenBracketToken)
+                    || precedingToken.IsKind(SyntaxKind.OpenParenToken)
+                    || precedingToken.IsKind(SyntaxKind.CloseParenToken);
+
+                if (followsSpecialCharacter && precededBySpace)
+                {
+                    SyntaxToken correctedPreceding = precedingToken.WithoutTrailingWhitespace().WithoutFormatting();
+                    replacements.Add(precedingToken, correctedPreceding);
+                }
+                else if (!followsSpecialCharacter && !precededBySpace)
+                {
+                    SyntaxToken correctedPreceding = precedingToken.WithoutTrailingWhitespace();
+                    SyntaxTrivia whitespace = SyntaxFactory.Whitespace(" ");
+                    correctedPreceding =
+                        correctedPreceding
+                        .WithTrailingTrivia(correctedPreceding.TrailingTrivia.Add(whitespace))
+                        .WithoutFormatting();
+                    replacements.Add(precedingToken, correctedPreceding);
+                }
+            }
+
+            if (token.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia) || token.TrailingTrivia.Any(SyntaxKind.EndOfLineTrivia))
+            {
+                SyntaxToken corrected = token.WithoutTrailingWhitespace(removeEndOfLineTrivia: true).WithoutFormatting();
+                replacements.Add(token, corrected);
+            }
+
+            var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
+            Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
+
+            return Task.FromResult(updatedDocument);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022CodeFixProvider.cs
@@ -47,11 +47,11 @@
                 if (!token.IsKind(SyntaxKind.PlusToken))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
         {
 
             bool precededBySpace;
@@ -95,7 +95,7 @@
             }
 
             var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
-            Document updatedDocument = context.Document.WithSyntaxRoot(transformed);
+            Document updatedDocument = document.WithSyntaxRoot(transformed);
 
             return Task.FromResult(updatedDocument);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1026CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1026CodeFixProvider.cs
@@ -44,14 +44,14 @@
                 if (token.IsMissing)
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Remove space", t => GetTransformedDocument(context, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove space", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
         {
             SyntaxToken corrected = token.WithoutTrailingWhitespace().WithoutFormatting();
-            Document updatedDocument = context.Document.WithSyntaxRoot(root.ReplaceToken(token, corrected));
+            Document updatedDocument = document.WithSyntaxRoot(root.ReplaceToken(token, corrected));
 
             return Task.FromResult(updatedDocument);
         }


### PR DESCRIPTION
I reworked all code fixes to increase performace.

They will now create the changed document only if they are requested to do so.

I also moved the GetSyntaxRootAsync out of the loop because it is not dependant on the diagnostic. I also noticed that GetSyntaxRootAsync was called twice in a code fix so I tidied that up too.

So most of this is just moving stuff around.

Fixes #529