### PR TITLE
Async cleanup

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
@@ -18,7 +18,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeDeclarationDocumentation(string type, string modifiers, bool requiresDiagnostic, bool hasDocumentation)
@@ -39,7 +39,7 @@ TypeName
                     this.CSharpDiagnostic().WithLocation(3, 1)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers, type), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers, type), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestNestedTypeDeclarationDocumentation(string type, string modifiers, bool requiresDiagnostic, bool hasDocumentation)
@@ -72,7 +72,7 @@ public class OuterClass
                     this.CSharpDiagnostic().WithLocation(8, 5)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers, type), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers, type), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestDelegateDeclarationDocumentation(string modifiers, bool requiresDiagnostic, bool hasDocumentation)
@@ -93,7 +93,7 @@ DelegateName()
                     this.CSharpDiagnostic().WithLocation(3, 1)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestNestedDelegateDeclarationDocumentation(string modifiers, bool requiresDiagnostic, bool hasDocumentation)
@@ -126,7 +126,7 @@ public class OuterClass
                     this.CSharpDiagnostic().WithLocation(8, 5)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestMethodDeclarationDocumentation(string modifiers, bool isExplicitInterfaceMethod, bool requiresDiagnostic, bool hasDocumentation)
@@ -160,7 +160,7 @@ public class OuterClass
                 };
 
             string explicitInterfaceText = isExplicitInterfaceMethod ? " IInterface." : string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers, explicitInterfaceText), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers, explicitInterfaceText), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestInterfaceMethodDeclarationDocumentation(bool hasDocumentation)
@@ -193,7 +193,7 @@ public interface InterfaceName
                     this.CSharpDiagnostic().WithLocation(8, 5)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, !hasDocumentation ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, !hasDocumentation ? expected : EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestInterfacePropertyDeclarationDocumentation(bool hasDocumentation)
@@ -228,7 +228,7 @@ public interface InterfaceName
                     this.CSharpDiagnostic().WithLocation(8, 12)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, !hasDocumentation ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, !hasDocumentation ? expected : EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestInterfaceEventDeclarationDocumentation(bool hasDocumentation)
@@ -258,7 +258,7 @@ public interface InterfaceName
                     this.CSharpDiagnostic().WithLocation(8, 25)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, !hasDocumentation ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, !hasDocumentation ? expected : EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestInterfaceIndexerDeclarationDocumentation(bool hasDocumentation)
@@ -287,7 +287,7 @@ public interface InterfaceName
                     this.CSharpDiagnostic().WithLocation(8, 5)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, !hasDocumentation ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, !hasDocumentation ? expected : EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestConstructorDeclarationDocumentation(string modifiers, bool requiresDiagnostic, bool hasDocumentation)
@@ -320,7 +320,7 @@ public class OuterClass
                     this.CSharpDiagnostic().WithLocation(8, 5)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestDestructorDeclarationDocumentation(bool requiresDiagnostic, bool hasDocumentation)
@@ -351,7 +351,7 @@ public class OuterClass
                     this.CSharpDiagnostic().WithLocation(7, 6)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestPropertyDeclarationDocumentation(string modifiers, bool isExplicitInterfaceProperty, bool requiresDiagnostic, bool hasDocumentation)
@@ -383,7 +383,7 @@ public class OuterClass
                 };
 
             string explicitInterfaceText = isExplicitInterfaceProperty ? " IInterface." : string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers, explicitInterfaceText), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers, explicitInterfaceText), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestIndexerDeclarationDocumentation(string modifiers, bool isExplicitInterfaceIndexer, bool requiresDiagnostic, bool hasDocumentation)
@@ -415,7 +415,7 @@ public class OuterClass
                 };
 
             string explicitInterfaceText = isExplicitInterfaceIndexer ? " IInterface." : string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers, explicitInterfaceText), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers, explicitInterfaceText), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestEventDeclarationDocumentation(string modifiers, bool isExplicitInterfaceEvent, bool requiresDiagnostic, bool hasDocumentation)
@@ -469,7 +469,7 @@ public class OuterClass
                 };
 
             string explicitInterfaceText = isExplicitInterfaceEvent ? " IInterface." : string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers, explicitInterfaceText), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers, explicitInterfaceText), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestFieldDeclarationDocumentation(string modifiers, bool requiresDiagnostic, bool hasDocumentation)
@@ -498,7 +498,7 @@ public class OuterClass
                     this.CSharpDiagnostic().WithLocation(8, 19)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestEventFieldDeclarationDocumentation(string modifiers, bool requiresDiagnostic, bool hasDocumentation)
@@ -527,303 +527,303 @@ public class OuterClass
                     this.CSharpDiagnostic().WithLocation(8, 19)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(hasDocumentation ? testCodeWithDocumentation : testCodeWithoutDocumentation, modifiers), requiresDiagnostic ? expected : EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithoutDocumentation(string type)
         {
-            await this.TestTypeDeclarationDocumentation(type, string.Empty, true, false);
-            await this.TestTypeDeclarationDocumentation(type, "internal", true, false);
-            await this.TestTypeDeclarationDocumentation(type, "public", true, false);
+            await this.TestTypeDeclarationDocumentation(type, string.Empty, true, false).ConfigureAwait(false);
+            await this.TestTypeDeclarationDocumentation(type, "internal", true, false).ConfigureAwait(false);
+            await this.TestTypeDeclarationDocumentation(type, "public", true, false).ConfigureAwait(false);
 
-            await this.TestNestedTypeDeclarationDocumentation(type, string.Empty, false, false);
-            await this.TestNestedTypeDeclarationDocumentation(type, "private", false, false);
-            await this.TestNestedTypeDeclarationDocumentation(type, "protected", true, false);
-            await this.TestNestedTypeDeclarationDocumentation(type, "internal", true, false);
-            await this.TestNestedTypeDeclarationDocumentation(type, "protected internal", true, false);
-            await this.TestNestedTypeDeclarationDocumentation(type, "public", true, false);
+            await this.TestNestedTypeDeclarationDocumentation(type, string.Empty, false, false).ConfigureAwait(false);
+            await this.TestNestedTypeDeclarationDocumentation(type, "private", false, false).ConfigureAwait(false);
+            await this.TestNestedTypeDeclarationDocumentation(type, "protected", true, false).ConfigureAwait(false);
+            await this.TestNestedTypeDeclarationDocumentation(type, "internal", true, false).ConfigureAwait(false);
+            await this.TestNestedTypeDeclarationDocumentation(type, "protected internal", true, false).ConfigureAwait(false);
+            await this.TestNestedTypeDeclarationDocumentation(type, "public", true, false).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithDocumentation(string type)
         {
-            await this.TestTypeDeclarationDocumentation(type, string.Empty, false, true);
-            await this.TestTypeDeclarationDocumentation(type, "internal", false, true);
-            await this.TestTypeDeclarationDocumentation(type, "public", false, true);
+            await this.TestTypeDeclarationDocumentation(type, string.Empty, false, true).ConfigureAwait(false);
+            await this.TestTypeDeclarationDocumentation(type, "internal", false, true).ConfigureAwait(false);
+            await this.TestTypeDeclarationDocumentation(type, "public", false, true).ConfigureAwait(false);
 
-            await this.TestNestedTypeDeclarationDocumentation(type, string.Empty, false, true);
-            await this.TestNestedTypeDeclarationDocumentation(type, "private", false, true);
-            await this.TestNestedTypeDeclarationDocumentation(type, "protected", false, true);
-            await this.TestNestedTypeDeclarationDocumentation(type, "internal", false, true);
-            await this.TestNestedTypeDeclarationDocumentation(type, "protected internal", false, true);
-            await this.TestNestedTypeDeclarationDocumentation(type, "public", false, true);
+            await this.TestNestedTypeDeclarationDocumentation(type, string.Empty, false, true).ConfigureAwait(false);
+            await this.TestNestedTypeDeclarationDocumentation(type, "private", false, true).ConfigureAwait(false);
+            await this.TestNestedTypeDeclarationDocumentation(type, "protected", false, true).ConfigureAwait(false);
+            await this.TestNestedTypeDeclarationDocumentation(type, "internal", false, true).ConfigureAwait(false);
+            await this.TestNestedTypeDeclarationDocumentation(type, "protected internal", false, true).ConfigureAwait(false);
+            await this.TestNestedTypeDeclarationDocumentation(type, "public", false, true).ConfigureAwait(false);
         }
 
 
         [Fact]
         public async Task TestClassWithoutDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("class");
+            await this.TestTypeWithoutDocumentation("class").ConfigureAwait(false);
         }
         [Fact]
         public async Task TestStructWithoutDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("struct");
+            await this.TestTypeWithoutDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEnumWithoutDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("enum");
+            await this.TestTypeWithoutDocumentation("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithoutDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("interface");
+            await this.TestTypeWithoutDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithDocumentation()
         {
-            await this.TestTypeWithDocumentation("class");
+            await this.TestTypeWithDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithDocumentation()
         {
-            await this.TestTypeWithDocumentation("struct");
+            await this.TestTypeWithDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEnumWithDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("enum");
+            await this.TestTypeWithoutDocumentation("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("interface");
+            await this.TestTypeWithoutDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDelegateWithoutDocumentation()
         {
-            await this.TestDelegateDeclarationDocumentation(string.Empty, true, false);
-            await this.TestDelegateDeclarationDocumentation("internal", true, false);
-            await this.TestDelegateDeclarationDocumentation("public", true, false);
+            await this.TestDelegateDeclarationDocumentation(string.Empty, true, false).ConfigureAwait(false);
+            await this.TestDelegateDeclarationDocumentation("internal", true, false).ConfigureAwait(false);
+            await this.TestDelegateDeclarationDocumentation("public", true, false).ConfigureAwait(false);
 
-            await this.TestNestedDelegateDeclarationDocumentation(string.Empty, false, false);
-            await this.TestNestedDelegateDeclarationDocumentation("private", false, false);
-            await this.TestNestedDelegateDeclarationDocumentation("protected", true, false);
-            await this.TestNestedDelegateDeclarationDocumentation("internal", true, false);
-            await this.TestNestedDelegateDeclarationDocumentation("protected internal", true, false);
-            await this.TestNestedDelegateDeclarationDocumentation("public", true, false);
+            await this.TestNestedDelegateDeclarationDocumentation(string.Empty, false, false).ConfigureAwait(false);
+            await this.TestNestedDelegateDeclarationDocumentation("private", false, false).ConfigureAwait(false);
+            await this.TestNestedDelegateDeclarationDocumentation("protected", true, false).ConfigureAwait(false);
+            await this.TestNestedDelegateDeclarationDocumentation("internal", true, false).ConfigureAwait(false);
+            await this.TestNestedDelegateDeclarationDocumentation("protected internal", true, false).ConfigureAwait(false);
+            await this.TestNestedDelegateDeclarationDocumentation("public", true, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDelegateWithDocumentation()
         {
-            await this.TestDelegateDeclarationDocumentation(string.Empty, false, true);
-            await this.TestDelegateDeclarationDocumentation("internal", false, true);
-            await this.TestDelegateDeclarationDocumentation("public", false, true);
+            await this.TestDelegateDeclarationDocumentation(string.Empty, false, true).ConfigureAwait(false);
+            await this.TestDelegateDeclarationDocumentation("internal", false, true).ConfigureAwait(false);
+            await this.TestDelegateDeclarationDocumentation("public", false, true).ConfigureAwait(false);
 
-            await this.TestDelegateDeclarationDocumentation(string.Empty, false, true);
-            await this.TestDelegateDeclarationDocumentation("private", false, true);
-            await this.TestDelegateDeclarationDocumentation("protected", false, true);
-            await this.TestDelegateDeclarationDocumentation("internal", false, true);
-            await this.TestDelegateDeclarationDocumentation("protected internal", false, true);
-            await this.TestDelegateDeclarationDocumentation("public", false, true);
+            await this.TestDelegateDeclarationDocumentation(string.Empty, false, true).ConfigureAwait(false);
+            await this.TestDelegateDeclarationDocumentation("private", false, true).ConfigureAwait(false);
+            await this.TestDelegateDeclarationDocumentation("protected", false, true).ConfigureAwait(false);
+            await this.TestDelegateDeclarationDocumentation("internal", false, true).ConfigureAwait(false);
+            await this.TestDelegateDeclarationDocumentation("protected internal", false, true).ConfigureAwait(false);
+            await this.TestDelegateDeclarationDocumentation("public", false, true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestMethodWithoutDocumentation()
         {
-            await this.TestMethodDeclarationDocumentation(string.Empty, false, false, false);
-            await this.TestMethodDeclarationDocumentation(string.Empty, true, true, false);
-            await this.TestMethodDeclarationDocumentation("private", false, false, false);
-            await this.TestMethodDeclarationDocumentation("protected", false, true, false);
-            await this.TestMethodDeclarationDocumentation("internal", false, true, false);
-            await this.TestMethodDeclarationDocumentation("protected internal", false, true, false);
-            await this.TestMethodDeclarationDocumentation("public", false, true, false);
+            await this.TestMethodDeclarationDocumentation(string.Empty, false, false, false).ConfigureAwait(false);
+            await this.TestMethodDeclarationDocumentation(string.Empty, true, true, false).ConfigureAwait(false);
+            await this.TestMethodDeclarationDocumentation("private", false, false, false).ConfigureAwait(false);
+            await this.TestMethodDeclarationDocumentation("protected", false, true, false).ConfigureAwait(false);
+            await this.TestMethodDeclarationDocumentation("internal", false, true, false).ConfigureAwait(false);
+            await this.TestMethodDeclarationDocumentation("protected internal", false, true, false).ConfigureAwait(false);
+            await this.TestMethodDeclarationDocumentation("public", false, true, false).ConfigureAwait(false);
 
-            await this.TestInterfaceMethodDeclarationDocumentation(false);
+            await this.TestInterfaceMethodDeclarationDocumentation(false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestMethodWithDocumentation()
         {
-            await this.TestMethodDeclarationDocumentation(string.Empty, false, false, true);
-            await this.TestMethodDeclarationDocumentation(string.Empty, true, false, true);
-            await this.TestMethodDeclarationDocumentation("private", false, false, true);
-            await this.TestMethodDeclarationDocumentation("protected", false, false, true);
-            await this.TestMethodDeclarationDocumentation("internal", false, false, true);
-            await this.TestMethodDeclarationDocumentation("protected internal", false, false, true);
-            await this.TestMethodDeclarationDocumentation("public", false, false, true);
+            await this.TestMethodDeclarationDocumentation(string.Empty, false, false, true).ConfigureAwait(false);
+            await this.TestMethodDeclarationDocumentation(string.Empty, true, false, true).ConfigureAwait(false);
+            await this.TestMethodDeclarationDocumentation("private", false, false, true).ConfigureAwait(false);
+            await this.TestMethodDeclarationDocumentation("protected", false, false, true).ConfigureAwait(false);
+            await this.TestMethodDeclarationDocumentation("internal", false, false, true).ConfigureAwait(false);
+            await this.TestMethodDeclarationDocumentation("protected internal", false, false, true).ConfigureAwait(false);
+            await this.TestMethodDeclarationDocumentation("public", false, false, true).ConfigureAwait(false);
 
-            await this.TestInterfaceMethodDeclarationDocumentation(true);
+            await this.TestInterfaceMethodDeclarationDocumentation(true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstructorWithoutDocumentation()
         {
-            await this.TestConstructorDeclarationDocumentation(string.Empty, false, false);
-            await this.TestConstructorDeclarationDocumentation("private", false, false);
-            await this.TestConstructorDeclarationDocumentation("protected", true, false);
-            await this.TestConstructorDeclarationDocumentation("internal", true, false);
-            await this.TestConstructorDeclarationDocumentation("protected internal", true, false);
-            await this.TestConstructorDeclarationDocumentation("public", true, false);
+            await this.TestConstructorDeclarationDocumentation(string.Empty, false, false).ConfigureAwait(false);
+            await this.TestConstructorDeclarationDocumentation("private", false, false).ConfigureAwait(false);
+            await this.TestConstructorDeclarationDocumentation("protected", true, false).ConfigureAwait(false);
+            await this.TestConstructorDeclarationDocumentation("internal", true, false).ConfigureAwait(false);
+            await this.TestConstructorDeclarationDocumentation("protected internal", true, false).ConfigureAwait(false);
+            await this.TestConstructorDeclarationDocumentation("public", true, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstructorWithDocumentation()
         {
-            await this.TestConstructorDeclarationDocumentation(string.Empty, false, true);
-            await this.TestConstructorDeclarationDocumentation("private", false, true);
-            await this.TestConstructorDeclarationDocumentation("protected", false, true);
-            await this.TestConstructorDeclarationDocumentation("internal", false, true);
-            await this.TestConstructorDeclarationDocumentation("protected internal", false, true);
-            await this.TestConstructorDeclarationDocumentation("public", false, true);
+            await this.TestConstructorDeclarationDocumentation(string.Empty, false, true).ConfigureAwait(false);
+            await this.TestConstructorDeclarationDocumentation("private", false, true).ConfigureAwait(false);
+            await this.TestConstructorDeclarationDocumentation("protected", false, true).ConfigureAwait(false);
+            await this.TestConstructorDeclarationDocumentation("internal", false, true).ConfigureAwait(false);
+            await this.TestConstructorDeclarationDocumentation("protected internal", false, true).ConfigureAwait(false);
+            await this.TestConstructorDeclarationDocumentation("public", false, true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDestructorWithoutDocumentation()
         {
-            await this.TestDestructorDeclarationDocumentation(true, false);
+            await this.TestDestructorDeclarationDocumentation(true, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDestructorWithDocumentation()
         {
-            await this.TestDestructorDeclarationDocumentation(false, true);
+            await this.TestDestructorDeclarationDocumentation(false, true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestFieldWithoutDocumentation()
         {
-            await this.TestFieldDeclarationDocumentation(string.Empty, false, false);
-            await this.TestFieldDeclarationDocumentation("private", false, false);
-            await this.TestFieldDeclarationDocumentation("protected", true, false);
-            await this.TestFieldDeclarationDocumentation("internal", true, false);
-            await this.TestFieldDeclarationDocumentation("protected internal", true, false);
-            await this.TestFieldDeclarationDocumentation("public", true, false);
+            await this.TestFieldDeclarationDocumentation(string.Empty, false, false).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentation("private", false, false).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentation("protected", true, false).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentation("internal", true, false).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentation("protected internal", true, false).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentation("public", true, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestFieldWithDocumentation()
         {
-            await this.TestFieldDeclarationDocumentation(string.Empty, false, true);
-            await this.TestFieldDeclarationDocumentation("private", false, true);
-            await this.TestFieldDeclarationDocumentation("protected", false, true);
-            await this.TestFieldDeclarationDocumentation("internal", false, true);
-            await this.TestFieldDeclarationDocumentation("protected internal", false, true);
-            await this.TestFieldDeclarationDocumentation("public", false, true);
+            await this.TestFieldDeclarationDocumentation(string.Empty, false, true).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentation("private", false, true).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentation("protected", false, true).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentation("internal", false, true).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentation("protected internal", false, true).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentation("public", false, true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPropertyWithoutDocumentation()
         {
-            await this.TestPropertyDeclarationDocumentation(string.Empty, false, false, false);
-            await this.TestPropertyDeclarationDocumentation(string.Empty, true, true, false);
-            await this.TestPropertyDeclarationDocumentation("private", false, false, false);
-            await this.TestPropertyDeclarationDocumentation("protected", false, true, false);
-            await this.TestPropertyDeclarationDocumentation("internal", false, true, false);
-            await this.TestPropertyDeclarationDocumentation("protected internal", false, true, false);
-            await this.TestPropertyDeclarationDocumentation("public", false, true, false);
+            await this.TestPropertyDeclarationDocumentation(string.Empty, false, false, false).ConfigureAwait(false);
+            await this.TestPropertyDeclarationDocumentation(string.Empty, true, true, false).ConfigureAwait(false);
+            await this.TestPropertyDeclarationDocumentation("private", false, false, false).ConfigureAwait(false);
+            await this.TestPropertyDeclarationDocumentation("protected", false, true, false).ConfigureAwait(false);
+            await this.TestPropertyDeclarationDocumentation("internal", false, true, false).ConfigureAwait(false);
+            await this.TestPropertyDeclarationDocumentation("protected internal", false, true, false).ConfigureAwait(false);
+            await this.TestPropertyDeclarationDocumentation("public", false, true, false).ConfigureAwait(false);
 
-            await this.TestInterfacePropertyDeclarationDocumentation(false);
+            await this.TestInterfacePropertyDeclarationDocumentation(false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPropertyWithDocumentation()
         {
-            await this.TestPropertyDeclarationDocumentation(string.Empty, false, false, true);
-            await this.TestPropertyDeclarationDocumentation(string.Empty, true, false, true);
-            await this.TestPropertyDeclarationDocumentation("private", false, false, true);
-            await this.TestPropertyDeclarationDocumentation("protected", false, false, true);
-            await this.TestPropertyDeclarationDocumentation("internal", false, false, true);
-            await this.TestPropertyDeclarationDocumentation("protected internal", false, false, true);
-            await this.TestPropertyDeclarationDocumentation("public", false, false, true);
+            await this.TestPropertyDeclarationDocumentation(string.Empty, false, false, true).ConfigureAwait(false);
+            await this.TestPropertyDeclarationDocumentation(string.Empty, true, false, true).ConfigureAwait(false);
+            await this.TestPropertyDeclarationDocumentation("private", false, false, true).ConfigureAwait(false);
+            await this.TestPropertyDeclarationDocumentation("protected", false, false, true).ConfigureAwait(false);
+            await this.TestPropertyDeclarationDocumentation("internal", false, false, true).ConfigureAwait(false);
+            await this.TestPropertyDeclarationDocumentation("protected internal", false, false, true).ConfigureAwait(false);
+            await this.TestPropertyDeclarationDocumentation("public", false, false, true).ConfigureAwait(false);
 
-            await this.TestInterfacePropertyDeclarationDocumentation(true);
+            await this.TestInterfacePropertyDeclarationDocumentation(true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestIndexerWithoutDocumentation()
         {
-            await this.TestIndexerDeclarationDocumentation(string.Empty, false, false, false);
-            await this.TestIndexerDeclarationDocumentation(string.Empty, true, true, false);
-            await this.TestIndexerDeclarationDocumentation("private", false, false, false);
-            await this.TestIndexerDeclarationDocumentation("protected", false, true, false);
-            await this.TestIndexerDeclarationDocumentation("internal", false, true, false);
-            await this.TestIndexerDeclarationDocumentation("protected internal", false, true, false);
-            await this.TestIndexerDeclarationDocumentation("public", false, true, false);
+            await this.TestIndexerDeclarationDocumentation(string.Empty, false, false, false).ConfigureAwait(false);
+            await this.TestIndexerDeclarationDocumentation(string.Empty, true, true, false).ConfigureAwait(false);
+            await this.TestIndexerDeclarationDocumentation("private", false, false, false).ConfigureAwait(false);
+            await this.TestIndexerDeclarationDocumentation("protected", false, true, false).ConfigureAwait(false);
+            await this.TestIndexerDeclarationDocumentation("internal", false, true, false).ConfigureAwait(false);
+            await this.TestIndexerDeclarationDocumentation("protected internal", false, true, false).ConfigureAwait(false);
+            await this.TestIndexerDeclarationDocumentation("public", false, true, false).ConfigureAwait(false);
 
-            await this.TestInterfaceIndexerDeclarationDocumentation(false);
+            await this.TestInterfaceIndexerDeclarationDocumentation(false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestIndexerWithDocumentation()
         {
-            await this.TestIndexerDeclarationDocumentation(string.Empty, false, false, true);
-            await this.TestIndexerDeclarationDocumentation(string.Empty, true, false, true);
-            await this.TestIndexerDeclarationDocumentation("private", false, false, true);
-            await this.TestIndexerDeclarationDocumentation("protected", false, false, true);
-            await this.TestIndexerDeclarationDocumentation("internal", false, false, true);
-            await this.TestIndexerDeclarationDocumentation("protected internal", false, false, true);
-            await this.TestIndexerDeclarationDocumentation("public", false, false, true);
+            await this.TestIndexerDeclarationDocumentation(string.Empty, false, false, true).ConfigureAwait(false);
+            await this.TestIndexerDeclarationDocumentation(string.Empty, true, false, true).ConfigureAwait(false);
+            await this.TestIndexerDeclarationDocumentation("private", false, false, true).ConfigureAwait(false);
+            await this.TestIndexerDeclarationDocumentation("protected", false, false, true).ConfigureAwait(false);
+            await this.TestIndexerDeclarationDocumentation("internal", false, false, true).ConfigureAwait(false);
+            await this.TestIndexerDeclarationDocumentation("protected internal", false, false, true).ConfigureAwait(false);
+            await this.TestIndexerDeclarationDocumentation("public", false, false, true).ConfigureAwait(false);
 
-            await this.TestInterfaceIndexerDeclarationDocumentation(true);
+            await this.TestInterfaceIndexerDeclarationDocumentation(true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEventWithoutDocumentation()
         {
-            await this.TestEventDeclarationDocumentation(string.Empty, false, false, false);
-            await this.TestEventDeclarationDocumentation(string.Empty, true, true, false);
-            await this.TestEventDeclarationDocumentation("private", false, false, false);
-            await this.TestEventDeclarationDocumentation("protected", false, true, false);
-            await this.TestEventDeclarationDocumentation("internal", false, true, false);
-            await this.TestEventDeclarationDocumentation("protected internal", false, true, false);
-            await this.TestEventDeclarationDocumentation("public", false, true, false);
+            await this.TestEventDeclarationDocumentation(string.Empty, false, false, false).ConfigureAwait(false);
+            await this.TestEventDeclarationDocumentation(string.Empty, true, true, false).ConfigureAwait(false);
+            await this.TestEventDeclarationDocumentation("private", false, false, false).ConfigureAwait(false);
+            await this.TestEventDeclarationDocumentation("protected", false, true, false).ConfigureAwait(false);
+            await this.TestEventDeclarationDocumentation("internal", false, true, false).ConfigureAwait(false);
+            await this.TestEventDeclarationDocumentation("protected internal", false, true, false).ConfigureAwait(false);
+            await this.TestEventDeclarationDocumentation("public", false, true, false).ConfigureAwait(false);
 
-            await this.TestInterfaceEventDeclarationDocumentation(false);
+            await this.TestInterfaceEventDeclarationDocumentation(false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEventWithDocumentation()
         {
-            await this.TestEventDeclarationDocumentation(string.Empty, false, false, true);
-            await this.TestEventDeclarationDocumentation(string.Empty, true, false, true);
-            await this.TestEventDeclarationDocumentation("private", false, false, true);
-            await this.TestEventDeclarationDocumentation("protected", false, false, true);
-            await this.TestEventDeclarationDocumentation("internal", false, false, true);
-            await this.TestEventDeclarationDocumentation("protected internal", false, false, true);
-            await this.TestEventDeclarationDocumentation("public", false, false, true);
+            await this.TestEventDeclarationDocumentation(string.Empty, false, false, true).ConfigureAwait(false);
+            await this.TestEventDeclarationDocumentation(string.Empty, true, false, true).ConfigureAwait(false);
+            await this.TestEventDeclarationDocumentation("private", false, false, true).ConfigureAwait(false);
+            await this.TestEventDeclarationDocumentation("protected", false, false, true).ConfigureAwait(false);
+            await this.TestEventDeclarationDocumentation("internal", false, false, true).ConfigureAwait(false);
+            await this.TestEventDeclarationDocumentation("protected internal", false, false, true).ConfigureAwait(false);
+            await this.TestEventDeclarationDocumentation("public", false, false, true).ConfigureAwait(false);
 
-            await this.TestInterfaceEventDeclarationDocumentation(true);
+            await this.TestInterfaceEventDeclarationDocumentation(true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEventFieldWithoutDocumentation()
         {
-            await this.TestEventFieldDeclarationDocumentation(string.Empty, false, false);
-            await this.TestEventFieldDeclarationDocumentation("private", false, false);
-            await this.TestEventFieldDeclarationDocumentation("protected", true, false);
-            await this.TestEventFieldDeclarationDocumentation("internal", true, false);
-            await this.TestEventFieldDeclarationDocumentation("protected internal", true, false);
-            await this.TestEventFieldDeclarationDocumentation("public", true, false);
+            await this.TestEventFieldDeclarationDocumentation(string.Empty, false, false).ConfigureAwait(false);
+            await this.TestEventFieldDeclarationDocumentation("private", false, false).ConfigureAwait(false);
+            await this.TestEventFieldDeclarationDocumentation("protected", true, false).ConfigureAwait(false);
+            await this.TestEventFieldDeclarationDocumentation("internal", true, false).ConfigureAwait(false);
+            await this.TestEventFieldDeclarationDocumentation("protected internal", true, false).ConfigureAwait(false);
+            await this.TestEventFieldDeclarationDocumentation("public", true, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEventFieldWithDocumentation()
         {
-            await this.TestEventFieldDeclarationDocumentation(string.Empty, false, true);
-            await this.TestEventFieldDeclarationDocumentation("private", false, true);
-            await this.TestEventFieldDeclarationDocumentation("protected", false, true);
-            await this.TestEventFieldDeclarationDocumentation("internal", false, true);
-            await this.TestEventFieldDeclarationDocumentation("protected internal", false, true);
-            await this.TestEventFieldDeclarationDocumentation("public", false, true);
+            await this.TestEventFieldDeclarationDocumentation(string.Empty, false, true).ConfigureAwait(false);
+            await this.TestEventFieldDeclarationDocumentation("private", false, true).ConfigureAwait(false);
+            await this.TestEventFieldDeclarationDocumentation("protected", false, true).ConfigureAwait(false);
+            await this.TestEventFieldDeclarationDocumentation("internal", false, true).ConfigureAwait(false);
+            await this.TestEventFieldDeclarationDocumentation("protected internal", false, true).ConfigureAwait(false);
+            await this.TestEventFieldDeclarationDocumentation("public", false, true).ConfigureAwait(false);
         }
 
         [Fact]
@@ -843,8 +843,8 @@ public class OuterClass
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 14);
 
-            await this.VerifyCSharpDiagnosticAsync(testCodeWithDocumentation, EmptyDiagnosticResults, CancellationToken.None);
-            await this.VerifyCSharpDiagnosticAsync(testCodeWithEmptyDocumentation, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCodeWithDocumentation, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCodeWithEmptyDocumentation, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -865,8 +865,8 @@ public class OuterClass
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 14);
 
-            await this.VerifyCSharpDiagnosticAsync(testCodeWithDocumentation, EmptyDiagnosticResults, CancellationToken.None);
-            await this.VerifyCSharpDiagnosticAsync(testCodeWithEmptyDocumentation, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCodeWithDocumentation, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCodeWithEmptyDocumentation, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -877,7 +877,7 @@ public class OuterClass
 {
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCodeWithDocumentation, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCodeWithDocumentation, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -888,7 +888,7 @@ public class OuterClass
  */
 public void SomeMethod() { }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCodeWithDocumentation, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCodeWithDocumentation, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
@@ -18,7 +18,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -31,9 +31,9 @@
 public partial {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "class"), EmptyDiagnosticResults, CancellationToken.None);
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "struct"), EmptyDiagnosticResults, CancellationToken.None);
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "interface"), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "class"), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "struct"), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "interface"), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -47,9 +47,9 @@ TypeName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "class"), expected, CancellationToken.None);
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "struct"), expected, CancellationToken.None);
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "interface"), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "class"), expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "struct"), expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "interface"), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -66,9 +66,9 @@ TypeName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "class"), expected, CancellationToken.None);
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "struct"), expected, CancellationToken.None);
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "interface"), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "class"), expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "struct"), expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "interface"), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -85,7 +85,7 @@ public partial class TypeName
     /// </summary>
     partial void MemberName();
 }}";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -102,7 +102,7 @@ public partial class TypeName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 18);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -122,7 +122,7 @@ public partial class TypeName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 18);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1602UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1602UnitTests.cs
@@ -18,7 +18,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -35,7 +35,7 @@ enum TypeName
     /// </summary>
     Bar
 }}";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ enum TypeName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 5);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -69,7 +69,7 @@ enum TypeName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 5);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1603UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1603UnitTests.cs
@@ -18,7 +18,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -27,7 +27,7 @@
             var testCode = @"
 /// Foo
 public class Foo { }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -36,7 +36,7 @@ public class Foo { }";
             var testCode = @"
 /// <summary/>
 public class Foo { }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -45,7 +45,7 @@ public class Foo { }";
             var testCode = @"
 /// <summary></summary>
 public class Foo { }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -54,7 +54,7 @@ public class Foo { }";
             var testCode = @"
 /// <![CDATA[Foo]]>
 public class Foo { }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -66,7 +66,7 @@ public class Foo { }";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("Invalid token.").WithLocation(2, 13);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -78,7 +78,7 @@ public class Foo { }";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("Invalid token.").WithLocation(2, 23);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -90,7 +90,7 @@ public class Foo { }";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("Invalid token.").WithLocation(2, 13);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -105,7 +105,7 @@ public class Foo { }";
                     .WithLocation(2, 5)
                     .WithLocation(2, 15);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -119,7 +119,7 @@ public class Foo { }";
                 this.CSharpDiagnostic().WithArguments("The XML tag 'summary' is not closed.")
                     .WithLocation(2, 5);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1604UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1604UnitTests.cs
@@ -18,7 +18,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeNoDocumentation(string typeName)
@@ -27,7 +27,7 @@
 {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithDocumentation(string typeName)
@@ -39,7 +39,7 @@
 {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithInheritedDocumentation(string typeName)
@@ -49,7 +49,7 @@
 {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithoutDocumentation(string typeName)
@@ -63,103 +63,103 @@ TypeName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEnumWithDocumentation()
         {
-            await this.TestTypeWithDocumentation("enum");
+            await this.TestTypeWithDocumentation("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithDocumentation()
         {
-            await this.TestTypeWithDocumentation("class");
+            await this.TestTypeWithDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithDocumentation()
         {
-            await this.TestTypeWithDocumentation("struct");
+            await this.TestTypeWithDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithDocumentation()
         {
-            await this.TestTypeWithDocumentation("interface");
+            await this.TestTypeWithDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEnumWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("enum");
+            await this.TestTypeWithInheritedDocumentation("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("class");
+            await this.TestTypeWithInheritedDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("struct");
+            await this.TestTypeWithInheritedDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("interface");
+            await this.TestTypeWithInheritedDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEnumWithoutDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("enum");
+            await this.TestTypeWithoutDocumentation("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithoutDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("class");
+            await this.TestTypeWithoutDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithoutDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("struct");
+            await this.TestTypeWithoutDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithoutDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("interface");
+            await this.TestTypeWithoutDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEnumNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("enum");
+            await this.TestTypeNoDocumentation("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("class");
+            await this.TestTypeNoDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("struct");
+            await this.TestTypeNoDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("interface");
+            await this.TestTypeNoDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
@@ -168,7 +168,7 @@ TypeName
             var testCode = @"
 public delegate 
 TypeName();";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -180,7 +180,7 @@ TypeName();";
 /// </summary>
 public delegate 
 TypeName();";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -190,7 +190,7 @@ TypeName();";
 /// <inheritdoc/>
 public delegate 
 TypeName();";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -203,7 +203,7 @@ void TypeName();";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 6);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -217,7 +217,7 @@ public class ClassName
 {
     public void Test() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -234,7 +234,7 @@ public class ClassName
     /// </summary>
     public void Test() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -249,7 +249,7 @@ public class ClassName
     /// <inheritdoc/>
     public void Test() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -267,7 +267,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 17);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -281,7 +281,7 @@ public class ClassName
 {
     public ClassName() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -298,7 +298,7 @@ public class ClassName
     /// </summary>
     public ClassName() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -313,7 +313,7 @@ public class ClassName
     /// <inheritdoc/>
     public ClassName() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -331,7 +331,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 12);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -345,7 +345,7 @@ public class ClassName
 {
     ~ClassName() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -362,7 +362,7 @@ public class ClassName
     /// </summary>
     ~ClassName() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -377,7 +377,7 @@ public class ClassName
     /// <inheritdoc/>
     ~ClassName() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -395,7 +395,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 6);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -412,7 +412,7 @@ public class ClassName
     /// </summary>
     public ClassName Property { get; set; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -427,7 +427,7 @@ public class ClassName
     /// <inheritdoc/>
     public ClassName Property { get; set; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -441,7 +441,7 @@ public class ClassName
 {
     public ClassName Property { get; set; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -459,7 +459,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 22);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -476,7 +476,7 @@ public class ClassName
     /// </summary>
     public ClassName this[string t] { get { return null; } }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -491,7 +491,7 @@ public class ClassName
     /// <inheritdoc/>
     public ClassName this[string t] { get { return null; } }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -505,7 +505,7 @@ public class ClassName
 {
     public ClassName this[string t] { get { return null; } }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -523,7 +523,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 22);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -540,7 +540,7 @@ public class ClassName
     /// </summary>
     public ClassName Foo;
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -555,7 +555,7 @@ public class ClassName
     /// <inheritdoc/>
     public ClassName Foo;
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -569,7 +569,7 @@ public class ClassName
 {
     public ClassName Foo;
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -587,7 +587,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 22);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -604,7 +604,7 @@ public class ClassName
     /// </summary>
     public event System.Action Foo;
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -619,7 +619,7 @@ public class ClassName
     /// <inheritdoc/>
     public event System.Action Foo;
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -633,7 +633,7 @@ public class ClassName
 {
     public ClassName Foo;
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -651,7 +651,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 32);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -668,7 +668,7 @@ public interface InterfaceName
     /// </summary>
     event System.Action Foo { add; remove; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -683,7 +683,7 @@ public interface InterfaceName
     /// <inheritdoc/>
     event System.Action Foo { add; remove; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -697,7 +697,7 @@ public interface InterfaceName
 {
     event System.Action Foo { add; remove; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -715,7 +715,7 @@ public interface InterfaceName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 25);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1605UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1605UnitTests.cs
@@ -18,7 +18,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeNoDocumentation(string typeName)
@@ -27,7 +27,7 @@
 partial {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithSummaryDocumentation(string typeName)
@@ -39,7 +39,7 @@ partial {0} TypeName
 partial {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithContentDocumentation(string typeName)
@@ -51,7 +51,7 @@ partial {0} TypeName
 partial {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithInheritedDocumentation(string typeName)
@@ -61,7 +61,7 @@ partial {0} TypeName
 partial {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithoutDocumentation(string typeName)
@@ -75,103 +75,103 @@ TypeName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithDocumentation()
         {
-            await this.TestTypeWithSummaryDocumentation("class");
+            await this.TestTypeWithSummaryDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithDocumentation()
         {
-            await this.TestTypeWithSummaryDocumentation("struct");
+            await this.TestTypeWithSummaryDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithDocumentation()
         {
-            await this.TestTypeWithSummaryDocumentation("interface");
+            await this.TestTypeWithSummaryDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithContentDocumentation()
         {
-            await this.TestTypeWithContentDocumentation("class");
+            await this.TestTypeWithContentDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithContentDocumentation()
         {
-            await this.TestTypeWithContentDocumentation("struct");
+            await this.TestTypeWithContentDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithContentDocumentation()
         {
-            await this.TestTypeWithContentDocumentation("interface");
+            await this.TestTypeWithContentDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("class");
+            await this.TestTypeWithInheritedDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("struct");
+            await this.TestTypeWithInheritedDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("interface");
+            await this.TestTypeWithInheritedDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithoutDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("class");
+            await this.TestTypeWithoutDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithoutDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("struct");
+            await this.TestTypeWithoutDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithoutDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("interface");
+            await this.TestTypeWithoutDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEnumNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("enum");
+            await this.TestTypeNoDocumentation("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("class");
+            await this.TestTypeNoDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("struct");
+            await this.TestTypeNoDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("interface");
+            await this.TestTypeNoDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
@@ -185,7 +185,7 @@ public class ClassName
 {
     partial void Test();
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -202,7 +202,7 @@ public class ClassName
     /// </summary>
     partial void Test();
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -219,7 +219,7 @@ public class ClassName
     /// </content>
     partial void Test();
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -234,7 +234,7 @@ public class ClassName
     /// <inheritdoc/>
     partial void Test();
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -252,7 +252,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 18);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1606UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1606UnitTests.cs
@@ -18,7 +18,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeNoDocumentation(string typeName)
@@ -27,7 +27,7 @@
 {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithDocumentation(string typeName)
@@ -39,7 +39,7 @@
 {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithInheritedDocumentation(string typeName)
@@ -49,7 +49,7 @@
 {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithoutDocumentation(string typeName)
@@ -65,103 +65,103 @@ TypeName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEnumWithDocumentation()
         {
-            await this.TestTypeWithDocumentation("enum");
+            await this.TestTypeWithDocumentation("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithDocumentation()
         {
-            await this.TestTypeWithDocumentation("class");
+            await this.TestTypeWithDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithDocumentation()
         {
-            await this.TestTypeWithDocumentation("struct");
+            await this.TestTypeWithDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithDocumentation()
         {
-            await this.TestTypeWithDocumentation("interface");
+            await this.TestTypeWithDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEnumWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("enum");
+            await this.TestTypeWithInheritedDocumentation("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("class");
+            await this.TestTypeWithInheritedDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("struct");
+            await this.TestTypeWithInheritedDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("interface");
+            await this.TestTypeWithInheritedDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEnumWithoutDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("enum");
+            await this.TestTypeWithoutDocumentation("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithoutDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("class");
+            await this.TestTypeWithoutDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithoutDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("struct");
+            await this.TestTypeWithoutDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithoutDocumentation()
         {
-            await this.TestTypeWithoutDocumentation("interface");
+            await this.TestTypeWithoutDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEnumNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("enum");
+            await this.TestTypeNoDocumentation("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("class");
+            await this.TestTypeNoDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("struct");
+            await this.TestTypeNoDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("interface");
+            await this.TestTypeNoDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
@@ -170,7 +170,7 @@ TypeName
             var testCode = @"
 public delegate 
 TypeName();";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -182,7 +182,7 @@ TypeName();";
 /// </summary>
 public delegate 
 TypeName();";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -192,7 +192,7 @@ TypeName();";
 /// <inheritdoc/>
 public delegate 
 TypeName();";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -207,7 +207,7 @@ void TypeName();";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 6);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -221,7 +221,7 @@ public class ClassName
 {
     public void Test() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -238,7 +238,7 @@ public class ClassName
     /// </summary>
     public void Test() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -253,7 +253,7 @@ public class ClassName
     /// <inheritdoc/>
     public void Test() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -273,7 +273,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 17);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -287,7 +287,7 @@ public class ClassName
 {
     public ClassName() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -304,7 +304,7 @@ public class ClassName
     /// </summary>
     public ClassName() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -319,7 +319,7 @@ public class ClassName
     /// <inheritdoc/>
     public ClassName() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -339,7 +339,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 12);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -353,7 +353,7 @@ public class ClassName
 {
     ~ClassName() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -370,7 +370,7 @@ public class ClassName
     /// </summary>
     ~ClassName() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -385,7 +385,7 @@ public class ClassName
     /// <inheritdoc/>
     ~ClassName() { }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -405,7 +405,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 6);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -422,7 +422,7 @@ public class ClassName
     /// </summary>
     public ClassName Property { get; set; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -437,7 +437,7 @@ public class ClassName
     /// <inheritdoc/>
     public ClassName Property { get; set; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -451,7 +451,7 @@ public class ClassName
 {
     public ClassName Property { get; set; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -471,7 +471,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 22);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -488,7 +488,7 @@ public class ClassName
     /// </summary>
     public ClassName this[string t] { get { return null; } }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -503,7 +503,7 @@ public class ClassName
     /// <inheritdoc/>
     public ClassName this[string t] { get { return null; } }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -517,7 +517,7 @@ public class ClassName
 {
     public ClassName this[string t] { get { return null; } }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -537,7 +537,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 22);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -554,7 +554,7 @@ public class ClassName
     /// </summary>
     public ClassName Foo;
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -569,7 +569,7 @@ public class ClassName
     /// <inheritdoc/>
     public ClassName Foo;
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -583,7 +583,7 @@ public class ClassName
 {
     public ClassName Foo;
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -603,7 +603,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 22);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -620,7 +620,7 @@ public class ClassName
     /// </summary>
     public event System.Action Foo;
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -635,7 +635,7 @@ public class ClassName
     /// <inheritdoc/>
     public event System.Action Foo;
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -649,7 +649,7 @@ public class ClassName
 {
     public ClassName Foo;
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -669,7 +669,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 32);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -686,7 +686,7 @@ public interface InterfaceName
     /// </summary>
     event System.Action Foo { add; remove; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -701,7 +701,7 @@ public interface InterfaceName
     /// <inheritdoc/>
     event System.Action Foo { add; remove; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -715,7 +715,7 @@ public interface InterfaceName
 {
     event System.Action Foo { add; remove; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -735,7 +735,7 @@ public interface InterfaceName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 25);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1607UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1607UnitTests.cs
@@ -18,7 +18,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeNoDocumentation(string typeName)
@@ -27,7 +27,7 @@
 partial {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithSummaryDocumentation(string typeName)
@@ -39,7 +39,7 @@ partial {0} TypeName
 partial {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithContentDocumentation(string typeName)
@@ -51,7 +51,7 @@ partial {0} TypeName
 partial {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithInheritedDocumentation(string typeName)
@@ -61,7 +61,7 @@ partial {0} TypeName
 partial {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithoutSummaryDocumentation(string typeName)
@@ -77,7 +77,7 @@ TypeName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithoutContentDocumentation(string typeName)
@@ -93,115 +93,115 @@ TypeName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithDocumentation()
         {
-            await this.TestTypeWithSummaryDocumentation("class");
+            await this.TestTypeWithSummaryDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithDocumentation()
         {
-            await this.TestTypeWithSummaryDocumentation("struct");
+            await this.TestTypeWithSummaryDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithDocumentation()
         {
-            await this.TestTypeWithSummaryDocumentation("interface");
+            await this.TestTypeWithSummaryDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithContentDocumentation()
         {
-            await this.TestTypeWithContentDocumentation("class");
+            await this.TestTypeWithContentDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithContentDocumentation()
         {
-            await this.TestTypeWithContentDocumentation("struct");
+            await this.TestTypeWithContentDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithContentDocumentation()
         {
-            await this.TestTypeWithContentDocumentation("interface");
+            await this.TestTypeWithContentDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("class");
+            await this.TestTypeWithInheritedDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("struct");
+            await this.TestTypeWithInheritedDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("interface");
+            await this.TestTypeWithInheritedDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithoutSummaryDocumentation()
         {
-            await this.TestTypeWithoutSummaryDocumentation("class");
+            await this.TestTypeWithoutSummaryDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithoutContentDocumentation()
         {
-            await this.TestTypeWithoutContentDocumentation("class");
+            await this.TestTypeWithoutContentDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithoutSummaryDocumentation()
         {
-            await this.TestTypeWithoutSummaryDocumentation("struct");
+            await this.TestTypeWithoutSummaryDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithoutContentDocumentation()
         {
-            await this.TestTypeWithoutContentDocumentation("struct");
+            await this.TestTypeWithoutContentDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithoutSummaryDocumentation()
         {
-            await this.TestTypeWithoutSummaryDocumentation("interface");
+            await this.TestTypeWithoutSummaryDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithoutContentDocumentation()
         {
-            await this.TestTypeWithoutContentDocumentation("interface");
+            await this.TestTypeWithoutContentDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("class");
+            await this.TestTypeNoDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("struct");
+            await this.TestTypeNoDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("interface");
+            await this.TestTypeNoDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
@@ -215,7 +215,7 @@ public class ClassName
 {
     partial void Test();
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -232,7 +232,7 @@ public class ClassName
     /// </summary>
     partial void Test();
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -249,7 +249,7 @@ public class ClassName
     /// </content>
     partial void Test();
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -264,7 +264,7 @@ public class ClassName
     /// <inheritdoc/>
     partial void Test();
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -284,7 +284,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 18);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -304,7 +304,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 18);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1608UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1608UnitTests.cs
@@ -18,7 +18,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeNoDocumentation(string typeName)
@@ -27,7 +27,7 @@
 {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithSummaryDocumentation(string typeName)
@@ -39,7 +39,7 @@
 {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithContentDocumentation(string typeName)
@@ -51,7 +51,7 @@
 {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithInheritedDocumentation(string typeName)
@@ -61,7 +61,7 @@
 {0} TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithoutSummaryDocumentation(string typeName)
@@ -74,7 +74,7 @@
 TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestTypeWithoutContentDocumentation(string typeName)
@@ -87,115 +87,115 @@ partial {0}
 TypeName
 {{
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithDocumentation()
         {
-            await this.TestTypeWithSummaryDocumentation("class");
+            await this.TestTypeWithSummaryDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithDocumentation()
         {
-            await this.TestTypeWithSummaryDocumentation("struct");
+            await this.TestTypeWithSummaryDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithDocumentation()
         {
-            await this.TestTypeWithSummaryDocumentation("interface");
+            await this.TestTypeWithSummaryDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithContentDocumentation()
         {
-            await this.TestTypeWithContentDocumentation("class");
+            await this.TestTypeWithContentDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithContentDocumentation()
         {
-            await this.TestTypeWithContentDocumentation("struct");
+            await this.TestTypeWithContentDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithContentDocumentation()
         {
-            await this.TestTypeWithContentDocumentation("interface");
+            await this.TestTypeWithContentDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("class");
+            await this.TestTypeWithInheritedDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("struct");
+            await this.TestTypeWithInheritedDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithInheritedDocumentation()
         {
-            await this.TestTypeWithInheritedDocumentation("interface");
+            await this.TestTypeWithInheritedDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithoutSummaryDocumentation()
         {
-            await this.TestTypeWithoutSummaryDocumentation("class");
+            await this.TestTypeWithoutSummaryDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassWithoutContentDocumentation()
         {
-            await this.TestTypeWithoutContentDocumentation("class");
+            await this.TestTypeWithoutContentDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithoutSummaryDocumentation()
         {
-            await this.TestTypeWithoutSummaryDocumentation("struct");
+            await this.TestTypeWithoutSummaryDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructWithoutContentDocumentation()
         {
-            await this.TestTypeWithoutContentDocumentation("struct");
+            await this.TestTypeWithoutContentDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithoutSummaryDocumentation()
         {
-            await this.TestTypeWithoutSummaryDocumentation("interface");
+            await this.TestTypeWithoutSummaryDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceWithoutContentDocumentation()
         {
-            await this.TestTypeWithoutContentDocumentation("interface");
+            await this.TestTypeWithoutContentDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("class");
+            await this.TestTypeNoDocumentation("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("struct");
+            await this.TestTypeNoDocumentation("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceNoDocumentation()
         {
-            await this.TestTypeNoDocumentation("interface");
+            await this.TestTypeNoDocumentation("interface").ConfigureAwait(false);
         }
 
         [Fact]
@@ -211,7 +211,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(2, 5);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -228,7 +228,7 @@ public class ClassName
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(2, 5);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1609UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1609UnitTests.cs
@@ -18,7 +18,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -38,7 +38,7 @@ public class ClassName
     /// </value>
     public ClassName Property { get; set; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -53,7 +53,7 @@ public class ClassName
     /// <inheritdoc/>
     public ClassName Property { get; set; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ public class ClassName
 {
     public ClassName Property { get; set; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -86,7 +86,7 @@ public class ClassName
 }";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 22);
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1610UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1610UnitTests.cs
@@ -18,7 +18,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
         
         [Fact]
@@ -35,7 +35,7 @@ public class ClassName
     /// </value>
     public ClassName Property { get; set; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ public class ClassName
     /// <inheritdoc/>
     public ClassName Property { get; set; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -64,7 +64,7 @@ public class ClassName
 {
     public ClassName Property { get; set; }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -83,7 +83,7 @@ public class ClassName
 }";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 22);
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
@@ -20,7 +20,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -36,7 +36,7 @@
         }
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
 
@@ -56,25 +56,25 @@
         }}
     }}
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, modifiers), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, modifiers), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEmptyPublicConstructor()
         {
-            await this.TestEmptyConstructor("public");
+            await this.TestEmptyConstructor("public").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEmptyNonPublicConstructor()
         {
-            await this.TestEmptyConstructor("private");
+            await this.TestEmptyConstructor("private").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEmptyStaticConstructor()
         {
-            await this.TestEmptyConstructor("static");
+            await this.TestEmptyConstructor("static").ConfigureAwait(false);
         }
 
         private async Task TestConstructorCorrectDocumentation(string modifiers, string part1, string part2, string part3, bool generic)
@@ -94,7 +94,7 @@
     }}
 }}";
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
             // Then test splitting after the <see> element
             testCode = @"namespace FooNamespace
@@ -112,7 +112,7 @@
     }}
 }}";
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
             // Then test splitting before the <see> element
             testCode = @"namespace FooNamespace
@@ -130,89 +130,89 @@
     }}
 }}";
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestConstructorCorrectDocumentationSimple(string modifiers, string part1, string part2, bool generic)
         {
-            await this.TestConstructorCorrectDocumentation(modifiers, part1, part2, ".", generic);
+            await this.TestConstructorCorrectDocumentation(modifiers, part1, part2, ".", generic).ConfigureAwait(false);
         }
 
         private async Task TestConstructorCorrectDocumentationCustomized(string modifiers, string part1, string part2, bool generic)
         {
-            await this.TestConstructorCorrectDocumentation(modifiers, part1, part2, " with A and B.", generic);
+            await this.TestConstructorCorrectDocumentation(modifiers, part1, part2, " with A and B.", generic).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNonPrivateConstructorCorrectDocumentationSimple()
         {
-            await this.TestConstructorCorrectDocumentationSimple("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false);
+            await this.TestConstructorCorrectDocumentationSimple("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNonPrivateConstructorCorrectDocumentationCustomized()
         {
-            await this.TestConstructorCorrectDocumentationCustomized("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false);
+            await this.TestConstructorCorrectDocumentationCustomized("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNonPrivateConstructorCorrectDocumentationGenericSimple()
         {
-            await this.TestConstructorCorrectDocumentationSimple("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true);
+            await this.TestConstructorCorrectDocumentationSimple("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNonPrivateConstructorCorrectDocumentationGenericCustomized()
         {
-            await this.TestConstructorCorrectDocumentationCustomized("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true);
+            await this.TestConstructorCorrectDocumentationCustomized("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrivateConstructorCorrectDocumentation()
         {
-            await this.TestConstructorCorrectDocumentation("private", PrivateConstructorStandardText[0], PrivateConstructorStandardText[1], string.Empty, false);
+            await this.TestConstructorCorrectDocumentation("private", PrivateConstructorStandardText[0], PrivateConstructorStandardText[1], string.Empty, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrivateConstructorCorrectDocumentation_NonPrivateSimple()
         {
-            await this.TestConstructorCorrectDocumentationSimple("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false);
+            await this.TestConstructorCorrectDocumentationSimple("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrivateConstructorCorrectDocumentation_NonPrivateCustomized()
         {
-            await this.TestConstructorCorrectDocumentationCustomized("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false);
+            await this.TestConstructorCorrectDocumentationCustomized("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrivateConstructorCorrectDocumentationGeneric()
         {
-            await this.TestConstructorCorrectDocumentation("private", PrivateConstructorStandardText[0], PrivateConstructorStandardText[1], string.Empty, true);
+            await this.TestConstructorCorrectDocumentation("private", PrivateConstructorStandardText[0], PrivateConstructorStandardText[1], string.Empty, true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrivateConstructorCorrectDocumentationGeneric_NonPrivateSimple()
         {
-            await this.TestConstructorCorrectDocumentationSimple("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true);
+            await this.TestConstructorCorrectDocumentationSimple("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrivateConstructorCorrectDocumentationGeneric_NonPrivateCustomized()
         {
-            await this.TestConstructorCorrectDocumentationCustomized("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true);
+            await this.TestConstructorCorrectDocumentationCustomized("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticConstructorCorrectDocumentation()
         {
-            await this.TestConstructorCorrectDocumentation("static", StaticConstructorStandardText[0], StaticConstructorStandardText[1], string.Empty, false);
+            await this.TestConstructorCorrectDocumentation("static", StaticConstructorStandardText[0], StaticConstructorStandardText[1], string.Empty, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticConstructorCorrectDocumentationGeneric()
         {
-            await this.TestConstructorCorrectDocumentation("static", StaticConstructorStandardText[0], StaticConstructorStandardText[1], string.Empty, true);
+            await this.TestConstructorCorrectDocumentation("static", StaticConstructorStandardText[0], StaticConstructorStandardText[1], string.Empty, true).ConfigureAwait(false);
         }
 
         private async Task TestConstructorMissingDocumentation(string modifiers, string part1, string part2, bool generic)
@@ -235,7 +235,7 @@
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 13);
 
             await this.VerifyCSharpDiagnosticAsync(testCode,
-                expected, CancellationToken.None);
+                expected, CancellationToken.None).ConfigureAwait(false);
 
 
             var fixedCode = @"namespace FooNamespace
@@ -255,43 +255,43 @@
 
             string part3 = part2.EndsWith(".") ? string.Empty : ".";
             fixedCode = string.Format(fixedCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers);
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNonPrivateConstructorMissingDocumentation()
         {
-            await this.TestConstructorMissingDocumentation("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false);
+            await this.TestConstructorMissingDocumentation("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNonPrivateConstructorMissingDocumentationGeneric()
         {
-            await this.TestConstructorMissingDocumentation("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true);
+            await this.TestConstructorMissingDocumentation("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrivateConstructorMissingDocumentation()
         {
-            await this.TestConstructorMissingDocumentation("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false);
+            await this.TestConstructorMissingDocumentation("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrivateConstructorMissingDocumentationGeneric()
         {
-            await this.TestConstructorMissingDocumentation("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true);
+            await this.TestConstructorMissingDocumentation("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticConstructorMissingDocumentation()
         {
-            await this.TestConstructorMissingDocumentation("static", StaticConstructorStandardText[0], StaticConstructorStandardText[1], false);
+            await this.TestConstructorMissingDocumentation("static", StaticConstructorStandardText[0], StaticConstructorStandardText[1], false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticConstructorMissingDocumentationGeneric()
         {
-            await this.TestConstructorMissingDocumentation("static", StaticConstructorStandardText[0], StaticConstructorStandardText[1], true);
+            await this.TestConstructorMissingDocumentation("static", StaticConstructorStandardText[0], StaticConstructorStandardText[1], true).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1643UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1643UnitTests.cs
@@ -20,7 +20,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -36,7 +36,7 @@
         }
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
 
@@ -55,7 +55,7 @@
         }
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
         private async Task TestDestructorCorrectDocumentation(string part1, string part2, string part3, bool generic)
         {
@@ -74,7 +74,7 @@
     }}
 }}";
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
             // Then test splitting after the <see> element
             testCode = @"namespace FooNamespace
@@ -92,7 +92,7 @@
     }}
 }}";
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
             // Then test splitting before the <see> element
             testCode = @"namespace FooNamespace
@@ -110,41 +110,41 @@
     }}
 }}";
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestDestructorCorrectDocumentationSimpleImpl(string part1, string part2, bool generic)
         {
-            await this.TestDestructorCorrectDocumentation(part1, part2, ".", generic);
+            await this.TestDestructorCorrectDocumentation(part1, part2, ".", generic).ConfigureAwait(false);
         }
 
         private async Task TestDestructorCorrectDocumentationCustomizedImpl(string part1, string part2, bool generic)
         {
-            await this.TestDestructorCorrectDocumentation(part1, part2, " with A and B.", generic);
+            await this.TestDestructorCorrectDocumentation(part1, part2, " with A and B.", generic).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDestructorCorrectDocumentationSimple()
         {
-            await this.TestDestructorCorrectDocumentationSimpleImpl(DestructorStandardText[0], DestructorStandardText[1], false);
+            await this.TestDestructorCorrectDocumentationSimpleImpl(DestructorStandardText[0], DestructorStandardText[1], false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDestructorCorrectDocumentationCustomized()
         {
-            await this.TestDestructorCorrectDocumentationCustomizedImpl(DestructorStandardText[0], DestructorStandardText[1], false);
+            await this.TestDestructorCorrectDocumentationCustomizedImpl(DestructorStandardText[0], DestructorStandardText[1], false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNonPrivateConstructorCorrectDocumentationGenericSimple()
         {
-            await this.TestDestructorCorrectDocumentationSimpleImpl(DestructorStandardText[0], DestructorStandardText[1], true);
+            await this.TestDestructorCorrectDocumentationSimpleImpl(DestructorStandardText[0], DestructorStandardText[1], true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDestructorCorrectDocumentationGenericCustomized()
         {
-            await this.TestDestructorCorrectDocumentationCustomizedImpl(DestructorStandardText[0], DestructorStandardText[1], true);
+            await this.TestDestructorCorrectDocumentationCustomizedImpl(DestructorStandardText[0], DestructorStandardText[1], true).ConfigureAwait(false);
         }
 
         private async Task TestDestructorMissingDocumentationImpl(string part1, string part2, bool generic)
@@ -166,7 +166,7 @@
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 13);
 
             await this.VerifyCSharpDiagnosticAsync(testCode,
-                expected, CancellationToken.None);
+                expected, CancellationToken.None).ConfigureAwait(false);
 
 
             var fixedCode = @"namespace FooNamespace
@@ -185,19 +185,19 @@
 
             string part3 = part2.EndsWith(".") ? string.Empty : ".";
             fixedCode = string.Format(fixedCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3);
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDestructorMissingDocumentation()
         {
-            await this.TestDestructorMissingDocumentationImpl(DestructorStandardText[0], DestructorStandardText[1], false);
+            await this.TestDestructorMissingDocumentationImpl(DestructorStandardText[0], DestructorStandardText[1], false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDestructorMissingDocumentationGeneric()
         {
-            await this.TestDestructorMissingDocumentationImpl(DestructorStandardText[0], DestructorStandardText[1], true);
+            await this.TestDestructorMissingDocumentationImpl(DestructorStandardText[0], DestructorStandardText[1], true).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/CodeFixVerifier.Helper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/CodeFixVerifier.Helper.cs
@@ -90,7 +90,7 @@ namespace TestHelper
         private static async Task<string> GetStringFromDocumentAsync(Document document, CancellationToken cancellationToken)
         {
             var simplifiedDoc = await Simplifier.ReduceAsync(document, Simplifier.Annotation, cancellationToken: cancellationToken).ConfigureAwait(false);
-            var formatted = await Formatter.FormatAsync(simplifiedDoc, Formatter.Annotation, cancellationToken: cancellationToken);
+            var formatted = await Formatter.FormatAsync(simplifiedDoc, Formatter.Annotation, cancellationToken: cancellationToken).ConfigureAwait(false);
             var sourceText = await formatted.GetTextAsync(cancellationToken).ConfigureAwait(false);
             return sourceText.ToString();
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1516UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1516UnitTests.cs
@@ -82,14 +82,14 @@ namespace Foot
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestCorrectSpacing()
         {
             
-            await this.VerifyCSharpDiagnosticAsync(CorrectCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(CorrectCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -159,9 +159,9 @@ namespace Foot
                 this.CSharpDiagnostic().WithLocation(45, 11)
             };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
-            await this.VerifyCSharpFixAsync(testCode, CorrectCode);
+            await this.VerifyCSharpFixAsync(testCode, CorrectCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -186,7 +186,7 @@ namespace Foo
     }
 }
 ";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -223,7 +223,7 @@ namespace Foo
                 this.CSharpDiagnostic().WithLocation(16, 10)
             };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"using System;
 
@@ -251,7 +251,7 @@ namespace Foo
 }
 ";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -276,7 +276,7 @@ public struct Struct
                 this.CSharpDiagnostic().WithLocation(10, 10),
             };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
 
             string fixedCode = @"using System;
@@ -295,7 +295,7 @@ public struct Struct
     void Bar() { }
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -335,7 +335,7 @@ public class Foo
                 this.CSharpDiagnostic().WithLocation(23, 9)
             };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
 
             string fixedCode = @"using System;
@@ -369,7 +369,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1517UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1517UnitTests.cs
@@ -31,7 +31,7 @@ public class Foo
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ public class Foo
         public async Task TestWithBlankLinesAtStartOfFile()
         {
             var testCode = "\r\n\r\n" + BaseCode;
-            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(1, 1), CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(1, 1), CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -51,7 +51,7 @@ public class Foo
         public async Task TestWithBlankLinefeedOnlyLinesAtStartOfFile()
         {
             var testCode = "\n\n" + BaseCode;
-            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(1, 1), CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(1, 1), CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ public class Foo
         public async Task TestWithNonWhitespaceTrivia()
         {
             var testCode = "#if true\r\n" + BaseCode + "\r\n#endif\r\n";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ public class Foo
         public async Task TestWithNonWhitespaceTriviaAndLeadingBlankLines()
         {
             var testCode = "\r\n\r\n#if true\r\n" + BaseCode + "\r\n#endif\r\n";
-            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(1, 1), CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(1, 1), CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ public class Foo
         [Fact]
         public async Task TestWithoutCarriageReturnLineFeedAtStartOfFile()
         {
-            await this.VerifyCSharpDiagnosticAsync(BaseCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(BaseCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ public class Foo
         public async Task TestWithInvalidSpacing()
         {
             var testCode = "    " + BaseCode;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -102,7 +102,7 @@ public class Foo
             var testCode = "\r\n\r\n" + BaseCode;
             var fixedTestCode = BaseCode;
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -114,7 +114,7 @@ public class Foo
             var testCode = "\r\n   " + BaseCode;
             var fixedTestCode = "   " + BaseCode;
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ public class Foo
             var testCode = "   \r\n   \r\n" + BaseCode;
             var fixedTestCode = BaseCode;
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -138,7 +138,7 @@ public class Foo
             var testCode = "\r\n\r\n#if true\r\n" + BaseCode + "\r\n#endif\r\n";
             var fixedTestCode = "#if true\r\n" + BaseCode + "\r\n#endif\r\n";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1518UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1518UnitTests.cs
@@ -31,7 +31,7 @@ public class Foo
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ public class Foo
         public async Task TestWithBlankLinesAtEndOfFile()
         {
             var testCode = BaseCode + "\r\n\r\n";
-            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(9, 1), CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(9, 1), CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -51,7 +51,7 @@ public class Foo
         public async Task TestWithLineFeedOnlyBlankLinesAtEndOfFile()
         {
             var testCode = BaseCode + "\n\n";
-            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(9, 1), CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(9, 1), CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -61,7 +61,7 @@ public class Foo
         public async Task TestWithSingleCarriageReturnLineFeedAtEndOfFile()
         {
             var testCode = BaseCode + "\r\n";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ public class Foo
         public async Task TestWithSingleLineFeedAtEndOfFile()
         {
             var testCode = BaseCode + "\n";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -80,7 +80,7 @@ public class Foo
         [Fact]
         public async Task TestWithoutCarriageReturnLineFeedAtEndOfFile()
         {
-            await this.VerifyCSharpDiagnosticAsync(BaseCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(BaseCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -90,7 +90,7 @@ public class Foo
         public async Task TestFileEndsWithSpaces()
         {
             var testCode = BaseCode + "\r\n          ";
-            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(9, 1), CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(9, 1), CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -100,7 +100,7 @@ public class Foo
         public async Task TestFileEndingWithComment()
         {
             var testCode = BaseCode + "\r\n// Test comment";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -110,7 +110,7 @@ public class Foo
         public async Task TestFileEndingWithCommentAndSpuriousWhitespace()
         {
             var testCode = BaseCode + "\r\n// Test comment\r\n   \r\n";
-            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(10, 1), CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(10, 1), CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -120,7 +120,7 @@ public class Foo
         public async Task TestFileEndingWithEndIf()
         {
             var testCode = "#if true\r\n" + BaseCode + "\r\n#endif\r\n";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -130,7 +130,7 @@ public class Foo
         public async Task TestFileEndingWithEndIfWithSpuriousWhitespace()
         {
             var testCode = "#if true\r\n" + BaseCode + "\r\n#endif\r\n   \r\n";
-            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(11, 1), CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(11, 1), CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -143,7 +143,7 @@ public class Foo
             var testCode = BaseCode + "\r\n\r\n";
             var fixedTestCode = BaseCode + "\r\n";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -156,7 +156,7 @@ public class Foo
             var testCode = BaseCode + "\r\n   \r\n   \r\n";
             var fixedTestCode = BaseCode + "\r\n";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -169,7 +169,7 @@ public class Foo
             var testCode = BaseCode + "\n   \n   \n";
             var fixedTestCode = BaseCode + "\n";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -182,7 +182,7 @@ public class Foo
             var testCode = "#if true\r\n" + BaseCode + "\r\n#endif\r\n   \r\n";
             var fixedTestCode = "#if true\r\n" + BaseCode + "\r\n#endif\r\n";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/DebugMessagesUnitTestsBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/DebugMessagesUnitTestsBase.cs
@@ -28,133 +28,133 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Field_Pass()
         {
-            await this.TestConstantMessage_Field_Pass("\" foo \"");
+            await this.TestConstantMessage_Field_Pass("\" foo \"").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Field_PassExpression()
         {
-            await this.TestConstantMessage_Field_Pass("\" \" + \"foo\" + \" \"");
+            await this.TestConstantMessage_Field_Pass("\" \" + \"foo\" + \" \"").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Field_PassWrongType()
         {
-            await this.TestConstantMessage_Field_Pass("3");
+            await this.TestConstantMessage_Field_Pass("3").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Local_Pass()
         {
-            await this.TestConstantMessage_Local_Pass("\" foo \"");
+            await this.TestConstantMessage_Local_Pass("\" foo \"").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Local_PassExpression()
         {
-            await this.TestConstantMessage_Local_Pass("\" \" + \"foo\" + \" \"");
+            await this.TestConstantMessage_Local_Pass("\" \" + \"foo\" + \" \"").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Local_PassWrongType()
         {
-            await this.TestConstantMessage_Local_Pass("3");
+            await this.TestConstantMessage_Local_Pass("3").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Inline_Pass()
         {
-            await this.TestConstantMessage_Inline_Pass("\" foo \"");
+            await this.TestConstantMessage_Inline_Pass("\" foo \"").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Inline_PassExpression()
         {
-            await this.TestConstantMessage_Inline_Pass("\" \" + \"foo\" + \" \"");
+            await this.TestConstantMessage_Inline_Pass("\" \" + \"foo\" + \" \"").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Inline_PassWrongType()
         {
-            await this.TestConstantMessage_Inline_Pass("3");
+            await this.TestConstantMessage_Inline_Pass("3").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Field_FailNull()
         {
-            await this.TestConstantMessage_Field_Fail("null");
+            await this.TestConstantMessage_Field_Fail("null").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Field_FailEmpty()
         {
-            await this.TestConstantMessage_Field_Fail("\"\"");
+            await this.TestConstantMessage_Field_Fail("\"\"").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Field_FailWhitespace()
         {
-            await this.TestConstantMessage_Field_Fail("\"  \"");
+            await this.TestConstantMessage_Field_Fail("\"  \"").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Field_FailExpressionWhitespace()
         {
-            await this.TestConstantMessage_Field_Fail("\"  \" + \"  \"");
+            await this.TestConstantMessage_Field_Fail("\"  \" + \"  \"").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Local_FailNull()
         {
-            await this.TestConstantMessage_Local_Fail("null");
+            await this.TestConstantMessage_Local_Fail("null").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Local_FailEmpty()
         {
-            await this.TestConstantMessage_Local_Fail("\"\"");
+            await this.TestConstantMessage_Local_Fail("\"\"").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Local_FailWhitespace()
         {
-            await this.TestConstantMessage_Local_Fail("\"  \"");
+            await this.TestConstantMessage_Local_Fail("\"  \"").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Local_FailExpressionWhitespace()
         {
-            await this.TestConstantMessage_Local_Fail("\"  \" + \"  \"");
+            await this.TestConstantMessage_Local_Fail("\"  \" + \"  \"").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Inline_FailNull()
         {
-            await this.TestConstantMessage_Inline_Fail("null");
+            await this.TestConstantMessage_Inline_Fail("null").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Inline_FailEmpty()
         {
-            await this.TestConstantMessage_Inline_Fail("\"\"");
+            await this.TestConstantMessage_Inline_Fail("\"\"").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Inline_FailWhitespace()
         {
-            await this.TestConstantMessage_Inline_Fail("\"  \"");
+            await this.TestConstantMessage_Inline_Fail("\"  \"").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstantMessage_Inline_FailExpressionWhitespace()
         {
-            await this.TestConstantMessage_Inline_Fail("\"  \" + \"  \"");
+            await this.TestConstantMessage_Inline_Fail("\"  \" + \"  \"").ConfigureAwait(false);
         }
 
         private async Task TestConstantMessage_Field_Pass(string argument)
@@ -169,7 +169,7 @@ public class Foo
     }}}}
 }}}}";
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(this.BuildTestCode(testCodeFormat), argument), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(this.BuildTestCode(testCodeFormat), argument), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestConstantMessage_Local_Pass(string argument)
@@ -184,7 +184,7 @@ public class Foo
     }}}}
 }}}}";
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(this.BuildTestCode(testCodeFormat), argument), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(this.BuildTestCode(testCodeFormat), argument), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestConstantMessage_Inline_Pass(string argument)
@@ -198,7 +198,7 @@ public class Foo
     }}}}
 }}}}";
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(this.BuildTestCode(testCodeFormat), argument), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(this.BuildTestCode(testCodeFormat), argument), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestConstantMessage_Field_Fail(string argument)
@@ -215,7 +215,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(this.BuildTestCode(testCodeFormat), argument), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(this.BuildTestCode(testCodeFormat), argument), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestConstantMessage_Local_Fail(string argument)
@@ -232,7 +232,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(this.BuildTestCode(testCodeFormat), argument), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(this.BuildTestCode(testCodeFormat), argument), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestConstantMessage_Inline_Fail(string argument)
@@ -248,7 +248,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(this.BuildTestCode(testCodeFormat), argument), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(this.BuildTestCode(testCodeFormat), argument), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -263,7 +263,7 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyCSharpDiagnosticAsync(this.BuildTestCode(testCode), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(this.BuildTestCode(testCode), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -287,7 +287,7 @@ class Debug
 }}
 ";
 
-            await this.VerifyCSharpDiagnosticAsync(this.BuildTestCode(testCode), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(this.BuildTestCode(testCode), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -302,7 +302,7 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected virtual string BuildTestCode(string format)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/FileMayOnlyContainTestBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/FileMayOnlyContainTestBase.cs
@@ -23,7 +23,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -32,7 +32,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
             var testCode = @"%1 Foo
 {
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode.Replace("%1", this.Keyword), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode.Replace("%1", this.Keyword), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, this.Keyword.Length + 2);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode.Replace("%1", this.Keyword), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode.Replace("%1", this.Keyword), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
                     this.CSharpDiagnostic().WithLocation(7, this.Keyword.Length + 2)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode.Replace("%1", this.Keyword), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode.Replace("%1", this.Keyword), expected, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1119UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1119UnitTests.cs
@@ -17,7 +17,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -30,7 +30,7 @@
         int x = 1;
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -51,7 +51,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(5, 19)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -60,7 +60,7 @@
         int x = 1;
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -84,7 +84,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(5, 21),
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -93,7 +93,7 @@
         int x = 1;
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -106,7 +106,7 @@
         int x = ToString();
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -127,7 +127,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(5, 31)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -136,7 +136,7 @@
         string x = ToString();
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -150,7 +150,7 @@
         int x = Local + Local.IndexOf('x');
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -174,7 +174,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(6, 59),
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -184,7 +184,7 @@
         string x = Local.ToString() + Local.IndexOf('x');
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -198,7 +198,7 @@
         this.Local = Local;
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -220,7 +220,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(6, 20)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -230,7 +230,7 @@
         this.Local = Local;
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -251,7 +251,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(6, 23)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -261,7 +261,7 @@
         int x = Local;
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -274,7 +274,7 @@
         int x = (int)3;
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -295,7 +295,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(5, 24)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -304,7 +304,7 @@
         int x = (int)3;
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -318,7 +318,7 @@
         x = (int)3;
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -339,7 +339,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(6, 20)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -349,7 +349,7 @@
         x = (int)3;
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -362,7 +362,7 @@
         string x = ((int)3).ToString();
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -376,7 +376,7 @@
         x = ((int)3).ToString();
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -395,7 +395,7 @@
         x = -x;
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -436,7 +436,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(11, 16),
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -451,7 +451,7 @@
         x = -x;
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -465,7 +465,7 @@
         x = 3 * unchecked(5);
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -490,7 +490,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(6, 30),
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -500,7 +500,7 @@
         x = 3 * unchecked(5);
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -513,7 +513,7 @@
         string x = nameof(Foo) + ""Bar"";
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -533,7 +533,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(5, 32)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -542,7 +542,7 @@
         string x = nameof(Foo) + ""Bar"";
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -555,7 +555,7 @@
         bool x = "" is string;
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -568,7 +568,7 @@
         string x = ("""" is string).ToString();
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -592,7 +592,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(6, 26),
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -602,7 +602,7 @@
         x = """" is string;
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -616,7 +616,7 @@
         string x = y = ""foo"";
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -637,7 +637,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(6, 30)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -647,7 +647,7 @@
         string x = y = ""foo"";
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -662,7 +662,7 @@
         x = (y = ""foo"").ToString();
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -675,7 +675,7 @@
         string x = true ? ""foo"" : ""bar"";
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -695,7 +695,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(5, 41)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -704,7 +704,7 @@
         string x = true ? ""foo"" : ""bar"";
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -718,7 +718,7 @@
         string x = (true ? ""foo"" : ""bar"").ToString();
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -731,7 +731,7 @@
         string x = ""foo"" ?? ""bar"";
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -751,7 +751,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(5, 35)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -760,7 +760,7 @@
         string x = ""foo"" ?? ""bar"";
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -774,7 +774,7 @@
         string x = (""foo"" ?? ""bar"").ToString();
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -788,7 +788,7 @@
         System.Func<string, string> y = (v) => v;
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -812,7 +812,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(6, 50),
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -822,7 +822,7 @@
         System.Func<string, string> y = (v) => v;
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -836,7 +836,7 @@
         string y = ((v) => v)(""foo"");
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -849,7 +849,7 @@
         int[] x = new int[10];
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -869,7 +869,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(5, 31)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -878,7 +878,7 @@
         int[] x = new int[10];
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -891,7 +891,7 @@
         string x = (new int[10]).ToString();
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -904,7 +904,7 @@
         var x = from y in new int[10] select y + 1;
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -924,7 +924,7 @@
                     this.CSharpDiagnostic(ParenthesesDiagnosticId).WithLocation(5, 52)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -933,7 +933,7 @@
         var x = from y in new int[10] select y + 1;
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -946,7 +946,7 @@
         var x = (from y in new int[10] select y + 1).ToString();
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -959,7 +959,7 @@
         var x = (await System.Threading.Tasks.Task.Delay(10).ContinueWith(() => System.Threading.Tasks.Task.FromResult(1))).ToString();
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -974,7 +974,7 @@
         var z = 1 * ~(1 + 1);
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -1004,7 +1004,7 @@
                 ;
         }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -1016,7 +1016,7 @@
             var fixedCode = @"#if NET20 || NET35
 // Foo
 #endif";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1400UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1400UnitTests.cs
@@ -18,241 +18,241 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassDeclarationAsync()
         {
-            await this.TestTypeDeclarationAsync("class");
+            await this.TestTypeDeclarationAsync("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassDeclarationWithAttributesAsync()
         {
-            await this.TestTypeDeclarationWithAttributesAsync("class");
+            await this.TestTypeDeclarationWithAttributesAsync("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestClassDeclarationWithDirectivesAsync()
         {
-            await this.TestTypeDeclarationWithDirectivesAsync("class");
+            await this.TestTypeDeclarationWithDirectivesAsync("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNestedClassDeclarationAsync()
         {
-            await this.TestNestedTypeDeclarationAsync("class");
+            await this.TestNestedTypeDeclarationAsync("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNestedClassDeclarationWithAttributesAsync()
         {
-            await this.TestNestedTypeDeclarationWithAttributesAsync("class");
+            await this.TestNestedTypeDeclarationWithAttributesAsync("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNestedClassDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedTypeDeclarationWithDirectivesAsync("class");
+            await this.TestNestedTypeDeclarationWithDirectivesAsync("class").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPartialClassDeclarationAsync()
         {
-            await this.TestTypeDeclarationAsync("partial class", warning: false);
+            await this.TestTypeDeclarationAsync("partial class", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPartialClassDeclarationWithAttributesAsync()
         {
-            await this.TestTypeDeclarationWithAttributesAsync("partial class", warning: false);
+            await this.TestTypeDeclarationWithAttributesAsync("partial class", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPartialClassDeclarationWithDirectivesAsync()
         {
-            await this.TestTypeDeclarationWithDirectivesAsync("partial class", warning: false);
+            await this.TestTypeDeclarationWithDirectivesAsync("partial class", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceDeclarationAsync()
         {
-            await this.TestTypeDeclarationAsync("interface");
+            await this.TestTypeDeclarationAsync("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceDeclarationWithAttributesAsync()
         {
-            await this.TestTypeDeclarationWithAttributesAsync("interface");
+            await this.TestTypeDeclarationWithAttributesAsync("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceDeclarationWithDirectivesAsync()
         {
-            await this.TestTypeDeclarationWithDirectivesAsync("interface");
+            await this.TestTypeDeclarationWithDirectivesAsync("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNestedInterfaceDeclarationAsync()
         {
-            await this.TestNestedTypeDeclarationAsync("interface");
+            await this.TestNestedTypeDeclarationAsync("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNestedInterfaceDeclarationWithAttributesAsync()
         {
-            await this.TestNestedTypeDeclarationWithAttributesAsync("interface");
+            await this.TestNestedTypeDeclarationWithAttributesAsync("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNestedInterfaceDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedTypeDeclarationWithDirectivesAsync("interface");
+            await this.TestNestedTypeDeclarationWithDirectivesAsync("interface").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPartialInterfaceDeclarationAsync()
         {
-            await this.TestTypeDeclarationAsync("partial interface", warning: false);
+            await this.TestTypeDeclarationAsync("partial interface", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPartialInterfaceDeclarationWithAttributesAsync()
         {
-            await this.TestTypeDeclarationWithAttributesAsync("partial interface", warning: false);
+            await this.TestTypeDeclarationWithAttributesAsync("partial interface", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPartialInterfaceDeclarationWithDirectivesAsync()
         {
-            await this.TestTypeDeclarationWithDirectivesAsync("partial interface", warning: false);
+            await this.TestTypeDeclarationWithDirectivesAsync("partial interface", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructDeclarationAsync()
         {
-            await this.TestTypeDeclarationAsync("struct");
+            await this.TestTypeDeclarationAsync("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructDeclarationWithAttributesAsync()
         {
-            await this.TestTypeDeclarationWithAttributesAsync("struct");
+            await this.TestTypeDeclarationWithAttributesAsync("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStructDeclarationWithDirectivesAsync()
         {
-            await this.TestTypeDeclarationWithDirectivesAsync("struct");
+            await this.TestTypeDeclarationWithDirectivesAsync("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNestedStructDeclarationAsync()
         {
-            await this.TestNestedTypeDeclarationAsync("struct");
+            await this.TestNestedTypeDeclarationAsync("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNestedStructDeclarationWithAttributesAsync()
         {
-            await this.TestNestedTypeDeclarationWithAttributesAsync("struct");
+            await this.TestNestedTypeDeclarationWithAttributesAsync("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNestedStructDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedTypeDeclarationWithDirectivesAsync("struct");
+            await this.TestNestedTypeDeclarationWithDirectivesAsync("struct").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPartialStructDeclarationAsync()
         {
-            await this.TestTypeDeclarationAsync("partial struct", warning: false);
+            await this.TestTypeDeclarationAsync("partial struct", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPartialStructDeclarationWithAttributesAsync()
         {
-            await this.TestTypeDeclarationWithAttributesAsync("partial struct", warning: false);
+            await this.TestTypeDeclarationWithAttributesAsync("partial struct", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPartialStructDeclarationWithDirectivesAsync()
         {
-            await this.TestTypeDeclarationWithDirectivesAsync("partial struct", warning: false);
+            await this.TestTypeDeclarationWithDirectivesAsync("partial struct", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEnumDeclarationAsync()
         {
-            await this.TestTypeDeclarationAsync("enum");
+            await this.TestTypeDeclarationAsync("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEnumDeclarationWithAttributesAsync()
         {
-            await this.TestTypeDeclarationWithAttributesAsync("enum");
+            await this.TestTypeDeclarationWithAttributesAsync("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEnumDeclarationWithDirectivesAsync()
         {
-            await this.TestTypeDeclarationWithDirectivesAsync("enum");
+            await this.TestTypeDeclarationWithDirectivesAsync("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNestedEnumDeclarationAsync()
         {
-            await this.TestNestedTypeDeclarationAsync("enum");
+            await this.TestNestedTypeDeclarationAsync("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNestedEnumDeclarationWithAttributesAsync()
         {
-            await this.TestNestedTypeDeclarationWithAttributesAsync("enum");
+            await this.TestNestedTypeDeclarationWithAttributesAsync("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNestedEnumDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedTypeDeclarationWithDirectivesAsync("enum");
+            await this.TestNestedTypeDeclarationWithDirectivesAsync("enum").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDelegateDeclarationAsync()
         {
-            await this.TestDeclarationAsync("internal", "TypeName", "delegate int TypeName", "  ( int\n parameter\n );");
+            await this.TestDeclarationAsync("internal", "TypeName", "delegate int TypeName", "  ( int\n parameter\n );").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDelegateDeclarationWithAttributesAsync()
         {
-            await this.TestDeclarationWithAttributesAsync("internal", "TypeName", "delegate int TypeName", "  ( int\n parameter\n );");
+            await this.TestDeclarationWithAttributesAsync("internal", "TypeName", "delegate int TypeName", "  ( int\n parameter\n );").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDelegateDeclarationWithDirectivesAsync()
         {
-            await this.TestDeclarationWithDirectivesAsync("internal", "TypeName", "delegate int TypeName", "  ( int\n parameter\n );");
+            await this.TestDeclarationWithDirectivesAsync("internal", "TypeName", "delegate int TypeName", "  ( int\n parameter\n );").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNestedDelegateDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "TypeName", "delegate int TypeName", "  ( int\n parameter\n );");
+            await this.TestNestedDeclarationAsync("private", "TypeName", "delegate int TypeName", "  ( int\n parameter\n );").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNestedDelegateDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "TypeName", "delegate int TypeName", "  ( int\n parameter\n );");
+            await this.TestNestedDeclarationWithAttributesAsync("private", "TypeName", "delegate int TypeName", "  ( int\n parameter\n );").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNestedDelegateDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "TypeName", "delegate int TypeName", "  ( int\n parameter\n );");
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "TypeName", "delegate int TypeName", "  ( int\n parameter\n );").ConfigureAwait(false);
         }
 
         #region EventDeclarationSyntax
@@ -260,55 +260,55 @@
         [Fact]
         public async Task TestEventDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "event EventHandler MemberName", "{ add { } remove { } }");
+            await this.TestNestedDeclarationAsync("private", "MemberName", "event EventHandler MemberName", "{ add { } remove { } }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEventDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "event EventHandler MemberName", "{ add { } remove { } }");
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "event EventHandler MemberName", "{ add { } remove { } }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEventDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "event EventHandler MemberName", "{ add { } remove { } }");
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "event EventHandler MemberName", "{ add { } remove { } }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticEventDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "static event EventHandler MemberName", "{ add { } remove { } }");
+            await this.TestNestedDeclarationAsync("private", "MemberName", "static event EventHandler MemberName", "{ add { } remove { } }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticEventDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "static event EventHandler MemberName", "{ add { } remove { } }");
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "static event EventHandler MemberName", "{ add { } remove { } }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticEventDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "static event EventHandler MemberName", "{ add { } remove { } }");
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "static event EventHandler MemberName", "{ add { } remove { } }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestExplicitInterfaceEventDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "event EventHandler IInterface.MemberName", "{ add { } remove { } }", warning: false);
+            await this.TestNestedDeclarationAsync("private", "MemberName", "event EventHandler IInterface.MemberName", "{ add { } remove { } }", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestExplicitInterfaceEventDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "event EventHandler IInterface.MemberName", "{ add { } remove { } }", warning: false);
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "event EventHandler IInterface.MemberName", "{ add { } remove { } }", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestExplicitInterfaceEventDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "event EventHandler IInterface.MemberName", "{ add { } remove { } }", warning: false);
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "event EventHandler IInterface.MemberName", "{ add { } remove { } }", warning: false).ConfigureAwait(false);
         }
 
         #endregion
@@ -318,91 +318,91 @@
         [Fact]
         public async Task TestMethodDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "void MemberName", "  ( int\n parameter\n ) { }");
+            await this.TestNestedDeclarationAsync("private", "MemberName", "void MemberName", "  ( int\n parameter\n ) { }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestMethodDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "void MemberName", "  ( int\n parameter\n ) { }");
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "void MemberName", "  ( int\n parameter\n ) { }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestMethodDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "void MemberName", "  ( int\n parameter\n ) { }");
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "void MemberName", "  ( int\n parameter\n ) { }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticMethodDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "static void MemberName", "  ( int\n parameter\n ) { }");
+            await this.TestNestedDeclarationAsync("private", "MemberName", "static void MemberName", "  ( int\n parameter\n ) { }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticMethodDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "static void MemberName", "  ( int\n parameter\n ) { }");
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "static void MemberName", "  ( int\n parameter\n ) { }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticMethodDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "static void MemberName", "  ( int\n parameter\n ) { }");
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "static void MemberName", "  ( int\n parameter\n ) { }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestExplicitInterfaceMethodDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "void IInterface.MemberName", "  ( int\n parameter\n ) { }", warning: false);
+            await this.TestNestedDeclarationAsync("private", "MemberName", "void IInterface.MemberName", "  ( int\n parameter\n ) { }", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestExplicitInterfaceMethodDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "void IInterface.MemberName", "  ( int\n parameter\n ) { }", warning: false);
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "void IInterface.MemberName", "  ( int\n parameter\n ) { }", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestExplicitInterfaceMethodDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "void IInterface.MemberName", "  ( int\n parameter\n ) { }", warning: false);
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "void IInterface.MemberName", "  ( int\n parameter\n ) { }", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceMethodDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "void MemberName", "  ( int\n parameter\n );", containingType: "interface", warning: false);
+            await this.TestNestedDeclarationAsync("private", "MemberName", "void MemberName", "  ( int\n parameter\n );", containingType: "interface", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceMethodDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "void MemberName", "  ( int\n parameter\n );", containingType: "interface", warning: false);
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "void MemberName", "  ( int\n parameter\n );", containingType: "interface", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceMethodDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "void MemberName", "  ( int\n parameter\n );", containingType: "interface", warning: false);
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "void MemberName", "  ( int\n parameter\n );", containingType: "interface", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPartialMethodDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "partial void MemberName", "  ( int\n parameter\n );", containingType: "partial class", warning: false);
+            await this.TestNestedDeclarationAsync("private", "MemberName", "partial void MemberName", "  ( int\n parameter\n );", containingType: "partial class", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPartialMethodDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "partial void MemberName", "  ( int\n parameter\n );", containingType: "partial class", warning: false);
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "partial void MemberName", "  ( int\n parameter\n );", containingType: "partial class", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPartialMethodDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "partial void MemberName", "  ( int\n parameter\n );", containingType: "partial class", warning: false);
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "partial void MemberName", "  ( int\n parameter\n );", containingType: "partial class", warning: false).ConfigureAwait(false);
         }
 
         #endregion
@@ -412,73 +412,73 @@
         [Fact]
         public async Task TestPropertyDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "EventHandler MemberName", "{ get; set; }");
+            await this.TestNestedDeclarationAsync("private", "MemberName", "EventHandler MemberName", "{ get; set; }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPropertyDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "EventHandler MemberName", "{ get; set; }");
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "EventHandler MemberName", "{ get; set; }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPropertyDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "EventHandler MemberName", "{ get; set; }");
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "EventHandler MemberName", "{ get; set; }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticPropertyDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "static EventHandler MemberName", "{ get; set; }");
+            await this.TestNestedDeclarationAsync("private", "MemberName", "static EventHandler MemberName", "{ get; set; }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticPropertyDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "static EventHandler MemberName", "{ get; set; }");
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "static EventHandler MemberName", "{ get; set; }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticPropertyDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "static EventHandler MemberName", "{ get; set; }");
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "static EventHandler MemberName", "{ get; set; }").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestExplicitInterfacePropertyDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "EventHandler IInterface.MemberName", "{ get; set; }", warning: false);
+            await this.TestNestedDeclarationAsync("private", "MemberName", "EventHandler IInterface.MemberName", "{ get; set; }", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestExplicitInterfacePropertyDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "EventHandler IInterface.MemberName", "{ get; set; }", warning: false);
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "EventHandler IInterface.MemberName", "{ get; set; }", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestExplicitInterfacePropertyDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "EventHandler IInterface.MemberName", "{ get; set; }", warning: false);
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "EventHandler IInterface.MemberName", "{ get; set; }", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfacePropertyDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "EventHandler MemberName", "{ get; set; }", containingType: "interface", warning: false);
+            await this.TestNestedDeclarationAsync("private", "MemberName", "EventHandler MemberName", "{ get; set; }", containingType: "interface", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfacePropertyDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "EventHandler MemberName", "{ get; set; }", containingType: "interface", warning: false);
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "EventHandler MemberName", "{ get; set; }", containingType: "interface", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfacePropertyDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "EventHandler MemberName", "{ get; set; }", containingType: "interface", warning: false);
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "EventHandler MemberName", "{ get; set; }", containingType: "interface", warning: false).ConfigureAwait(false);
         }
 
         #endregion
@@ -488,55 +488,55 @@
         [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestEventFieldDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "event EventHandler MemberName", ", AnotherMemberName;");
+            await this.TestNestedDeclarationAsync("private", "MemberName", "event EventHandler MemberName", ", AnotherMemberName;").ConfigureAwait(false);
         }
 
         [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestEventFieldDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "event EventHandler MemberName", ", AnotherMemberName;");
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "event EventHandler MemberName", ", AnotherMemberName;").ConfigureAwait(false);
         }
 
         [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestEventFieldDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "event EventHandler MemberName", ", AnotherMemberName;");
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "event EventHandler MemberName", ", AnotherMemberName;").ConfigureAwait(false);
         }
 
         [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestStaticEventFieldDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "static event EventHandler MemberName", ", AnotherMemberName;");
+            await this.TestNestedDeclarationAsync("private", "MemberName", "static event EventHandler MemberName", ", AnotherMemberName;").ConfigureAwait(false);
         }
 
         [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestStaticEventFieldDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "static event EventHandler MemberName", ", AnotherMemberName;");
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "static event EventHandler MemberName", ", AnotherMemberName;").ConfigureAwait(false);
         }
 
         [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestStaticEventFieldDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "static event EventHandler MemberName", ", AnotherMemberName;");
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "static event EventHandler MemberName", ", AnotherMemberName;").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceEventFieldDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "event EventHandler MemberName", ", AnotherMemberName;", containingType: "interface", warning: false);
+            await this.TestNestedDeclarationAsync("private", "MemberName", "event EventHandler MemberName", ", AnotherMemberName;", containingType: "interface", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceEventFieldDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "event EventHandler MemberName", ", AnotherMemberName;", containingType: "interface", warning: false);
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "event EventHandler MemberName", ", AnotherMemberName;", containingType: "interface", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestInterfaceEventFieldDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "event EventHandler MemberName", ", AnotherMemberName;", containingType: "interface", warning: false);
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "event EventHandler MemberName", ", AnotherMemberName;", containingType: "interface", warning: false).ConfigureAwait(false);
         }
 
         #endregion
@@ -546,37 +546,37 @@
         [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestFieldDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "System.EventHandler MemberName", ", AnotherMemberName;");
+            await this.TestNestedDeclarationAsync("private", "MemberName", "System.EventHandler MemberName", ", AnotherMemberName;").ConfigureAwait(false);
         }
 
         [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestFieldDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "System.EventHandler MemberName", ", AnotherMemberName;");
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "System.EventHandler MemberName", ", AnotherMemberName;").ConfigureAwait(false);
         }
 
         [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestFieldDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "System.EventHandler MemberName", ", AnotherMemberName;");
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "System.EventHandler MemberName", ", AnotherMemberName;").ConfigureAwait(false);
         }
 
         [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestStaticFieldDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "MemberName", "static System.EventHandler MemberName", ", AnotherMemberName;");
+            await this.TestNestedDeclarationAsync("private", "MemberName", "static System.EventHandler MemberName", ", AnotherMemberName;").ConfigureAwait(false);
         }
 
         [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestStaticFieldDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "static System.EventHandler MemberName", ", AnotherMemberName;");
+            await this.TestNestedDeclarationWithAttributesAsync("private", "MemberName", "static System.EventHandler MemberName", ", AnotherMemberName;").ConfigureAwait(false);
         }
 
         [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestStaticFieldDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "static System.EventHandler MemberName", ", AnotherMemberName;");
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "MemberName", "static System.EventHandler MemberName", ", AnotherMemberName;").ConfigureAwait(false);
         }
 
         #endregion
@@ -586,19 +586,19 @@
         [Fact]
         public async Task TestOperatorDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("public", "+", "static OuterTypeName operator +", "  ( OuterTypeName x,OuterTypeName  y ) { throw new System.Exception(); }", elementName: "op_Addition");
+            await this.TestNestedDeclarationAsync("public", "+", "static OuterTypeName operator +", "  ( OuterTypeName x,OuterTypeName  y ) { throw new System.Exception(); }", elementName: "op_Addition").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestOperatorDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("public", "+", "static OuterTypeName operator +", "  ( OuterTypeName x,OuterTypeName  y ) { throw new System.Exception(); }", elementName: "op_Addition");
+            await this.TestNestedDeclarationWithAttributesAsync("public", "+", "static OuterTypeName operator +", "  ( OuterTypeName x,OuterTypeName  y ) { throw new System.Exception(); }", elementName: "op_Addition").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestOperatorDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("public", "+", "static OuterTypeName operator +", "  ( OuterTypeName x,OuterTypeName  y ) { throw new System.Exception(); }", elementName: "op_Addition");
+            await this.TestNestedDeclarationWithDirectivesAsync("public", "+", "static OuterTypeName operator +", "  ( OuterTypeName x,OuterTypeName  y ) { throw new System.Exception(); }", elementName: "op_Addition").ConfigureAwait(false);
         }
 
         #endregion
@@ -608,19 +608,19 @@
         [Fact]
         public async Task TestConversionOperatorDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("public", "bool", "static explicit operator bool", "  ( OuterTypeName x ) { throw new System.Exception(); }", elementName: "op_Explicit");
+            await this.TestNestedDeclarationAsync("public", "bool", "static explicit operator bool", "  ( OuterTypeName x ) { throw new System.Exception(); }", elementName: "op_Explicit").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConversionOperatorDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("public", "bool", "static explicit operator bool", "  ( OuterTypeName x ) { throw new System.Exception(); }", elementName: "op_Explicit");
+            await this.TestNestedDeclarationWithAttributesAsync("public", "bool", "static explicit operator bool", "  ( OuterTypeName x ) { throw new System.Exception(); }", elementName: "op_Explicit").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConversionOperatorDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("public", "bool", "static explicit operator bool", "  ( OuterTypeName x ) { throw new System.Exception(); }", elementName: "op_Explicit");
+            await this.TestNestedDeclarationWithDirectivesAsync("public", "bool", "static explicit operator bool", "  ( OuterTypeName x ) { throw new System.Exception(); }", elementName: "op_Explicit").ConfigureAwait(false);
         }
 
         #endregion
@@ -630,37 +630,37 @@
         [Fact]
         public async Task TestIndexerDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "this", "EventHandler this[int", " index ] { get { throw new System.Exception(); } set { throw new System.Exception(); } }", elementName: "this[]");
+            await this.TestNestedDeclarationAsync("private", "this", "EventHandler this[int", " index ] { get { throw new System.Exception(); } set { throw new System.Exception(); } }", elementName: "this[]").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestIndexerDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "this", "EventHandler this[int", " index ] { get { throw new System.Exception(); } set { throw new System.Exception(); } }", elementName: "this[]");
+            await this.TestNestedDeclarationWithAttributesAsync("private", "this", "EventHandler this[int", " index ] { get { throw new System.Exception(); } set { throw new System.Exception(); } }", elementName: "this[]").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestIndexerDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "this", "EventHandler this[int", " index ] { get { throw new System.Exception(); } set { throw new System.Exception(); } }", elementName: "this[]");
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "this", "EventHandler this[int", " index ] { get { throw new System.Exception(); } set { throw new System.Exception(); } }", elementName: "this[]").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestExplicitInterfaceIndexerDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "this", "EventHandler IInterface.this[int", " index ] { get { throw new System.Exception(); } set { throw new System.Exception(); } }", warning: false);
+            await this.TestNestedDeclarationAsync("private", "this", "EventHandler IInterface.this[int", " index ] { get { throw new System.Exception(); } set { throw new System.Exception(); } }", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestExplicitInterfaceIndexerDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "this", "EventHandler IInterface.this[int", " index ] { get { throw new System.Exception(); } set { throw new System.Exception(); } }", warning: false);
+            await this.TestNestedDeclarationWithAttributesAsync("private", "this", "EventHandler IInterface.this[int", " index ] { get { throw new System.Exception(); } set { throw new System.Exception(); } }", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestExplicitInterfaceIndexerDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "this", "EventHandler IInterface.this[int", " index ] { get { throw new System.Exception(); } set { throw new System.Exception(); } }", warning: false);
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "this", "EventHandler IInterface.this[int", " index ] { get { throw new System.Exception(); } set { throw new System.Exception(); } }", warning: false).ConfigureAwait(false);
         }
 
         #endregion
@@ -670,69 +670,69 @@
         [Fact]
         public async Task TestConstructorDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "OuterTypeName", "OuterTypeName(", " ) { }", elementName: ".ctor");
+            await this.TestNestedDeclarationAsync("private", "OuterTypeName", "OuterTypeName(", " ) { }", elementName: ".ctor").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstructorDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "OuterTypeName", "OuterTypeName(", " ) { }", elementName: ".ctor");
+            await this.TestNestedDeclarationWithAttributesAsync("private", "OuterTypeName", "OuterTypeName(", " ) { }", elementName: ".ctor").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstructorDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "OuterTypeName", "OuterTypeName(", " ) { }", elementName: ".ctor");
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "OuterTypeName", "OuterTypeName(", " ) { }", elementName: ".ctor").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticConstructorDeclarationAsync()
         {
-            await this.TestNestedDeclarationAsync("private", "OuterTypeName", "static OuterTypeName(", " ) { }", warning: false);
+            await this.TestNestedDeclarationAsync("private", "OuterTypeName", "static OuterTypeName(", " ) { }", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticConstructorDeclarationWithAttributesAsync()
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "OuterTypeName", "static OuterTypeName(", " ) { }", warning: false);
+            await this.TestNestedDeclarationWithAttributesAsync("private", "OuterTypeName", "static OuterTypeName(", " ) { }", warning: false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticConstructorDeclarationWithDirectivesAsync()
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "OuterTypeName", "static OuterTypeName(", " ) { }", warning: false);
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "OuterTypeName", "static OuterTypeName(", " ) { }", warning: false).ConfigureAwait(false);
         }
 
         #endregion
 
         private async Task TestTypeDeclarationAsync(string keyword, bool warning = true)
         {
-            await this.TestDeclarationAsync("internal", "TypeName", $"{keyword} TypeName", "{\n}", warning: warning);
+            await this.TestDeclarationAsync("internal", "TypeName", $"{keyword} TypeName", "{\n}", warning: warning).ConfigureAwait(false);
         }
 
         private async Task TestTypeDeclarationWithAttributesAsync(string keyword, bool warning = true)
         {
-            await this.TestDeclarationWithAttributesAsync("internal", "TypeName", $"{keyword} TypeName", "{\n}", warning: warning);
+            await this.TestDeclarationWithAttributesAsync("internal", "TypeName", $"{keyword} TypeName", "{\n}", warning: warning).ConfigureAwait(false);
         }
 
         private async Task TestTypeDeclarationWithDirectivesAsync(string keyword, bool warning = true)
         {
-            await this.TestDeclarationWithDirectivesAsync("internal", "TypeName", $"{keyword} TypeName", "{\n}", warning: warning);
+            await this.TestDeclarationWithDirectivesAsync("internal", "TypeName", $"{keyword} TypeName", "{\n}", warning: warning).ConfigureAwait(false);
         }
 
         private async Task TestNestedTypeDeclarationAsync(string keyword, bool warning = true)
         {
-            await this.TestNestedDeclarationAsync("private", "TypeName", $"{keyword} TypeName", "{\n}", warning: warning);
+            await this.TestNestedDeclarationAsync("private", "TypeName", $"{keyword} TypeName", "{\n}", warning: warning).ConfigureAwait(false);
         }
 
         private async Task TestNestedTypeDeclarationWithAttributesAsync(string keyword, bool warning = true)
         {
-            await this.TestNestedDeclarationWithAttributesAsync("private", "TypeName", $"{keyword} TypeName", "{\n}", warning: warning);
+            await this.TestNestedDeclarationWithAttributesAsync("private", "TypeName", $"{keyword} TypeName", "{\n}", warning: warning).ConfigureAwait(false);
         }
 
         private async Task TestNestedTypeDeclarationWithDirectivesAsync(string keyword, bool warning = true)
         {
-            await this.TestNestedDeclarationWithDirectivesAsync("private", "TypeName", $"{keyword} TypeName", "{\n}", warning: warning);
+            await this.TestNestedDeclarationWithDirectivesAsync("private", "TypeName", $"{keyword} TypeName", "{\n}", warning: warning).ConfigureAwait(false);
         }
 
         private async Task TestDeclarationAsync(string modifier, string identifier, string keywordLine, string linesAfter, string elementName = null, bool warning = true)
@@ -743,19 +743,19 @@
 
             if (!warning)
             {
-                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
                 return;
             }
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(elementName ?? identifier).WithLocation(2, 4 + keywordLine.IndexOf(identifier));
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTestCode = $@"
  {Tab} {modifier} {keywordLine}
 {linesAfter}";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
         private async Task TestDeclarationWithAttributesAsync(string modifier, string identifier, string keywordLine, string linesAfter, string elementName = null, bool warning = true)
@@ -767,20 +767,20 @@
 
             if (!warning)
             {
-                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
                 return;
             }
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(elementName ?? identifier).WithLocation(3, 4 + keywordLine.IndexOf(identifier));
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTestCode = $@"
   [Serializable]
  {Tab} {modifier} {keywordLine}
 {linesAfter}";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
         private async Task TestDeclarationWithDirectivesAsync(string modifier, string identifier, string keywordLine, string linesAfter, string elementName = null, bool warning = true)
@@ -793,13 +793,13 @@
 
             if (!warning)
             {
-                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
                 return;
             }
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(elementName ?? identifier).WithLocation(3, 4 + keywordLine.IndexOf(identifier));
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTestCode = $@"
  #  if true
@@ -807,7 +807,7 @@
 # endif
 {linesAfter}";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
         private async Task TestNestedDeclarationAsync(string modifier, string identifier, string keywordLine, string linesAfter, string containingType = "class", string elementName = null, bool warning = true)
@@ -819,20 +819,20 @@ public {containingType} OuterTypeName {{
 
             if (!warning)
             {
-                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
                 return;
             }
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(elementName ?? identifier).WithLocation(3, 4 + keywordLine.IndexOf(identifier));
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTestCode = $@"
 public {containingType} OuterTypeName {{
  {Tab} {modifier} {keywordLine}
 {linesAfter} }}";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
         private async Task TestNestedDeclarationWithAttributesAsync(string modifier, string identifier, string keywordLine, string linesAfter, string containingType = "class", string elementName = null, bool warning = true)
@@ -845,13 +845,13 @@ public {containingType} OuterTypeName {{
 
             if (!warning)
             {
-                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
                 return;
             }
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(elementName ?? identifier).WithLocation(4, 4 + keywordLine.IndexOf(identifier));
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTestCode = $@"
 public {containingType} OuterTypeName {{
@@ -859,7 +859,7 @@ public {containingType} OuterTypeName {{
  {Tab} {modifier} {keywordLine}
 {linesAfter} }}";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
         private async Task TestNestedDeclarationWithDirectivesAsync(string modifier, string identifier, string keywordLine, string linesAfter, string containingType = "class", string elementName = null, bool warning = true)
@@ -873,13 +873,13 @@ public {containingType} OuterTypeName {{
 
             if (!warning)
             {
-                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
                 return;
             }
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(elementName ?? identifier).WithLocation(4, 4 + keywordLine.IndexOf(identifier));
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTestCode = $@"
 public {containingType} OuterTypeName {{
@@ -888,7 +888,7 @@ public {containingType} OuterTypeName {{
 # endif
 {linesAfter} }}";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1401UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1401UnitTests.cs
@@ -15,7 +15,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -28,7 +28,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 19);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -41,7 +41,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 21);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     string bar;
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -63,7 +63,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     public string bar;
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 {
     public const string bar = ""qwe"";
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402UnitTests.cs
@@ -42,7 +42,7 @@ public partial class Foo
 
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
         }
 
@@ -59,7 +59,7 @@ public partial class Bar
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 22);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
         }
 
@@ -74,7 +74,7 @@ public partial class Bar
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1403UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1403UnitTests.cs
@@ -38,7 +38,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 15);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1404UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1404UnitTests.cs
@@ -16,7 +16,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
 
@@ -31,7 +31,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 6);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -65,7 +65,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 66);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 66);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 66);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -115,7 +115,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -133,7 +133,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 66);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -153,7 +153,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 
             try
             {
-                await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+                await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             }
             catch (NullReferenceException)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1405UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1405UnitTests.cs
@@ -49,7 +49,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1407UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1407UnitTests.cs
@@ -16,7 +16,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         int x = 1 - 1 + 1 - 1;
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -42,7 +42,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         int x = 1 / 1 * 1 / 1;
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         int x = 1 >> 1 << 1 >> 1;
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 21);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -80,7 +80,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -95,7 +95,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 17);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -105,7 +105,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         int x = 1 + (1 * 1);
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -131,7 +131,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         int x = (1 * 1) * 1;
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -150,7 +150,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
                     this.CSharpDiagnostic().WithLocation(5, 25)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -160,7 +160,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -179,7 +179,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
                     this.CSharpDiagnostic().WithLocation(5, 26)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -189,7 +189,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -216,7 +216,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1408UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1408UnitTests.cs
@@ -16,7 +16,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         bool x = true || false || true || false;
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -42,7 +42,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         bool x = true && false && true && false;
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 26);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -67,7 +67,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 18);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -92,7 +92,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         bool x = (true || false) && true;
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         bool x = true || (false == true);
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -132,7 +132,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -145,7 +145,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         bool x = (true && false) || true;
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -164,7 +164,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
                     this.CSharpDiagnostic().WithLocation(5, 35)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -174,7 +174,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -201,7 +201,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1410UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1410UnitTests.cs
@@ -16,7 +16,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         System.Func<int> getRandomNumber = delegate { return 3; };
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -42,7 +42,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         System.Func<int, int> getNumber = delegate (int i) { return i; };
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 52);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -79,7 +79,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpFixAsync(oldSource, newSource, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(oldSource, newSource, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -101,7 +101,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpFixAsync(oldSource, newSource, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(oldSource, newSource, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1411UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1411UnitTests.cs
@@ -16,7 +16,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -29,7 +29,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     {
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -42,7 +42,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     {
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -55,7 +55,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     {
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 21);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
                     this.CSharpDiagnostic().WithLocation(3, 67)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -111,7 +111,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpFixAsync(oldSource, newSource, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(oldSource, newSource, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -133,7 +133,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpFixAsync(oldSource, newSource, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(oldSource, newSource, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -155,7 +155,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     }
 }";
 
-            await this.VerifyCSharpFixAsync(oldSource, newSource, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(oldSource, newSource, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
@@ -19,7 +19,7 @@
 
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -32,7 +32,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("test").WithLocation(1, 18);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -43,7 +43,7 @@
 
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -56,7 +56,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("test").WithLocation(1, 14);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -67,7 +67,7 @@
 
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -79,7 +79,7 @@
 }";
 
             // Reported as SA1302
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -90,7 +90,7 @@
 
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -103,7 +103,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("test").WithLocation(1, 15);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -114,7 +114,7 @@
 
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -127,7 +127,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("test").WithLocation(1, 13);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -138,7 +138,7 @@
 public delegate void Test();
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -151,7 +151,7 @@ public delegate void test();
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("test").WithLocation(3, 22);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -174,7 +174,7 @@ public delegate void test();
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -199,7 +199,7 @@ public delegate void test();
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("testEvent").WithLocation(5, 23);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -211,7 +211,7 @@ public delegate void test();
     public event Test TestEvent;
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -225,7 +225,7 @@ public delegate void test();
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("testEvent").WithLocation(4, 23);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -238,7 +238,7 @@ public void Test()
 
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -253,7 +253,7 @@ public void test()
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("test").WithLocation(3, 13);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -264,7 +264,7 @@ public void test()
 public string Test { get; set; }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -277,7 +277,7 @@ public string test { get; set; }
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("test").WithLocation(3, 15);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -288,7 +288,7 @@ public string test { get; set; }
 public string Test;
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -299,7 +299,7 @@ public string Test;
 internal string Test;
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -310,7 +310,7 @@ internal string Test;
 const string Test;
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -321,7 +321,7 @@ const string Test;
 protected readonly string Test;
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -332,7 +332,7 @@ protected readonly string Test;
 protected string Test;
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -343,7 +343,7 @@ protected string Test;
 readonly string test;
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -355,7 +355,7 @@ public string test;
 }";
 
             // Handled by SA1307
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -367,7 +367,7 @@ internal string test;
 }";
 
             // Handled by SA1307
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -379,7 +379,7 @@ const string test;
 }";
 
             // Reported as SA1303
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -390,7 +390,7 @@ const string test;
 public string test;
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -402,7 +402,7 @@ protected readonly string test;
 }";
 
             // Handled by SA1304
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1302UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1302UnitTests.cs
@@ -16,7 +16,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -29,14 +29,14 @@ public interface Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(2, 18);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"
 public interface IFoo
 {
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -52,7 +52,7 @@ public class Bar : Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(2, 18);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"
 public interface IFoo
@@ -63,7 +63,7 @@ public class Bar : IFoo
 }";
 
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -76,14 +76,14 @@ public interface iFoo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(2, 18);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"
 public interface IiFoo
 {
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -99,7 +99,7 @@ public class Bar
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 22);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -109,7 +109,7 @@ public class Bar
 {
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -123,7 +123,7 @@ public class Bar
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -138,7 +138,7 @@ public class NativeMethods
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -155,7 +155,7 @@ public class NativeMethodsClass
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 22);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"
 public class NativeMethodsClass
@@ -166,7 +166,7 @@ public class NativeMethodsClass
     }
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -184,7 +184,7 @@ public class MyNativeMethods
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1303UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1303UnitTests.cs
@@ -15,7 +15,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -28,7 +28,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 25);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
     public const string bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
     public const string bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -64,7 +64,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -94,7 +94,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 25);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -117,7 +117,7 @@ namespace Test
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 36);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -128,7 +128,7 @@ namespace Test
     public const string Bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -140,7 +140,7 @@ namespace Test
 }";
 
             // Fields starting with an underscore are reported as SA1309
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -151,7 +151,7 @@ namespace Test
     public string bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1304UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1304UnitTests.cs
@@ -16,7 +16,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -29,14 +29,14 @@ namespace StyleCop.Analyzers.Test.NamingRules
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 28);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
     public readonly string Bar = ""baz"";
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
     public readonly string Bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -60,13 +60,13 @@ namespace StyleCop.Analyzers.Test.NamingRules
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 31);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
     protected readonly string Bar = ""baz"";
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -77,7 +77,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
     protected readonly string Bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -90,13 +90,13 @@ namespace StyleCop.Analyzers.Test.NamingRules
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 30);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
     internal readonly string Bar = ""baz"";
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -107,7 +107,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
     internal readonly string Bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -118,7 +118,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
     readonly string bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -129,7 +129,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
     public string bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -140,7 +140,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
     private readonly string bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1306UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1306UnitTests.cs
@@ -16,7 +16,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
 
@@ -28,7 +28,7 @@
 string Bar, car, Dar;
 }}";
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, modifiers), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, modifiers), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestThatDiagnosticIsReported_SingleFieldImpl(string modifiers)
@@ -49,7 +49,7 @@ string Dar;
                     this.CSharpDiagnostic().WithArguments("Dar").WithLocation(8, 8)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, modifiers), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, modifiers), expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {{
@@ -61,7 +61,7 @@ string car;
 string dar;
 }}";
 
-            await this.VerifyCSharpFixAsync(string.Format(testCode, modifiers), string.Format(fixedCode, modifiers));
+            await this.VerifyCSharpFixAsync(string.Format(testCode, modifiers), string.Format(fixedCode, modifiers)).ConfigureAwait(false);
         }
 
         private async Task TestThatDiagnosticIsReported_MultipleFieldsImpl(string modifiers)
@@ -78,7 +78,7 @@ string Bar, car, Dar;
                     this.CSharpDiagnostic().WithArguments("Dar").WithLocation(4, 18)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, modifiers), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, modifiers), expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {{
@@ -86,41 +86,41 @@ string Bar, car, Dar;
 string bar, car, dar;
 }}";
 
-            await this.VerifyCSharpFixAsync(string.Format(testCode, modifiers), string.Format(fixedCode, modifiers));
+            await this.VerifyCSharpFixAsync(string.Format(testCode, modifiers), string.Format(fixedCode, modifiers)).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestThatDiagnosticIsReported_SingleField()
         {
-            await this.TestThatDiagnosticIsReported_SingleFieldImpl(string.Empty);
-            await this.TestThatDiagnosticIsReported_SingleFieldImpl("readonly");
-            await this.TestThatDiagnosticIsReported_SingleFieldImpl("private");
-            await this.TestThatDiagnosticIsReported_SingleFieldImpl("private readonly");
+            await this.TestThatDiagnosticIsReported_SingleFieldImpl(string.Empty).ConfigureAwait(false);
+            await this.TestThatDiagnosticIsReported_SingleFieldImpl("readonly").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsReported_SingleFieldImpl("private").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsReported_SingleFieldImpl("private readonly").ConfigureAwait(false);
         }
 
         [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestThatDiagnosticIsReported_MultipleFields()
         {
-            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl(string.Empty);
-            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("readonly");
-            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("private");
-            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("private readonly");
+            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl(string.Empty).ConfigureAwait(false);
+            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("readonly").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("private").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("private readonly").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestThatDiagnosticIsNotReported()
         {
-            await this.TestThatDiagnosticIsNotReportedImpl("const");
-            await this.TestThatDiagnosticIsNotReportedImpl("private const");
-            await this.TestThatDiagnosticIsNotReportedImpl("internal const");
-            await this.TestThatDiagnosticIsNotReportedImpl("protected const");
-            await this.TestThatDiagnosticIsNotReportedImpl("protected internal const");
+            await this.TestThatDiagnosticIsNotReportedImpl("const").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsNotReportedImpl("private const").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsNotReportedImpl("internal const").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsNotReportedImpl("protected const").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsNotReportedImpl("protected internal const").ConfigureAwait(false);
 
-            await this.TestThatDiagnosticIsNotReportedImpl("internal readonly");
-            await this.TestThatDiagnosticIsNotReportedImpl("protected readonly");
-            await this.TestThatDiagnosticIsNotReportedImpl("protected internal readonly");
-            await this.TestThatDiagnosticIsNotReportedImpl("public");
-            await this.TestThatDiagnosticIsNotReportedImpl("internal");
+            await this.TestThatDiagnosticIsNotReportedImpl("internal readonly").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsNotReportedImpl("protected readonly").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsNotReportedImpl("protected internal readonly").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsNotReportedImpl("public").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsNotReportedImpl("internal").ConfigureAwait(false);
         }
 
         [Fact]
@@ -132,7 +132,7 @@ string bar, car, dar;
     public string _bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -143,7 +143,7 @@ string bar, car, dar;
     public string bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -154,7 +154,7 @@ string bar, car, dar;
     string Bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1307UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1307UnitTests.cs
@@ -16,7 +16,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
 
@@ -28,7 +28,7 @@
 string Bar, car, Dar;
 }}";
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, modifiers), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, modifiers), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestThatDiagnosticIsReported_SingleFieldImpl(string modifiers)
@@ -49,7 +49,7 @@ string dar;
                     this.CSharpDiagnostic().WithArguments("dar").WithLocation(8, 8),
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, modifiers), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, modifiers), expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {{
@@ -61,7 +61,7 @@ string Car;
 string Dar;
 }}";
 
-            await this.VerifyCSharpFixAsync(string.Format(testCode, modifiers), string.Format(fixedCode, modifiers));
+            await this.VerifyCSharpFixAsync(string.Format(testCode, modifiers), string.Format(fixedCode, modifiers)).ConfigureAwait(false);
         }
 
         private async Task TestThatDiagnosticIsReported_MultipleFieldsImpl(string modifiers)
@@ -78,7 +78,7 @@ string bar, Car, dar;
                     this.CSharpDiagnostic().WithArguments("dar").WithLocation(4, 18),
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, modifiers), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, modifiers), expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {{
@@ -86,44 +86,44 @@ string bar, Car, dar;
 string Bar, Car, Dar;
 }}";
 
-            await this.VerifyCSharpFixAsync(string.Format(testCode, modifiers), string.Format(fixedCode, modifiers));
+            await this.VerifyCSharpFixAsync(string.Format(testCode, modifiers), string.Format(fixedCode, modifiers)).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestThatDiagnosticIsReported_SingleField()
         {
-            await this.TestThatDiagnosticIsReported_SingleFieldImpl("public");
-            await this.TestThatDiagnosticIsReported_SingleFieldImpl("internal");
-            await this.TestThatDiagnosticIsReported_SingleFieldImpl("protected internal");
-            await this.TestThatDiagnosticIsReported_SingleFieldImpl("public readonly");
-            await this.TestThatDiagnosticIsReported_SingleFieldImpl("internal readonly");
+            await this.TestThatDiagnosticIsReported_SingleFieldImpl("public").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsReported_SingleFieldImpl("internal").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsReported_SingleFieldImpl("protected internal").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsReported_SingleFieldImpl("public readonly").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsReported_SingleFieldImpl("internal readonly").ConfigureAwait(false);
         }
 
         [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
         public async Task TestThatDiagnosticIsReported_MultipleFields()
         {
-            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("public");
-            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("internal");
-            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("protected internal");
-            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("public readonly");
-            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("internal readonly");
+            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("public").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("internal").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("protected internal").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("public readonly").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("internal readonly").ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestThatDiagnosticIsNotReported()
         {
-            await this.TestThatDiagnosticIsNotReportedImpl(string.Empty);
-            await this.TestThatDiagnosticIsNotReportedImpl("readonly");
-            await this.TestThatDiagnosticIsNotReportedImpl("private");
+            await this.TestThatDiagnosticIsNotReportedImpl(string.Empty).ConfigureAwait(false);
+            await this.TestThatDiagnosticIsNotReportedImpl("readonly").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsNotReportedImpl("private").ConfigureAwait(false);
 
-            await this.TestThatDiagnosticIsNotReportedImpl("const");
-            await this.TestThatDiagnosticIsNotReportedImpl("private const");
-            await this.TestThatDiagnosticIsNotReportedImpl("protected const");
-            await this.TestThatDiagnosticIsNotReportedImpl("protected const");
+            await this.TestThatDiagnosticIsNotReportedImpl("const").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsNotReportedImpl("private const").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsNotReportedImpl("protected const").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsNotReportedImpl("protected const").ConfigureAwait(false);
             
-            await this.TestThatDiagnosticIsNotReportedImpl("private readonly");
-            await this.TestThatDiagnosticIsNotReportedImpl("protected readonly");
-            await this.TestThatDiagnosticIsNotReportedImpl("protected internal readonly");
+            await this.TestThatDiagnosticIsNotReportedImpl("private readonly").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsNotReportedImpl("protected readonly").ConfigureAwait(false);
+            await this.TestThatDiagnosticIsNotReportedImpl("protected internal readonly").ConfigureAwait(false);
         }
 
         [Fact]
@@ -135,7 +135,7 @@ string Bar, Car, Dar;
     public string _bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -146,7 +146,7 @@ string Bar, Car, Dar;
     public string bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1309UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1309UnitTests.cs
@@ -16,7 +16,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -29,14 +29,14 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("_bar").WithLocation(3, 19);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
     public string bar = ""baz"";
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -47,7 +47,7 @@
     public string bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -58,7 +58,7 @@
     internal string _bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -71,16 +71,16 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("_bar").WithLocation(3, 21);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class FooNativeMethodsClass
 {
     internal string bar = ""baz"";
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -94,7 +94,7 @@
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1311UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1311UnitTests.cs
@@ -16,7 +16,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -29,14 +29,14 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 35);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
     public static readonly string Bar = ""baz"";
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -49,14 +49,14 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 37);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
     internal static readonly string B = ""baz"";
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -74,7 +74,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 35);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -86,7 +86,7 @@
     }
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -97,7 +97,7 @@
     public static readonly string Bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -108,7 +108,7 @@
     public readonly string bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -119,7 +119,7 @@
     public static string bar = ""baz"";
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -137,7 +137,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 35);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Bar
 {
@@ -149,7 +149,7 @@
     }
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -169,7 +169,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 35);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"public class Foo
 {
@@ -183,7 +183,7 @@
     public static readonly string Bar;
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1212UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1212UnitTests.cs
@@ -15,7 +15,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -42,7 +42,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -87,7 +87,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -107,7 +107,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -124,7 +124,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -151,7 +151,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -176,7 +176,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -196,7 +196,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -216,7 +216,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -232,7 +232,7 @@ public class Foo
     public int Property => field;
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1100UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1100UnitTests.cs
@@ -34,7 +34,7 @@ public class FooChild : Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(14, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public class Foo
@@ -52,7 +52,7 @@ public class FooChild : Foo
         this.Bar();
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -77,7 +77,7 @@ public class FooChild : Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(14, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public class Foo
@@ -95,7 +95,7 @@ public class FooChild : Foo
         this.Bar();
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -122,7 +122,7 @@ public class FooChild : Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -151,7 +151,7 @@ public class FooChild : Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(14, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public class Foo
@@ -173,7 +173,7 @@ public class FooChild : Foo
 
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -200,7 +200,7 @@ public class FooChild : Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -225,7 +225,7 @@ public class FooChild : Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(14, 17);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public class Foo
@@ -243,7 +243,7 @@ public class FooChild : Foo
         var s = this.Bar;
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -271,7 +271,7 @@ public class FooChild : Foo
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(14, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public class Foo
@@ -293,7 +293,7 @@ public class FooChild : Foo
 
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -321,7 +321,7 @@ public class FooChild : Foo
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(14, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public class Foo
@@ -343,7 +343,7 @@ public class FooChild : Foo
 
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -371,7 +371,7 @@ public class FooChild : Foo
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(14, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public class Foo
@@ -393,7 +393,7 @@ public class FooChild : Foo
 
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -421,7 +421,7 @@ public class FooChild : Foo
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(14, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public class Foo
@@ -443,7 +443,7 @@ public class FooChild : Foo
         s = string.Empty;
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -471,7 +471,7 @@ public class FooChild : Foo
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(14, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public class Foo
@@ -493,7 +493,7 @@ public class FooChild : Foo
 
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -521,7 +521,7 @@ public class FooChild : Foo
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(14, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public class Foo
@@ -543,7 +543,7 @@ public class FooChild : Foo
 
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -571,7 +571,7 @@ public class FooChild : Foo
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(14, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public class Foo
@@ -593,7 +593,7 @@ public class FooChild : Foo
         s = string.Empty;
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -621,7 +621,7 @@ public class FooChild : Foo
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(14, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public class Foo
@@ -643,7 +643,7 @@ public class FooChild : Foo
 
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -670,7 +670,7 @@ public class FooChild : Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
         }
 
@@ -698,7 +698,7 @@ public class FooChild : Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
         }
 
@@ -726,7 +726,7 @@ public class FooChild : Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
         }
 
@@ -755,7 +755,7 @@ public class FooChild : Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -780,7 +780,7 @@ public class FooChild : Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(11, 12);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public class Foo
@@ -798,7 +798,7 @@ public class FooChild : Foo
         }
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -824,7 +824,7 @@ public class FooChild : Foo
 }";
 
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -850,7 +850,7 @@ public class FooChild : Foo
 }";
 
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -867,7 +867,7 @@ public struct S
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 16);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public struct S
@@ -877,7 +877,7 @@ public struct S
         return this.ToString();
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -916,7 +916,7 @@ public class FooChild : Foo
                     this.CSharpDiagnostic().WithLocation(24, 9)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public class Foo
@@ -944,7 +944,7 @@ public class FooChild : Foo
         this.Bar2();
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -971,7 +971,7 @@ public class FooChild : Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(14, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public class Foo
@@ -991,7 +991,7 @@ public class FooChild : Foo
         .Bar();
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -1013,7 +1013,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 17);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
             var fixedTest = @"
 public class Foo
@@ -1028,7 +1028,7 @@ public class Foo
         .ToString();
     }
 }";
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1101UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1101UnitTests.cs
@@ -256,13 +256,13 @@
                 this.CSharpDiagnostic().WithLocation(106, 48),
             };
 
-            await this.VerifyCSharpDiagnosticAsync(ReferenceCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(ReferenceCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrefixLocalCallsWithThisCodeFix()
         {
-            await this.VerifyCSharpFixAsync(ReferenceCode, FixedCode, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpFixAsync(ReferenceCode, FixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1102UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1102UnitTests.cs
@@ -15,7 +15,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -35,7 +35,7 @@ public class Foo4
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(11, 21);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -54,7 +54,7 @@ public class Foo4
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 33);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -71,7 +71,7 @@ public class Foo4
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 38);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
 
@@ -110,7 +110,7 @@ public class Foo4
                     this.CSharpDiagnostic().WithLocation(21, 21),
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -128,7 +128,7 @@ public class Foo4
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -149,7 +149,7 @@ public class Foo4
                     this.CSharpDiagnostic().WithLocation(6, 17),
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -177,7 +177,7 @@ public class Foo4
                     this.CSharpDiagnostic().WithLocation(12, 21),
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1106UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1106UnitTests.cs
@@ -15,7 +15,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -33,7 +33,7 @@ class TestClass
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 13);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ class TestClass
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ class TestClass
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -83,7 +83,7 @@ class TestClass
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -102,7 +102,7 @@ class TestClass
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -121,7 +121,7 @@ class TestClass
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1110UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1110UnitTests.cs
@@ -15,7 +15,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -33,7 +33,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 21);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
         }
 
@@ -67,7 +67,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -81,7 +81,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -99,7 +99,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 13);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -117,7 +117,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 13);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -135,7 +135,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 13);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -154,7 +154,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 13);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -176,7 +176,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(11, 13);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -196,7 +196,7 @@ Baz();
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -218,7 +218,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -236,7 +236,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -251,7 +251,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
         [Fact]
         public async Task TestConstructorWithQualifiedNameCallOpeningBracketInTheNextLine()
@@ -271,7 +271,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -292,7 +292,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 5);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -310,7 +310,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -336,7 +336,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(15, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -355,7 +355,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -378,7 +378,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -394,7 +394,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -411,7 +411,7 @@ class Foo
     }
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -428,7 +428,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -451,7 +451,7 @@ public class Foo
                     this.CSharpDiagnostic().WithLocation(6, 1)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -467,7 +467,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -482,7 +482,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -494,7 +494,7 @@ public class Foo
     public delegate void MyDel(int i);
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -516,7 +516,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -534,7 +534,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -552,7 +552,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -571,7 +571,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -587,7 +587,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -605,7 +605,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -623,7 +623,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -641,7 +641,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -656,7 +656,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -674,7 +674,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -689,7 +689,7 @@ public class Foo
         }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1111UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1111UnitTests.cs
@@ -15,7 +15,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -33,7 +33,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -53,7 +53,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -69,7 +69,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -84,7 +84,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -102,7 +102,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -122,7 +122,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -138,7 +138,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -153,7 +153,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -176,7 +176,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(12, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -197,7 +197,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -221,7 +221,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(13, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -242,7 +242,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -263,7 +263,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -286,7 +286,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(12, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
 
@@ -311,7 +311,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(13, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -332,7 +332,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -353,7 +353,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -374,7 +374,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -397,7 +397,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -415,7 +415,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -441,7 +441,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(15, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -460,7 +460,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -480,7 +480,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -500,7 +500,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -518,7 +518,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -539,7 +539,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -561,7 +561,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(11, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -584,7 +584,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(12, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -603,7 +603,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -622,7 +622,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -650,7 +650,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(17, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -665,7 +665,7 @@ public class Foo
 	}
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -680,7 +680,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -692,7 +692,7 @@ public class Foo
     public delegate void Del(int i, string s);
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -704,7 +704,7 @@ public class Foo
     public delegate void Del();
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -726,7 +726,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -745,7 +745,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -765,7 +765,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -788,7 +788,7 @@ public class Foo
                     this.CSharpDiagnostic().WithLocation(6, 1)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -804,7 +804,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -816,7 +816,7 @@ public class Foo
 {
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -831,7 +831,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -843,7 +843,7 @@ public class Foo
 {
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -855,7 +855,7 @@ public class Foo
 {
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -875,7 +875,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -891,7 +891,7 @@ public class Foo
         MyEvent(1,2);
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -908,7 +908,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -929,7 +929,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -953,7 +953,7 @@ namespace Test
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(12, 17);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -970,7 +970,7 @@ public class Foo
         };
     }
 }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -985,7 +985,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -1003,7 +1003,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -1021,7 +1021,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 5);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -1036,7 +1036,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1112UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1112UnitTests.cs
@@ -16,7 +16,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -34,7 +34,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -66,7 +66,7 @@ string s)
 }";
 
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -84,7 +84,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -99,7 +99,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -116,7 +116,7 @@ string s)
 }";
 
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -134,7 +134,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -150,7 +150,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -165,7 +165,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -183,7 +183,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -205,7 +205,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -221,7 +221,7 @@ class Foo
 }";
 
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -240,7 +240,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -255,7 +255,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1113UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1113UnitTests.cs
@@ -15,7 +15,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -31,7 +31,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 21);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -52,7 +52,7 @@
                     this.CSharpDiagnostic().WithLocation(5, 21)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -66,7 +66,7 @@
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -83,7 +83,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 37);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -105,7 +105,7 @@
                     this.CSharpDiagnostic().WithLocation(7, 37)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -120,7 +120,7 @@
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -140,7 +140,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 30);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -165,7 +165,7 @@
                     this.CSharpDiagnostic().WithLocation(10, 30)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -183,7 +183,7 @@
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -199,7 +199,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 16);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -220,7 +220,7 @@
                     this.CSharpDiagnostic().WithLocation(5, 16)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -234,7 +234,7 @@
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -254,7 +254,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 21);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -279,7 +279,7 @@
                     this.CSharpDiagnostic().WithLocation(5, 21)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -297,7 +297,7 @@
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -321,7 +321,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(13, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -350,7 +350,7 @@
                     this.CSharpDiagnostic().WithLocation(14, 5)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -372,7 +372,7 @@
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -393,7 +393,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 13);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -411,7 +411,7 @@
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -425,7 +425,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -444,7 +444,7 @@
                     this.CSharpDiagnostic().WithLocation(5, 1)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -455,7 +455,7 @@
     delegate void Del(string str, int i);
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -477,7 +477,7 @@
                     this.CSharpDiagnostic().WithLocation(7, 17)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -491,7 +491,7 @@
         }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -505,7 +505,7 @@
         }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -520,7 +520,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -532,7 +532,7 @@
     public static extern int MessageBox(IntPtr hWnd, String text, String caption, uint type);
  }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -554,7 +554,7 @@
                     this.CSharpDiagnostic().WithLocation(5, 1)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -568,7 +568,7 @@
         }
     }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -586,7 +586,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -601,7 +601,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -617,7 +617,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -635,7 +635,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -650,7 +650,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -665,7 +665,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -685,7 +685,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -704,7 +704,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -720,7 +720,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -736,7 +736,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -760,7 +760,7 @@ public class Foo4
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(13, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -781,7 +781,7 @@ public class Foo4
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -802,7 +802,7 @@ public class Foo4
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1114UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1114UnitTests.cs
@@ -15,7 +15,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -34,7 +34,7 @@ string s)
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -50,7 +50,7 @@ string s)
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -65,7 +65,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -82,7 +82,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -101,7 +101,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -117,7 +117,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -132,7 +132,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -149,7 +149,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -168,7 +168,7 @@ string s)
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -184,7 +184,7 @@ string s)
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -199,7 +199,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -213,7 +213,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -236,7 +236,7 @@ public class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(12, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -256,7 +256,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -275,7 +275,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -292,7 +292,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -314,7 +314,7 @@ int i]
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -333,7 +333,7 @@ int i]
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -351,7 +351,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -370,7 +370,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -403,7 +403,7 @@ var a = new int[
                     this.CSharpDiagnostic().WithLocation(14, 1)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -419,7 +419,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -434,7 +434,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -454,7 +454,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -471,7 +471,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -487,7 +487,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -518,7 +518,7 @@ class Foo
                     this.CSharpDiagnostic().WithLocation(16, 1)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -541,7 +541,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -564,7 +564,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -583,7 +583,7 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -599,7 +599,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -614,7 +614,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -627,7 +627,7 @@ class Foo
 
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -646,7 +646,7 @@ Conditional(""DEBUG""),Conditional(""DEBUG2"")]
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -662,7 +662,7 @@ Conditional(""DEBUG""),Conditional(""DEBUG2"")]
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -677,7 +677,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -693,7 +693,7 @@ string s);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -706,7 +706,7 @@ class Foo
 string s);
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -718,7 +718,7 @@ class Foo
     public delegate void Bar(string s);
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -730,7 +730,7 @@ class Foo
     public delegate void Bar();
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -752,7 +752,7 @@ int z, int j)
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -771,7 +771,7 @@ int z, int j)
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -789,7 +789,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -807,7 +807,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -829,7 +829,7 @@ z,j) =>
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -848,7 +848,7 @@ z,j) =>
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -866,7 +866,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -884,7 +884,7 @@ class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -903,7 +903,7 @@ int i)
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -919,7 +919,7 @@ int i)
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -934,7 +934,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -953,7 +953,7 @@ Foo a, Foo b)
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -972,7 +972,7 @@ Foo a)
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -988,7 +988,7 @@ Foo a, Foo b)
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -1003,7 +1003,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -1018,7 +1018,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1121UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1121UnitTests.cs
@@ -59,9 +59,9 @@
             {
                 try
                 {
-                    await func(item.Item1, item.Item2);
-                    await func(item.Item1, "System." + item.Item2);
-                    await func(item.Item1, "global::System." + item.Item2);
+                    await func(item.Item1, item.Item2).ConfigureAwait(false);
+                    await func(item.Item1, "System." + item.Item2).ConfigureAwait(false);
+                    await func(item.Item1, "global::System." + item.Item2).ConfigureAwait(false);
                 }
                 catch (Exception ex)
                 {
@@ -74,50 +74,50 @@
             foreach (var item in types)
             {
                 // Allow CS8019 here because the code fix makes the using directive unnecessary
-                await this.VerifyCSharpFixAsync(string.Format(testSource, item.Item2), string.Format(testSource, item.Item1), allowNewCompilerDiagnostics: true);
-                await this.VerifyCSharpFixAsync(string.Format(testSource, "System." + item.Item2), string.Format(testSource, item.Item1));
-                await this.VerifyCSharpFixAsync(string.Format(testSource, "global::System." + item.Item2), string.Format(testSource, item.Item1));
+                await this.VerifyCSharpFixAsync(string.Format(testSource, item.Item2), string.Format(testSource, item.Item1), allowNewCompilerDiagnostics: true).ConfigureAwait(false);
+                await this.VerifyCSharpFixAsync(string.Format(testSource, "System." + item.Item2), string.Format(testSource, item.Item1)).ConfigureAwait(false);
+                await this.VerifyCSharpFixAsync(string.Format(testSource, "global::System." + item.Item2), string.Format(testSource, item.Item1)).ConfigureAwait(false);
             }
         }
 
         private async Task TestAllCases(Func<string, string, Task> func)
         {
-            await this.TestCases(func, AllTypes);
+            await this.TestCases(func, AllTypes).ConfigureAwait(false);
         }
 
         private async Task VerifyAllFixes(string testSource)
         {
-            await this.VerifyFixes(testSource, AllTypes);
+            await this.VerifyFixes(testSource, AllTypes).ConfigureAwait(false);
         }
 
         private async Task TestEnumTypeCases(Func<string, string, Task> func)
         {
-            await this.TestCases(func, EnumBaseTypes);
+            await this.TestCases(func, EnumBaseTypes).ConfigureAwait(false);
         }
 
         private async Task VerifyEnumTypeFixes(string testSource)
         {
-            await this.VerifyFixes(testSource, AllTypes);
+            await this.VerifyFixes(testSource, AllTypes).ConfigureAwait(false);
         }
 
         private async Task TestValueTypeCases(Func<string, string, Task> func)
         {
-            await this.TestCases(func, ValueTypes);
+            await this.TestCases(func, ValueTypes).ConfigureAwait(false);
         }
 
         private async Task VerifyValueTypeFixes(string testSource)
         {
-            await this.VerifyFixes(testSource, AllTypes);
+            await this.VerifyFixes(testSource, AllTypes).ConfigureAwait(false);
         }
 
         private async Task TestReferenceTypeCases(Func<string, string, Task> func)
         {
-            await this.TestCases(func, ReferenceTypes);
+            await this.TestCases(func, ReferenceTypes).ConfigureAwait(false);
         }
 
         private async Task VerifyReferenceTypeFixes(string testSource)
         {
-            await this.VerifyFixes(testSource, ReferenceTypes);
+            await this.VerifyFixes(testSource, ReferenceTypes).ConfigureAwait(false);
         }
 
 
@@ -125,7 +125,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestVariableDeclarationImpl(string predefined, string fullName)
@@ -140,8 +140,8 @@ public class Foo
 }}";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, predefined), EmptyDiagnosticResults, CancellationToken.None);
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, predefined), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -156,13 +156,13 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyAllFixes(testSource);
+            await this.VerifyAllFixes(testSource).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestVariableDeclaration()
         {
-            await this.TestAllCases(this.TestVariableDeclarationImpl);
+            await this.TestAllCases(this.TestVariableDeclarationImpl).ConfigureAwait(false);
         }
 
         private async Task TestDefaultDeclarationImpl(string predefined, string fullName)
@@ -177,13 +177,13 @@ public class Foo
 }}";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 28);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDefaultDeclaration()
         {
-            await this.TestAllCases(this.TestDefaultDeclarationImpl);
+            await this.TestAllCases(this.TestDefaultDeclarationImpl).ConfigureAwait(false);
         }
 
         [Fact]
@@ -198,7 +198,7 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyAllFixes(testSource);
+            await this.VerifyAllFixes(testSource).ConfigureAwait(false);
         }
 
         private async Task TestTypeOfImpl(string predefined, string fullName)
@@ -213,13 +213,13 @@ public class Foo
 }}";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 27);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestTypeOf()
         {
-            await this.TestAllCases(this.TestTypeOfImpl);
+            await this.TestAllCases(this.TestTypeOfImpl).ConfigureAwait(false);
         }
 
         [Fact]
@@ -234,7 +234,7 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyAllFixes(testSource);
+            await this.VerifyAllFixes(testSource).ConfigureAwait(false);
         }
 
         private async Task TestReturnTypeImpl(string predefined, string fullName)
@@ -248,13 +248,13 @@ public class Foo
 }}";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 12);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestReturnType()
         {
-            await this.TestAllCases(this.TestReturnTypeImpl);
+            await this.TestAllCases(this.TestReturnTypeImpl).ConfigureAwait(false);
         }
 
         [Fact]
@@ -268,7 +268,7 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyAllFixes(testSource);
+            await this.VerifyAllFixes(testSource).ConfigureAwait(false);
         }
 
         private async Task TestEnumBaseTypeImpl(string predefined, string fullName)
@@ -282,13 +282,13 @@ public class Foo
 }}";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 23);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEnumBaseType()
         {
-            await this.TestEnumTypeCases(this.TestEnumBaseTypeImpl);
+            await this.TestEnumTypeCases(this.TestEnumBaseTypeImpl).ConfigureAwait(false);
         }
 
         [Fact]
@@ -302,7 +302,7 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyEnumTypeFixes(testSource);
+            await this.VerifyEnumTypeFixes(testSource).ConfigureAwait(false);
         }
 
         private async Task TestPointerDeclarationImpl(string predefined, string fullName)
@@ -317,13 +317,13 @@ public class Foo
 }}";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPointerDeclaration()
         {
-            await this.TestValueTypeCases(this.TestPointerDeclarationImpl);
+            await this.TestValueTypeCases(this.TestPointerDeclarationImpl).ConfigureAwait(false);
         }
 
         [Fact]
@@ -338,7 +338,7 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyValueTypeFixes(testSource);
+            await this.VerifyValueTypeFixes(testSource).ConfigureAwait(false);
         }
 
         private async Task TestArgumentImpl(string predefined, string fullName)
@@ -352,13 +352,13 @@ public class Foo
 }}";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 21);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestArgument()
         {
-            await this.TestAllCases(this.TestArgumentImpl);
+            await this.TestAllCases(this.TestArgumentImpl).ConfigureAwait(false);
         }
 
         [Fact]
@@ -372,7 +372,7 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyAllFixes(testSource);
+            await this.VerifyAllFixes(testSource).ConfigureAwait(false);
         }
 
         private async Task TestIndexerImpl(string predefined, string fullName)
@@ -393,13 +393,13 @@ public class Foo
                     this.CSharpDiagnostic().WithLocation(7, 30),
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestIndexer()
         {
-            await this.TestAllCases(this.TestIndexerImpl);
+            await this.TestAllCases(this.TestIndexerImpl).ConfigureAwait(false);
         }
 
         [Fact]
@@ -415,7 +415,7 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyAllFixes(testSource);
+            await this.VerifyAllFixes(testSource).ConfigureAwait(false);
         }
 
         private async Task TestGenericAndLambdaImpl(string predefined, string fullName)
@@ -437,13 +437,13 @@ public class Foo
                     this.CSharpDiagnostic().WithLocation(8, 22),
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestGenericAndLambda()
         {
-            await this.TestAllCases(this.TestGenericAndLambdaImpl);
+            await this.TestAllCases(this.TestGenericAndLambdaImpl).ConfigureAwait(false);
         }
 
         [Fact]
@@ -460,7 +460,7 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyAllFixes(testSource);
+            await this.VerifyAllFixes(testSource).ConfigureAwait(false);
         }
 
         private async Task TestArrayImpl(string predefined, string fullName)
@@ -475,13 +475,13 @@ public class Foo
 }}";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 25);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestArray()
         {
-            await this.TestAllCases(this.TestArrayImpl);
+            await this.TestAllCases(this.TestArrayImpl).ConfigureAwait(false);
         }
 
         [Fact]
@@ -496,7 +496,7 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyAllFixes(testSource);
+            await this.VerifyAllFixes(testSource).ConfigureAwait(false);
         }
 
         private async Task TestStackAllocArrayImpl(string predefined, string fullName)
@@ -511,13 +511,13 @@ public class Foo
 }}";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 32);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStackAllocArray()
         {
-            await this.TestAllCases(this.TestStackAllocArrayImpl);
+            await this.TestAllCases(this.TestStackAllocArrayImpl).ConfigureAwait(false);
         }
 
         [Fact]
@@ -532,7 +532,7 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyValueTypeFixes(testSource);
+            await this.VerifyValueTypeFixes(testSource).ConfigureAwait(false);
         }
 
         private async Task TestImplicitCastImpl(string predefined, string fullName)
@@ -552,13 +552,13 @@ public class Foo
                     this.CSharpDiagnostic().WithLocation(7, 29),
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestImplicitCast()
         {
-            await this.TestAllCases(this.TestImplicitCastImpl);
+            await this.TestAllCases(this.TestImplicitCastImpl).ConfigureAwait(false);
         }
 
         [Fact]
@@ -574,7 +574,7 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyValueTypeFixes(testSource);
+            await this.VerifyValueTypeFixes(testSource).ConfigureAwait(false);
         }
 
         private async Task TestExplicitCastImpl(string predefined, string fullName)
@@ -589,13 +589,13 @@ public class Foo
 }}";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 25);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestExplicitCast()
         {
-            await this.TestReferenceTypeCases(this.TestExplicitCastImpl);
+            await this.TestReferenceTypeCases(this.TestExplicitCastImpl).ConfigureAwait(false);
         }
 
         [Fact]
@@ -610,7 +610,7 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyValueTypeFixes(testSource);
+            await this.VerifyValueTypeFixes(testSource).ConfigureAwait(false);
         }
 
         private async Task TestNullableImpl(string predefined, string fullName)
@@ -625,13 +625,13 @@ public class Foo
 }}";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNullable()
         {
-            await this.TestValueTypeCases(this.TestNullableImpl);
+            await this.TestValueTypeCases(this.TestNullableImpl).ConfigureAwait(false);
         }
 
         [Fact]
@@ -646,7 +646,7 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyValueTypeFixes(testSource);
+            await this.VerifyValueTypeFixes(testSource).ConfigureAwait(false);
         }
 
         [Fact]
@@ -663,7 +663,7 @@ public class Foo
 ";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 5);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -688,7 +688,7 @@ public class Foo
 }
 ";
 
-            await this.VerifyCSharpFixAsync(oldSource, newSource, allowNewCompilerDiagnostics: true);
+            await this.VerifyCSharpFixAsync(oldSource, newSource, allowNewCompilerDiagnostics: true).ConfigureAwait(false);
         }
 
         [Fact]
@@ -705,7 +705,7 @@ public class Foo
 ";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 5);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -730,7 +730,7 @@ public class Foo
 }
 ";
 
-            await this.VerifyCSharpFixAsync(oldSource, newSource, allowNewCompilerDiagnostics: true);
+            await this.VerifyCSharpFixAsync(oldSource, newSource, allowNewCompilerDiagnostics: true).ConfigureAwait(false);
         }
 
         [Fact]
@@ -748,8 +748,8 @@ public class {0} {{}}
 ";
             foreach (var item in AllTypes)
             {
-                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "@" + item.Item1), EmptyDiagnosticResults, CancellationToken.None);
-                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, item.Item2), EmptyDiagnosticResults, CancellationToken.None);
+                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "@" + item.Item1), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, item.Item2), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -771,8 +771,8 @@ public namespace {0}
 ";
             foreach (var item in AllTypes)
             {
-                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "@" + item.Item1), EmptyDiagnosticResults, CancellationToken.None);
-                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, item.Item2), EmptyDiagnosticResults, CancellationToken.None);
+                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "@" + item.Item1), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, item.Item2), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             }
         }
 
@@ -793,15 +793,15 @@ namespace Foo
 ";
             foreach (var item in AllTypes)
             {
-                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "System." + item.Item2), EmptyDiagnosticResults, CancellationToken.None);
+                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "System." + item.Item2), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             }
 
             var expected = this.CSharpDiagnostic().WithLocation(8, 41);
 
             foreach (var item in AllTypes)
             {
-                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "System." + item.Item2 + ".ToString"), expected, CancellationToken.None);
-                await this.VerifyCSharpFixAsync(string.Format(testCode, "System." + item.Item2 + ".ToString"), string.Format(testCode, item.Item1 + ".ToString"));
+                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "System." + item.Item2 + ".ToString"), expected, CancellationToken.None).ConfigureAwait(false);
+                await this.VerifyCSharpFixAsync(string.Format(testCode, "System." + item.Item2 + ".ToString"), string.Format(testCode, item.Item1 + ".ToString")).ConfigureAwait(false);
             }
         }
 
@@ -823,8 +823,8 @@ namespace Foo
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 41);
             foreach (var item in AllTypes)
             {
-                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "System." + item.Item2), expected, CancellationToken.None);
-                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, item.Item1), EmptyDiagnosticResults, CancellationToken.None);
+                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, "System." + item.Item2), expected, CancellationToken.None).ConfigureAwait(false);
+                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, item.Item1), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1122UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1122UnitTests.cs
@@ -20,7 +20,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestEmptyStringLiteral(bool useVerbatimLiteral)
@@ -35,7 +35,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 23);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, useVerbatimLiteral ? "@" : string.Empty), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, useVerbatimLiteral ? "@" : string.Empty), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestParenthesizedEmptyStringLiteral(bool useVerbatimLiteral)
@@ -50,7 +50,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 24);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, useVerbatimLiteral ? "@" : string.Empty), expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, useVerbatimLiteral ? "@" : string.Empty), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestLocalStringLiteralImpl(bool useVerbatimLiteral, bool isConst)
@@ -69,7 +69,7 @@ string test = {0}"""";
                     this.CSharpDiagnostic().WithLocation(6, 15)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, useVerbatimLiteral ? "@" : string.Empty, isConst ? "const" : string.Empty), isConst ? EmptyDiagnosticResults : expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, useVerbatimLiteral ? "@" : string.Empty, isConst ? "const" : string.Empty), isConst ? EmptyDiagnosticResults : expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestParenthesizedLocalStringLiteralImpl(bool useVerbatimLiteral, bool isConst)
@@ -88,7 +88,7 @@ string test = ({0}"""");
                     this.CSharpDiagnostic().WithLocation(6, 16)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, useVerbatimLiteral ? "@" : string.Empty, isConst ? "const" : string.Empty), isConst ? EmptyDiagnosticResults : expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, useVerbatimLiteral ? "@" : string.Empty, isConst ? "const" : string.Empty), isConst ? EmptyDiagnosticResults : expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         public async Task TestWhitespaceStringLiteral(bool useVerbatimLiteral)
@@ -100,7 +100,7 @@ string test = ({0}"""");
         string test = {0}""  "";
     }}
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, useVerbatimLiteral ? "@" : string.Empty), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, useVerbatimLiteral ? "@" : string.Empty), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestAttributeStringLiteralImpl(bool useVerbatimLiteral)
@@ -114,7 +114,7 @@ public class Foo
     {{
     }}
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, useVerbatimLiteral ? "@" : string.Empty), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, useVerbatimLiteral ? "@" : string.Empty), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestDefaultParameterStringLiteralImpl(bool useVerbatimLiteral)
@@ -127,7 +127,7 @@ public class Foo
     }}
 }}";
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, useVerbatimLiteral ? "@" : string.Empty), EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, useVerbatimLiteral ? "@" : string.Empty), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         public async Task TestNullInMethod()
@@ -139,7 +139,7 @@ public class Foo
         string test = null;
     }}
 }}";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         private async Task TestSimpleCodeFix(bool useVerbatimLiteral)
@@ -159,7 +159,7 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpFixAsync(string.Format(oldSource, useVerbatimLiteral ? "@" : string.Empty), newSource);
+            await this.VerifyCSharpFixAsync(string.Format(oldSource, useVerbatimLiteral ? "@" : string.Empty), newSource).ConfigureAwait(false);
         }
 
         [Fact]
@@ -182,115 +182,115 @@ public class Foo
     }
 }";
 
-            await this.VerifyCSharpFixAsync(oldSource, newSource);
+            await this.VerifyCSharpFixAsync(oldSource, newSource).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestLiteralInMethodVerbatim()
         {
-            await this.TestEmptyStringLiteral(true);
+            await this.TestEmptyStringLiteral(true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestLiteralInMethod()
         {
-            await this.TestEmptyStringLiteral(false);
+            await this.TestEmptyStringLiteral(false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestParenthesizedLiteralInMethodVerbatim()
         {
-            await this.TestParenthesizedEmptyStringLiteral(true);
+            await this.TestParenthesizedEmptyStringLiteral(true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestParenthesizedLiteralInMethod()
         {
-            await this.TestParenthesizedEmptyStringLiteral(false);
+            await this.TestParenthesizedEmptyStringLiteral(false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestLocalStringLiteralVerbatim()
         {
-            await this.TestLocalStringLiteralImpl(true, false);
+            await this.TestLocalStringLiteralImpl(true, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestLocalStringLiteral()
         {
-            await this.TestLocalStringLiteralImpl(false, false);
+            await this.TestLocalStringLiteralImpl(false, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstStringLiteralVerbatim()
         {
-            await this.TestLocalStringLiteralImpl(true, true);
+            await this.TestLocalStringLiteralImpl(true, true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestConstStringLiteral()
         {
-            await this.TestLocalStringLiteralImpl(false, true);
+            await this.TestLocalStringLiteralImpl(false, true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestParenthesizedLocalStringLiteralVerbatim()
         {
-            await this.TestParenthesizedLocalStringLiteralImpl(true, false);
+            await this.TestParenthesizedLocalStringLiteralImpl(true, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestParenthesizedLocalStringLiteral()
         {
-            await this.TestParenthesizedLocalStringLiteralImpl(false, false);
+            await this.TestParenthesizedLocalStringLiteralImpl(false, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestParenthesizedConstStringLiteralVerbatim()
         {
-            await this.TestParenthesizedLocalStringLiteralImpl(true, true);
+            await this.TestParenthesizedLocalStringLiteralImpl(true, true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestParenthesizedConstStringLiteral()
         {
-            await this.TestParenthesizedLocalStringLiteralImpl(false, true);
+            await this.TestParenthesizedLocalStringLiteralImpl(false, true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestAttributeStringLiteralVerbatim()
         {
-            await this.TestAttributeStringLiteralImpl(true);
+            await this.TestAttributeStringLiteralImpl(true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestAttributeStringLiteral()
         {
-            await this.TestAttributeStringLiteralImpl(false);
+            await this.TestAttributeStringLiteralImpl(false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDefaultParameterStringLiteralVerbatim()
         {
-            await this.TestDefaultParameterStringLiteralImpl(true);
+            await this.TestDefaultParameterStringLiteralImpl(true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDefaultParameterStringLiteral()
         {
-            await this.TestDefaultParameterStringLiteralImpl(false);
+            await this.TestDefaultParameterStringLiteralImpl(false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestLiteralInMethodVerbatimCodeFix()
         {
-            await this.TestSimpleCodeFix(true);
+            await this.TestSimpleCodeFix(true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestLiteralInMethodCodeFix()
         {
-            await this.TestSimpleCodeFix(false);
+            await this.TestSimpleCodeFix(false).ConfigureAwait(false);
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/NumberSignSpacingTestBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/NumberSignSpacingTestBase.cs
@@ -28,7 +28,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -61,8 +61,8 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 21);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -98,14 +98,14 @@
             string test;
 
             test = string.Format(testFormat, this.Sign + "3");
-            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, this.Sign + " 3");
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(8, 17);
 
-            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -141,14 +141,14 @@
             string test;
 
             test = string.Format(testFormat, this.Sign + "3");
-            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, this.Sign + " 3");
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(8, 17);
 
-            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -182,8 +182,8 @@
             string test;
 
             test = string.Format(testFormat, " " + this.Sign + "3");
-            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, this.Sign + "3");
             DiagnosticResult[] expected =
@@ -191,8 +191,8 @@
                     this.CSharpDiagnostic().WithArguments(string.Empty, "preceded").WithLocation(7, 20)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, " " + this.Sign + " 3");
             expected =
@@ -201,8 +201,8 @@
                     this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 21)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, this.Sign + " 3");
             expected =
@@ -212,8 +212,8 @@
                     this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 20)
                 };
 
-            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -247,14 +247,14 @@
             string test;
 
             test = string.Format(testFormat, this.Sign + "3");
-            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, this.Sign + " 3");
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 25);
 
-            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -288,16 +288,16 @@
             string test;
 
             test = string.Format(testFormat, this.Sign + "3");
-            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, " " + this.Sign + "3");
             DiagnosticResult[] expected =
                 {
                     this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 27)
                 };
-            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, this.Sign + " 3");
             expected =
@@ -305,8 +305,8 @@
                 {
                     this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 26)
                 };
-            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, " " + this.Sign + " 3");
             expected =
@@ -315,8 +315,8 @@
                     this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 27),
                     this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 27)
                 };
-            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -350,16 +350,16 @@
             string test;
 
             test = string.Format(testFormat, this.Sign + "3");
-            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, " " + this.Sign + "3");
             DiagnosticResult[] expected =
                 {
                     this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 23)
                 };
-            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, this.Sign + " 3");
             expected =
@@ -367,8 +367,8 @@
                 {
                     this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 22)
                 };
-            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, " " + this.Sign + " 3");
             expected =
@@ -377,8 +377,8 @@
                     this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 23),
                     this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 23)
                 };
-            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -412,16 +412,16 @@
             string test;
 
             test = string.Format(testFormat, this.Sign + "3");
-            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, " " + this.Sign + "3");
             DiagnosticResult[] expected =
                 {
                     this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 32)
                 };
-            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, this.Sign + " 3");
             expected =
@@ -429,8 +429,8 @@
                 {
                     this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 31)
                 };
-            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, " " + this.Sign + " 3");
             expected =
@@ -439,8 +439,8 @@
                     this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 32),
                     this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 32)
                 };
-            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override abstract CodeFixProvider GetCSharpCodeFixProvider();

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1000UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1000UnitTests.cs
@@ -20,7 +20,7 @@
         public async Task TestEmptySource()
         {
             var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -34,7 +34,7 @@ catch
 }
 ";
 
-            await this.TestKeywordStatement(statement, EmptyDiagnosticResults, statement);
+            await this.TestKeywordStatement(statement, EmptyDiagnosticResults, statement).ConfigureAwait(false);
         }
 
         [Fact]
@@ -56,11 +56,11 @@ catch (Exception ex)
 }
 ";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("catch", string.Empty, "followed").WithLocation(10, 1);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -76,11 +76,11 @@ catch (Exception ex)
 }
 ";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("fixed", string.Empty, "followed").WithLocation(7, 13);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -96,11 +96,11 @@ catch (Exception ex)
 }
 ";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("for", string.Empty, "followed").WithLocation(7, 13);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -116,11 +116,11 @@ catch (Exception ex)
 }
 ";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("foreach", string.Empty, "followed").WithLocation(7, 13);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -130,11 +130,11 @@ catch (Exception ex)
 
             string statementWithSpace = @"var result = from @x in y select x;";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("from", string.Empty, "followed").WithLocation(7, 26);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -148,11 +148,11 @@ select z;";
 group @x by x.A into z
 select z;";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("group", string.Empty, "followed").WithLocation(8, 1);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -168,11 +168,11 @@ select z;";
 }
 ";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("if", string.Empty, "followed").WithLocation(7, 13);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -182,11 +182,11 @@ select z;";
 
             string statementWithSpace = @"var result = from x in @y select x;";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("in", string.Empty, "followed").WithLocation(7, 33);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -200,11 +200,11 @@ select z;";
 group x by x.A into @z
 select z;";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("into", string.Empty, "followed").WithLocation(8, 16);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -218,11 +218,11 @@ select z;";
 join @a in b on x.A equals a.B
 select z;";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("join", string.Empty, "followed").WithLocation(8, 16);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -236,11 +236,11 @@ select x;";
 let @z = 3
 select x;";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("let", string.Empty, "followed").WithLocation(8, 1);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -256,11 +256,11 @@ select x;";
 }
 ";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("lock", string.Empty, "followed").WithLocation(7, 13);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -274,11 +274,11 @@ select z;";
 orderby (x.A)
 select z;";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("orderby", string.Empty, "followed").WithLocation(8, 1);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -288,11 +288,11 @@ select z;";
 
             string statementWithSpace = @"return ;";
 
-            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("return", " not", "followed").WithLocation(7, 13);
 
-            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -302,11 +302,11 @@ select z;";
 
             string statementWithSpace = @"return (3);";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("return", string.Empty, "followed").WithLocation(7, 13);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -316,11 +316,11 @@ select z;";
 
             string statementWithSpace = @"var result = from x in y select @x;";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("select", string.Empty, "followed").WithLocation(7, 38);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -330,11 +330,11 @@ select z;";
 
             string statementWithSpace = @"int* x = stackalloc @Int32[3];";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("stackalloc", string.Empty, "followed").WithLocation(7, 22);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -354,11 +354,11 @@ default:
 }
 ";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("switch", string.Empty, "followed").WithLocation(7, 13);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -368,11 +368,11 @@ default:
 
             string statementWithSpace = @"throw (new Exception());";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("throw", string.Empty, "followed").WithLocation(7, 13);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -396,11 +396,11 @@ catch (Exception ex)
 }
 ";
 
-            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("throw", " not", "followed").WithLocation(12, 5);
 
-            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -416,11 +416,11 @@ catch (Exception ex)
 }
 ";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("using", string.Empty, "followed").WithLocation(7, 13);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -434,11 +434,11 @@ select z;";
 where (x.A)
 select z;";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("where", string.Empty, "followed").WithLocation(8, 1);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -454,11 +454,11 @@ select z;";
 }
 ";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("while", string.Empty, "followed").WithLocation(7, 13);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -468,10 +468,10 @@ select z;";
             // that no diagnostic is reported for its use with a space.
 
             string statementWithSpace = @"yield return 3;";
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             string statementWithSpace2 = @"yield break;";
-            await this.TestKeywordStatement(statementWithSpace2, EmptyDiagnosticResults, statementWithSpace2);
+            await this.TestKeywordStatement(statementWithSpace2, EmptyDiagnosticResults, statementWithSpace2).ConfigureAwait(false);
         }
 
         [Fact]
@@ -481,11 +481,11 @@ select z;";
 
             string statementWithSpace = @"int x = checked (3);";
 
-            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("checked", " not", "followed").WithLocation(7, 21);
 
-            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -505,11 +505,11 @@ default :
 }
 ";
 
-            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("default", " not", "followed").WithLocation(9, 1);
 
-            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -519,11 +519,11 @@ default :
 
             string statementWithSpace = @"int x = default (int);";
 
-            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("default", " not", "followed").WithLocation(7, 21);
 
-            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -533,11 +533,11 @@ default :
 
             string statementWithSpace = @"string x = nameof (x);";
 
-            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("nameof", " not", "followed").WithLocation(7, 24);
 
-            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -547,11 +547,11 @@ default :
 
             string statementWithSpace = @"int x = sizeof (int);";
 
-            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("sizeof", " not", "followed").WithLocation(7, 21);
 
-            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -561,11 +561,11 @@ default :
 
             string statementWithSpace = @"Type x = typeof (int);";
 
-            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("typeof", " not", "followed").WithLocation(7, 22);
 
-            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -575,11 +575,11 @@ default :
 
             string statementWithSpace = @"int x = unchecked (3);";
 
-            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("unchecked", " not", "followed").WithLocation(7, 21);
 
-            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -589,11 +589,11 @@ default :
 
             string statementWithSpace = @"int x = new @Int32();";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("new", string.Empty, "followed").WithLocation(7, 21);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -603,11 +603,11 @@ default :
 
             string statementWithSpace = @"int[] x = new @Int32[3];";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("new", string.Empty, "followed").WithLocation(7, 23);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -617,10 +617,10 @@ default :
 
             string statementWithSpace = @"int[] x = new [] { 3 };";
 
-            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace).ConfigureAwait(false);
 
             // this case is handled by SA1026, so it shouldn't be reported here
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -634,11 +634,11 @@ default :
 {
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(statementWithoutSpace, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(statementWithoutSpace, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("new", " not", "followed").WithLocation(7, 43);
 
-            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -652,11 +652,11 @@ default :
 {
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(statementWithoutSpace, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(statementWithoutSpace, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("new", " not", "followed").WithLocation(7, 46);
 
-            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -670,11 +670,11 @@ default :
 {
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(statementWithoutSpace, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(statementWithoutSpace, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("new", " not", "followed").WithLocation(7, 50);
 
-            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -688,11 +688,11 @@ default :
 {
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(statementWithoutSpace, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(statementWithoutSpace, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("new", " not", "followed").WithLocation(7, 44);
 
-            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -706,11 +706,11 @@ default :
 {
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(statementWithoutSpace, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(statementWithoutSpace, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("new", " not", "followed").WithLocation(7, 47);
 
-            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -724,11 +724,11 @@ default :
 {
 }";
 
-            await this.VerifyCSharpDiagnosticAsync(statementWithoutSpace, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(statementWithoutSpace, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("new", " not", "followed").WithLocation(7, 51);
 
-            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace);
+            await this.TestKeywordStatement(statementWithSpace, expected, statementWithoutSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -738,8 +738,8 @@ default :
 
             string statementWithSpace = @"var result = await (x);";
 
-            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace, asyncMethod: false);
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace, asyncMethod: false);
+            await this.TestKeywordStatement(statementWithoutSpace, EmptyDiagnosticResults, statementWithoutSpace, asyncMethod: false).ConfigureAwait(false);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace, asyncMethod: false).ConfigureAwait(false);
         }
 
         [Fact]
@@ -749,11 +749,11 @@ default :
 
             string statementWithSpace = @"var result = await (x);";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace, asyncMethod: true);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace, asyncMethod: true).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("await", string.Empty, "followed").WithLocation(7, 26);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace, asyncMethod: true);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace, asyncMethod: true).ConfigureAwait(false);
         }
 
         [Fact]
@@ -775,11 +775,11 @@ default:
 }
 ";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("case", string.Empty, "followed").WithLocation(9, 1);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -807,11 +807,11 @@ default:
 }
 ";
 
-            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestKeywordStatement(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("case", string.Empty, "followed").WithLocation(10, 10);
 
-            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestKeywordStatement(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         private Task TestKeywordStatement(string statement, DiagnosticResult expected, string fixedStatement, bool asyncMethod = false)
@@ -837,8 +837,8 @@ default:
             string testCode = string.Format(testCodeFormat, asyncModifier, statement);
             string fixedTest = string.Format(testCodeFormat, asyncModifier, fixedStatement);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
@@ -31,7 +31,7 @@
         public async Task TestSpaceAfterComma()
         {
             string statement = "f(a, b);";
-            await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement);
+            await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement).ConfigureAwait(false);
         }
 
         [Fact]
@@ -40,11 +40,11 @@
             string statementWithoutSpace = @"f(a,b);";
             string statementWithSpace = @"f(a, b);";
 
-            await this.TestCommaInStatementOrDecl(statementWithSpace, EmptyDiagnosticResults, statementWithSpace);
+            await this.TestCommaInStatementOrDecl(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(7, 16);
 
-            await this.TestCommaInStatementOrDecl(statementWithoutSpace, expected, statementWithSpace);
+            await this.TestCommaInStatementOrDecl(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
 
         [Fact]
@@ -55,7 +55,7 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 17);
 
-            await this.TestCommaInStatementOrDecl(spaceBeforeComma, expected, spaceOnlyAfterComma);
+            await this.TestCommaInStatementOrDecl(spaceBeforeComma, expected, spaceOnlyAfterComma).ConfigureAwait(false);
         }
 
         [Fact]
@@ -66,28 +66,28 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 17);
 
-            await this.TestCommaInStatementOrDecl(spaceBeforeComma, expected, spaceOnlyAfterComma);
+            await this.TestCommaInStatementOrDecl(spaceBeforeComma, expected, spaceOnlyAfterComma).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestLastCommaInLine()
         {
             string statement = $"f(a,{Environment.NewLine}b);";
-            await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement);
+            await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestFirstCommaInLine()
         {
             string statement = $"f(a{Environment.NewLine}, b);";
-            await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement);
+            await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestCommentBeforeFirstCommaInLine()
         {
             string statement = $"f(a // comment{Environment.NewLine}, b);";
-            await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement);
+            await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement).ConfigureAwait(false);
         }
 
         [Fact]
@@ -98,14 +98,14 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 41);
 
-            await this.TestCommaInStatementOrDecl(statement, expected, fixedStatement);
+            await this.TestCommaInStatementOrDecl(statement, expected, fixedStatement).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestCommaFollowedByAngleBracketInFuncType()
         {
             string statement = @"var a = typeof(System.Func<,>);";
-            await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement);
+            await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement).ConfigureAwait(false);
         }
 
         [Fact]
@@ -113,7 +113,7 @@
         {
             // This is correct by SA1001, and reported as an error by SA1015
             string statement = @"var a = typeof(System.Func<, >);";
-            await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement);
+            await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement).ConfigureAwait(false);
         }
 
         [Fact]
@@ -124,14 +124,14 @@
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 41);
 
-            await this.TestCommaInStatementOrDecl(statement, expected, fixedStatement);
+            await this.TestCommaInStatementOrDecl(statement, expected, fixedStatement).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestCommaFollowedByCommaInFuncType()
         {
             string statement = @"var a = typeof(System.Func<,,>);";
-            await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement);
+            await this.TestCommaInStatementOrDecl(statement, EmptyDiagnosticResults, statement).ConfigureAwait(false);
         }
 
         [Fact]
@@ -141,7 +141,7 @@
             string fixedStatement = @"var a = typeof(System.Func<,,>);";
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 42);
 
-            await this.TestCommaInStatementOrDecl(statement, expected, fixedStatement);
+            await this.TestCommaInStatementOrDecl(statement, expected, fixedStatement).ConfigureAwait(false);
         }
 
         private Task TestCommaInStatementOrDecl(string originalStatement, DiagnosticResult expected, string fixedStatement)
@@ -165,8 +165,8 @@
             string originalCode = string.Format(template, originalStatement);
             string fixedCode = string.Format(template, fixedStatement);
 
-            await this.VerifyCSharpDiagnosticAsync(originalCode, expected, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(originalCode, fixedCode, cancellationToken: CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(originalCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(originalCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
@@ -63,8 +63,8 @@ namespace TestHelper
         private async Task VerifyFixAsync(string language, DiagnosticAnalyzer analyzer, CodeFixProvider codeFixProvider, string oldSource, string newSource, int? codeFixIndex, bool allowNewCompilerDiagnostics, CancellationToken cancellationToken)
         {
             var document = CreateDocument(oldSource, language);
-            var analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzer, new[] { document }, cancellationToken);
-            var compilerDiagnostics = await GetCompilerDiagnosticsAsync(document, cancellationToken);
+            var analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzer, new[] { document }, cancellationToken).ConfigureAwait(false);
+            var compilerDiagnostics = await GetCompilerDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false);
             var attempts = analyzerDiagnostics.Length;
 
             for (int i = 0; i < attempts; ++i)
@@ -85,7 +85,7 @@ namespace TestHelper
                 }
 
                 document = await ApplyFixAsync(document, actions.ElementAt(0), cancellationToken).ConfigureAwait(false);
-                analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzer, new[] { document }, cancellationToken);
+                analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzer, new[] { document }, cancellationToken).ConfigureAwait(false);
 
                 //check if there are analyzer diagnostics left after the code fix
                 if (!analyzerDiagnostics.Any())
@@ -100,7 +100,7 @@ namespace TestHelper
             if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
             {
                 // Format and get the compiler diagnostics again so that the locations make sense in the output
-                document = await Formatter.FormatAsync(document, Formatter.Annotation, cancellationToken: cancellationToken);
+                document = await Formatter.FormatAsync(document, Formatter.Annotation, cancellationToken: cancellationToken).ConfigureAwait(false);
                 newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false));
 
                 Assert.True(false,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
@@ -106,7 +106,7 @@ namespace TestHelper
                 Assert.True(false,
                     string.Format("Fix introduced new compiler diagnostics:\r\n{0}\r\n\r\nNew document:\r\n{1}\r\n",
                         string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString())),
-                        (await document.GetSyntaxRootAsync().ConfigureAwait(false)).ToFullString()));
+                        (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false)).ToFullString()));
             }
 
             //after applying all of the code fixes, compare the resulting string to the inputted one

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/DiagnosticVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/DiagnosticVerifier.cs
@@ -87,7 +87,7 @@ namespace TestHelper
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that the task will observe.</param>
         private async Task VerifyDiagnosticsAsync(string[] sources, string language, DiagnosticAnalyzer analyzer, DiagnosticResult[] expected, CancellationToken cancellationToken)
         {
-            var diagnostics = await GetSortedDiagnosticsAsync(sources, language, analyzer, cancellationToken);
+            var diagnostics = await GetSortedDiagnosticsAsync(sources, language, analyzer, cancellationToken).ConfigureAwait(false);
             VerifyDiagnosticResults(diagnostics, analyzer, expected);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -51,11 +51,11 @@
                 if (node == null)
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Add standard text.", token => GetTransformedDocument(context.Document, root, node)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Add standard text.", token => GetTransformedDocumentAsync(context.Document, root, node)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, XmlElementSyntax node)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, XmlElementSyntax node)
         {
             var classDeclaration = node.FirstAncestorOrSelf<ClassDeclarationSyntax>();
             var declarationSyntax = node.FirstAncestorOrSelf<BaseMethodDeclarationSyntax>();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/RenameHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/RenameHelper.cs
@@ -14,13 +14,13 @@
             var annotatedSolution = document.Project.Solution.WithDocumentSyntaxRoot(document.Id, annotatedRoot);
             var annotatedDocument = annotatedSolution.GetDocument(document.Id);
 
-            annotatedRoot = await annotatedDocument.GetSyntaxRootAsync(cancellationToken);
+            annotatedRoot = await annotatedDocument.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var annotatedToken = annotatedRoot.FindToken(declarationToken.SpanStart);
 
-            var semanticModel = await annotatedDocument.GetSemanticModelAsync(cancellationToken);
+            var semanticModel = await annotatedDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var symbol = semanticModel?.GetDeclaredSymbol(annotatedToken.Parent, cancellationToken);
 
-            var newSolution = await Renamer.RenameSymbolAsync(annotatedSolution, symbol, newName, null, cancellationToken);
+            var newSolution = await Renamer.RenameSymbolAsync(annotatedSolution, symbol, newName, null, cancellationToken).ConfigureAwait(false);
 
             // TODO: return annotatedSolution instead of newSolution if newSolution contains any new errors (for any project)
             return newSolution;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1516CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1516CodeFixProvider.cs
@@ -41,12 +41,12 @@
                 var leadingTrivia = node?.GetLeadingTrivia();
                 if (leadingTrivia != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create("Insert new line", token => GetTransformedDocument(context, syntaxRoot, node, (SyntaxTriviaList)leadingTrivia)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Insert new line", token => GetTransformedDocumentAsync(context, syntaxRoot, node, (SyntaxTriviaList)leadingTrivia)), diagnostic);
                 }
             }
         }
 
-        private static Task<Document> GetTransformedDocument(CodeFixContext context, SyntaxNode syntaxRoot, SyntaxNode node, SyntaxTriviaList leadingTrivia)
+        private static Task<Document> GetTransformedDocumentAsync(CodeFixContext context, SyntaxNode syntaxRoot, SyntaxNode node, SyntaxTriviaList leadingTrivia)
         {
             var newTriviaList = leadingTrivia;
             newTriviaList = newTriviaList.Insert(0, SyntaxFactory.ElasticCarriageReturnLineFeed);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1517CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1517CodeFixProvider.cs
@@ -35,13 +35,13 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create("Remove blank lines at the start of the file", token => GetTransformedDocument(context.Document, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove blank lines at the start of the file", token => GetTransformedDocumentAsync(context.Document, token)), diagnostic);
             }
 
             return Task.FromResult(true);
         }
 
-        private static async Task<Document> GetTransformedDocument(Document document, CancellationToken token)
+        private static async Task<Document> GetTransformedDocumentAsync(Document document, CancellationToken token)
         {
             var syntaxRoot = await document.GetSyntaxRootAsync(token).ConfigureAwait(false);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1518CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1518CodeFixProvider.cs
@@ -35,13 +35,13 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create("Remove blank lines at the end of the file", token => GetTransformedDocument(context.Document, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove blank lines at the end of the file", token => GetTransformedDocumentAsync(context.Document, token)), diagnostic);
             }
 
             return Task.FromResult(true);
         }
 
-        private static async Task<Document> GetTransformedDocument(Document document, CancellationToken token)
+        private static async Task<Document> GetTransformedDocumentAsync(Document document, CancellationToken token)
         {
             var syntaxRoot = await document.GetSyntaxRootAsync(token).ConfigureAwait(false);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
@@ -50,12 +50,12 @@
 
                 if (syntax != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create("Remove parenthesis", token => GetTransformedDocument(context.Document, root, syntax)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Remove parenthesis", token => GetTransformedDocumentAsync(context.Document, root, syntax)), diagnostic);
                 }
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, ParenthesizedExpressionSyntax syntax)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, ParenthesizedExpressionSyntax syntax)
         {
             var leadingTrivia = syntax.OpenParenToken.GetAllTrivia().Concat(syntax.Expression.GetLeadingTrivia());
             var trailingTrivia = syntax.Expression.GetTrailingTrivia().Concat(syntax.CloseParenToken.GetAllTrivia());

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
@@ -50,11 +50,11 @@
                 if (declarationNode == null)
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Declare accessibility", token => GetTransformedDocument(context.Document, root, declarationNode)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Declare accessibility", token => GetTransformedDocumentAsync(context.Document, root, declarationNode)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxNode declarationNode)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxNode declarationNode)
         {
             SyntaxNode updatedDeclarationNode;
             switch (declarationNode.Kind())

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1402FileMayOnlyContainASingleClass.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1402FileMayOnlyContainASingleClass.cs
@@ -58,7 +58,7 @@
 
         private async void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
         {
-            var syntaxRoot = await context.Tree.GetRootAsync(context.CancellationToken);
+            var syntaxRoot = await context.Tree.GetRootAsync(context.CancellationToken).ConfigureAwait(false);
 
             var descentNodes = syntaxRoot.DescendantNodes(descendIntoChildren: node => node != null && !node.IsKind(SyntaxKind.ClassDeclaration));
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1402FileMayOnlyContainASingleClass.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1402FileMayOnlyContainASingleClass.cs
@@ -53,10 +53,10 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterSyntaxTreeAction(this.HandleSyntaxTree);
+            context.RegisterSyntaxTreeAction(this.HandleSyntaxTreeAsync);
         }
 
-        private async void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
+        private async void HandleSyntaxTreeAsync(SyntaxTreeAnalysisContext context)
         {
             var syntaxRoot = await context.Tree.GetRootAsync(context.CancellationToken).ConfigureAwait(false);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1403FileMayOnlyContainASingleNamespace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1403FileMayOnlyContainASingleNamespace.cs
@@ -53,7 +53,7 @@
 
         private async void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
         {
-            var syntaxRoot = await context.Tree.GetRootAsync(context.CancellationToken);
+            var syntaxRoot = await context.Tree.GetRootAsync(context.CancellationToken).ConfigureAwait(false);
 
             var descentNodes = syntaxRoot.DescendantNodes(descendIntoChildren: node => node != null && !node.IsKind(SyntaxKind.ClassDeclaration));
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1403FileMayOnlyContainASingleNamespace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1403FileMayOnlyContainASingleNamespace.cs
@@ -48,10 +48,10 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterSyntaxTreeAction(this.HandleSyntaxTree);
+            context.RegisterSyntaxTreeAction(this.HandleSyntaxTreeAsync);
         }
 
-        private async void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
+        private async void HandleSyntaxTreeAsync(SyntaxTreeAnalysisContext context)
         {
             var syntaxRoot = await context.Tree.GetRootAsync(context.CancellationToken).ConfigureAwait(false);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
@@ -48,12 +48,12 @@
                 BinaryExpressionSyntax syntax = node as BinaryExpressionSyntax;
                 if (syntax != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create("Add parenthesis", token => GetTransformedDocument(context.Document, root, syntax)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Add parenthesis", token => GetTransformedDocumentAsync(context.Document, root, syntax)), diagnostic);
                 }
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, BinaryExpressionSyntax syntax)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, BinaryExpressionSyntax syntax)
         {
             var newNode = SyntaxFactory.ParenthesizedExpression(syntax.WithoutTrivia())
                 .WithTriviaFrom(syntax)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408FixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408FixAllProvider.cs
@@ -19,11 +19,11 @@
             switch (fixAllContext.Scope)
             {
             case FixAllScope.Document:
-                var newRoot = await this.FixAllInDocumentAsync(fixAllContext, fixAllContext.Document);
+                var newRoot = await this.FixAllInDocumentAsync(fixAllContext, fixAllContext.Document).ConfigureAwait(false);
                 return CodeAction.Create("Add parentheses", token => Task.FromResult(fixAllContext.Document.WithSyntaxRoot(newRoot)));
 
             case FixAllScope.Project:
-                Solution solution = await this.GetProjectFixesAsync(fixAllContext, fixAllContext.Project);
+                Solution solution = await this.GetProjectFixesAsync(fixAllContext, fixAllContext.Project).ConfigureAwait(false);
                 return CodeAction.Create("Add parentheses", token => Task.FromResult(solution));
 
             case FixAllScope.Solution:
@@ -31,7 +31,7 @@
                 var projectIds = newSolution.ProjectIds;
                 for (int i = 0; i < projectIds.Count; i++)
                 {
-                    newSolution = await this.GetProjectFixesAsync(fixAllContext, newSolution.GetProject(projectIds[i]));
+                    newSolution = await this.GetProjectFixesAsync(fixAllContext, newSolution.GetProject(projectIds[i])).ConfigureAwait(false);
                 }
                 return CodeAction.Create("Add parentheses", token => Task.FromResult(newSolution));
 
@@ -52,7 +52,7 @@
             }
             for (int i = 0; i < oldDocuments.Length; i++)
             {
-                var newDocumentRoot = await newDocuments[i];
+                var newDocumentRoot = await newDocuments[i].ConfigureAwait(false);
                 solution = solution.WithDocumentSyntaxRoot(oldDocuments[i].Id, newDocumentRoot);
             }
 
@@ -61,7 +61,7 @@
 
         private async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
         {
-            var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document);
+            var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
 
             var newDocument = document;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1410SA1411CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1410SA1411CodeFixProvider.cs
@@ -53,12 +53,12 @@
 
                 if (node != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create("Remove parenthesis", token => GetTransformedDocument(context.Document, root, node)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Remove parenthesis", token => GetTransformedDocumentAsync(context.Document, root, node)), diagnostic);
                 }
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxNode node)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxNode node)
         {
             // The first token is the open parenthesis token. This token has all the inner trivia
             var firstToken = node.GetFirstToken();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
@@ -48,11 +48,11 @@
                     return;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create("Replace 'base.' with 'this.'", token => GetTransformedDocument(context.Document, root, node)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Replace 'base.' with 'this.'", token => GetTransformedDocumentAsync(context.Document, root, node)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxNode node)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxNode node)
         {
             var thisExpressionSyntax = SyntaxFactory.ThisExpression()
                 .WithTriviaFrom(node)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
@@ -47,11 +47,11 @@
                 if (node == null)
                     return;
 
-                context.RegisterCodeFix(CodeAction.Create("Prefix reference with 'this.'", token => GetTransformedDocument(context.Document, root, diagnostic, node)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Prefix reference with 'this.'", token => GetTransformedDocumentAsync(context.Document, root, diagnostic, node)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, Diagnostic diagnostic, SimpleNameSyntax node)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, Diagnostic diagnostic, SimpleNameSyntax node)
         {
             var qualifiedExpression =
                 SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, SyntaxFactory.ThisExpression(), node.WithoutTrivia().WithoutFormatting())

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
@@ -56,7 +56,7 @@
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-            var semanticModel = await context.Document.GetSemanticModelAsync();
+            var semanticModel = await context.Document.GetSemanticModelAsync().ConfigureAwait(false);
 
             if (semanticModel == null)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
@@ -56,7 +56,7 @@
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
             var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-            var semanticModel = await context.Document.GetSemanticModelAsync().ConfigureAwait(false);
+            var semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
 
             if (semanticModel == null)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
@@ -85,12 +85,12 @@
                 if (typeInfo.Type != null)
                 {
                     SpecialType specialType = typeInfo.Type.SpecialType;
-                    context.RegisterCodeFix(CodeAction.Create("Replace with built-in type", token => GetTransformedDocument(context.Document, root, node, specialType)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create("Replace with built-in type", token => GetTransformedDocumentAsync(context.Document, root, node, specialType)), diagnostic);
                 }
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxNode node, SpecialType specialType)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxNode node, SpecialType specialType)
         {
             var newNode = SyntaxFactory.PredefinedType(SyntaxFactory.Token(PredefinedSpecialTypes[specialType]))
                 .WithTriviaFrom(node)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
@@ -54,12 +54,12 @@
                 var node = root?.FindNode(diagnostic.Location.SourceSpan, findInsideTrivia: true, getInnermostNodeForTie: true);
                 if (node != null && node.IsKind(SyntaxKind.StringLiteralExpression))
                 {
-                    context.RegisterCodeFix(CodeAction.Create($"Replace with string.Empty", token => GetTransformedDocument(context.Document, root, node)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create($"Replace with string.Empty", token => GetTransformedDocumentAsync(context.Document, root, node)), diagnostic);
                 }
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxNode node)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxNode node)
         {
             var newSyntaxRoot = root.ReplaceNode(node, StringEmptyExpression);
             return Task.FromResult(document.WithSyntaxRoot(newSyntaxRoot));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
@@ -46,7 +46,7 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            var root = await context.Document.GetSyntaxRootAsync().ConfigureAwait(false);
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1122UseStringEmptyForEmptyStrings.DiagnosticId))

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000CodeFixProvider.cs
@@ -45,11 +45,11 @@
                 if (token.IsMissing)
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxToken token)
         {
             bool isAddingSpace = true;
             switch (token.Kind())

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
@@ -46,11 +46,11 @@
                 if (!token.IsKind(SyntaxKind.CommaToken))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxToken token)
         {
             Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002CodeFixProvider.cs
@@ -46,11 +46,11 @@
                 if (!token.IsKind(SyntaxKind.SemicolonToken))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxToken token)
         {
             Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
@@ -48,11 +48,11 @@
                 if (token.IsMissing)
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxToken token)
         {
             Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
@@ -46,11 +46,11 @@
                 if (!trivia.IsKind(SyntaxKind.SingleLineCommentTrivia))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Insert space", t => GetTransformedDocument(context.Document, root, trivia)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Insert space", t => GetTransformedDocumentAsync(context.Document, root, trivia)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxTrivia trivia)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxTrivia trivia)
         {
             string text = trivia.ToFullString();
             if (!text.StartsWith("//"))

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1006CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1006CodeFixProvider.cs
@@ -45,11 +45,11 @@
                 if (keywordToken.IsMissing)
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Remove space", t => GetTransformedDocument(context.Document, root, keywordToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove space", t => GetTransformedDocumentAsync(context.Document, root, keywordToken)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken keywordToken)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxToken keywordToken)
         {
             SyntaxToken hashToken = keywordToken.GetPreviousToken(includeDirectives: true);
             if (!hashToken.IsKind(SyntaxKind.HashToken))

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1007CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1007CodeFixProvider.cs
@@ -47,11 +47,11 @@
                 if (token.HasTrailingTrivia && token.TrailingTrivia[0].IsKind(SyntaxKind.WhitespaceTrivia))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Insert space", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Insert space", t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxToken token)
         {
             SyntaxTrivia whitespace = SyntaxFactory.Whitespace(" ");
             SyntaxToken corrected = token.WithTrailingTrivia(token.TrailingTrivia.Insert(0, whitespace)).WithoutFormatting();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010CodeFixProvider.cs
@@ -46,10 +46,10 @@
                 if (!token.IsKind(SyntaxKind.OpenBracketToken))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
             }
         }
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxToken token)
         {
 
             Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
@@ -46,11 +46,11 @@
                 if (!token.IsKind(SyntaxKind.CloseBracketToken))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxToken token)
         {
 
             Dictionary<SyntaxToken, SyntaxToken> replacements = new Dictionary<SyntaxToken, SyntaxToken>();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016CodeFixProvider.cs
@@ -51,11 +51,11 @@
                 if (!token.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxToken token)
         {
             SyntaxToken corrected = token.WithoutTrailingWhitespace().WithoutFormatting();
             SyntaxNode transformed = root.ReplaceToken(token, corrected);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017CodeFixProvider.cs
@@ -45,11 +45,11 @@
                 if (!token.IsKind(SyntaxKind.CloseBracketToken))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxToken token)
         {
             bool firstInLine = token.HasLeadingTrivia || token.GetLocation()?.GetMappedLineSpan().StartLinePosition.Character == 0;
             if (firstInLine)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
@@ -53,11 +53,11 @@
                 if (!previousToken.HasTrailingTrivia)
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Remove space", t => GetTransformedDocument(context.Document, root, previousToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove space", t => GetTransformedDocumentAsync(context.Document, root, previousToken)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken previousToken)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxToken previousToken)
         {
             SyntaxToken corrected = previousToken.WithoutTrailingWhitespace().WithoutFormatting();
             Document updatedDocument = document.WithSyntaxRoot(root.ReplaceToken(previousToken, corrected));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021CodeFixProvider.cs
@@ -47,11 +47,11 @@
                 if (!token.IsKind(SyntaxKind.MinusToken))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxToken token)
         {
             bool precededBySpace;
             bool firstInLine;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022CodeFixProvider.cs
@@ -47,11 +47,11 @@
                 if (!token.IsKind(SyntaxKind.PlusToken))
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Fix spacing", t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxToken token)
         {
 
             bool precededBySpace;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1026CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1026CodeFixProvider.cs
@@ -44,11 +44,11 @@
                 if (token.IsMissing)
                     continue;
 
-                context.RegisterCodeFix(CodeAction.Create("Remove space", t => GetTransformedDocument(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove space", t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxToken token)
         {
             SyntaxToken corrected = token.WithoutTrailingWhitespace().WithoutFormatting();
             Document updatedDocument = document.WithSyntaxRoot(root.ReplaceToken(token, corrected));


### PR DESCRIPTION
Considering the number of lines changed, I encourage you to look at the individual commits.

* Use `ConfigureAwait(false)` with all `await` operations (automated detection and refactoring per Code Cracker CC0070).
* Pass a `CancellationToken` to asynchronous methods when available and supported.
* Rename asynchronous methods with the `Async` suffix (automated detection and refactoring per Code Cracker CC0061).