### PR TITLE
Sa1307 is reported on read only fields

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1307UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1307UnitTests.cs
@@ -95,8 +95,6 @@ string Bar, Car, Dar;
             await this.TestThatDiagnosticIsReported_SingleFieldImpl("public");
             await this.TestThatDiagnosticIsReported_SingleFieldImpl("internal");
             await this.TestThatDiagnosticIsReported_SingleFieldImpl("protected internal");
-            await this.TestThatDiagnosticIsReported_SingleFieldImpl("public readonly");
-            await this.TestThatDiagnosticIsReported_SingleFieldImpl("internal readonly");
         }
 
         [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/496")]
@@ -105,8 +103,6 @@ string Bar, Car, Dar;
             await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("public");
             await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("internal");
             await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("protected internal");
-            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("public readonly");
-            await this.TestThatDiagnosticIsReported_MultipleFieldsImpl("internal readonly");
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1307AccessibleFieldsMustBeginWithUpperCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1307AccessibleFieldsMustBeginWithUpperCaseLetter.cs
@@ -72,7 +72,7 @@
                             && char.IsLower(name[0]) 
                             && !NamedTypeHelpers.IsContainedInNativeMethodsClass(declaration))
                         {
-                            context.ReportDiagnostic(Diagnostic.Create(Descriptor, declarator.GetLocation(), name));
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptor, declarator.Identifier.GetLocation(), name));
                         }
                     }
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1307AccessibleFieldsMustBeginWithUpperCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1307AccessibleFieldsMustBeginWithUpperCaseLetter.cs
@@ -59,7 +59,8 @@
         {
             // To improve performance we are looking for the field instead of the declarator directly. That way we don't get called for local variables.
             FieldDeclarationSyntax declaration = context.Node as FieldDeclarationSyntax;
-            if (declaration != null && declaration.Declaration != null)
+            // Exclude read only fields because they are handled by SA1304
+            if (declaration != null && declaration.Declaration != null && !declaration.Modifiers.Any(SyntaxKind.ReadOnlyKeyword))
             {
                 if (declaration.Modifiers.Any(SyntaxKind.PublicKeyword) || declaration.Modifiers.Any(SyntaxKind.InternalKeyword))
                 {


### PR DESCRIPTION
We usually try to reduce the number of diagnostic reported for the same issue. Read only fields are reported by SA1304 so we should not report SA1307 here. We have a test that makes sure that read only fields are not reported, but the test is currently broken because of the roslyn bug that made us disable a bunch of tests. So we have a regression test when we have rc2.
I also changed that the diagnostic was reported on the whole declarator and not on the identifier directly.