### PR TITLE
Implemented diagnostic for SA1108: BlockStatementsMustNotContainEmbeddedComments

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1108UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1108UnitTests.cs
@@ -168,7 +168,7 @@ public class Foo
         public async Task TestCheckedUncheckedStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
         {
             var testCode = @"
-public clas Foo
+public class Foo
 {
     public void F()
     {
@@ -233,7 +233,7 @@ public class Foo
         {
 
         }
-        catch (NullReferenceException e)
+        catch (System.NullReferenceException e)
         //bb
         {
                 
@@ -264,7 +264,7 @@ public class Foo
         public async Task TestSwitchStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
         {
             var testCode = @"
-public clas Foo
+public class Foo
 {
     public void F()
     {
@@ -318,7 +318,7 @@ public class Foo
     public void F()
     {
         //comment
-        foreach (var e in Enumerable.Empty<int>())
+        foreach (var e in System.Linq.Enumerable.Empty<int>())
         // Comment
         {
             //comment
@@ -396,13 +396,16 @@ namespace Foo
     public class Bar
     {
         public int Prop
-        //aa
         {
-            return 0;
-        }
-        set
-        //bb
-        {
+            get
+            //aa
+            {
+                return 0;
+            }
+            set
+            //bb
+            {
+            }
         }
     }
 }";

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1108UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1108UnitTests.cs
@@ -1,0 +1,393 @@
+﻿namespace StyleCop.Analyzers.Test.ReadabilityRules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.ReadabilityRules;
+    using TestHelper;
+    using Xunit;
+
+    public class SA1108UnitTests : CodeFixVerifier
+    {
+        [Fact]
+        public async Task TestEmptySource()
+        {
+            var testCode = string.Empty;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestIfStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
+        {
+            var testCode = @"
+public void F()
+{
+    //comment
+    if (true)
+    // Comment
+    {
+        //comment
+    }
+    else
+    //comment
+    {
+        //inner comment
+    }
+}";
+
+            var firstDiagnostic = this.CSharpDiagnostic().WithLocation(6, 5);
+            var secondDiagnostic = this.CSharpDiagnostic().WithLocation(11, 5);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, new [] {firstDiagnostic, secondDiagnostic}, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestIfStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracketCommentedCode()
+        {
+            var testCode = @"
+public void F()
+{
+    if (true)
+    //// if (true)
+    {
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestIfWithPreprocessorDirectiveCommentBetweenStatementDeclarationAndOpeningCurlyBracketCommentedCode()
+        {
+            var testCode = @"
+public void F()
+{
+    if (true)
+    #if true
+    /* line 1
+       line 2 */
+    {
+    }
+    #endif
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 5);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestCodeBlockInsideMethod()
+        {
+            var testCode = @"
+public void F()
+{
+    //comment
+    {
+
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestWhileStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
+        {
+            var testCode = @"
+public void F()
+{
+    //comment
+    while (true)
+    // Comment
+    {
+        //comment
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 5);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestWhileStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracketOneLine()
+        {
+            var testCode = @"
+public void F()
+{
+    //comment
+    while (true) /* Comment */ { /*comment */ }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 18);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestDoWhileStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
+        {
+            var testCode = @"
+public void F()
+{
+    //comment
+    do
+    //aa
+    {
+
+    } while (true);
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 5);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestCheckedUncheckedStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
+        {
+            var testCode = @"
+public void F()
+{
+    int a = 0;
+    checked
+    //aa
+    {
+        a++;
+    }
+    unchecked
+    //bb
+    {
+        a++;
+    }
+}";
+
+            DiagnosticResult first = this.CSharpDiagnostic().WithLocation(6, 5);
+            DiagnosticResult second = this.CSharpDiagnostic().WithLocation(11, 5);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, new []{first, second}, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestFixedStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
+        {
+            var testCode = @"
+public class TestUnsafe
+{
+    class Point
+    {
+        public int x;
+        public int y;
+    } 
+
+    unsafe static void TestMethod()
+    {
+        Point pt = new Point();
+        fixed (int* p = &pt.x)//aa
+        {
+            *p = 1;
+        }
+
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(13, 31);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestTryCatchFinallyStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
+        {
+            var testCode = @"
+public void F()
+{
+   try
+    //aa
+    {
+
+    }
+    catch (NullReferenceException e)
+    //bb
+    {
+                
+    }
+    catch
+    //cc
+    {
+                
+    }
+    finally
+    /* line 1
+       line 2 */
+    {
+                
+    }
+}";
+
+            DiagnosticResult first = this.CSharpDiagnostic().WithLocation(5, 5);
+            DiagnosticResult second = this.CSharpDiagnostic().WithLocation(10, 5);
+            DiagnosticResult third = this.CSharpDiagnostic().WithLocation(15, 5);
+            DiagnosticResult fourth = this.CSharpDiagnostic().WithLocation(20, 5);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, new []{first, second, third, fourth}, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestSwitchStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
+        {
+            var testCode = @"
+public void F()
+{
+    var i = 0;
+    //bb
+    switch (i)
+    //aa
+    {
+        // comment
+        case 1:
+            return;
+        default:
+            return;
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 5);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestForStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
+        {
+            var testCode = @"
+public void F()
+{
+    //comment
+    for (int i=0; i < 5; i++)
+    // Comment
+    {
+        //comment
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 5);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestForeachStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
+        {
+            var testCode = @"
+public void F()
+{
+    //comment
+    foreach (var e in Enumerable.Empty<int>())
+    // Comment
+    {
+        //comment
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 5);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestLockStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
+        {
+            var testCode = @"
+public void F()
+{
+    //comment
+    lock(this)
+    // Comment
+    {
+        //comment
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 5);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestMethodDeclarationCommentBetweenDeclarationAndOpeningCurlyBracket()
+        {
+            var testCode = @"
+public class Bar
+{
+    //comment
+    public void F()
+    //comment
+    {
+        //inner comment
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestClassDeclarationCommentBetweenDeclarationAndOpeningCurlyBracket()
+        {
+            var testCode = @"
+namespace Foo
+{
+    //comment
+    public class Bar
+    //comment
+    {
+        //comment
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestPropertyDeclarationCommentBetweenDeclarationAndOpeningCurlyBracket()
+        {
+            var testCode = @"
+namespace Foo
+{
+    public class Bar
+    {
+        public int Prop
+        //aa
+        {
+            return 0;
+        }
+        set
+        //bb
+        {
+        }
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestNamespaceDeclarationCommentBetweenDeclarationAndOpeningCurlyBracket()
+        {
+            var testCode = @"
+namespace Foo
+//comment
+{
+    //inner
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new SA1108BlockStatementsMustNotContainEmbeddedComments();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1108UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1108UnitTests.cs
@@ -20,23 +20,26 @@
         public async Task TestIfStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
         {
             var testCode = @"
-public void F()
+public class Foo
 {
-    //comment
-    if (true)
-    // Comment
+    public void F()
     {
         //comment
-    }
-    else
-    //comment
-    {
-        //inner comment
+        if (true)
+        // Comment
+        {
+            //comment
+        }
+        else
+        //comment
+        {
+            //inner comment
+        }
     }
 }";
 
-            var firstDiagnostic = this.CSharpDiagnostic().WithLocation(6, 5);
-            var secondDiagnostic = this.CSharpDiagnostic().WithLocation(11, 5);
+            var firstDiagnostic = this.CSharpDiagnostic().WithLocation(8, 9);
+            var secondDiagnostic = this.CSharpDiagnostic().WithLocation(13, 9);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, new [] {firstDiagnostic, secondDiagnostic}, CancellationToken.None);
         }
@@ -45,11 +48,14 @@ public void F()
         public async Task TestIfStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracketCommentedCode()
         {
             var testCode = @"
-public void F()
+public class Foo
 {
-    if (true)
-    //// if (true)
+    public void F()
     {
+        if (true)
+        //// if (true)
+        {
+        }
     }
 }";
 
@@ -60,18 +66,21 @@ public void F()
         public async Task TestIfWithPreprocessorDirectiveCommentBetweenStatementDeclarationAndOpeningCurlyBracketCommentedCode()
         {
             var testCode = @"
-public void F()
+public class Foo
 {
-    if (true)
-    #if true
-    /* line 1
-       line 2 */
+    public void F()
     {
+        if (true)
+        #if true
+        /* line 1
+           line 2 */
+        {
+        }
+        #endif
     }
-    #endif
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 5);
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 9);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
         }
@@ -80,11 +89,14 @@ public void F()
         public async Task TestCodeBlockInsideMethod()
         {
             var testCode = @"
-public void F()
+public class Foo
 {
-    //comment
+    public void F()
     {
+        //comment
+        {
 
+        }
     }
 }";
 
@@ -95,17 +107,19 @@ public void F()
         public async Task TestWhileStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
         {
             var testCode = @"
-public void F()
+public class Foo
 {
-    //comment
-    while (true)
-    // Comment
+    public void F()
     {
         //comment
+        while (true)
+        // Comment
+        {
+            //comment
+        }
     }
 }";
-
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 5);
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 9);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
         }
@@ -114,13 +128,16 @@ public void F()
         public async Task TestWhileStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracketOneLine()
         {
             var testCode = @"
-public void F()
+public class Foo
 {
-    //comment
-    while (true) /* Comment */ { /*comment */ }
+    public void F()
+    {
+        //comment
+        while (true) /* Comment */ { /*comment */ }
+    }
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 18);
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 22);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
         }
@@ -129,17 +146,20 @@ public void F()
         public async Task TestDoWhileStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
         {
             var testCode = @"
-public void F()
+public class Foo
 {
-    //comment
-    do
-    //aa
+    public void F()
     {
+        //comment
+        do
+        //aa
+        {
 
-    } while (true);
+        } while (true);
+    }
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 5);
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 9);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
         }
@@ -148,23 +168,26 @@ public void F()
         public async Task TestCheckedUncheckedStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
         {
             var testCode = @"
-public void F()
+public clas Foo
 {
-    int a = 0;
-    checked
-    //aa
+    public void F()
     {
-        a++;
-    }
-    unchecked
-    //bb
-    {
-        a++;
+        int a = 0;
+        checked
+        //aa
+        {
+            a++;
+        }
+        unchecked
+        //bb
+        {
+            a++;
+        }
     }
 }";
 
-            DiagnosticResult first = this.CSharpDiagnostic().WithLocation(6, 5);
-            DiagnosticResult second = this.CSharpDiagnostic().WithLocation(11, 5);
+            DiagnosticResult first = this.CSharpDiagnostic().WithLocation(8, 9);
+            DiagnosticResult second = this.CSharpDiagnostic().WithLocation(13, 9);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, new []{first, second}, CancellationToken.None);
         }
@@ -201,35 +224,38 @@ public class TestUnsafe
         public async Task TestTryCatchFinallyStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
         {
             var testCode = @"
-public void F()
+public class Foo
 {
-   try
-    //aa
+    public void F()
     {
+       try
+        //aa
+        {
 
-    }
-    catch (NullReferenceException e)
-    //bb
-    {
+        }
+        catch (NullReferenceException e)
+        //bb
+        {
                 
-    }
-    catch
-    //cc
-    {
+        }
+        catch
+        //cc
+        {
                 
-    }
-    finally
-    /* line 1
-       line 2 */
-    {
+        }
+        finally
+        /* line 1
+           line 2 */
+        {
                 
+        }
     }
 }";
 
-            DiagnosticResult first = this.CSharpDiagnostic().WithLocation(5, 5);
-            DiagnosticResult second = this.CSharpDiagnostic().WithLocation(10, 5);
-            DiagnosticResult third = this.CSharpDiagnostic().WithLocation(15, 5);
-            DiagnosticResult fourth = this.CSharpDiagnostic().WithLocation(20, 5);
+            DiagnosticResult first = this.CSharpDiagnostic().WithLocation(7, 9);
+            DiagnosticResult second = this.CSharpDiagnostic().WithLocation(12, 9);
+            DiagnosticResult third = this.CSharpDiagnostic().WithLocation(17, 9);
+            DiagnosticResult fourth = this.CSharpDiagnostic().WithLocation(22, 9);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, new []{first, second, third, fourth}, CancellationToken.None);
         }
@@ -238,22 +264,25 @@ public void F()
         public async Task TestSwitchStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
         {
             var testCode = @"
-public void F()
+public clas Foo
 {
-    var i = 0;
-    //bb
-    switch (i)
-    //aa
+    public void F()
     {
-        // comment
-        case 1:
-            return;
-        default:
-            return;
+        var i = 0;
+        //bb
+        switch (i)
+        //aa
+        {
+            // comment
+            case 1:
+                return;
+            default:
+                return;
+        }
     }
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 5);
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 9);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
         }
@@ -262,17 +291,20 @@ public void F()
         public async Task TestForStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
         {
             var testCode = @"
-public void F()
+public class Foo
 {
-    //comment
-    for (int i=0; i < 5; i++)
-    // Comment
+    public void F()
     {
         //comment
+        for (int i=0; i < 5; i++)
+        // Comment
+        {
+            //comment
+        }
     }
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 5);
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 9);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
         }
@@ -281,17 +313,20 @@ public void F()
         public async Task TestForeachStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
         {
             var testCode = @"
-public void F()
+public class Foo
 {
-    //comment
-    foreach (var e in Enumerable.Empty<int>())
-    // Comment
+    public void F()
     {
         //comment
+        foreach (var e in Enumerable.Empty<int>())
+        // Comment
+        {
+            //comment
+        }
     }
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 5);
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 9);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
         }
@@ -300,17 +335,20 @@ public void F()
         public async Task TestLockStatementCommentBetweenStatementDeclarationAndOpeningCurlyBracket()
         {
             var testCode = @"
-public void F()
+public class Foo
 {
-    //comment
-    lock(this)
-    // Comment
+    public void F()
     {
         //comment
+        lock(this)
+        // Comment
+        {
+            //comment
+        }
     }
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 5);
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 9);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1108UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1108UnitTests.cs
@@ -41,7 +41,7 @@ public class Foo
             var firstDiagnostic = this.CSharpDiagnostic().WithLocation(8, 9);
             var secondDiagnostic = this.CSharpDiagnostic().WithLocation(13, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, new [] {firstDiagnostic, secondDiagnostic}, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, new [] { firstDiagnostic, secondDiagnostic }, CancellationToken.None);
         }
 
         [Fact]
@@ -189,7 +189,7 @@ public class Foo
             DiagnosticResult first = this.CSharpDiagnostic().WithLocation(8, 9);
             DiagnosticResult second = this.CSharpDiagnostic().WithLocation(13, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, new []{first, second}, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, new []{ first, second }, CancellationToken.None);
         }
 
         [Fact]
@@ -257,7 +257,7 @@ public class Foo
             DiagnosticResult third = this.CSharpDiagnostic().WithLocation(17, 9);
             DiagnosticResult fourth = this.CSharpDiagnostic().WithLocation(22, 9);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, new []{first, second, third, fourth}, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(testCode, new []{ first, second, third, fourth }, CancellationToken.None);
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -167,6 +167,7 @@
     <Compile Include="ReadabilityRules\SA1101UnitTests.cs" />
     <Compile Include="ReadabilityRules\SA1102UnitTests.cs" />
     <Compile Include="ReadabilityRules\SA1106UnitTests.cs" />
+    <Compile Include="ReadabilityRules\SA1108UnitTests.cs" />
     <Compile Include="ReadabilityRules\SA1110UnitTests.cs" />
     <Compile Include="ReadabilityRules\SA1111UnitTests.cs" />
     <Compile Include="ReadabilityRules\SA1112UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1108BlockStatementsMustNotContainEmbeddedComments.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1108BlockStatementsMustNotContainEmbeddedComments.cs
@@ -98,10 +98,6 @@
             }
 
             var previousToken = openBraceToken.GetPreviousToken();
-            if (previousToken.IsMissing)
-            {
-                return;
-            }
 
             this.FindAllComments(context, previousToken, openBraceToken);
         }
@@ -109,7 +105,7 @@
         private void AnalyzeBlock(SyntaxNodeAnalysisContext context)
         {
             var block = (BlockSyntax) context.Node;
-            if (block.Parent == null || !this.supportedKinds.Any(block.Parent.IsKind))
+            if (!this.supportedKinds.Any(block.Parent.IsKind))
             {
                 return;
             }
@@ -132,8 +128,7 @@
         private void FindAllComments(SyntaxNodeAnalysisContext context, SyntaxToken previousToken, SyntaxToken openBraceToken)
         {
             var comments = previousToken.TrailingTrivia.Where(this.IsComment)
-                .Union(openBraceToken.LeadingTrivia.Where(this.IsComment))
-                .ToList();
+                .Concat(openBraceToken.LeadingTrivia.Where(this.IsComment));
             foreach (var comment in comments)
             {
                 context.ReportDiagnostic(Diagnostic.Create(Descriptor, comment.GetLocation()));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1108BlockStatementsMustNotContainEmbeddedComments.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1108BlockStatementsMustNotContainEmbeddedComments.cs
@@ -1,7 +1,10 @@
 ﻿namespace StyleCop.Analyzers.ReadabilityRules
 {
     using System.Collections.Immutable;
+    using System.Linq;
     using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
 
     /// <summary>
@@ -47,7 +50,7 @@
         /// </summary>
         public const string DiagnosticId = "SA1108";
         private const string Title = "Block statements must not contain embedded comments";
-        private const string MessageFormat = "TODO: Message format";
+        private const string MessageFormat = "Block statements must not contain embedded comments.";
         private const string Category = "StyleCop.CSharp.ReadabilityRules";
         private const string Description = "A C# statement contains a comment between the declaration of the statement and the opening curly bracket of the statement.";
         private const string HelpLink = "http://www.stylecop.com/docs/SA1108.html";
@@ -58,19 +61,90 @@
         private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
             ImmutableArray.Create(Descriptor);
 
-        /// <inheritdoc/>
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        private readonly SyntaxKind[] supportedKinds = new[]
         {
-            get
-            {
-                return SupportedDiagnosticsValue;
-            }
-        }
+            SyntaxKind.ForEachStatement,
+            SyntaxKind.ForStatement,
+            SyntaxKind.WhileStatement,
+            SyntaxKind.DoStatement,
+            SyntaxKind.IfStatement,
+            SyntaxKind.ElseClause,
+            SyntaxKind.LockStatement,
+            SyntaxKind.TryStatement,
+            SyntaxKind.CatchClause,
+            SyntaxKind.FinallyClause,
+            SyntaxKind.CheckedStatement,
+            SyntaxKind.UncheckedStatement,
+            SyntaxKind.FixedStatement
+        };
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => SupportedDiagnosticsValue;
 
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            // TODO: Implement analysis
+            context.RegisterSyntaxNodeAction(this.AnalyzeBlock, SyntaxKind.Block);
+            context.RegisterSyntaxNodeAction(this.AnalyzeSwitch, SyntaxKind.SwitchStatement);
+        }
+
+        private void AnalyzeSwitch(SyntaxNodeAnalysisContext context)
+        {
+            var switchStatement = (SwitchStatementSyntax) context.Node;
+            var openBraceToken = switchStatement.OpenBraceToken;
+            if (openBraceToken.IsMissing)
+            {
+                return;
+            }
+
+            var previousToken = openBraceToken.GetPreviousToken();
+            if (previousToken.IsMissing)
+            {
+                return;
+            }
+
+            this.FindAllComments(context, previousToken, openBraceToken);
+        }
+
+        private void AnalyzeBlock(SyntaxNodeAnalysisContext context)
+        {
+            var block = (BlockSyntax) context.Node;
+            if (block.Parent == null || !this.supportedKinds.Any(block.Parent.IsKind))
+            {
+                return;
+            }
+
+            var openBraceToken = block.OpenBraceToken;
+            if (openBraceToken.IsMissing)
+            {
+                return;
+            }
+
+            var previousToken = openBraceToken.GetPreviousToken();
+            if (previousToken.IsMissing)
+            {
+                return;
+            }
+
+            this.FindAllComments(context, previousToken, openBraceToken);
+        }
+
+        private void FindAllComments(SyntaxNodeAnalysisContext context, SyntaxToken previousToken, SyntaxToken openBraceToken)
+        {
+            var comments = previousToken.TrailingTrivia.Where(this.IsComment)
+                .Union(openBraceToken.LeadingTrivia.Where(this.IsComment))
+                .ToList();
+            foreach (var comment in comments)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, comment.GetLocation()));
+            }
+        }
+
+
+        private bool IsComment(SyntaxTrivia syntaxTrivia)
+        {
+            return (syntaxTrivia.IsKind(SyntaxKind.SingleLineCommentTrivia) && !syntaxTrivia.ToFullString().StartsWith(@"////")) ||
+                   syntaxTrivia.IsKind(SyntaxKind.MultiLineCommentTrivia);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1108BlockStatementsMustNotContainEmbeddedComments.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1108BlockStatementsMustNotContainEmbeddedComments.cs
@@ -138,8 +138,10 @@
 
         private bool IsComment(SyntaxTrivia syntaxTrivia)
         {
-            return (syntaxTrivia.IsKind(SyntaxKind.SingleLineCommentTrivia) && !syntaxTrivia.ToFullString().StartsWith(@"////")) ||
-                   syntaxTrivia.IsKind(SyntaxKind.MultiLineCommentTrivia);
+            var isSingleLineComment = syntaxTrivia.IsKind(SyntaxKind.SingleLineCommentTrivia) 
+                                      && !syntaxTrivia.ToFullString().StartsWith(@"////");
+            return isSingleLineComment
+                   || syntaxTrivia.IsKind(SyntaxKind.MultiLineCommentTrivia);
         }
     }
 }


### PR DESCRIPTION
Fixes #42.
Additional diagnostic is proposed in #605.
Unit tests for this diagnostic also check if parts thatshould be caught in #605 are not caught here. Probably during implementation of #605 I will update tests for this diagnostic, to be sure 2 diagnostics are not reported for the same issue.