### PR TITLE
Expand XmlSyntaxFactory functionality

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/ElementDocumentationSummaryBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/ElementDocumentationSummaryBase.cs
@@ -158,20 +158,20 @@ namespace StyleCop.Analyzers.DocumentationRules
 
         private void HandleDeclaration(SyntaxNodeAnalysisContext context, SyntaxNode node, params Location[] locations)
         {
-            var documentation = XmlCommentHelper.GetDocumentationStructure(node);
+            var documentation = node.GetDocumentationCommentTriviaSyntax();
             if (documentation == null)
             {
                 // missing documentation is reported by SA1600, SA1601, and SA1602
                 return;
             }
 
-            if (XmlCommentHelper.GetTopLevelElement(documentation, XmlCommentHelper.InheritdocXmlTag) != null)
+            if (documentation.Content.GetFirstXmlElement(XmlCommentHelper.InheritdocXmlTag) != null)
             {
                 // Ignore nodes with an <inheritdoc/> tag.
                 return;
             }
 
-            var summaryXmlElement = XmlCommentHelper.GetTopLevelElement(documentation, XmlCommentHelper.SummaryXmlTag);
+            var summaryXmlElement = documentation.Content.GetFirstXmlElement(XmlCommentHelper.SummaryXmlTag);
             this.HandleXmlElement(context, summaryXmlElement, locations);
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PartialElementDocumentationSummaryBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PartialElementDocumentationSummaryBase.cs
@@ -33,18 +33,6 @@ namespace StyleCop.Analyzers.DocumentationRules
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleMethodDeclaration, SyntaxKind.MethodDeclaration);
         }
 
-        private static XmlNodeSyntax GetTopLevelElement(DocumentationCommentTriviaSyntax syntax, string tagName)
-        {
-            XmlElementSyntax elementSyntax = syntax.Content.OfType<XmlElementSyntax>().FirstOrDefault(element => string.Equals(element.StartTag.Name.ToString(), tagName));
-            if (elementSyntax != null)
-            {
-                return elementSyntax;
-            }
-
-            XmlEmptyElementSyntax emptyElementSyntax = syntax.Content.OfType<XmlEmptyElementSyntax>().FirstOrDefault(element => string.Equals(element.Name.ToString(), tagName));
-            return emptyElementSyntax;
-        }
-
         private void HandleTypeDeclaration(SyntaxNodeAnalysisContext context)
         {
             var node = context.Node as BaseTypeDeclarationSyntax;
@@ -81,23 +69,23 @@ namespace StyleCop.Analyzers.DocumentationRules
 
         private void HandleDeclaration(SyntaxNodeAnalysisContext context, SyntaxNode node, params Location[] locations)
         {
-            var documentation = XmlCommentHelper.GetDocumentationStructure(node);
+            var documentation = node.GetDocumentationCommentTriviaSyntax();
             if (documentation == null)
             {
                 // missing documentation is reported by SA1600, SA1601, and SA1602
                 return;
             }
 
-            if (GetTopLevelElement(documentation, XmlCommentHelper.InheritdocXmlTag) != null)
+            if (documentation.Content.GetFirstXmlElement(XmlCommentHelper.InheritdocXmlTag) != null)
             {
                 // Ignore nodes with an <inheritdoc/> tag.
                 return;
             }
 
-            var xmlElement = GetTopLevelElement(documentation, XmlCommentHelper.SummaryXmlTag);
+            var xmlElement = documentation.Content.GetFirstXmlElement(XmlCommentHelper.SummaryXmlTag);
             if (xmlElement == null)
             {
-                xmlElement = GetTopLevelElement(documentation, XmlCommentHelper.ContentXmlTag);
+                xmlElement = documentation.Content.GetFirstXmlElement(XmlCommentHelper.ContentXmlTag);
             }
 
             this.HandleXmlElement(context, xmlElement, locations);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertyDocumentationSummaryBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertyDocumentationSummaryBase.cs
@@ -39,21 +39,21 @@
 
         private void HandleDeclaration(SyntaxNodeAnalysisContext context, SyntaxNode node, params Location[] locations)
         {
-            var documentation = XmlCommentHelper.GetDocumentationStructure(node);
+            var documentation = node.GetDocumentationCommentTriviaSyntax();
             if (documentation == null)
             {
                 // missing documentation is reported by SA1600, SA1601, and SA1602
                 return;
             }
 
-            if (XmlCommentHelper.GetTopLevelElement(documentation, XmlCommentHelper.InheritdocXmlTag) != null)
+            if (documentation.Content.GetFirstXmlElement(XmlCommentHelper.InheritdocXmlTag) != null)
             {
                 // Ignore nodes with an <inheritdoc/> tag.
                 return;
             }
 
-            var summaryXmlElement = XmlCommentHelper.GetTopLevelElement(documentation, XmlCommentHelper.ValueXmlTag);
-            this.HandleXmlElement(context, summaryXmlElement, locations);
+            var valueXmlElement = documentation.Content.GetFirstXmlElement(XmlCommentHelper.ValueXmlTag);
+            this.HandleXmlElement(context, valueXmlElement, locations);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1608ElementDocumentationMustNotHaveDefaultSummary.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1608ElementDocumentationMustNotHaveDefaultSummary.cs
@@ -68,7 +68,7 @@
 
             if (documentationTrivia != null)
             {
-                var summaryElement = XmlCommentHelper.GetTopLevelElement(documentationTrivia, XmlCommentHelper.SummaryXmlTag) as XmlElementSyntax;
+                var summaryElement = documentationTrivia.Content.GetFirstXmlElement(XmlCommentHelper.SummaryXmlTag) as XmlElementSyntax;
 
                 if (summaryElement != null)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1611ElementParametersMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1611ElementParametersMustBeDocumented.cs
@@ -64,7 +64,7 @@
         {
             var node = context.Node;
 
-            var documentation = XmlCommentHelper.GetDocumentationStructure(node);
+            var documentation = node.GetDocumentationCommentTriviaSyntax();
 
             if (documentation != null)
             {
@@ -75,13 +75,13 @@
                     return;
                 }
 
-                if (XmlCommentHelper.GetTopLevelElement(documentation, XmlCommentHelper.InheritdocXmlTag) != null)
+                if (documentation.Content.GetFirstXmlElement(XmlCommentHelper.InheritdocXmlTag) != null)
                 {
                     // Ignore nodes with an <inheritdoc/> tag.
                     return;
                 }
 
-                var xmlParameterNames = XmlCommentHelper.GetTopLevelElements(documentation, XmlCommentHelper.ParamTag)
+                var xmlParameterNames = documentation.Content.GetXmlElements(XmlCommentHelper.ParamTag)
                     .Select(XmlCommentHelper.GetFirstAttributeOrDefault<XmlNameAttributeSyntax>)
                     .Where(x => x != null)
                     .ToImmutableArray();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1615ElementReturnValueMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1615ElementReturnValueMustBeDocumented.cs
@@ -79,20 +79,20 @@
                 return;
             }
 
-            var documentationStructure = XmlCommentHelper.GetDocumentationStructure(context.Node);
+            var documentationStructure = context.Node.GetDocumentationCommentTriviaSyntax();
 
             if (documentationStructure == null)
             {
                 return;
             }
 
-            if (XmlCommentHelper.GetTopLevelElement(documentationStructure, XmlCommentHelper.InheritdocXmlTag) != null)
+            if (documentationStructure.Content.GetFirstXmlElement(XmlCommentHelper.InheritdocXmlTag) != null)
             {
                 // Don't report if the documentation is inherited.
                 return;
             }
 
-            if (XmlCommentHelper.GetTopLevelElement(documentationStructure, XmlCommentHelper.ReturnsXmlTag) == null)
+            if (documentationStructure.Content.GetFirstXmlElement(XmlCommentHelper.ReturnsXmlTag) == null)
             {
                 context.ReportDiagnostic(Diagnostic.Create(Descriptor, returnType.GetLocation()));
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1617CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1617CodeFixProvider.cs
@@ -49,10 +49,10 @@
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var node = root.FindNode(diagnostic.Location.SourceSpan);
-            var documentation = XmlCommentHelper.GetDocumentationStructure(node);
+            var documentation = node.GetDocumentationCommentTriviaSyntax();
 
             // Check if the return value is documented
-            var returnsElement = XmlCommentHelper.GetTopLevelElement(documentation, XmlCommentHelper.ReturnsXmlTag);
+            var returnsElement = documentation.Content.GetFirstXmlElement(XmlCommentHelper.ReturnsXmlTag);
 
             if (returnsElement == null)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1617VoidReturnValueMustNotBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1617VoidReturnValueMustNotBeDocumented.cs
@@ -70,7 +70,7 @@
 
         private static void HandleMember(SyntaxNodeAnalysisContext context, TypeSyntax returnValue)
         {
-            var documentation = XmlCommentHelper.GetDocumentationStructure(context.Node);
+            var documentation = context.Node.GetDocumentationCommentTriviaSyntax();
 
             if (context.Node != null && documentation != null)
             {
@@ -80,7 +80,7 @@
                 if (returnType != null && returnType.Keyword.IsKind(SyntaxKind.VoidKeyword))
                 {
                     // Check if the return value is documented
-                    var returnsElement = XmlCommentHelper.GetTopLevelElement(documentation, XmlCommentHelper.ReturnsXmlTag);
+                    var returnsElement = documentation.Content.GetFirstXmlElement(XmlCommentHelper.ReturnsXmlTag);
 
                     if (returnsElement != null)
                     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -11,6 +11,7 @@
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Formatting;
     using SpacingRules;
 
     /// <summary>
@@ -114,10 +115,11 @@
                 throw new InvalidOperationException("XmlElementSyntax has invalid method as its parent");
             }
 
-            var list = BuildStandardText(typeDeclaration.Identifier, typeParameterList, standardText[0], standardText[1]);
+            string newLineText = document.Project.Solution.Workspace.Options.GetOption(FormattingOptions.NewLine, LanguageNames.CSharp);
+            var list = BuildStandardText(typeDeclaration.Identifier, typeParameterList, newLineText, standardText[0], standardText[1]);
 
             var newContent = node.Content.InsertRange(0, list);
-            var newNode = node.WithContent(newContent);
+            var newNode = node.WithContent(newContent).AdjustDocumentationCommentNewLineTrivia();
 
             var newRoot = root.ReplaceNode(node, newNode);
 
@@ -126,7 +128,7 @@
             return Task.FromResult(newDocument);
         }
 
-        private static SyntaxList<XmlNodeSyntax> BuildStandardText(SyntaxToken identifier, TypeParameterListSyntax typeParameters, string preText, string postText)
+        private static SyntaxList<XmlNodeSyntax> BuildStandardText(SyntaxToken identifier, TypeParameterListSyntax typeParameters, string newLineText, string preText, string postText)
         {
             TypeSyntax identifierName;
 
@@ -140,29 +142,11 @@
                 identifierName = SyntaxFactory.GenericName(identifier.WithoutTrivia(), ParameterToArgumentListSyntax(typeParameters));
             }
 
-            var list = new SyntaxList<XmlNodeSyntax>();
-
-            list = list.Add(XmlNewLine());
-            list = list.Add(CreateTextSyntax(preText).WithLeadingTrivia(XmlLineStart()));
-            list = list.Add(CreateSeeSyntax(identifierName));
-            list = list.Add(CreateTextSyntax(postText.EndsWith(".") ? postText : (postText + ".")));
-
-            return list;
-        }
-
-        private static SyntaxTriviaList XmlLineStart()
-        {
-            return SyntaxFactory.TriviaList(
-                SyntaxFactory.ElasticMarker,
-                SyntaxFactory.DocumentationCommentExterior("/// "));
-        }
-
-        private static XmlTextSyntax XmlNewLine()
-        {
-            var tokenList = new SyntaxTokenList();
-            tokenList = tokenList.Add(SyntaxFactory.XmlTextNewLine(default(SyntaxTriviaList), "\r\n", "\r\n", default(SyntaxTriviaList)));
-
-            return SyntaxFactory.XmlText(tokenList);
+            return XmlSyntaxFactory.List(
+                XmlSyntaxFactory.NewLine(newLineText),
+                XmlSyntaxFactory.Text(preText),
+                XmlSyntaxFactory.SeeElement(SyntaxFactory.TypeCref(identifierName)),
+                XmlSyntaxFactory.Text(postText.EndsWith(".") ? postText : (postText + ".")));
         }
 
         private static TypeArgumentListSyntax ParameterToArgumentListSyntax(TypeParameterListSyntax typeParameters)
@@ -178,46 +162,6 @@
             }
 
             return SyntaxFactory.TypeArgumentList(list);
-        }
-
-        private static  XmlNodeSyntax CreateSeeSyntax(TypeSyntax identifier)
-        {
-            NameMemberCrefSyntax cref;
-
-            var genericName = identifier as GenericNameSyntax;
-
-            if (genericName != null)
-            {
-                // In Xml a type argument list is enclosed in braces, not greater/less than tokens.
-                var lessThanToken = SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.LessThanToken, "{", "{", default(SyntaxTriviaList));
-                var greaterThanToken = SyntaxFactory.Token(default(SyntaxTriviaList), SyntaxKind.GreaterThanToken, "}", "}", default(SyntaxTriviaList));
-                var newList = SyntaxFactory.TypeArgumentList(lessThanToken, genericName.TypeArgumentList.Arguments, greaterThanToken);
-                genericName = genericName.WithTypeArgumentList(newList);
-                cref = SyntaxFactory.NameMemberCref(genericName);
-            }
-            else
-            {
-                cref = SyntaxFactory.NameMemberCref(identifier).WithoutFormatting();
-            }
-
-            var attributes = new SyntaxList<XmlAttributeSyntax>();
-
-            attributes = attributes.Add(SyntaxFactory.XmlCrefAttribute(SyntaxFactory.XmlName(XmlCommentHelper.CrefArgumentName), SyntaxFactory.Token(SyntaxKind.DoubleQuoteToken), cref, SyntaxFactory.Token(SyntaxKind.DoubleQuoteToken)));
-
-            return SyntaxFactory.XmlEmptyElement(SyntaxFactory.XmlName(XmlCommentHelper.SeeXmlTag).WithTrailingTrivia(SyntaxFactory.ElasticSpace), attributes);
-        }
-
-        private static XmlTextSyntax CreateTextSyntax(string text)
-        {
-            var tokenList = new SyntaxTokenList();
-            tokenList = tokenList.Add(XmlTextLiteral(text));
-
-            return SyntaxFactory.XmlText(tokenList);
-        }
-
-        private static SyntaxToken XmlTextLiteral(string text)
-        {
-            return SyntaxFactory.XmlTextLiteral(default(SyntaxTriviaList), text, text, default(SyntaxTriviaList));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/StandardTextDiagnosticBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/StandardTextDiagnosticBase.cs
@@ -58,13 +58,13 @@
                 return MatchResult.Unknown;
             }
 
-            var documentationStructure = XmlCommentHelper.GetDocumentationStructure(declarationSyntax);
+            var documentationStructure = declarationSyntax.GetDocumentationCommentTriviaSyntax();
             if (documentationStructure == null)
             {
                 return MatchResult.Unknown;
             }
 
-            var summaryElement = XmlCommentHelper.GetTopLevelElement(documentationStructure, XmlCommentHelper.SummaryXmlTag) as XmlElementSyntax;
+            var summaryElement = documentationStructure.Content.GetFirstXmlElement(XmlCommentHelper.SummaryXmlTag) as XmlElementSyntax;
             if (summaryElement == null)
             {
                 return MatchResult.Unknown;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
@@ -22,6 +22,7 @@
         internal const string SeeXmlTag = "see";
         internal const string ParamTag = "param";
         internal const string CrefArgumentName = "cref";
+        internal const string NameArgumentName = "name";
 
         /// <summary>
         /// The &lt;placeholder&gt; tag is a Sandcastle Help File Builder extension to the standard XML documentation

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
@@ -9,7 +9,7 @@
     using Microsoft.CodeAnalysis.CSharp.Syntax;
 
     /// <summary>
-    /// Provides helper methods to work with Xml comments
+    /// Provides helper methods to work with XML comments
     /// </summary>
     internal static class XmlCommentHelper
     {
@@ -30,10 +30,10 @@
         internal const string PlaceholderTag = "placeholder";
 
         /// <summary>
-        /// This helper is used by documentation diagnostics to check if a xml comment should be considered empty.
+        /// This helper is used by documentation diagnostics to check if a XML comment should be considered empty.
         /// A comment is empty if 
         /// - it is null
-        /// - it does not have any text in any xml element and it does not have an empty xml element in it.
+        /// - it does not have any text in any XML element and it does not have an empty XML element in it.
         /// </summary>
         /// <param name="xmlComment">The xmlComment that should be checked</param>
         /// <returns>true, if the comment should be considered empty, false otherwise.</returns>
@@ -56,8 +56,8 @@
         }
 
         /// <summary>
-        /// This helper is used by documentation diagnostics to check if a xml comment should be considered empty.
-        /// A comment is empty if it does not have any text in any xml element and it does not have an empty xml element in it.
+        /// This helper is used by documentation diagnostics to check if a XML comment should be considered empty.
+        /// A comment is empty if it does not have any text in any XML element and it does not have an empty XML element in it.
         /// </summary>
         /// <param name="xmlSyntax">The xmlSyntax that should be checked</param>
         /// <returns>true, if the comment should be considered empty, false otherwise.</returns>
@@ -125,7 +125,7 @@
         /// Checks if a SyntaxTrivia contains a DocumentationCommentTriviaSyntax and returns true if it is considered empty
         /// </summary>
         /// <param name="commentTrivia">A SyntaxTrivia containing possible documentation</param>
-        /// <returns>true if commentTrivia does not have documentation in it orthe documentation in SyntaxTriviais considered empty. False otherwise.</returns>
+        /// <returns>true if commentTrivia does not have documentation in it or the documentation in SyntaxTriviais considered empty. False otherwise.</returns>
         internal static bool IsMissingOrEmpty(SyntaxTrivia commentTrivia)
         {
             if (!commentTrivia.HasStructure)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlSyntaxFactory.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlSyntaxFactory.cs
@@ -1,11 +1,20 @@
 ﻿namespace StyleCop.Analyzers.Helpers
 {
+    using System;
+    using System.Xml.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
 
     internal static class XmlSyntaxFactory
     {
+        public static DocumentationCommentTriviaSyntax DocumentationComment(string newLineText, params XmlNodeSyntax[] content)
+        {
+            return SyntaxFactory.DocumentationCommentTrivia(SyntaxKind.SingleLineDocumentationCommentTrivia, List(content))
+                .WithLeadingTrivia(SyntaxFactory.DocumentationCommentExterior("/// "))
+                .WithTrailingTrivia(SyntaxFactory.EndOfLine(newLineText));
+        }
+
         public static XmlElementSyntax MultiLineElement(string localName, string newLineText, SyntaxList<XmlNodeSyntax> content)
         {
             return MultiLineElement(SyntaxFactory.XmlName(localName), newLineText, content);
@@ -32,14 +41,75 @@
                 SyntaxFactory.XmlElementEndTag(name));
         }
 
+        public static XmlEmptyElementSyntax EmptyElement(string localName)
+        {
+            return SyntaxFactory.XmlEmptyElement(SyntaxFactory.XmlName(localName));
+        }
+
         public static SyntaxList<XmlNodeSyntax> List(params XmlNodeSyntax[] nodes)
         {
             return SyntaxFactory.List(nodes);
         }
 
+        public static XmlTextSyntax Text(string value)
+        {
+            return Text(TextLiteral(value));
+        }
+
         public static XmlTextSyntax Text(params SyntaxToken[] textTokens)
         {
             return SyntaxFactory.XmlText(SyntaxFactory.TokenList(textTokens));
+        }
+
+        public static XmlTextAttributeSyntax TextAttribute(string name, string value)
+        {
+            return TextAttribute(name, TextLiteral(value));
+        }
+
+        public static XmlTextAttributeSyntax TextAttribute(string name, params SyntaxToken[] textTokens)
+        {
+            return TextAttribute(SyntaxFactory.XmlName(name), SyntaxKind.DoubleQuoteToken, SyntaxFactory.TokenList(textTokens));
+        }
+
+        public static XmlTextAttributeSyntax TextAttribute(string name, SyntaxKind quoteKind, SyntaxTokenList textTokens)
+        {
+            return TextAttribute(SyntaxFactory.XmlName(name), SyntaxKind.DoubleQuoteToken, textTokens);
+        }
+
+        public static XmlTextAttributeSyntax TextAttribute(XmlNameSyntax name, SyntaxKind quoteKind, SyntaxTokenList textTokens)
+        {
+            return SyntaxFactory.XmlTextAttribute(
+                name,
+                SyntaxFactory.Token(quoteKind),
+                textTokens,
+                SyntaxFactory.Token(quoteKind))
+                .WithLeadingTrivia(SyntaxFactory.Whitespace(" "));
+        }
+
+        public static XmlNameAttributeSyntax NameAttribute(string parameterName)
+        {
+            return SyntaxFactory.XmlNameAttribute(
+                SyntaxFactory.XmlName(XmlCommentHelper.NameArgumentName),
+                SyntaxFactory.Token(SyntaxKind.DoubleQuoteToken),
+                parameterName,
+                SyntaxFactory.Token(SyntaxKind.DoubleQuoteToken))
+                .WithLeadingTrivia(SyntaxFactory.Whitespace(" "));
+        }
+
+        public static XmlCrefAttributeSyntax CrefAttribute(CrefSyntax cref)
+        {
+            return CrefAttribute(cref, SyntaxKind.DoubleQuoteToken);
+        }
+
+        public static XmlCrefAttributeSyntax CrefAttribute(CrefSyntax cref, SyntaxKind quoteKind)
+        {
+            cref = cref.ReplaceTokens(cref.DescendantTokens(), ReplaceBracketTokens);
+            return SyntaxFactory.XmlCrefAttribute(
+                SyntaxFactory.XmlName(XmlCommentHelper.CrefArgumentName),
+                SyntaxFactory.Token(quoteKind),
+                cref,
+                SyntaxFactory.Token(quoteKind))
+                .WithLeadingTrivia(SyntaxFactory.Whitespace(" "));
         }
 
         public static XmlTextSyntax NewLine(string text)
@@ -68,9 +138,165 @@
             return token;
         }
 
+        public static SyntaxToken TextLiteral(string value)
+        {
+            string encoded = new XText(value).ToString();
+            return SyntaxFactory.XmlTextLiteral(
+                SyntaxFactory.TriviaList(),
+                encoded,
+                value,
+                SyntaxFactory.TriviaList());
+        }
+
+        public static XmlElementSyntax SummaryElement(string newLineText, params XmlNodeSyntax[] content)
+        {
+            return SummaryElement(newLineText, List(content));
+        }
+
+        public static XmlElementSyntax SummaryElement(string newLineText, SyntaxList<XmlNodeSyntax> content)
+        {
+            return MultiLineElement(XmlCommentHelper.SummaryXmlTag, newLineText, content);
+        }
+
+        public static XmlElementSyntax RemarksElement(string newLineText, params XmlNodeSyntax[] content)
+        {
+            return RemarksElement(newLineText, List(content));
+        }
+
+        public static XmlElementSyntax RemarksElement(string newLineText, SyntaxList<XmlNodeSyntax> content)
+        {
+            return MultiLineElement("remarks", newLineText, content);
+        }
+
+        public static XmlElementSyntax ReturnsElement(string newLineText, params XmlNodeSyntax[] content)
+        {
+            return ReturnsElement(newLineText, List(content));
+        }
+
+        public static XmlElementSyntax ReturnsElement(string newLineText, SyntaxList<XmlNodeSyntax> content)
+        {
+            return MultiLineElement(XmlCommentHelper.ReturnsXmlTag, newLineText, content);
+        }
+
+        public static XmlElementSyntax ValueElement(string newLineText, params XmlNodeSyntax[] content)
+        {
+            return ValueElement(newLineText, List(content));
+        }
+
+        public static XmlElementSyntax ValueElement(string newLineText, SyntaxList<XmlNodeSyntax> content)
+        {
+            return MultiLineElement(XmlCommentHelper.ValueXmlTag, newLineText, content);
+        }
+
+        public static XmlElementSyntax ExceptionElement(CrefSyntax cref, params XmlNodeSyntax[] content)
+        {
+            return ExceptionElement(cref, List(content));
+        }
+
+        public static XmlElementSyntax ExceptionElement(CrefSyntax cref, SyntaxList<XmlNodeSyntax> content)
+        {
+            XmlElementSyntax element = Element("exception", content);
+            return element.WithStartTag(element.StartTag.AddAttributes(CrefAttribute(cref)));
+        }
+
+        public static XmlElementSyntax ParaElement(params XmlNodeSyntax[] content)
+        {
+            return ParaElement(List(content));
+        }
+
+        public static XmlElementSyntax ParaElement(SyntaxList<XmlNodeSyntax> content)
+        {
+            return Element("para", content);
+        }
+
+        public static XmlElementSyntax ParamElement(string parameterName, params XmlNodeSyntax[] content)
+        {
+            return ParamElement(parameterName, List(content));
+        }
+
+        public static XmlElementSyntax ParamElement(string parameterName, SyntaxList<XmlNodeSyntax> content)
+        {
+            XmlElementSyntax element = Element("param", content);
+            return element.WithStartTag(element.StartTag.AddAttributes(NameAttribute(parameterName)));
+        }
+
+        public static XmlEmptyElementSyntax ParamRefElement(string parameterName)
+        {
+            return EmptyElement("paramref").AddAttributes(NameAttribute(parameterName));
+        }
+
+        public static XmlEmptyElementSyntax SeeElement(CrefSyntax cref)
+        {
+            return EmptyElement("see").AddAttributes(CrefAttribute(cref));
+        }
+
+        public static XmlEmptyElementSyntax SeeAlsoElement(CrefSyntax cref)
+        {
+            return EmptyElement("seealso").AddAttributes(CrefAttribute(cref));
+        }
+
+        public static XmlElementSyntax SeeAlsoElement(Uri linkAddress, SyntaxList<XmlNodeSyntax> linkText)
+        {
+            XmlElementSyntax element = Element("seealso", linkText);
+            return element.WithStartTag(element.StartTag.AddAttributes(TextAttribute("href", linkAddress.ToString())));
+        }
+
+        public static XmlEmptyElementSyntax NullKeywordElement()
+        {
+            return KeywordElement("null");
+        }
+
+        private static XmlEmptyElementSyntax KeywordElement(string keyword)
+        {
+            return EmptyElement("see").AddAttributes(
+                TextAttribute("langword", keyword));
+        }
+
+        public static XmlElementSyntax PlaceholderElement(params XmlNodeSyntax[] content)
+        {
+            return PlaceholderElement(List(content));
+        }
+
         public static XmlElementSyntax PlaceholderElement(SyntaxList<XmlNodeSyntax> content)
         {
             return Element(XmlCommentHelper.PlaceholderTag, content);
+        }
+
+        public static XmlEmptyElementSyntax ThreadSafetyElement()
+        {
+            return ThreadSafetyElement(true, false);
+        }
+
+        public static XmlEmptyElementSyntax ThreadSafetyElement(bool @static, bool instance)
+        {
+            return EmptyElement("threadsafety").AddAttributes(
+                TextAttribute("static", @static.ToString().ToLowerInvariant()),
+                TextAttribute("instance", instance.ToString().ToLowerInvariant()));
+        }
+
+        public static XmlEmptyElementSyntax PreliminaryElement()
+        {
+            return EmptyElement("preliminary");
+        }
+
+        public static XmlElementSyntax TokenElement(string value)
+        {
+            return Element("token", List(Text(value)));
+        }
+
+        private static SyntaxToken ReplaceBracketTokens(SyntaxToken originalToken, SyntaxToken rewrittenToken)
+        {
+            if (rewrittenToken.IsKind(SyntaxKind.LessThanToken) && string.Equals("<", rewrittenToken.Text, StringComparison.Ordinal))
+            {
+                return SyntaxFactory.Token(rewrittenToken.LeadingTrivia, SyntaxKind.LessThanToken, "{", rewrittenToken.ValueText, rewrittenToken.TrailingTrivia);
+            }
+
+            if (rewrittenToken.IsKind(SyntaxKind.GreaterThanToken) && string.Equals(">", rewrittenToken.Text, StringComparison.Ordinal))
+            {
+                return SyntaxFactory.Token(rewrittenToken.LeadingTrivia, SyntaxKind.GreaterThanToken, "}", rewrittenToken.ValueText, rewrittenToken.TrailingTrivia);
+            }
+
+            return rewrittenToken;
         }
     }
 }


### PR DESCRIPTION
Blocked on (and includes the work of) #606.

* Expand the `XmlSyntaxFactory` class introduced by #606.
* Simplify certain uses of `XmlCommentHelper` using `XmlSyntaxFactory` methods.