### PR TITLE
Implement new block-level documentation diagnostics

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1653UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1653UnitTests.cs
@@ -1,0 +1,328 @@
+﻿namespace StyleCop.Analyzers.Test.DocumentationRules
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.DocumentationRules;
+    using TestHelper;
+    using Xunit;
+
+    /// <summary>
+    /// This class contains unit tests for <see cref="SA1653PlaceTextInParagraphs"/>.
+    /// </summary>
+    public class SA1653UnitTests : CodeFixVerifier
+    {
+        [Fact]
+        public async Task TestNoDocumentationAsync()
+        {
+            var testCode = @"
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestSummaryDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Summary.
+/// </summary>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestSimpleParagraphBlockAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// <para>Remarks.</para>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestTwoSimpleParagraphBlockAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// <para>Remarks.</para>
+/// <para>Remarks.</para>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMultipleBlockElementsAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// <!-- Supported XML documentation comment block-level elements -->
+/// <code>Remarks.</code>
+/// <list><item>Item</item></list>
+/// <note><para>Remarks.</para></note>
+/// <para>Remarks.</para>
+/// <!-- Supported SHFB elements which may be block-level elements -->
+/// <inheritdoc/>
+/// <token>SomeTokenName</token>
+/// <include />
+/// <!-- Supported HTML block-level elements -->
+/// <div>Remarks.</div>
+/// <p>Remarks.</p>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestSimpleInlineBlockAsync()
+        {
+            var testCode = @"
+/// <remarks>Remarks.</remarks>
+public class ClassName
+{
+}";
+
+            var fixedCode = @"
+/// <remarks><para>Remarks.</para></remarks>
+public class ClassName
+{
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(2, 14);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMultiLineInlineBlockAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// Remarks.
+/// </remarks>
+public class ClassName
+{
+}";
+
+            var fixedCode = @"
+/// <remarks>
+/// <para>Remarks.</para>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 5);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMultiLineParagraphInlineBlockAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// Remarks.
+/// Line 2.
+/// </remarks>
+public class ClassName
+{
+}";
+
+            var fixedCode = @"
+/// <remarks>
+/// <para>Remarks.
+/// Line 2.</para>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 5);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestFirstParagraphInlineBlockAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// Remarks.
+/// <para>Paragraph 2.</para>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            var fixedCode = @"
+/// <remarks>
+/// <para>Remarks.</para>
+/// <para>Paragraph 2.</para>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 5);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInlineParagraphAndCodeAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// Remarks.
+/// <code>Code.</code>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            var fixedCode = @"
+/// <remarks>
+/// <para>Remarks.</para>
+/// <code>Code.</code>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 5);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestCodeAndInlineParagraphAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// <code>Code.</code>
+/// Remarks.
+/// </remarks>
+public class ClassName
+{
+}";
+
+            var fixedCode = @"
+/// <remarks>
+/// <code>Code.</code>
+/// <para>Remarks.</para>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 5);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestThreeInlineParagraphsWithOtherElementsAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// Leading remarks.
+/// <code>Code.</code>
+/// <para>Remarks.</para>
+/// <note>Note.</note>
+/// Closing remarks.
+/// </remarks>
+public class ClassName
+{
+}";
+
+            var fixedCode = @"
+/// <remarks>
+/// <para>Leading remarks.</para>
+/// <code>Code.</code>
+/// <para>Remarks.</para>
+/// <note><para>Note.</para></note>
+/// <para>Closing remarks.</para>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(3, 5),
+                this.CSharpDiagnostic().WithLocation(6, 11),
+                this.CSharpDiagnostic().WithLocation(7, 5),
+            };
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestSeeIsAnInlineElementAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// Leading remarks.
+/// <see cref=""ClassName""/>
+/// <para>Remarks.</para>
+/// <note>Note.</note>
+/// Closing remarks.
+/// </remarks>
+public class ClassName
+{
+}";
+
+            var fixedCode = @"
+/// <remarks>
+/// <para>Leading remarks.
+/// <see cref=""ClassName""/></para>
+/// <para>Remarks.</para>
+/// <note><para>Note.</para></note>
+/// <para>Closing remarks.</para>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(3, 5),
+                this.CSharpDiagnostic().WithLocation(6, 11),
+                this.CSharpDiagnostic().WithLocation(7, 5),
+            };
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new SA1653PlaceTextInParagraphs();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new SA1653CodeFixProvider();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1653UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1653UnitTests.cs
@@ -322,7 +322,7 @@ public class ClassName
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
-            return new SA1653CodeFixProvider();
+            return new BlockLevelDocumentationCodeFixProvider();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1654UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1654UnitTests.cs
@@ -1,0 +1,330 @@
+﻿namespace StyleCop.Analyzers.Test.DocumentationRules
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.DocumentationRules;
+    using TestHelper;
+    using Xunit;
+
+    /// <summary>
+    /// This class contains unit tests for <see cref="SA1654UseChildBlocksConsistently"/>.
+    /// </summary>
+    public class SA1654UnitTests : CodeFixVerifier
+    {
+        [Fact]
+        public async Task TestNoDocumentationAsync()
+        {
+            var testCode = @"
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestSummaryDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Summary.
+/// </summary>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestSimpleParagraphBlockAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// <para>Summary.</para>
+/// </summary>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestTwoSimpleParagraphBlockAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// <para>Summary.</para>
+/// <para>Summary.</para>
+/// </summary>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMultipleBlockElementsAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// <!-- Supported XML documentation comment block-level elements -->
+/// <code>Summary.</code>
+/// <list><item>Item</item></list>
+/// <note><para>Summary.</para></note>
+/// <para>Summary.</para>
+/// <!-- Supported SHFB elements which may be block-level elements -->
+/// <inheritdoc/>
+/// <token>SomeTokenName</token>
+/// <include />
+/// <!-- Supported HTML block-level elements -->
+/// <div>Summary.</div>
+/// <p>Summary.</p>
+/// </summary>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestSimpleInlineBlockAsync()
+        {
+            var testCode = @"
+/// <summary>Summary.</summary>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMultiLineParagraphInlineBlockAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Remarks.
+/// Line 2.
+/// </summary>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestFirstParagraphInlineBlockAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Summary.
+/// <para>Paragraph 2.</para>
+/// </summary>
+public class ClassName
+{
+}";
+
+            var fixedCode = @"
+/// <summary>
+/// <para>Summary.</para>
+/// <para>Paragraph 2.</para>
+/// </summary>
+public class ClassName
+{
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 5);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestFirstParagraphInlineBlockInRemarksAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// Remarks.
+/// <para>Paragraph 2.</para>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            // reported as SA1653
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInlineParagraphAndCodeAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Summary.
+/// <code>Code.</code>
+/// </summary>
+public class ClassName
+{
+}";
+
+            var fixedCode = @"
+/// <summary>
+/// <para>Summary.</para>
+/// <code>Code.</code>
+/// </summary>
+public class ClassName
+{
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 5);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInlineParagraphAndCodeInRemarksAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// Remarks.
+/// <code>Code.</code>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            // reported as SA1653
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestCodeAndInlineParagraphAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// <code>Code.</code>
+/// Summary.
+/// </summary>
+public class ClassName
+{
+}";
+
+            var fixedCode = @"
+/// <summary>
+/// <code>Code.</code>
+/// <para>Summary.</para>
+/// </summary>
+public class ClassName
+{
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 5);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestCodeAndInlineParagraphInRemarksAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// <code>Code.</code>
+/// Remarks.
+/// </remarks>
+public class ClassName
+{
+}";
+
+            // reported as SA1653
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestThreeInlineParagraphsWithOtherElementsAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Leading summary.
+/// <code>Code.</code>
+/// <para>Summary.</para>
+/// <note>Note.</note>
+/// Closing summary.
+/// </summary>
+public class ClassName
+{
+}";
+
+            var fixedCode = @"
+/// <summary>
+/// <para>Leading summary.</para>
+/// <code>Code.</code>
+/// <para>Summary.</para>
+/// <note>Note.</note>
+/// <para>Closing summary.</para>
+/// </summary>
+public class ClassName
+{
+}";
+
+            // the <note> element is also covered by SA1653, even when it appears inside the <summary> element.
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(3, 5),
+                this.CSharpDiagnostic().WithLocation(7, 5),
+            };
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestThreeInlineParagraphsWithOtherElementsInRemarksAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// Leading remarks.
+/// <code>Code.</code>
+/// <para>Remarks.</para>
+/// <note>Note.</note>
+/// Closing remarks.
+/// </remarks>
+public class ClassName
+{
+}";
+
+            // reported as SA1653
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestSeeIsAnInlineElementAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Leading summary.
+/// <see cref=""ClassName""/>.
+/// </summary>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new SA1654UseChildBlocksConsistently();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new BlockLevelDocumentationCodeFixProvider();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1655UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1655UnitTests.cs
@@ -1,0 +1,356 @@
+﻿namespace StyleCop.Analyzers.Test.DocumentationRules
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.DocumentationRules;
+    using TestHelper;
+    using Xunit;
+
+    /// <summary>
+    /// This class contains unit tests for <see cref="SA1655UseChildBlocksConsistentlyAcrossElementsOfTheSameKind"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>This set of tests includes tests with the same inputs as <see cref="SA1653UnitTests"/> and
+    /// <see cref="SA1654UseChildBlocksConsistently"/> to ensure
+    /// <see cref="SA1655UseChildBlocksConsistentlyAcrossElementsOfTheSameKind"/> is not also reported in those
+    /// cases.</para>
+    /// </remarks>
+    public class SA1655UnitTests : CodeFixVerifier
+    {
+        [Fact]
+        public async Task TestNoDocumentationAsync()
+        {
+            var testCode = @"
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestSummaryDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Summary.
+/// </summary>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestSimpleParagraphBlockAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// <para>Summary.</para>
+/// </summary>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestTwoSimpleParagraphBlockAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// <para>Summary.</para>
+/// <para>Summary.</para>
+/// </summary>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMultipleBlockElementsAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// <!-- Supported XML documentation comment block-level elements -->
+/// <code>Summary.</code>
+/// <list><item>Item</item></list>
+/// <note><para>Summary.</para></note>
+/// <para>Summary.</para>
+/// <!-- Supported SHFB elements which may be block-level elements -->
+/// <inheritdoc/>
+/// <token>SomeTokenName</token>
+/// <include />
+/// <!-- Supported HTML block-level elements -->
+/// <div>Summary.</div>
+/// <p>Summary.</p>
+/// </summary>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestSimpleInlineBlockAsync()
+        {
+            var testCode = @"
+/// <summary>Summary.</summary>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMultiLineParagraphInlineBlockAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Remarks.
+/// Line 2.
+/// </summary>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestFirstParagraphInlineBlockAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Summary.
+/// <para>Paragraph 2.</para>
+/// </summary>
+public class ClassName
+{
+}";
+
+            // reported as SA1654
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestFirstParagraphInlineBlockInRemarksAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// Remarks.
+/// <para>Paragraph 2.</para>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            // reported as SA1653
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInlineParagraphAndCodeAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Summary.
+/// <code>Code.</code>
+/// </summary>
+public class ClassName
+{
+}";
+
+            // reported as SA1654
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInlineParagraphAndCodeInRemarksAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// Remarks.
+/// <code>Code.</code>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            // reported as SA1653
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestCodeAndInlineParagraphAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// <code>Code.</code>
+/// Summary.
+/// </summary>
+public class ClassName
+{
+}";
+
+            // reported as SA1654
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestCodeAndInlineParagraphInRemarksAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// <code>Code.</code>
+/// Remarks.
+/// </remarks>
+public class ClassName
+{
+}";
+
+            // reported as SA1653
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestThreeInlineParagraphsWithOtherElementsAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Leading summary.
+/// <code>Code.</code>
+/// <para>Summary.</para>
+/// <note>Note.</note>
+/// Closing summary.
+/// </summary>
+public class ClassName
+{
+}";
+
+            // reported as SA1653 and SA1654
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestThreeInlineParagraphsWithOtherElementsInRemarksAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// Leading remarks.
+/// <code>Code.</code>
+/// <para>Remarks.</para>
+/// <note>Note.</note>
+/// Closing remarks.
+/// </remarks>
+public class ClassName
+{
+}";
+
+            // reported as SA1653
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestSeeIsAnInlineElementAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Leading summary.
+/// <see cref=""ClassName""/>.
+/// </summary>
+public class ClassName
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestExceptionElementsAsync()
+        {
+            var testCode = @"
+using System;
+public class ClassName
+{
+    /// <exception cref=""ArgumentNullException"">If <paramref name=""x""/> is <see langword=""null""/>.</exception>
+    /// <exception cref=""ArgumentException"">
+    /// If <paramref name=""x""/> is empty.
+    /// <para>-or-</para>
+    /// <para>If <paramref name=""y""/> is empty.</para>
+    /// </exception>
+    public void MethodName(string x, string y)
+    {
+    }
+}";
+
+            var fixedCode = @"
+using System;
+public class ClassName
+{
+    /// <exception cref=""ArgumentNullException""><para>If <paramref name=""x""/> is <see langword=""null""/>.</para></exception>
+    /// <exception cref=""ArgumentException"">
+    /// If <paramref name=""x""/> is empty.
+    /// <para>-or-</para>
+    /// <para>If <paramref name=""y""/> is empty.</para>
+    /// </exception>
+    public void MethodName(string x, string y)
+    {
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 49);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestListItemsAsync()
+        {
+            var testCode = @"
+/// <remarks>
+/// <list type=""bullet"">
+/// <item>Item 1.</item>
+/// <item><para>Item 2.</para></item>
+/// </list>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            var fixedCode = @"
+/// <remarks>
+/// <list type=""bullet"">
+/// <item><para>Item 1.</para></item>
+/// <item><para>Item 2.</para></item>
+/// </list>
+/// </remarks>
+public class ClassName
+{
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 11);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new SA1655UseChildBlocksConsistentlyAcrossElementsOfTheSameKind();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new BlockLevelDocumentationCodeFixProvider();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ExportCodeFixProviderAttributeNameTest.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ExportCodeFixProviderAttributeNameTest.cs
@@ -18,6 +18,7 @@
                 var codeFixProviders = typeof(SA1110OpeningParenthesisMustBeOnDeclarationLine)
                     .Assembly
                     .GetTypes()
+                    .Where(t => !t.IsAbstract)
                     .Where(t => typeof(CodeFixProvider).IsAssignableFrom(t));
 
                 return codeFixProviders.Select(x => new[] { x });

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -170,6 +170,7 @@
     <Compile Include="DocumentationRules\SA1650UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1651UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1652UnitTests.cs" />
+    <Compile Include="DocumentationRules\SA1653UnitTests.cs" />
     <Compile Include="ExclusionTests.cs" />
     <Compile Include="ExportCodeFixProviderAttributeNameTest.cs" />
     <Compile Include="Helpers\CodeFixVerifier.Helper.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -171,6 +171,7 @@
     <Compile Include="DocumentationRules\SA1651UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1652UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1653UnitTests.cs" />
+    <Compile Include="DocumentationRules\SA1654UnitTests.cs" />
     <Compile Include="ExclusionTests.cs" />
     <Compile Include="ExportCodeFixProviderAttributeNameTest.cs" />
     <Compile Include="Helpers\CodeFixVerifier.Helper.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -172,6 +172,7 @@
     <Compile Include="DocumentationRules\SA1652UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1653UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1654UnitTests.cs" />
+    <Compile Include="DocumentationRules\SA1655UnitTests.cs" />
     <Compile Include="ExclusionTests.cs" />
     <Compile Include="ExportCodeFixProviderAttributeNameTest.cs" />
     <Compile Include="Helpers\CodeFixVerifier.Helper.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/BlockLevelDocumentationAnalyzerBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/BlockLevelDocumentationAnalyzerBase.cs
@@ -1,0 +1,216 @@
+﻿namespace StyleCop.Analyzers.DocumentationRules
+{
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.CodeAnalysis.Text;
+    using StyleCop.Analyzers.Helpers;
+    using StyleCop.Analyzers.SpacingRules;
+
+    /// <summary>
+    /// This is the base class for diagnostic analyzers which report diagnostics for inline content in documentation
+    /// comments which should be placed in block element.
+    /// </summary>
+    public abstract class BlockLevelDocumentationAnalyzerBase : DiagnosticAnalyzer
+    {
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeAction(this.HandleXmlElementSyntax, SyntaxKind.XmlElement);
+        }
+
+        private void HandleXmlElementSyntax(SyntaxNodeAnalysisContext context)
+        {
+            XmlElementSyntax syntax = (XmlElementSyntax)context.Node;
+            if (!this.ElementRequiresBlockContent(syntax))
+            {
+                return;
+            }
+
+            int nonBlockStartIndex = -1;
+            int nonBlockEndIndex = -1;
+            for (int i = 0; i < syntax.Content.Count; i++)
+            {
+                if (IsIgnoredElement(syntax.Content[i]))
+                {
+                    continue;
+                }
+
+                if (IsBlockLevelNode(syntax.Content[i]))
+                {
+                    this.ReportDiagnosticIfRequired(context, syntax.Content, nonBlockStartIndex, nonBlockEndIndex);
+                    nonBlockStartIndex = -1;
+                    continue;
+                }
+                else
+                {
+                    nonBlockEndIndex = i;
+                    if (nonBlockStartIndex < 0)
+                    {
+                        nonBlockStartIndex = i;
+                    }
+                }
+            }
+
+            this.ReportDiagnosticIfRequired(context, syntax.Content, nonBlockStartIndex, nonBlockEndIndex);
+        }
+
+        private void ReportDiagnosticIfRequired(SyntaxNodeAnalysisContext context, SyntaxList<XmlNodeSyntax> content, int nonBlockStartIndex, int nonBlockEndIndex)
+        {
+            if (nonBlockStartIndex < 0 || nonBlockEndIndex < nonBlockStartIndex)
+            {
+                return;
+            }
+
+            XmlNodeSyntax startNode = content[nonBlockStartIndex];
+            XmlNodeSyntax stopNode = content[nonBlockEndIndex];
+            Location location = Location.Create(startNode.GetLocation().SourceTree, TextSpan.FromBounds(GetEffectiveStart(startNode), GetEffectiveEnd(stopNode)));
+            context.ReportDiagnostic(Diagnostic.Create(this.SupportedDiagnostics[0], location));
+        }
+
+        private static int GetEffectiveStart(XmlNodeSyntax node)
+        {
+            XmlTextSyntax textNode = node as XmlTextSyntax;
+            if (textNode != null)
+            {
+                foreach (SyntaxToken textToken in textNode.TextTokens)
+                {
+                    if (string.IsNullOrWhiteSpace(textToken.Text))
+                    {
+                        continue;
+                    }
+
+                    for (int i = 0; i < textToken.Text.Length; i++)
+                    {
+                        if (!char.IsWhiteSpace(textToken.Text[i]))
+                        {
+                            return textToken.SpanStart + i;
+                        }
+                    }
+
+                    return textToken.SpanStart + textToken.Text.Length;
+                }
+            }
+
+            return node.SpanStart;
+        }
+
+        private static int GetEffectiveEnd(XmlNodeSyntax node)
+        {
+            XmlTextSyntax textNode = node as XmlTextSyntax;
+            if (textNode != null)
+            {
+                foreach (SyntaxToken textToken in textNode.TextTokens.Reverse())
+                {
+                    if (string.IsNullOrWhiteSpace(textToken.Text))
+                    {
+                        continue;
+                    }
+
+                    for (int i = textToken.Text.Length - 1; i >= 0; i--)
+                    {
+                        if (!char.IsWhiteSpace(textToken.Text[i]))
+                        {
+                            return textToken.Span.End - (textToken.Text.Length - 1 - i);
+                        }
+                    }
+
+                    return textToken.Span.End - textToken.Text.Length;
+                }
+            }
+
+            return node.Span.End;
+        }
+
+        /// <summary>
+        /// Determines if a particular <see cref="XmlElementSyntax"/> syntax node requires its content to be placed in
+        /// block-level elements according to the rules of the current diagnostic.
+        /// </summary>
+        /// <param name="element">The element.</param>
+        /// <returns>
+        /// <para><see langword="true"/> if the element requires content to be placed in block-level elements.</para>
+        /// <para>-or-</para>
+        /// <para><see langword="false"/> if the element allows inline content which is not placed in a block-level
+        /// element.</para>
+        /// </returns>
+        protected abstract bool ElementRequiresBlockContent(XmlElementSyntax element);
+
+        private static bool IsIgnoredElement(XmlNodeSyntax node)
+        {
+            if (node == null)
+            {
+                return true;
+            }
+
+            return XmlCommentHelper.IsConsideredEmpty(node);
+        }
+
+        private static bool IsBlockLevelNode(XmlNodeSyntax node)
+        {
+            XmlElementSyntax elementSyntax = node as XmlElementSyntax;
+            if (elementSyntax != null)
+            {
+                return IsBlockLevelElement(elementSyntax);
+            }
+
+            XmlEmptyElementSyntax emptyElementSyntax = node as XmlEmptyElementSyntax;
+            if (emptyElementSyntax != null)
+            {
+                return IsBlockLevelElement(emptyElementSyntax);
+            }
+
+            // ignored elements may appear at block level
+            return IsIgnoredElement(node);
+        }
+
+        private static bool IsBlockLevelElement(XmlElementSyntax element)
+        {
+            return IsBlockLevelName(element.StartTag?.Name);
+        }
+
+        private static bool IsBlockLevelElement(XmlEmptyElementSyntax element)
+        {
+            return IsBlockLevelName(element.Name);
+        }
+
+        private static bool IsBlockLevelName(XmlNameSyntax name)
+        {
+            if (name == null || name.LocalName.IsMissingOrDefault())
+            {
+                // unrecognized => allow
+                return true;
+            }
+
+            if (name.Prefix != null)
+            {
+                // not a standard element => allow
+                return true;
+            }
+
+            switch (name.LocalName.ValueText)
+            {
+            // certain block-level elements
+            case "code":
+            case "list":
+            case XmlCommentHelper.NoteXmlTag:
+            case "para":
+                return true;
+
+            // potential block-level elements => allow
+            case XmlCommentHelper.InheritdocXmlTag:
+            case "include":
+            case "token":
+                return true;
+
+            // block-level HTML elements => allow for this diagnostic
+            case "div":
+            case "p":
+                return true;
+
+            default:
+                return false;
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/BlockLevelDocumentationCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/BlockLevelDocumentationCodeFixProvider.cs
@@ -25,7 +25,8 @@
         public override ImmutableArray<string> FixableDiagnosticIds { get; }
             = ImmutableArray.Create(
                 SA1653PlaceTextInParagraphs.DiagnosticId,
-                SA1654UseChildBlocksConsistently.DiagnosticId);
+                SA1654UseChildBlocksConsistently.DiagnosticId,
+                SA1655UseChildBlocksConsistentlyAcrossElementsOfTheSameKind.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/BlockLevelDocumentationCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/BlockLevelDocumentationCodeFixProvider.cs
@@ -23,7 +23,9 @@
     {
         /// <inheritdoc/>
         public override ImmutableArray<string> FixableDiagnosticIds { get; }
-            = ImmutableArray.Create(SA1653PlaceTextInParagraphs.DiagnosticId);
+            = ImmutableArray.Create(
+                SA1653PlaceTextInParagraphs.DiagnosticId,
+                SA1654UseChildBlocksConsistently.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/BlockLevelDocumentationCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/BlockLevelDocumentationCodeFixProvider.cs
@@ -14,17 +14,16 @@
     using StyleCop.Analyzers.Helpers;
 
     /// <summary>
-    /// Implements a code fix for <see cref="SA1653PlaceTextInParagraphs"/>.
+    /// Implements a code fix for diagnostics that need to insert &lt;para&gt; elements around inline documentation
+    /// content to form block-level documentation content.
     /// </summary>
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SA1653CodeFixProvider))]
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(BlockLevelDocumentationCodeFixProvider))]
     [Shared]
-    public class SA1653CodeFixProvider : CodeFixProvider
+    public class BlockLevelDocumentationCodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1653PlaceTextInParagraphs.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; }
+            = ImmutableArray.Create(SA1653PlaceTextInParagraphs.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
@@ -37,12 +36,12 @@
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!FixableDiagnostics.Contains(diagnostic.Id))
+                if (!this.FixableDiagnosticIds.Contains(diagnostic.Id))
                 {
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(DocumentationResources.SA1653CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), nameof(SA1653CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(DocumentationResources.BlockLevelDocumentationCodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), nameof(BlockLevelDocumentationCodeFixProvider)), diagnostic);
             }
 
             return Task.FromResult(true);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
@@ -62,6 +62,15 @@ namespace StyleCop.Analyzers.DocumentationRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Insert paragraph element.
+        /// </summary>
+        internal static string BlockLevelDocumentationCodeFix {
+            get {
+                return ResourceManager.GetString("BlockLevelDocumentationCodeFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Document value from summary.
         /// </summary>
         internal static string SA1609SA1610CodeFix {
@@ -373,15 +382,6 @@ namespace StyleCop.Analyzers.DocumentationRules {
         internal static string SA1652Title {
             get {
                 return ResourceManager.GetString("SA1652Title", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Insert paragraph element.
-        /// </summary>
-        internal static string SA1653CodeFix {
-            get {
-                return ResourceManager.GetString("SA1653CodeFix", resourceCulture);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
@@ -375,5 +375,14 @@ namespace StyleCop.Analyzers.DocumentationRules {
                 return ResourceManager.GetString("SA1652Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Insert paragraph element.
+        /// </summary>
+        internal static string SA1653CodeFix {
+            get {
+                return ResourceManager.GetString("SA1653CodeFix", resourceCulture);
+            }
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
@@ -222,4 +222,7 @@
   <data name="SA1652Title" xml:space="preserve">
     <value>Enable XML documentation output</value>
   </data>
+  <data name="SA1653CodeFix" xml:space="preserve">
+    <value>Insert paragraph element</value>
+  </data>
 </root>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="BlockLevelDocumentationCodeFix" xml:space="preserve">
+    <value>Insert paragraph element</value>
+  </data>
   <data name="SA1609SA1610CodeFix" xml:space="preserve">
     <value>Document value from summary</value>
   </data>
@@ -221,8 +224,5 @@
   </data>
   <data name="SA1652Title" xml:space="preserve">
     <value>Enable XML documentation output</value>
-  </data>
-  <data name="SA1653CodeFix" xml:space="preserve">
-    <value>Insert paragraph element</value>
   </data>
 </root>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1653CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1653CodeFixProvider.cs
@@ -1,0 +1,216 @@
+﻿namespace StyleCop.Analyzers.DocumentationRules
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Composition;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using StyleCop.Analyzers.Helpers;
+
+    /// <summary>
+    /// Implements a code fix for <see cref="SA1653PlaceTextInParagraphs"/>.
+    /// </summary>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SA1653CodeFixProvider))]
+    [Shared]
+    public class SA1653CodeFixProvider : CodeFixProvider
+    {
+        private static readonly ImmutableArray<string> FixableDiagnostics =
+            ImmutableArray.Create(SA1653PlaceTextInParagraphs.DiagnosticId);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+
+        /// <inheritdoc/>
+        public override FixAllProvider GetFixAllProvider()
+        {
+            return CustomFixAllProviders.BatchFixer;
+        }
+
+        /// <inheritdoc/>
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                if (!FixableDiagnostics.Contains(diagnostic.Id))
+                {
+                    continue;
+                }
+
+                context.RegisterCodeFix(CodeAction.Create(DocumentationResources.SA1653CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), nameof(SA1653CodeFixProvider)), diagnostic);
+            }
+
+            return Task.FromResult(true);
+        }
+
+        private static async Task<Document> GetTransformedDocumentAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            SyntaxNode enclosingNode = root.FindNode(diagnostic.Location.SourceSpan, findInsideTrivia: true);
+            XmlNodeSyntax xmlNodeSyntax = enclosingNode as XmlNodeSyntax;
+            if (xmlNodeSyntax == null)
+            {
+                return document;
+            }
+
+            XmlElementSyntax xmlElementSyntax = xmlNodeSyntax.FirstAncestorOrSelf<XmlElementSyntax>();
+            if (xmlElementSyntax == null)
+            {
+                return document;
+            }
+
+            SyntaxToken startToken = root.FindToken(diagnostic.Location.SourceSpan.Start, findInsideTrivia: true);
+            XmlNodeSyntax startNode = startToken.Parent as XmlNodeSyntax;
+            if (startNode == null || startNode == xmlElementSyntax)
+            {
+                return document;
+            }
+
+            while (startNode.Parent != xmlElementSyntax)
+            {
+                startNode = startNode.Parent as XmlNodeSyntax;
+                if (startNode == null)
+                {
+                    return document;
+                }
+            }
+
+            SyntaxToken stopToken = root.FindToken(diagnostic.Location.SourceSpan.End - 1, findInsideTrivia: true);
+            XmlNodeSyntax stopNode = stopToken.Parent as XmlNodeSyntax;
+            if (stopNode == null || stopNode == xmlElementSyntax)
+            {
+                return document;
+            }
+
+            while (stopNode.Parent != xmlElementSyntax)
+            {
+                stopNode = stopNode.Parent as XmlNodeSyntax;
+                if (stopNode == null)
+                {
+                    return document;
+                }
+            }
+
+            int startIndex = xmlElementSyntax.Content.IndexOf(startNode);
+            int stopIndex = xmlElementSyntax.Content.IndexOf(stopNode);
+            if (startIndex < 0 || stopIndex < 0)
+            {
+                return document;
+            }
+
+            XmlElementSyntax paragraph = XmlSyntaxFactory.ParaElement(xmlElementSyntax.Content.Skip(startIndex).Take(stopIndex - startIndex + 1).ToArray());
+            SyntaxList<XmlNodeSyntax> leadingWhitespaceContent;
+            SyntaxList<XmlNodeSyntax> trailingWhitespaceContent;
+            paragraph = TrimWhitespaceContent(paragraph, out leadingWhitespaceContent, out trailingWhitespaceContent);
+
+            SyntaxList<XmlNodeSyntax> newContent = XmlSyntaxFactory.List();
+            newContent = newContent.AddRange(xmlElementSyntax.Content.Take(startIndex));
+            newContent = newContent.AddRange(leadingWhitespaceContent);
+            newContent = newContent.Add(paragraph);
+            newContent = newContent.AddRange(trailingWhitespaceContent);
+            newContent = newContent.AddRange(xmlElementSyntax.Content.Skip(stopIndex + 1));
+            return document.WithSyntaxRoot(root.ReplaceNode(xmlElementSyntax, xmlElementSyntax.WithContent(newContent)));
+        }
+
+        private static XmlElementSyntax TrimWhitespaceContent(XmlElementSyntax paragraph, out SyntaxList<XmlNodeSyntax> leadingWhitespaceContent, out SyntaxList<XmlNodeSyntax> trailingWhitespaceContent)
+        {
+            SyntaxList<XmlNodeSyntax> completeContent = XmlSyntaxFactory.List(paragraph.Content.SelectMany(ExpandTextNodes).ToArray());
+
+            leadingWhitespaceContent = XmlSyntaxFactory.List(completeContent.TakeWhile(XmlCommentHelper.IsConsideredEmpty).ToArray());
+            trailingWhitespaceContent = XmlSyntaxFactory.List(completeContent.Skip(leadingWhitespaceContent.Count).Reverse().TakeWhile(XmlCommentHelper.IsConsideredEmpty).Reverse().ToArray());
+
+            SyntaxList<XmlNodeSyntax> trimmedContent = XmlSyntaxFactory.List(completeContent.Skip(leadingWhitespaceContent.Count).Take(completeContent.Count - leadingWhitespaceContent.Count - trailingWhitespaceContent.Count).ToArray());
+            SyntaxTriviaList leadingTrivia = SyntaxFactory.TriviaList();
+            SyntaxTriviaList trailingTrivia = SyntaxFactory.TriviaList();
+            if (trimmedContent.Any())
+            {
+                leadingTrivia = trimmedContent[0].GetLeadingTrivia();
+                trailingTrivia = trimmedContent.Last().GetTrailingTrivia();
+                trimmedContent = trimmedContent.Replace(trimmedContent[0], trimmedContent[0].WithoutLeadingTrivia());
+                trimmedContent = trimmedContent.Replace(trimmedContent.Last(), trimmedContent.Last().WithoutTrailingTrivia());
+            }
+            else
+            {
+                leadingTrivia = SyntaxFactory.TriviaList();
+                trailingTrivia = SyntaxFactory.TriviaList();
+            }
+
+            XmlElementSyntax result = paragraph;
+
+            if (leadingWhitespaceContent.Any())
+            {
+                var first = leadingWhitespaceContent[0];
+                var newFirst = first.WithLeadingTrivia(first.GetLeadingTrivia().InsertRange(0, paragraph.GetLeadingTrivia()));
+                leadingWhitespaceContent = leadingWhitespaceContent.Replace(first, newFirst);
+            }
+            else
+            {
+                leadingTrivia = leadingTrivia.InsertRange(0, result.GetLeadingTrivia());
+            }
+
+            if (trailingWhitespaceContent.Any())
+            {
+                var last = trailingWhitespaceContent.Last();
+                var newLast = last.WithLeadingTrivia(last.GetLeadingTrivia().AddRange(paragraph.GetTrailingTrivia()));
+                trailingWhitespaceContent = trailingWhitespaceContent.Replace(last, newLast);
+            }
+            else
+            {
+                trailingTrivia = trailingTrivia.AddRange(result.GetTrailingTrivia());
+            }
+
+            XmlTextSyntax firstTextNode = trimmedContent.FirstOrDefault() as XmlTextSyntax;
+            if (firstTextNode != null && firstTextNode.TextTokens.Any())
+            {
+                SyntaxToken firstTextToken = firstTextNode.TextTokens[0];
+                string leadingWhitespace = new string(firstTextToken.Text.Cast<char>().TakeWhile(char.IsWhiteSpace).ToArray());
+                if (leadingWhitespace.Length > 0)
+                {
+                    SyntaxToken newFirstTextToken = XmlSyntaxFactory.TextLiteral(firstTextToken.Text.Substring(leadingWhitespace.Length)).WithTriviaFrom(firstTextToken);
+                    XmlTextSyntax newFirstTextNode = firstTextNode.WithTextTokens(firstTextNode.TextTokens.Replace(firstTextToken, newFirstTextToken));
+                    trimmedContent = trimmedContent.Replace(firstTextNode, newFirstTextNode);
+                    leadingTrivia = leadingTrivia.Add(SyntaxFactory.Whitespace(leadingWhitespace));
+                }
+            }
+
+            XmlTextSyntax lastTextNode = trimmedContent.LastOrDefault() as XmlTextSyntax;
+            if (lastTextNode != null && lastTextNode.TextTokens.Any())
+            {
+                SyntaxToken lastTextToken = lastTextNode.TextTokens.Last();
+                string trailingWhitespace = new string(lastTextToken.Text.Cast<char>().Reverse().TakeWhile(char.IsWhiteSpace).Reverse().ToArray());
+                if (trailingWhitespace.Length > 0)
+                {
+                    SyntaxToken newLastTextToken = XmlSyntaxFactory.TextLiteral(lastTextToken.Text.Substring(0, lastTextToken.Text.Length - trailingWhitespace.Length)).WithTriviaFrom(lastTextToken);
+                    XmlTextSyntax newLastTextNode = lastTextNode.WithTextTokens(lastTextNode.TextTokens.Replace(lastTextToken, newLastTextToken));
+                    trimmedContent = trimmedContent.Replace(lastTextNode, newLastTextNode);
+                    trailingTrivia = trailingTrivia.Insert(0, SyntaxFactory.Whitespace(trailingWhitespace));
+                }
+            }
+
+            return result.WithContent(trimmedContent)
+                .WithLeadingTrivia(leadingTrivia)
+                .WithTrailingTrivia(trailingTrivia);
+        }
+
+        private static IEnumerable<XmlNodeSyntax> ExpandTextNodes(XmlNodeSyntax node)
+        {
+            XmlTextSyntax xmlTextSyntax = node as XmlTextSyntax;
+            if (xmlTextSyntax == null)
+            {
+                yield return node;
+                yield break;
+            }
+
+            foreach (var textToken in xmlTextSyntax.TextTokens)
+            {
+                yield return XmlSyntaxFactory.Text(textToken);
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1653PlaceTextInParagraphs.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1653PlaceTextInParagraphs.cs
@@ -1,0 +1,258 @@
+﻿namespace StyleCop.Analyzers.DocumentationRules
+{
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.CodeAnalysis.Text;
+    using StyleCop.Analyzers.Helpers;
+    using StyleCop.Analyzers.SpacingRules;
+
+    /// <summary>
+    /// Place text in paragraphs.
+    /// </summary>
+    /// <remarks>
+    /// <para>A violation of this rule occurs when a &lt;remarks&gt; or &lt;note&gt; documentation element contains
+    /// content which is not wrapped in a block-level element.</para>
+    /// </remarks>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class SA1653PlaceTextInParagraphs : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// The ID for diagnostics produced by the <see cref="SA1653PlaceTextInParagraphs"/> analyzer.
+        /// </summary>
+        public const string DiagnosticId = "SA1653";
+        private const string Title = "Place text in paragraphs";
+        private const string MessageFormat = "Place text in paragraphs";
+        private const string Category = "StyleCop.CSharp.DocumentationRules";
+        private const string Description = "The documentation for the element contains text which is not placed in paragraphs.";
+        private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1653.md";
+
+        private static readonly DiagnosticDescriptor Descriptor =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+
+        private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
+            ImmutableArray.Create(Descriptor);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        {
+            get
+            {
+                return SupportedDiagnosticsValue;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeActionHonorExclusions(HandleXmlElementSyntax, SyntaxKind.XmlElement);
+        }
+
+        private static void HandleXmlElementSyntax(SyntaxNodeAnalysisContext context)
+        {
+            XmlElementSyntax syntax = (XmlElementSyntax)context.Node;
+            if (!ElementRequiresBlockContent(syntax.StartTag?.Name))
+            {
+                return;
+            }
+
+            int nonBlockStartIndex = -1;
+            int nonBlockEndIndex = -1;
+            for (int i = 0; i < syntax.Content.Count; i++)
+            {
+                if (IsIgnoredElement(syntax.Content[i]))
+                {
+                    continue;
+                }
+
+                if (IsBlockLevelNode(syntax.Content[i]))
+                {
+                    ReportDiagnosticIfRequired(context, syntax.Content, nonBlockStartIndex, nonBlockEndIndex);
+                    nonBlockStartIndex = -1;
+                    continue;
+                }
+                else
+                {
+                    nonBlockEndIndex = i;
+                    if (nonBlockStartIndex < 0)
+                    {
+                        nonBlockStartIndex = i;
+                    }
+                }
+            }
+
+            ReportDiagnosticIfRequired(context, syntax.Content, nonBlockStartIndex, nonBlockEndIndex);
+        }
+
+        private static void ReportDiagnosticIfRequired(SyntaxNodeAnalysisContext context, SyntaxList<XmlNodeSyntax> content, int nonBlockStartIndex, int nonBlockEndIndex)
+        {
+            if (nonBlockStartIndex < 0 || nonBlockEndIndex < nonBlockStartIndex)
+            {
+                return;
+            }
+
+            XmlNodeSyntax startNode = content[nonBlockStartIndex];
+            XmlNodeSyntax stopNode = content[nonBlockEndIndex];
+            Location location = Location.Create(startNode.GetLocation().SourceTree, TextSpan.FromBounds(GetEffectiveStart(startNode), GetEffectiveEnd(stopNode)));
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));
+        }
+
+        private static int GetEffectiveStart(XmlNodeSyntax node)
+        {
+            XmlTextSyntax textNode = node as XmlTextSyntax;
+            if (textNode != null)
+            {
+                foreach (SyntaxToken textToken in textNode.TextTokens)
+                {
+                    if (string.IsNullOrWhiteSpace(textToken.Text))
+                    {
+                        continue;
+                    }
+
+                    for (int i = 0; i < textToken.Text.Length; i++)
+                    {
+                        if (!char.IsWhiteSpace(textToken.Text[i]))
+                        {
+                            return textToken.SpanStart + i;
+                        }
+                    }
+
+                    return textToken.SpanStart + textToken.Text.Length;
+                }
+            }
+
+            return node.SpanStart;
+        }
+
+        private static int GetEffectiveEnd(XmlNodeSyntax node)
+        {
+            XmlTextSyntax textNode = node as XmlTextSyntax;
+            if (textNode != null)
+            {
+                foreach (SyntaxToken textToken in textNode.TextTokens.Reverse())
+                {
+                    if (string.IsNullOrWhiteSpace(textToken.Text))
+                    {
+                        continue;
+                    }
+
+                    for (int i = textToken.Text.Length - 1; i >= 0; i--)
+                    {
+                        if (!char.IsWhiteSpace(textToken.Text[i]))
+                        {
+                            return textToken.Span.End - (textToken.Text.Length - 1 - i);
+                        }
+                    }
+
+                    return textToken.Span.End - textToken.Text.Length;
+                }
+            }
+
+            return node.Span.End;
+        }
+
+        private static bool ElementRequiresBlockContent(XmlNameSyntax name)
+        {
+            if (name == null || name.LocalName.IsMissingOrDefault())
+            {
+                // unrecognized
+                return false;
+            }
+
+            if (name.Prefix != null)
+            {
+                // not a standard element
+                return false;
+            }
+
+            switch (name.LocalName.ValueText)
+            {
+            case XmlCommentHelper.RemarksXmlTag:
+            case XmlCommentHelper.NoteXmlTag:
+                return true;
+
+            default:
+                return false;
+            }
+        }
+
+        private static bool IsIgnoredElement(XmlNodeSyntax node)
+        {
+            if (node == null)
+            {
+                return true;
+            }
+
+            return XmlCommentHelper.IsConsideredEmpty(node);
+        }
+
+        private static bool IsBlockLevelNode(XmlNodeSyntax node)
+        {
+            XmlElementSyntax elementSyntax = node as XmlElementSyntax;
+            if (elementSyntax != null)
+            {
+                return IsBlockLevelElement(elementSyntax);
+            }
+
+            XmlEmptyElementSyntax emptyElementSyntax = node as XmlEmptyElementSyntax;
+            if (emptyElementSyntax != null)
+            {
+                return IsBlockLevelElement(emptyElementSyntax);
+            }
+
+            // ignored elements may appear at block level
+            return IsIgnoredElement(node);
+        }
+
+        private static bool IsBlockLevelElement(XmlElementSyntax element)
+        {
+            return IsBlockLevelName(element.StartTag?.Name);
+        }
+
+        private static bool IsBlockLevelElement(XmlEmptyElementSyntax element)
+        {
+            return IsBlockLevelName(element.Name);
+        }
+
+        private static bool IsBlockLevelName(XmlNameSyntax name)
+        {
+            if (name == null || name.LocalName.IsMissingOrDefault())
+            {
+                // unrecognized => allow
+                return true;
+            }
+
+            if (name.Prefix != null)
+            {
+                // not a standard element => allow
+                return true;
+            }
+
+            switch (name.LocalName.ValueText)
+            {
+            // certain block-level elements
+            case "code":
+            case "list":
+            case XmlCommentHelper.NoteXmlTag:
+            case "para":
+                return true;
+
+            // potential block-level elements => allow
+            case XmlCommentHelper.InheritdocXmlTag:
+            case "include":
+            case "token":
+                return true;
+
+            // block-level HTML elements => allow for this diagnostic
+            case "div":
+            case "p":
+                return true;
+
+            default:
+                return false;
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1653PlaceTextInParagraphs.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1653PlaceTextInParagraphs.cs
@@ -2,10 +2,8 @@
 {
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
-    using Microsoft.CodeAnalysis.Text;
     using StyleCop.Analyzers.Helpers;
     using StyleCop.Analyzers.SpacingRules;
 
@@ -17,7 +15,7 @@
     /// content which is not wrapped in a block-level element.</para>
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SA1653PlaceTextInParagraphs : DiagnosticAnalyzer
+    public class SA1653PlaceTextInParagraphs : BlockLevelDocumentationAnalyzerBase
     {
         /// <summary>
         /// The ID for diagnostics produced by the <see cref="SA1653PlaceTextInParagraphs"/> analyzer.
@@ -45,116 +43,9 @@
         }
 
         /// <inheritdoc/>
-        public override void Initialize(AnalysisContext context)
+        protected override bool ElementRequiresBlockContent(XmlElementSyntax element)
         {
-            context.RegisterSyntaxNodeActionHonorExclusions(HandleXmlElementSyntax, SyntaxKind.XmlElement);
-        }
-
-        private static void HandleXmlElementSyntax(SyntaxNodeAnalysisContext context)
-        {
-            XmlElementSyntax syntax = (XmlElementSyntax)context.Node;
-            if (!ElementRequiresBlockContent(syntax.StartTag?.Name))
-            {
-                return;
-            }
-
-            int nonBlockStartIndex = -1;
-            int nonBlockEndIndex = -1;
-            for (int i = 0; i < syntax.Content.Count; i++)
-            {
-                if (IsIgnoredElement(syntax.Content[i]))
-                {
-                    continue;
-                }
-
-                if (IsBlockLevelNode(syntax.Content[i]))
-                {
-                    ReportDiagnosticIfRequired(context, syntax.Content, nonBlockStartIndex, nonBlockEndIndex);
-                    nonBlockStartIndex = -1;
-                    continue;
-                }
-                else
-                {
-                    nonBlockEndIndex = i;
-                    if (nonBlockStartIndex < 0)
-                    {
-                        nonBlockStartIndex = i;
-                    }
-                }
-            }
-
-            ReportDiagnosticIfRequired(context, syntax.Content, nonBlockStartIndex, nonBlockEndIndex);
-        }
-
-        private static void ReportDiagnosticIfRequired(SyntaxNodeAnalysisContext context, SyntaxList<XmlNodeSyntax> content, int nonBlockStartIndex, int nonBlockEndIndex)
-        {
-            if (nonBlockStartIndex < 0 || nonBlockEndIndex < nonBlockStartIndex)
-            {
-                return;
-            }
-
-            XmlNodeSyntax startNode = content[nonBlockStartIndex];
-            XmlNodeSyntax stopNode = content[nonBlockEndIndex];
-            Location location = Location.Create(startNode.GetLocation().SourceTree, TextSpan.FromBounds(GetEffectiveStart(startNode), GetEffectiveEnd(stopNode)));
-            context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));
-        }
-
-        private static int GetEffectiveStart(XmlNodeSyntax node)
-        {
-            XmlTextSyntax textNode = node as XmlTextSyntax;
-            if (textNode != null)
-            {
-                foreach (SyntaxToken textToken in textNode.TextTokens)
-                {
-                    if (string.IsNullOrWhiteSpace(textToken.Text))
-                    {
-                        continue;
-                    }
-
-                    for (int i = 0; i < textToken.Text.Length; i++)
-                    {
-                        if (!char.IsWhiteSpace(textToken.Text[i]))
-                        {
-                            return textToken.SpanStart + i;
-                        }
-                    }
-
-                    return textToken.SpanStart + textToken.Text.Length;
-                }
-            }
-
-            return node.SpanStart;
-        }
-
-        private static int GetEffectiveEnd(XmlNodeSyntax node)
-        {
-            XmlTextSyntax textNode = node as XmlTextSyntax;
-            if (textNode != null)
-            {
-                foreach (SyntaxToken textToken in textNode.TextTokens.Reverse())
-                {
-                    if (string.IsNullOrWhiteSpace(textToken.Text))
-                    {
-                        continue;
-                    }
-
-                    for (int i = textToken.Text.Length - 1; i >= 0; i--)
-                    {
-                        if (!char.IsWhiteSpace(textToken.Text[i]))
-                        {
-                            return textToken.Span.End - (textToken.Text.Length - 1 - i);
-                        }
-                    }
-
-                    return textToken.Span.End - textToken.Text.Length;
-                }
-            }
-
-            return node.Span.End;
-        }
-
-        private static bool ElementRequiresBlockContent(XmlNameSyntax name)
-        {
+            var name = element.StartTag?.Name;
             if (name == null || name.LocalName.IsMissingOrDefault())
             {
                 // unrecognized
@@ -171,83 +62,6 @@
             {
             case XmlCommentHelper.RemarksXmlTag:
             case XmlCommentHelper.NoteXmlTag:
-                return true;
-
-            default:
-                return false;
-            }
-        }
-
-        private static bool IsIgnoredElement(XmlNodeSyntax node)
-        {
-            if (node == null)
-            {
-                return true;
-            }
-
-            return XmlCommentHelper.IsConsideredEmpty(node);
-        }
-
-        private static bool IsBlockLevelNode(XmlNodeSyntax node)
-        {
-            XmlElementSyntax elementSyntax = node as XmlElementSyntax;
-            if (elementSyntax != null)
-            {
-                return IsBlockLevelElement(elementSyntax);
-            }
-
-            XmlEmptyElementSyntax emptyElementSyntax = node as XmlEmptyElementSyntax;
-            if (emptyElementSyntax != null)
-            {
-                return IsBlockLevelElement(emptyElementSyntax);
-            }
-
-            // ignored elements may appear at block level
-            return IsIgnoredElement(node);
-        }
-
-        private static bool IsBlockLevelElement(XmlElementSyntax element)
-        {
-            return IsBlockLevelName(element.StartTag?.Name);
-        }
-
-        private static bool IsBlockLevelElement(XmlEmptyElementSyntax element)
-        {
-            return IsBlockLevelName(element.Name);
-        }
-
-        private static bool IsBlockLevelName(XmlNameSyntax name)
-        {
-            if (name == null || name.LocalName.IsMissingOrDefault())
-            {
-                // unrecognized => allow
-                return true;
-            }
-
-            if (name.Prefix != null)
-            {
-                // not a standard element => allow
-                return true;
-            }
-
-            switch (name.LocalName.ValueText)
-            {
-            // certain block-level elements
-            case "code":
-            case "list":
-            case XmlCommentHelper.NoteXmlTag:
-            case "para":
-                return true;
-
-            // potential block-level elements => allow
-            case XmlCommentHelper.InheritdocXmlTag:
-            case "include":
-            case "token":
-                return true;
-
-            // block-level HTML elements => allow for this diagnostic
-            case "div":
-            case "p":
                 return true;
 
             default:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1654UseChildBlocksConsistently.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1654UseChildBlocksConsistently.cs
@@ -1,6 +1,7 @@
 ﻿namespace StyleCop.Analyzers.DocumentationRules
 {
     using System.Collections.Immutable;
+    using System.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
@@ -8,24 +9,24 @@
     using StyleCop.Analyzers.SpacingRules;
 
     /// <summary>
-    /// Place text in paragraphs.
+    /// Use child blocks consistently.
     /// </summary>
     /// <remarks>
-    /// <para>A violation of this rule occurs when a &lt;remarks&gt; or &lt;note&gt; documentation element contains
-    /// content which is not wrapped in a block-level element.</para>
+    /// <para>A violation of this rule occurs when a documentation element contains some children which are block-level
+    /// elements, but other children which are not.</para>
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SA1653PlaceTextInParagraphs : BlockLevelDocumentationAnalyzerBase
+    public class SA1654UseChildBlocksConsistently : BlockLevelDocumentationAnalyzerBase
     {
         /// <summary>
-        /// The ID for diagnostics produced by the <see cref="SA1653PlaceTextInParagraphs"/> analyzer.
+        /// The ID for diagnostics produced by the <see cref="SA1654UseChildBlocksConsistently"/> analyzer.
         /// </summary>
-        public const string DiagnosticId = "SA1653";
-        private const string Title = "Place text in paragraphs";
-        private const string MessageFormat = "Place text in paragraphs";
+        public const string DiagnosticId = "SA1654";
+        private const string Title = "Use child blocks consistently";
+        private const string MessageFormat = "Use child blocks consistently";
         private const string Category = "StyleCop.CSharp.DocumentationRules";
-        private const string Description = "The documentation for the element contains text which is not placed in paragraphs.";
-        private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1653.md";
+        private const string Description = "The documentation for the element contains some text which is wrapped in block-level elements, and other text which is written inline.";
+        private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1654.md";
 
         private static readonly DiagnosticDescriptor Descriptor =
             new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
@@ -62,10 +63,17 @@
             {
             case XmlCommentHelper.RemarksXmlTag:
             case XmlCommentHelper.NoteXmlTag:
-                return true;
+                if (semanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA1653PlaceTextInParagraphs.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
+                {
+                    // these elements are covered by SA1653, when enabled
+                    return false;
+                }
+
+                // otherwise this diagnostic will still apply
+                goto default;
 
             default:
-                return false;
+                return element.Content.Any(child => IsBlockLevelNode(child, false));
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1655UseChildBlocksConsistentlyAcrossElementsOfTheSameKind.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1655UseChildBlocksConsistentlyAcrossElementsOfTheSameKind.cs
@@ -1,0 +1,124 @@
+﻿namespace StyleCop.Analyzers.DocumentationRules
+{
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
+    using StyleCop.Analyzers.SpacingRules;
+
+    /// <summary>
+    /// Use child blocks consistently across elements of the same kind.
+    /// </summary>
+    /// <remarks>
+    /// <para>A violation of this rule occurs when a documentation contains sibling elements of the same kind, where
+    /// some siblings use block-level content, but others do not.</para>
+    /// </remarks>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class SA1655UseChildBlocksConsistentlyAcrossElementsOfTheSameKind : BlockLevelDocumentationAnalyzerBase
+    {
+        /// <summary>
+        /// The ID for diagnostics produced by the
+        /// <see cref="SA1655UseChildBlocksConsistentlyAcrossElementsOfTheSameKind"/> analyzer.
+        /// </summary>
+        public const string DiagnosticId = "SA1655";
+        private const string Title = "Use child blocks consistently across elements of the same kind";
+        private const string MessageFormat = "Use child blocks consistently across elements of the same kind";
+        private const string Category = "StyleCop.CSharp.DocumentationRules";
+        private const string Description = "The documentation for the element contains inline text, but the documentation for a sibling element of the same kind uses block-level elements.";
+        private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1655.md";
+
+        private static readonly DiagnosticDescriptor Descriptor =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+
+        private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
+            ImmutableArray.Create(Descriptor);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        {
+            get
+            {
+                return SupportedDiagnosticsValue;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override bool ElementRequiresBlockContent(XmlElementSyntax element, SemanticModel semanticModel)
+        {
+            var name = element.StartTag?.Name;
+            if (name == null || name.LocalName.IsMissingOrDefault())
+            {
+                // unrecognized
+                return false;
+            }
+
+            if (name.Prefix != null)
+            {
+                // not a standard element
+                return false;
+            }
+
+            switch (name.LocalName.ValueText)
+            {
+            case XmlCommentHelper.RemarksXmlTag:
+            case XmlCommentHelper.NoteXmlTag:
+                if (semanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA1653PlaceTextInParagraphs.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
+                {
+                    // these elements are covered by SA1653, when enabled
+                    return false;
+                }
+
+                // otherwise this diagnostic will still apply
+                goto default;
+
+            default:
+                if (semanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA1654UseChildBlocksConsistently.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
+                {
+                    if (element.Content.Any(child => IsBlockLevelNode(child, false)))
+                    {
+                        // these elements are covered by SA1654, when enabled
+                        return false;
+                    }
+                }
+
+                break;
+            }
+
+            SyntaxList<XmlNodeSyntax> parentContent;
+            XmlElementSyntax parentElement = element.Parent as XmlElementSyntax;
+            if (parentElement != null)
+            {
+                parentContent = parentElement.Content;
+            }
+            else
+            {
+                DocumentationCommentTriviaSyntax parentSyntax = element.Parent as DocumentationCommentTriviaSyntax;
+                if (parentSyntax != null)
+                {
+                    parentContent = parentSyntax.Content;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            foreach (XmlElementSyntax sibling in parentContent.GetXmlElements(name.LocalName.ValueText).OfType<XmlElementSyntax>())
+            {
+                if (sibling == element)
+                {
+                    continue;
+                }
+
+                if (sibling.Content.Any(child => IsBlockLevelNode(child, false)))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
@@ -16,7 +16,9 @@
         internal const string SummaryXmlTag = "summary";
         internal const string ContentXmlTag = "content";
         internal const string InheritdocXmlTag = "inheritdoc";
+        internal const string RemarksXmlTag = "remarks";
         internal const string ReturnsXmlTag = "returns";
+        internal const string NoteXmlTag = "note";
         internal const string ValueXmlTag = "value";
         internal const string SeeXmlTag = "see";
         internal const string ParamXmlTag = "param";

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -47,6 +47,8 @@
     <Compile Include="AnalyzerCategory.cs" />
     <Compile Include="AnalyzerConstants.cs" />
     <Compile Include="AnalyzerExtensions.cs" />
+    <Compile Include="DocumentationRules\BlockLevelDocumentationAnalyzerBase.cs" />
+    <Compile Include="DocumentationRules\BlockLevelDocumentationCodeFixProvider.cs" />
     <Compile Include="DocumentationRules\DocumentationResources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -105,7 +107,6 @@
     <Compile Include="DocumentationRules\SA1651CodeFixProvider.cs" />
     <Compile Include="DocumentationRules\SA1651DoNotUsePlaceholderElements.cs" />
     <Compile Include="DocumentationRules\SA1652EnableXmlDocumentationOutput.cs" />
-    <Compile Include="DocumentationRules\SA1653CodeFixProvider.cs" />
     <Compile Include="DocumentationRules\SA1653PlaceTextInParagraphs.cs" />
     <Compile Include="DocumentationRules\StandardTextDiagnosticBase.cs" />
     <Compile Include="GeneratedCodeAnalysisExtensions.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -108,6 +108,7 @@
     <Compile Include="DocumentationRules\SA1651DoNotUsePlaceholderElements.cs" />
     <Compile Include="DocumentationRules\SA1652EnableXmlDocumentationOutput.cs" />
     <Compile Include="DocumentationRules\SA1653PlaceTextInParagraphs.cs" />
+    <Compile Include="DocumentationRules\SA1654UseChildBlocksConsistently.cs" />
     <Compile Include="DocumentationRules\StandardTextDiagnosticBase.cs" />
     <Compile Include="GeneratedCodeAnalysisExtensions.cs" />
     <Compile Include="Helpers\AccessLevel.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -109,6 +109,7 @@
     <Compile Include="DocumentationRules\SA1652EnableXmlDocumentationOutput.cs" />
     <Compile Include="DocumentationRules\SA1653PlaceTextInParagraphs.cs" />
     <Compile Include="DocumentationRules\SA1654UseChildBlocksConsistently.cs" />
+    <Compile Include="DocumentationRules\SA1655UseChildBlocksConsistentlyAcrossElementsOfTheSameKind.cs" />
     <Compile Include="DocumentationRules\StandardTextDiagnosticBase.cs" />
     <Compile Include="GeneratedCodeAnalysisExtensions.cs" />
     <Compile Include="Helpers\AccessLevel.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -105,6 +105,8 @@
     <Compile Include="DocumentationRules\SA1651CodeFixProvider.cs" />
     <Compile Include="DocumentationRules\SA1651DoNotUsePlaceholderElements.cs" />
     <Compile Include="DocumentationRules\SA1652EnableXmlDocumentationOutput.cs" />
+    <Compile Include="DocumentationRules\SA1653CodeFixProvider.cs" />
+    <Compile Include="DocumentationRules\SA1653PlaceTextInParagraphs.cs" />
     <Compile Include="DocumentationRules\StandardTextDiagnosticBase.cs" />
     <Compile Include="GeneratedCodeAnalysisExtensions.cs" />
     <Compile Include="Helpers\AccessLevel.cs" />

--- a/StyleCopAnalyzers.sln
+++ b/StyleCopAnalyzers.sln
@@ -206,6 +206,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentat
 		documentation\SA1650.md = documentation\SA1650.md
 		documentation\SA1651.md = documentation\SA1651.md
 		documentation\SA1652.md = documentation\SA1652.md
+		documentation\SA1653.md = documentation\SA1653.md
 		documentation\SX1309.md = documentation\SX1309.md
 		documentation\SX1309S.md = documentation\SX1309S.md
 	EndProjectSection

--- a/StyleCopAnalyzers.sln
+++ b/StyleCopAnalyzers.sln
@@ -208,6 +208,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentat
 		documentation\SA1652.md = documentation\SA1652.md
 		documentation\SA1653.md = documentation\SA1653.md
 		documentation\SA1654.md = documentation\SA1654.md
+		documentation\SA1655.md = documentation\SA1655.md
 		documentation\SX1309.md = documentation\SX1309.md
 		documentation\SX1309S.md = documentation\SX1309S.md
 	EndProjectSection

--- a/StyleCopAnalyzers.sln
+++ b/StyleCopAnalyzers.sln
@@ -207,6 +207,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentat
 		documentation\SA1651.md = documentation\SA1651.md
 		documentation\SA1652.md = documentation\SA1652.md
 		documentation\SA1653.md = documentation\SA1653.md
+		documentation\SA1654.md = documentation\SA1654.md
 		documentation\SX1309.md = documentation\SX1309.md
 		documentation\SX1309S.md = documentation\SX1309S.md
 	EndProjectSection

--- a/documentation/SA1653.md
+++ b/documentation/SA1653.md
@@ -1,0 +1,65 @@
+﻿# SA1653
+
+<table>
+<tr>
+  <td>TypeName</td>
+  <td>SA1653PlaceTextInParagraphs</td>
+</tr>
+<tr>
+  <td>CheckId</td>
+  <td>SA1653</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Documentation Rules</td>
+</tr>
+</table>
+
+## Cause
+
+A `<remarks>` or `<note>` documentation element contains content which is not wrapped in a block-level element.
+
+## Rule description
+
+A violation of this rule occurs when a `<remarks>` or `<note>` documentation element contains content which is not
+wrapped in a block-level element.
+
+```csharp
+/// <summary>Summary text.</summary>
+/// <remarks>
+/// Remarks text.
+/// </remarks>
+public void SomeOperation()
+{
+}
+```
+
+## How to fix violations
+
+To fix a violation of this rule, place the content in a block-level element, such as a `<para>` element.
+
+```csharp
+/// <summary>Summary text.</summary>
+/// <remarks>
+/// <para>Remarks text.</para>
+/// </remarks>
+public void SomeOperation()
+{
+}
+```
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable SA1653 // Place text in paragraphs
+/// <summary>
+/// Summary text.
+/// </summary>
+/// <remarks>
+/// Inline remarks.
+/// </remarks>
+public void SomeOperation()
+#pragma warning restore SA1653 // Place text in paragraphs
+{
+}
+```

--- a/documentation/SA1654.md
+++ b/documentation/SA1654.md
@@ -1,0 +1,66 @@
+﻿# SA1654
+
+<table>
+<tr>
+  <td>TypeName</td>
+  <td>SA1654UseChildBlocksConsistently</td>
+</tr>
+<tr>
+  <td>CheckId</td>
+  <td>SA1654</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Documentation Rules</td>
+</tr>
+</table>
+
+## Cause
+
+A documentation element contains some children which are block-level elements, but other children which are not.
+
+## Rule description
+
+A violation of this rule occurs when a documentation element contains some children which are block-level elements, but
+other children which are not.
+
+```csharp
+/// <summary>Summary text.</summary>
+/// <param name="x">
+/// Parameter documentation.
+/// <para>Parameter documentation continued.</para>
+/// </param>
+public void SomeOperation(int x)
+{
+}
+```
+
+## How to fix violations
+
+To fix a violation of this rule, place the content in a block-level element, such as a `<para>` element.
+
+```csharp
+/// <summary>Summary text.</summary>
+/// <param name="x">
+/// <para>Parameter documentation.</para>
+/// <para>Parameter documentation continued.</para>
+/// </param>
+public void SomeOperation(int x)
+{
+}
+```
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable SA1654 // Use child blocks consistently
+/// <summary>Summary text.</summary>
+/// <param name="x">
+/// Inline content.
+/// <para>Block content.</para>
+/// </param>
+public void SomeOperation(int x)
+#pragma warning restore SA1654 // Use child blocks consistently
+{
+}
+```

--- a/documentation/SA1655.md
+++ b/documentation/SA1655.md
@@ -1,0 +1,76 @@
+﻿# SA1655
+
+<table>
+<tr>
+  <td>TypeName</td>
+  <td>SA1655UseChildBlocksConsistentlyAcrossElementsOfTheSameKind</td>
+</tr>
+<tr>
+  <td>CheckId</td>
+  <td>SA1655</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Documentation Rules</td>
+</tr>
+</table>
+
+## Cause
+
+The documentation for the element contains inline text, but the documentation for a sibling element of the same kind
+uses block-level elements.
+
+## Rule description
+
+A violation of this rule occurs when a documentation contains sibling elements of the same kind, where some siblings use
+block-level content, but others do not. In the following example, one `param` element uses inline content, while another
+`param` element uses block content.
+
+```csharp
+/// <summary>
+/// Summary text.
+/// </summary>
+/// <param name="x">Inline content.</param>
+/// <param name="y">
+/// <para>Block content.</para>
+/// </param>
+public void SomeOperation(int x, int y)
+{
+}
+```
+
+## How to fix violations
+
+To fix a violation of this rule, place the content in a block-level element, such as a `<para>` element.
+
+```csharp
+/// <summary>
+/// Summary text.
+/// </summary>
+/// <param name="x">
+/// <para>Block content.</para>
+/// </param>
+/// <param name="y">
+/// <para>Block content.</para>
+/// </param>
+public void SomeOperation(int x, int y)
+{
+}
+```
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable SA1655 // Use child blocks consistently across elements of the same kind
+/// <summary>
+/// Summary text.
+/// </summary>
+/// <param name="x">Inline content.</param>
+/// <param name="y">
+/// <para>Block content.</para>
+/// </param>
+public void SomeOperation(int x, int y)
+#pragma warning restore SA1655 // Use child blocks consistently across elements of the same kind
+{
+}
+```


### PR DESCRIPTION
This pull request includes the implementation of **three brand-new StyleCop rules**, along with code fixes for each. A description of each of these rules can be found on the associated issue:

* Implement new diagnostic SA1653 PlaceTextInParagraphs (fixes #601)
* Implement new diagnostic SA1654 UseChildBlocksConsistently (fixes #602)
* Implement new diagnostic SA1655 UseChildBlocksConsistentlyAcrossElementsOfTheSameKind (fixes #603)
