### PR TITLE
Fix 620

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1121UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1121UnitTests.cs
@@ -68,7 +68,6 @@
         {
             foreach (var item in types)
             {
-                // Allow CS8019 here because the code fix makes the using directive unnecessary
                 await this.VerifyCSharpFixAsync(string.Format(testSource, item.Item2), string.Format(testSource, item.Item1));
                 await this.VerifyCSharpFixAsync(string.Format(testSource, "System." + item.Item2), string.Format(testSource, item.Item1));
                 await this.VerifyCSharpFixAsync(string.Format(testSource, "global::System." + item.Item2), string.Format(testSource, item.Item1));

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1121UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1121UnitTests.cs
@@ -547,6 +547,60 @@ public class Foo
         }
 
         [Theory]
+        [MemberData(nameof(AllTypes))]
+        public async Task TestDocumentationCommentDirectReference(string predefined, string fullName)
+        {
+            string testCode = @"using System;
+/// <seealso cref=""{0}""/>
+public class Foo
+{{
+}}";
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(2, 20);
+
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllTypes))]
+        public async Task TestDocumentationCommentDirectReferenceCodeFix(string predefined, string fullName)
+        {
+            string testCode = @"using System;
+/// <seealso cref=""{0}""/>
+public class Foo
+{{
+}}";
+
+            await this.VerifyCSharpFixAsync(string.Format(testCode, fullName), string.Format(testCode, predefined), cancellationToken: CancellationToken.None);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllTypes))]
+        public async Task TestDocumentationCommentIndirectReference(string predefined, string fullName)
+        {
+            string testCode = @"using System;
+/// <seealso cref=""Convert.ToBoolean({0})""/>
+public class Foo
+{{
+}}";
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(2, 38);
+
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, fullName), expected, CancellationToken.None);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllTypes))]
+        public async Task TestDocumentationCommentIndirectReferenceCodeFix(string predefined, string fullName)
+        {
+            string testCode = @"using System;
+/// <seealso cref=""Convert.ToBoolean({0})""/>
+public class Foo
+{{
+}}";
+
+            await this.VerifyCSharpFixAsync(string.Format(testCode, fullName), string.Format(testCode, predefined), cancellationToken: CancellationToken.None);
+        }
+
+        [Theory]
         [MemberData(nameof(ReferenceTypes))]
         public async Task TestExplicitCast(string predefined, string fullName)
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Composition;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeActions;
@@ -54,16 +55,8 @@
         }
 
         /// <inheritdoc/>
-        public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-            var semanticModel = await context.Document.GetSemanticModelAsync();
-
-            if (semanticModel == null)
-            {
-                return;
-            }
-
             foreach (var diagnostic in context.Diagnostics)
             {
                 if (!diagnostic.Id.Equals(SA1121UseBuiltInTypeAlias.DiagnosticId))
@@ -71,36 +64,48 @@
                     continue;
                 }
 
-                var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
-
-                var memberAccess = node.Parent as MemberAccessExpressionSyntax;
-
-                if (memberAccess != null)
-                {
-                    if (node == memberAccess.Name)
-                    {
-                        node = memberAccess;
-                    }
-                }
-
-                var typeInfo = semanticModel.GetTypeInfo(node);
-
-                if (typeInfo.Type != null)
-                {
-                    SpecialType specialType = typeInfo.Type.SpecialType;
-                    context.RegisterCodeFix(CodeAction.Create("Replace with built-in type", token => GetTransformedDocument(context.Document, root, node, specialType)), diagnostic);
-                }
+                context.RegisterCodeFix(CodeAction.Create("Replace with built-in type", token => GetTransformedDocument(context.Document, diagnostic, token)), diagnostic);
             }
+
+            return Task.FromResult(true);
         }
 
-        private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxNode node, SpecialType specialType)
+        private static async Task<Document> GetTransformedDocument(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
         {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+            if (semanticModel == null)
+            {
+                return document;
+            }
+
+            var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+
+            var memberAccess = node.Parent as MemberAccessExpressionSyntax;
+
+            if (memberAccess != null)
+            {
+                if (node == memberAccess.Name)
+                {
+                    node = memberAccess;
+                }
+            }
+
+            var typeInfo = semanticModel.GetTypeInfo(node, cancellationToken);
+
+            if (typeInfo.Type == null)
+            {
+                return document;
+            }
+
+            SpecialType specialType = typeInfo.Type.SpecialType;
             var newNode = SyntaxFactory.PredefinedType(SyntaxFactory.Token(PredefinedSpecialTypes[specialType]))
                 .WithTriviaFrom(node)
                 .WithoutFormatting();
             var newRoot = root.ReplaceNode(node, newNode);
 
-            return Task.FromResult(document.WithSyntaxRoot(newRoot));
+            return document.WithSyntaxRoot(newRoot);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121UseBuiltInTypeAlias.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121UseBuiltInTypeAlias.cs
@@ -224,6 +224,10 @@
                 // this "weird" syntax appears for qualified references within a nameof expression
                 locationNode = identifierNameSyntax.Parent;
             }
+            else if (identifierNameSyntax.Parent is NameMemberCrefSyntax && identifierNameSyntax.Parent.Parent is QualifiedCrefSyntax)
+            {
+                locationNode = identifierNameSyntax.Parent.Parent;
+            }
 
             // Allow nameof
             if (this.IsNameInNameOfExpression(identifierNameSyntax))

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121UseBuiltInTypeAlias.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121UseBuiltInTypeAlias.cs
@@ -219,6 +219,11 @@
             {
                 locationNode = identifierNameSyntax.Parent;
             }
+            else if ((identifierNameSyntax.Parent as MemberAccessExpressionSyntax)?.Name == identifierNameSyntax)
+            {
+                // this "weird" syntax appears for qualified references within a nameof expression
+                locationNode = identifierNameSyntax.Parent;
+            }
 
             // Allow nameof
             if (this.IsNameInNameOfExpression(identifierNameSyntax))


### PR DESCRIPTION
* Fix reporting location of SA1121 within `nameof` expressions

  * Was: `nameof(System.[String].ToString)`
  * Now: `nameof([System.String].ToString)`

* Fix reporting location of SA1121 within `cref` attributes of documentation comments

  * Was: `<see cref="System.[String]"/>`
  * Now: `<see cref="[System.String]"/>`

* Fix #620