### PR TITLE
Remove unnecessary calls to SyntaxFactory.Whitespace

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -151,7 +151,7 @@
             {
                 var separator = list.GetSeparator(i);
                 // Make sure the parameter list looks nice
-                list = list.ReplaceSeparator(separator, separator.WithTrailingTrivia(SyntaxFactory.Whitespace(" ")));
+                list = list.ReplaceSeparator(separator, separator.WithTrailingTrivia(SyntaxFactory.Space));
             }
 
             return SyntaxFactory.TypeArgumentList(list);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
@@ -149,13 +149,13 @@
             if (modifiers.Count > 0)
             {
                 modifier = modifier.WithLeadingTrivia(modifiers[0].LeadingTrivia);
-                modifiers = modifiers.Replace(modifiers[0], modifiers[0].WithLeadingTrivia(SyntaxFactory.Whitespace(" ")));
+                modifiers = modifiers.Replace(modifiers[0], modifiers[0].WithLeadingTrivia(SyntaxFactory.ElasticSpace));
                 modifiers = modifiers.Insert(0, modifier);
             }
             else
             {
                 modifiers = SyntaxTokenList.Create(modifier.WithLeadingTrivia(leadingTriviaNode.GetLeadingTrivia()));
-                leadingTriviaNode = leadingTriviaNode.WithLeadingTrivia(SyntaxFactory.Whitespace(" "));
+                leadingTriviaNode = leadingTriviaNode.WithLeadingTrivia(SyntaxFactory.ElasticSpace);
             }
 
             return modifiers;
@@ -179,13 +179,13 @@
             if (modifiers.Count > 0)
             {
                 modifier = modifier.WithLeadingTrivia(modifiers[0].LeadingTrivia);
-                modifiers = modifiers.Replace(modifiers[0], modifiers[0].WithLeadingTrivia(SyntaxFactory.Whitespace(" ")));
+                modifiers = modifiers.Replace(modifiers[0], modifiers[0].WithLeadingTrivia(SyntaxFactory.ElasticSpace));
                 modifiers = modifiers.Insert(0, modifier);
             }
             else
             {
                 modifiers = SyntaxTokenList.Create(modifier.WithLeadingTrivia(leadingTriviaToken.LeadingTrivia));
-                leadingTriviaToken = leadingTriviaToken.WithLeadingTrivia(SyntaxFactory.Whitespace(" "));
+                leadingTriviaToken = leadingTriviaToken.WithLeadingTrivia(SyntaxFactory.ElasticSpace);
             }
 
             return modifiers;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000CodeFixProvider.cs
@@ -113,7 +113,7 @@
 
             if (isAddingSpace)
             {
-                SyntaxTrivia whitespace = SyntaxFactory.Whitespace(" ").WithoutFormatting();
+                SyntaxTrivia whitespace = SyntaxFactory.Space;
                 SyntaxToken corrected = token.WithTrailingTrivia(token.TrailingTrivia.Insert(0, whitespace));
                 Document updatedDocument = document.WithSyntaxRoot(root.ReplaceToken(token, corrected));
                 return Task.FromResult(updatedDocument);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
@@ -97,8 +97,7 @@
                 SyntaxToken intermediate = token.WithoutTrailingWhitespace();
                 SyntaxToken corrected =
                     intermediate
-                    .WithTrailingTrivia(intermediate.TrailingTrivia.Insert(0, SyntaxFactory.Whitespace(" ")))
-                    .WithoutFormatting();
+                    .WithTrailingTrivia(intermediate.TrailingTrivia.Insert(0, SyntaxFactory.Space));
                 replacements[token] = corrected;
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002CodeFixProvider.cs
@@ -88,8 +88,7 @@
                 SyntaxToken intermediate = token.WithoutTrailingWhitespace();
                 SyntaxToken corrected =
                     intermediate
-                    .WithTrailingTrivia(intermediate.TrailingTrivia.Insert(0, SyntaxFactory.Whitespace(" ")))
-                    .WithoutFormatting();
+                    .WithTrailingTrivia(intermediate.TrailingTrivia.Insert(0, SyntaxFactory.Space));
                 replacements[token] = corrected;
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
@@ -79,7 +79,7 @@
                 default:
                     if (!precedingToken.TrailingTrivia.Any(SyntaxKind.WhitespaceTrivia))
                     {
-                        SyntaxToken correctedPreceding = correctedPrecedingNoSpace.WithTrailingTrivia(correctedPrecedingNoSpace.TrailingTrivia.Insert(0, SyntaxFactory.Whitespace(" ")));
+                        SyntaxToken correctedPreceding = correctedPrecedingNoSpace.WithTrailingTrivia(correctedPrecedingNoSpace.TrailingTrivia.Insert(0, SyntaxFactory.ElasticSpace));
                         replacements[precedingToken] = correctedPreceding;
                     }
 
@@ -95,8 +95,7 @@
                     SyntaxToken correctedOperatorNoSpace = token.WithoutTrailingWhitespace();
                     SyntaxToken correctedOperator =
                         correctedOperatorNoSpace
-                        .WithTrailingTrivia(correctedOperatorNoSpace.TrailingTrivia.Insert(0, SyntaxFactory.Whitespace(" ")))
-                        .WithoutFormatting();
+                        .WithTrailingTrivia(correctedOperatorNoSpace.TrailingTrivia.Insert(0, SyntaxFactory.Space));
                     replacements[token] = correctedOperator;
                 }
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1007CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1007CodeFixProvider.cs
@@ -59,8 +59,7 @@
 
         private static Task<Document> GetTransformedDocument(Document document, SyntaxNode root, SyntaxToken token)
         {
-            SyntaxTrivia whitespace = SyntaxFactory.Whitespace(" ");
-            SyntaxToken corrected = token.WithTrailingTrivia(token.TrailingTrivia.Insert(0, whitespace)).WithoutFormatting();
+            SyntaxToken corrected = token.WithTrailingTrivia(token.TrailingTrivia.Insert(0, SyntaxFactory.Space));
             Document updatedDocument = document.WithSyntaxRoot(root.ReplaceToken(token, corrected));
 
             return Task.FromResult(updatedDocument);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021CodeFixProvider.cs
@@ -82,7 +82,7 @@
                 else if (!followsSpecialCharacter && !precededBySpace)
                 {
                     SyntaxToken correctedPreceding = precedingToken.WithoutTrailingWhitespace();
-                    SyntaxTrivia whitespace = SyntaxFactory.Whitespace(" ");
+                    SyntaxTrivia whitespace = SyntaxFactory.ElasticSpace;
                     correctedPreceding =
                         correctedPreceding
                         .WithTrailingTrivia(correctedPreceding.TrailingTrivia.Add(whitespace))

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022CodeFixProvider.cs
@@ -83,7 +83,7 @@
                 else if (!followsSpecialCharacter && !precededBySpace)
                 {
                     SyntaxToken correctedPreceding = precedingToken.WithoutTrailingWhitespace();
-                    SyntaxTrivia whitespace = SyntaxFactory.Whitespace(" ");
+                    SyntaxTrivia whitespace = SyntaxFactory.ElasticSpace;
                     correctedPreceding =
                         correctedPreceding
                         .WithTrailingTrivia(correctedPreceding.TrailingTrivia.Add(whitespace))


### PR DESCRIPTION
* Use `SyntaxFactory.ElasticSpace` instead of `SyntaxFactory.Whitespace(" ")`
* Use `SyntaxFactory.Space` instead of `SyntaxFactory.WhiteSpace(" ").WithoutFormatting()`