### PR TITLE
Add a mailmap entry for Vincent

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Vincent Weijsters <vweijsters@outlook.com>


### PR DESCRIPTION
This change causes the history to show Vincent Weijsters instead of vweijsters. :+1: 