### PR TITLE
SA1507 should permit a blank line after a comment

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1507UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1507UnitTests.cs
@@ -95,6 +95,53 @@ public class Foo
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
 
+        [Fact]
+        public async Task TestOneEmptyLineBetweenMultilineCommentAndFirstElement()
+        {
+            string testCode = @"/*
+*/
+
+namespace Microsoft
+{
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestOneEmptyLineBetweenSingleLineCommentAndFirstElement()
+        {
+            string testCode = @"//
+
+namespace Microsoft
+{
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TestMultipleEmptyLinesBetweenMultilineCommentAndFirstElement()
+        {
+            string testCode = @"/*
+*/
+
+
+namespace Microsoft
+{
+}
+";
+
+            var expectedDiagnostics = new[]
+            {
+                this.CSharpDiagnostic().WithLocation(3, 1),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostics, CancellationToken.None);
+        }
+
         /// <summary>
         /// Verifies that a verbatim string literal does not trigger any diagnostics.
         /// (This will be handled by SA1518)
@@ -179,6 +226,29 @@ public class Foo
 ";
 
             await this.VerifyCSharpFixAsync(TestCode, fixedTestCode);
+        }
+
+        [Fact]
+        public async Task TestValidBlankLineInVariousPlaces()
+        {
+            string testCode = @"using System;
+
+class FooBar
+{
+    void Foo()
+    {
+    }
+
+    void Bar()
+    {
+        Foo();
+
+        Foo();
+    }
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1507CodeMustNotContainMultipleBlankLinesInARow.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1507CodeMustNotContainMultipleBlankLinesInARow.cs
@@ -87,19 +87,19 @@
                 {
                     switch (leadingTrivia[i].Kind())
                     {
-                    case SyntaxKind.WhitespaceTrivia:
-                        break;
+                        case SyntaxKind.WhitespaceTrivia:
+                            break;
 
-                    case SyntaxKind.EndOfLineTrivia:
-                        blankLineEndIndex = i;
-                        blankLineCount++;
-                        break;
+                        case SyntaxKind.EndOfLineTrivia:
+                            blankLineEndIndex = i;
+                            blankLineCount++;
+                            break;
 
-                    default:
-                        ReportDiagnosticIfNecessary(context, leadingTrivia, blankLineIndex, blankLineEndIndex, blankLineCount);
-                        blankLineIndex = i + 1;
-                        blankLineCount = 0;
-                        break;
+                        default:
+                            ReportDiagnosticIfNecessary(context, leadingTrivia, blankLineIndex, blankLineEndIndex, blankLineCount);
+                            blankLineIndex = i + 1;
+                            blankLineCount = 0;
+                            break;
                     }
                 }
 
@@ -113,6 +113,19 @@
             {
                 // nothing to report
                 return;
+            }
+
+            if (blankLineIndex > 0)
+            {
+                var triviaBeforeBlankLines = leadingTrivia[blankLineIndex - 1];
+                if (triviaBeforeBlankLines.IsKind(SyntaxKind.SingleLineCommentTrivia) ||
+                    triviaBeforeBlankLines.IsKind(SyntaxKind.MultiLineCommentTrivia))
+                {
+                    // when blank lines appear after a comment, skip the first one
+                    // because that's part of the end of the comment trivia.
+                    blankLineIndex++;
+                    blankLineCount--;
+                }
             }
 
             if (blankLineCount < 2)


### PR DESCRIPTION
Prior to this change, a comment followed by a single blank line would cause SA1507 to misfire complaining about multiple blank lines. This is because its algorithm depended on Roslyn putting the first end of line token as trailing trivia of the token before it. But when the "token" before it is itself a comment, it is all just bundled up as leading trivia all in a row, which means that two EOL tokens really mean only one blank line.

Fix #672 