### PR TITLE
Add developmentDependency=true nuspec setting

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.nuspec
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.nuspec
@@ -13,6 +13,7 @@
     <releaseNotes>https://github.com/DotNetAnalyzers/StyleCopAnalyzers/releases/$version$</releaseNotes>
     <copyright>Copyright Sam Harwell 2015</copyright>
     <tags>StyleCop DotNetAnalyzers Roslyn Diagnostic Analyzer</tags>
+    <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.nuspec
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.nuspec
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0"?>
 <package>
-  <metadata>
+  <metadata minClientVersion="2.8">
     <id>StyleCop.Analyzers</id>
     <version>0.0.0</version>
     <title>StyleCop.Analyzers</title>


### PR DESCRIPTION
Consistent with http://docs.nuget.org/Create/Nuspec-Reference, setting this prevents any project that adds the StyleCop.Analyzers package from expressing it as a dependency to its own respective users.