### PR TITLE
Multiple fixes for SA1642 (ConstructorSummaryDocumentationMustBeginWithStandardText)

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
@@ -382,10 +382,8 @@ class ClassName
 
         [Theory]
         [InlineData("class", "class", "class")]
-        [InlineData("class", "struct", "class")]
         [InlineData("class", "struct", "struct")]
         [InlineData("struct", "class", "class")]
-        [InlineData("struct", "struct", "class")]
         [InlineData("struct", "struct", "struct")]
         public async Task TestAllowedOuterQualifiedNames(string outerTypeKind, string nestedTypeKind, string describedTypeKind)
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
@@ -143,73 +143,73 @@
         [Fact]
         public async Task TestNonPrivateConstructorCorrectDocumentationSimple()
         {
-            await this.TestConstructorCorrectDocumentationSimple("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationSimple("public", NonPrivateConstructorStandardText, " class", false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNonPrivateConstructorCorrectDocumentationCustomized()
         {
-            await this.TestConstructorCorrectDocumentationCustomized("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationCustomized("public", NonPrivateConstructorStandardText, " class", false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNonPrivateConstructorCorrectDocumentationGenericSimple()
         {
-            await this.TestConstructorCorrectDocumentationSimple("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationSimple("public", NonPrivateConstructorStandardText, " class", true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNonPrivateConstructorCorrectDocumentationGenericCustomized()
         {
-            await this.TestConstructorCorrectDocumentationCustomized("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationCustomized("public", NonPrivateConstructorStandardText, " class", true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrivateConstructorCorrectDocumentation()
         {
-            await this.TestConstructorCorrectDocumentation("private", PrivateConstructorStandardText[0], PrivateConstructorStandardText[1], string.Empty, false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentation("private", PrivateConstructorStandardText[0], " class" + PrivateConstructorStandardText[1], string.Empty, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrivateConstructorCorrectDocumentation_NonPrivateSimple()
         {
-            await this.TestConstructorCorrectDocumentationSimple("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationSimple("private", NonPrivateConstructorStandardText, " class", false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrivateConstructorCorrectDocumentation_NonPrivateCustomized()
         {
-            await this.TestConstructorCorrectDocumentationCustomized("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationCustomized("private", NonPrivateConstructorStandardText, " class", false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrivateConstructorCorrectDocumentationGeneric()
         {
-            await this.TestConstructorCorrectDocumentation("private", PrivateConstructorStandardText[0], PrivateConstructorStandardText[1], string.Empty, true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentation("private", PrivateConstructorStandardText[0], " class" + PrivateConstructorStandardText[1], string.Empty, true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrivateConstructorCorrectDocumentationGeneric_NonPrivateSimple()
         {
-            await this.TestConstructorCorrectDocumentationSimple("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationSimple("private", NonPrivateConstructorStandardText, " class", true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrivateConstructorCorrectDocumentationGeneric_NonPrivateCustomized()
         {
-            await this.TestConstructorCorrectDocumentationCustomized("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationCustomized("private", NonPrivateConstructorStandardText, " class", true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticConstructorCorrectDocumentation()
         {
-            await this.TestConstructorCorrectDocumentation("static", StaticConstructorStandardText[0], StaticConstructorStandardText[1], string.Empty, false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentation("static", StaticConstructorStandardText, " class.", string.Empty, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticConstructorCorrectDocumentationGeneric()
         {
-            await this.TestConstructorCorrectDocumentation("static", StaticConstructorStandardText[0], StaticConstructorStandardText[1], string.Empty, true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentation("static", StaticConstructorStandardText, " class.", string.Empty, true).ConfigureAwait(false);
         }
 
         private async Task TestConstructorMissingDocumentation(string modifiers, string part1, string part2, bool generic)
@@ -257,37 +257,37 @@
         [Fact]
         public async Task TestNonPrivateConstructorMissingDocumentation()
         {
-            await this.TestConstructorMissingDocumentation("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentation("public", NonPrivateConstructorStandardText, " class", false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNonPrivateConstructorMissingDocumentationGeneric()
         {
-            await this.TestConstructorMissingDocumentation("public", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentation("public", NonPrivateConstructorStandardText, " class", true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrivateConstructorMissingDocumentation()
         {
-            await this.TestConstructorMissingDocumentation("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], false).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentation("private", NonPrivateConstructorStandardText, " class", false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestPrivateConstructorMissingDocumentationGeneric()
         {
-            await this.TestConstructorMissingDocumentation("private", NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentation("private", NonPrivateConstructorStandardText, " class", true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticConstructorMissingDocumentation()
         {
-            await this.TestConstructorMissingDocumentation("static", StaticConstructorStandardText[0], StaticConstructorStandardText[1], false).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentation("static", StaticConstructorStandardText, " class.", false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestStaticConstructorMissingDocumentationGeneric()
         {
-            await this.TestConstructorMissingDocumentation("static", StaticConstructorStandardText[0], StaticConstructorStandardText[1], true).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentation("static", StaticConstructorStandardText, " class.", true).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
@@ -21,213 +21,248 @@
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestNoDocumentation()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestNoDocumentation(string typeKind)
         {
-            var testCode = @"namespace FooNamespace
-{
-    public class Foo<TFoo, TBar>
-    {                                                                                                 
-        public Foo()
-        {
-
-        }
-    }
-}";
+            var testCode = $@"namespace FooNamespace
+{{
+    public {typeKind} Foo<TFoo, TBar>
+    {{
+        public Foo(int arg)
+        {{
+        }}
+    }}
+}}";
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        private async Task TestEmptyConstructor(string modifiers)
+        private async Task TestEmptyConstructor(string typeKind, string modifiers)
         {
             var testCode = @"namespace FooNamespace
 {{
-    public class Foo<TFoo, TBar>
+    public {0} Foo<TFoo, TBar>
     {{
         /// 
         /// 
-        ///                                                                                                 
-        {0} 
-        Foo()
+        /// 
+        {1} 
+        Foo({2})
         {{
 
         }}
     }}
 }}";
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, modifiers), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+
+            string arguments = typeKind == "struct" && modifiers != "static" ? "int argument" : null;
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeKind, modifiers, arguments), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestEmptyPublicConstructor()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestEmptyPublicConstructor(string typeKind)
         {
-            await this.TestEmptyConstructor("public").ConfigureAwait(false);
+            await this.TestEmptyConstructor(typeKind, "public").ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestEmptyNonPublicConstructor()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestEmptyNonPublicConstructor(string typeKind)
         {
-            await this.TestEmptyConstructor("private").ConfigureAwait(false);
+            await this.TestEmptyConstructor(typeKind, "private").ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestEmptyStaticConstructor()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestEmptyStaticConstructor(string typeKind)
         {
-            await this.TestEmptyConstructor("static").ConfigureAwait(false);
+            await this.TestEmptyConstructor(typeKind, "static").ConfigureAwait(false);
         }
 
-        private async Task TestConstructorCorrectDocumentation(string modifiers, string part1, string part2, string part3, bool generic)
+        private async Task TestConstructorCorrectDocumentation(string typeKind, string modifiers, string part1, string part2, string part3, bool generic)
         {
             // First test it all on one line
             var testCode = @"namespace FooNamespace
 {{
-    public class Foo{0}
+    public {0} Foo{1}
     {{
         /// <summary>
-        /// {2}<see cref=""Foo{1}""/>{3}{4}
+        /// {3}<see cref=""Foo{2}""/>{4}{5}
         /// </summary>
-        {5} Foo()
+        {6} Foo({7})
         {{
 
         }}
     }}
 }}";
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            string arguments = typeKind == "struct" && modifiers != "static" ? "int argument" : null;
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeKind, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers, arguments), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
             // Then test splitting after the <see> element
             testCode = @"namespace FooNamespace
 {{
-    public class Foo{0}
+    public {0} Foo{1}
     {{
         /// <summary>
-        /// {2}<see cref=""Foo{1}""/>
-        /// {3}{4}
+        /// {3}<see cref=""Foo{2}""/>
+        /// {4}{5}
         /// </summary>
-        {5} Foo()
+        {6} Foo({7})
         {{
 
         }}
     }}
 }}";
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeKind, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers, arguments), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
 
             // Then test splitting before the <see> element
             testCode = @"namespace FooNamespace
 {{
-    public class Foo{0}
+    public {0} Foo{1}
     {{
         /// <summary>
-        /// {2}
-        /// <see cref=""Foo{1}""/>{3}{4}
+        /// {3}
+        /// <see cref=""Foo{2}""/>{4}{5}
         /// </summary>
-        {5} Foo()
+        {6} Foo({7})
         {{
 
         }}
     }}
 }}";
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeKind, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers, arguments), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        private async Task TestConstructorCorrectDocumentationSimple(string modifiers, string part1, string part2, bool generic)
+        private async Task TestConstructorCorrectDocumentationSimple(string typeKind, string modifiers, string part1, string part2, bool generic)
         {
-            await this.TestConstructorCorrectDocumentation(modifiers, part1, part2, ".", generic).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentation(typeKind, modifiers, part1, part2, ".", generic).ConfigureAwait(false);
         }
 
-        private async Task TestConstructorCorrectDocumentationCustomized(string modifiers, string part1, string part2, bool generic)
+        private async Task TestConstructorCorrectDocumentationCustomized(string typeKind, string modifiers, string part1, string part2, bool generic)
         {
-            await this.TestConstructorCorrectDocumentation(modifiers, part1, part2, " with A and B.", generic).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentation(typeKind, modifiers, part1, part2, " with A and B.", generic).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestNonPrivateConstructorCorrectDocumentationSimple()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestNonPrivateConstructorCorrectDocumentationSimple(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationSimple("public", NonPrivateConstructorStandardText, " class", false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationSimple(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestNonPrivateConstructorCorrectDocumentationCustomized()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestNonPrivateConstructorCorrectDocumentationCustomized(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationCustomized("public", NonPrivateConstructorStandardText, " class", false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationCustomized(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestNonPrivateConstructorCorrectDocumentationGenericSimple()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestNonPrivateConstructorCorrectDocumentationGenericSimple(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationSimple("public", NonPrivateConstructorStandardText, " class", true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationSimple(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestNonPrivateConstructorCorrectDocumentationGenericCustomized()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestNonPrivateConstructorCorrectDocumentationGenericCustomized(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationCustomized("public", NonPrivateConstructorStandardText, " class", true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationCustomized(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestPrivateConstructorCorrectDocumentation()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestPrivateConstructorCorrectDocumentation(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentation("private", PrivateConstructorStandardText[0], " class" + PrivateConstructorStandardText[1], string.Empty, false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentation(typeKind, "private", PrivateConstructorStandardText[0], $" {typeKind}" + PrivateConstructorStandardText[1], string.Empty, false).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestPrivateConstructorCorrectDocumentation_NonPrivateSimple()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestPrivateConstructorCorrectDocumentation_NonPrivateSimple(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationSimple("private", NonPrivateConstructorStandardText, " class", false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationSimple(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestPrivateConstructorCorrectDocumentation_NonPrivateCustomized()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestPrivateConstructorCorrectDocumentation_NonPrivateCustomized(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationCustomized("private", NonPrivateConstructorStandardText, " class", false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationCustomized(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestPrivateConstructorCorrectDocumentationGeneric()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestPrivateConstructorCorrectDocumentationGeneric(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentation("private", PrivateConstructorStandardText[0], " class" + PrivateConstructorStandardText[1], string.Empty, true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentation(typeKind, "private", PrivateConstructorStandardText[0], $" {typeKind}" + PrivateConstructorStandardText[1], string.Empty, true).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestPrivateConstructorCorrectDocumentationGeneric_NonPrivateSimple()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestPrivateConstructorCorrectDocumentationGeneric_NonPrivateSimple(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationSimple("private", NonPrivateConstructorStandardText, " class", true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationSimple(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestPrivateConstructorCorrectDocumentationGeneric_NonPrivateCustomized()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestPrivateConstructorCorrectDocumentationGeneric_NonPrivateCustomized(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationCustomized("private", NonPrivateConstructorStandardText, " class", true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationCustomized(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestStaticConstructorCorrectDocumentation()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestStaticConstructorCorrectDocumentation(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentation("static", StaticConstructorStandardText, " class.", string.Empty, false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentation(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", string.Empty, false).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestStaticConstructorCorrectDocumentationGeneric()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestStaticConstructorCorrectDocumentationGeneric(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentation("static", StaticConstructorStandardText, " class.", string.Empty, true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentation(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", string.Empty, true).ConfigureAwait(false);
         }
 
-        private async Task TestConstructorMissingDocumentation(string modifiers, string part1, string part2, bool generic)
+        private async Task TestConstructorMissingDocumentation(string typeKind, string modifiers, string part1, string part2, bool generic)
         {
             var testCode = @"namespace FooNamespace
 {{
-    public class Foo{0}
+    public {0} Foo{1}
     {{
         /// <summary>
         /// </summary>
-        {1} 
-        Foo()
+        {2}
+        Foo({3})
         {{
 
         }}
     }}
 }}";
-            testCode = string.Format(testCode, generic ? "<T1, T2>" : string.Empty, modifiers);
+            string arguments = typeKind == "struct" && modifiers != "static" ? "int argument" : null;
+            testCode = string.Format(testCode, typeKind, generic ? "<T1, T2>" : string.Empty, modifiers, arguments);
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 13);
 
@@ -236,13 +271,13 @@
 
             var fixedCode = @"namespace FooNamespace
 {{
-    public class Foo{0}
+    public {0} Foo{1}
     {{
         /// <summary>
-        /// {2}<see cref=""Foo{1}""/>{3}{4}
+        /// {3}<see cref=""Foo{2}""/>{4}{5}
         /// </summary>
-        {5} 
-        Foo()
+        {6}
+        Foo({7})
         {{
 
         }}
@@ -250,44 +285,126 @@
 }}";
 
             string part3 = part2.EndsWith(".") ? string.Empty : ".";
-            fixedCode = string.Format(fixedCode, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers);
+            fixedCode = string.Format(fixedCode, typeKind, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers, arguments);
             await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestNonPrivateConstructorMissingDocumentation()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestNonPrivateConstructorMissingDocumentation(string typeKind)
         {
-            await this.TestConstructorMissingDocumentation("public", NonPrivateConstructorStandardText, " class", false).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentation(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestNonPrivateConstructorMissingDocumentationGeneric()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestNonPrivateConstructorMissingDocumentationGeneric(string typeKind)
         {
-            await this.TestConstructorMissingDocumentation("public", NonPrivateConstructorStandardText, " class", true).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentation(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestPrivateConstructorMissingDocumentation()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestPrivateConstructorMissingDocumentation(string typeKind)
         {
-            await this.TestConstructorMissingDocumentation("private", NonPrivateConstructorStandardText, " class", false).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentation(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestPrivateConstructorMissingDocumentationGeneric()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestPrivateConstructorMissingDocumentationGeneric(string typeKind)
         {
-            await this.TestConstructorMissingDocumentation("private", NonPrivateConstructorStandardText, " class", true).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentation(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestStaticConstructorMissingDocumentation()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestStaticConstructorMissingDocumentation(string typeKind)
         {
-            await this.TestConstructorMissingDocumentation("static", StaticConstructorStandardText, " class.", false).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentation(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", false).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestStaticConstructorMissingDocumentationGeneric()
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestStaticConstructorMissingDocumentationGeneric(string typeKind)
         {
-            await this.TestConstructorMissingDocumentation("static", StaticConstructorStandardText, " class.", true).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentation(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", true).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// This is a regression test for DotNetAnalyzers/StyleCopAnalyzers#676 "SA1642 misfires on nested structs,
+        /// requiring text describing the outer type"
+        /// https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/676
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task TestStructNestedInClass()
+        {
+            string testCode = @"
+class ClassName
+{
+    struct StructName
+    {
+        /// <summary>
+        /// </summary>
+        StructName(int argument)
+        {
+        }
+    }
+}
+";
+            string fixedCode = @"
+class ClassName
+{
+    struct StructName
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref=""StructName""/> struct.
+        /// </summary>
+        StructName(int argument)
+        {
+        }
+    }
+}
+";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 13);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("class", "class", "class")]
+        [InlineData("class", "struct", "class")]
+        [InlineData("class", "struct", "struct")]
+        [InlineData("struct", "class", "class")]
+        [InlineData("struct", "struct", "class")]
+        [InlineData("struct", "struct", "struct")]
+        public async Task TestAllowedOuterQualifiedNames(string outerTypeKind, string nestedTypeKind, string describedTypeKind)
+        {
+            string testCode = $@"
+{outerTypeKind} OuterName
+{{
+    {nestedTypeKind} NestedName
+    {{
+        /// <summary>
+        /// Initializes a new instance of the <see cref=""OuterName.NestedName""/> {describedTypeKind}.
+        /// </summary>
+        NestedName(int argument)
+        {{
+        }}
+    }}
+}}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -172,44 +172,25 @@
 
             if (constructorDeclarationSyntax.Modifiers.Any(SyntaxKind.StaticKeyword))
             {
-                if (isStruct && this.HandleDeclaration(context, StaticConstructorStandardText, " struct.", false) == MatchResult.FoundMatch)
-                {
-                    return;
-                }
-
-                this.HandleDeclaration(context, StaticConstructorStandardText, " class.", true);
+                string secondPartText = isStruct ? " struct." : " class.";
+                this.HandleDeclaration(context, StaticConstructorStandardText, secondPartText, true);
             }
             else if (constructorDeclarationSyntax.Modifiers.Any(SyntaxKind.PrivateKeyword))
             {
-                if (isStruct)
-                {
-                    if (this.HandleDeclaration(context, PrivateConstructorStandardText[0], " struct" + PrivateConstructorStandardText[1], false) == MatchResult.FoundMatch)
-                    {
-                        return;
-                    }
+                string typeKindText = isStruct ? " struct" : " class";
 
-                    if (this.HandleDeclaration(context, NonPrivateConstructorStandardText, " struct", false) == MatchResult.FoundMatch)
-                    {
-                        return;
-                    }
-                }
-
-                if (this.HandleDeclaration(context, PrivateConstructorStandardText[0], " class" + PrivateConstructorStandardText[1], false) == MatchResult.FoundMatch)
+                if (this.HandleDeclaration(context, PrivateConstructorStandardText[0], typeKindText + PrivateConstructorStandardText[1], false) == MatchResult.FoundMatch)
                 {
                     return;
                 }
 
                 // also allow the non-private wording for private constructors
-                this.HandleDeclaration(context, NonPrivateConstructorStandardText, " class", true);
+                this.HandleDeclaration(context, NonPrivateConstructorStandardText, typeKindText, true);
             }
             else
             {
-                if (isStruct && this.HandleDeclaration(context, NonPrivateConstructorStandardText, " struct", false) == MatchResult.FoundMatch)
-                {
-                    return;
-                }
-
-                this.HandleDeclaration(context, NonPrivateConstructorStandardText, " class", true);
+                string typeKindText = isStruct ? " struct" : " class";
+                this.HandleDeclaration(context, NonPrivateConstructorStandardText, typeKindText, true);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -6,8 +6,6 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
-    using Helpers;
-    using System;
 
     /// <summary>
     /// The XML documentation header for a C# constructor does not contain the appropriate summary text.
@@ -104,18 +102,19 @@
         private const string HelpLink = "http://www.stylecop.com/docs/SA1642.html";
 
         /// <summary>
-        /// Gets a two-element array containing the standard text which is expected to appear at the beginning of the
-        /// <c>&lt;summary&gt;</c> documentation for a non-private constructor. The first element appears before the
-        /// name of the containing class, followed by a <c>&lt;see&gt;</c> element targeting the containing type, and
-        /// finally followed by the second element of this array.
+        /// Gets the standard text which is expected to appear at the beginning of the <c>&lt;summary&gt;</c>
+        /// documentation for a non-private constructor. This text appears before the name of the containing class,
+        /// followed by a <c>&lt;see&gt;</c> element targeting the containing type, and finally followed by <c>class</c>
+        /// or <c>struct</c> as appropriate for the containing type.
         /// </summary>
-        public static ImmutableArray<string> NonPrivateConstructorStandardText { get; } = ImmutableArray.Create("Initializes a new instance of the ", " class");
+        public static string NonPrivateConstructorStandardText { get; } = "Initializes a new instance of the ";
 
         /// <summary>
-        /// Gets a two-element array containing the standard text which is expected to appear at the beginning of the
-        /// <c>&lt;summary&gt;</c> documentation for a private constructor. The first element appears before the name of
-        /// the containing class, followed by a <c>&lt;see&gt;</c> element targeting the containing type, and finally
-        /// followed by the second element of this array.
+        /// Gets the standard text which is expected to appear at the beginning of the <c>&lt;summary&gt;</c>
+        /// documentation for a private constructor. The first element appears before the name of the containing class,
+        /// followed by a <c>&lt;see&gt;</c> element targeting the containing type, then by <c>class</c> or
+        /// <c>struct</c> as appropriate for the containing type, and finally followed by the second element of this
+        /// array.
         /// </summary>
         /// <remarks>
         /// <para>In addition to the format given in <see cref="PrivateConstructorStandardText"/>, a private constructor
@@ -125,15 +124,15 @@
         /// superior alternative to private constructors for the purpose of declaring utility types that cannot be
         /// instantiated.</para>
         /// </remarks>
-        public static ImmutableArray<string> PrivateConstructorStandardText { get; } = ImmutableArray.Create("Prevents a default instance of the ", " class from being created.");
+        public static ImmutableArray<string> PrivateConstructorStandardText { get; } = ImmutableArray.Create("Prevents a default instance of the ", " from being created.");
 
         /// <summary>
-        /// Gets a two-element array containing the standard text which is expected to appear at the beginning of the
-        /// <c>&lt;summary&gt;</c> documentation for a static constructor. The first element appears before the name of
-        /// the containing class, followed by a <c>&lt;see&gt;</c> element targeting the containing type, and finally
-        /// followed by the second element of this array.
+        /// Gets the standard text which is expected to appear at the beginning of the <c>&lt;summary&gt;</c>
+        /// documentation for a static constructor. The first element appears before the name of the containing class,
+        /// followed by a <c>&lt;see&gt;</c> element targeting the containing type, and finally followed by <c>class</c>
+        /// or <c>struct</c> as appropriate for the containing type.
         /// </summary>
-        public static ImmutableArray<string> StaticConstructorStandardText { get; } = ImmutableArray.Create("Initializes static members of the ", " class.");
+        public static string StaticConstructorStandardText { get; } = "Initializes static members of the ";
 
         private static readonly DiagnosticDescriptor Descriptor =
             new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, true, Description, HelpLink);
@@ -169,21 +168,48 @@
         {
             var constructorDeclarationSyntax = context.Node as ConstructorDeclarationSyntax;
 
+            bool isStruct = constructorDeclarationSyntax.Parent?.IsKind(SyntaxKind.StructDeclaration) ?? false;
+
             if (constructorDeclarationSyntax.Modifiers.Any(SyntaxKind.StaticKeyword))
             {
-                this.HandleDeclaration(context, StaticConstructorStandardText[0], StaticConstructorStandardText[1], true);
+                if (isStruct && this.HandleDeclaration(context, StaticConstructorStandardText, " struct.", false) == MatchResult.FoundMatch)
+                {
+                    return;
+                }
+
+                this.HandleDeclaration(context, StaticConstructorStandardText, " class.", true);
             }
             else if (constructorDeclarationSyntax.Modifiers.Any(SyntaxKind.PrivateKeyword))
             {
-                if (this.HandleDeclaration(context, PrivateConstructorStandardText[0], PrivateConstructorStandardText[1], false) != MatchResult.FoundMatch)
+                if (isStruct)
                 {
-                    // also allow the non-private wording for private constructors
-                    this.HandleDeclaration(context, NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true);
+                    if (this.HandleDeclaration(context, PrivateConstructorStandardText[0], " struct" + PrivateConstructorStandardText[1], false) == MatchResult.FoundMatch)
+                    {
+                        return;
+                    }
+
+                    if (this.HandleDeclaration(context, NonPrivateConstructorStandardText, " struct", false) == MatchResult.FoundMatch)
+                    {
+                        return;
+                    }
                 }
+
+                if (this.HandleDeclaration(context, PrivateConstructorStandardText[0], " class" + PrivateConstructorStandardText[1], false) == MatchResult.FoundMatch)
+                {
+                    return;
+                }
+
+                // also allow the non-private wording for private constructors
+                this.HandleDeclaration(context, NonPrivateConstructorStandardText, " class", true);
             }
             else
             {
-                this.HandleDeclaration(context, NonPrivateConstructorStandardText[0], NonPrivateConstructorStandardText[1], true);
+                if (isStruct && this.HandleDeclaration(context, NonPrivateConstructorStandardText, " struct", false) == MatchResult.FoundMatch)
+                {
+                    return;
+                }
+
+                this.HandleDeclaration(context, NonPrivateConstructorStandardText, " class", true);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -61,8 +61,20 @@
 
         private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, XmlElementSyntax node)
         {
-            var classDeclaration = node.FirstAncestorOrSelf<ClassDeclarationSyntax>();
+            var typeDeclaration = node.FirstAncestorOrSelf<BaseTypeDeclarationSyntax>();
             var declarationSyntax = node.FirstAncestorOrSelf<BaseMethodDeclarationSyntax>();
+            bool isStruct = typeDeclaration.IsKind(SyntaxKind.StructDeclaration);
+
+            TypeParameterListSyntax typeParameterList;
+            ClassDeclarationSyntax classDeclaration = typeDeclaration as ClassDeclarationSyntax;
+            if (classDeclaration != null)
+            {
+                typeParameterList = classDeclaration.TypeParameterList;
+            }
+            else
+            {
+                typeParameterList = (typeDeclaration as StructDeclarationSyntax)?.TypeParameterList;
+            }
 
             ImmutableArray<string> standardText;
             if (declarationSyntax is ConstructorDeclarationSyntax)
@@ -91,7 +103,7 @@
                 throw new InvalidOperationException("XmlElementSyntax has invalid method as its parent");
             }
 
-            var list = BuildStandardText(classDeclaration.Identifier, classDeclaration.TypeParameterList, standardText[0], standardText[1]);
+            var list = BuildStandardText(typeDeclaration.Identifier, typeParameterList, standardText[0], standardText[1]);
 
             var newContent = node.Content.InsertRange(0, list);
             var newNode = node.WithContent(newContent);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -81,17 +81,28 @@
             {
                 if (declarationSyntax.Modifiers.Any(SyntaxKind.StaticKeyword))
                 {
-                    standardText = SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.StaticConstructorStandardText;
-                }
-                else if (declarationSyntax.Modifiers.Any(SyntaxKind.PrivateKeyword))
-                {
-                    // Prefer to insert the "non-private" wording, even though both are considered acceptable by the
-                    // diagnostic. https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/413
-                    standardText = SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.NonPrivateConstructorStandardText;
+                    if (isStruct)
+                    {
+                        standardText = ImmutableArray.Create(SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.StaticConstructorStandardText, " struct.");
+                    }
+                    else
+                    {
+                        standardText = ImmutableArray.Create(SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.StaticConstructorStandardText, " class.");
+                    }
                 }
                 else
                 {
-                    standardText = SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.NonPrivateConstructorStandardText;
+                    // Prefer to insert the "non-private" wording for all constructors, even though both are considered
+                    // acceptable for private constructors by the diagnostic.
+                    // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/413
+                    if (isStruct)
+                    {
+                        standardText = ImmutableArray.Create(SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.NonPrivateConstructorStandardText, " struct.");
+                    }
+                    else
+                    {
+                        standardText = ImmutableArray.Create(SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.NonPrivateConstructorStandardText, " class.");
+                    }
                 }
             }
             else if (declarationSyntax is DestructorDeclarationSyntax)


### PR DESCRIPTION
* Require `struct` instead of `class` for struct types (Fixes #418)
* Fix support for nested types (Fixes #676)
* Use semantic checking of the type name reference instead of text checking

This means either of the following are now allowed:

```csharp
class ClassName
{
  struct StructName
  {
    /// <summary>
    /// Initializes a new instance of the <see cref="StructName"/> struct.
    /// </summary>
    StructName(int argument)
    {
    }
  }
}
```

```csharp
class ClassName
{
  struct StructName
  {
    /// <summary>
    /// Initializes a new instance of the <see cref="ClassName.StructName"/> struct.
    /// </summary>
    StructName(int argument)
    {
    }
  }
}
```
