### PR TITLE
Added WithSpan method to DiagnosticResult

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
@@ -31,16 +31,10 @@ using System;
 
 {code}";
 
-            var expected = new[]
+            DiagnosticResult[] expected =
             {
-                new DiagnosticResult
-                {
-                    Id = "CS0116",
-                    Severity = DiagnosticSeverity.Error,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 4, column) },
-                    Message = "A namespace cannot directly contain members such as fields or methods"
-                },
-                this.CSharpDiagnostic().WithLocation(4, column)
+                this.CSharpCompilerError("CS0116", "A namespace cannot directly contain members such as fields or methods").WithLocation(4, column),
+                this.CSharpDiagnostic().WithLocation(4, column),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1606UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1606UnitTests.cs
@@ -777,12 +777,9 @@ class Class1
 }
 ";
 
-            var expected = new DiagnosticResult
+            DiagnosticResult[] expected =
             {
-                Id = "CS1002",
-                Severity = DiagnosticSeverity.Error,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 5, 29) },
-                Message = "; expected"
+                this.CSharpCompilerError("CS1002", "; expected").WithLocation(5, 29),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticResult.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticResult.cs
@@ -5,15 +5,18 @@ namespace TestHelper
 {
     using System;
     using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Text;
 
     /// <summary>
     /// Structure that stores information about a <see cref="Diagnostic"/> appearing in a source.
     /// </summary>
     public struct DiagnosticResult
     {
+        private const string DefaultPath = "Test0.cs";
+
         private static readonly object[] EmptyArguments = new object[0];
 
-        private DiagnosticResultLocation[] locations;
+        private FileLinePositionSpan[] spans;
         private string message;
 
         public DiagnosticResult(DiagnosticDescriptor descriptor)
@@ -24,21 +27,16 @@ namespace TestHelper
             this.MessageFormat = descriptor.MessageFormat;
         }
 
-        public DiagnosticResultLocation[] Locations
+        public FileLinePositionSpan[] Spans
         {
             get
             {
-                if (this.locations == null)
-                {
-                    this.locations = new DiagnosticResultLocation[] { };
-                }
-
-                return this.locations;
+                return this.spans ?? (this.spans = new FileLinePositionSpan[] { });
             }
 
             set
             {
-                this.locations = value;
+                this.spans = value;
             }
         }
 
@@ -87,27 +85,11 @@ namespace TestHelper
             set;
         }
 
-        public string Path
+        public bool HasLocation
         {
             get
             {
-                return this.Locations.Length > 0 ? this.Locations[0].Path : string.Empty;
-            }
-        }
-
-        public int Line
-        {
-            get
-            {
-                return this.Locations.Length > 0 ? this.Locations[0].Line : -1;
-            }
-        }
-
-        public int Column
-        {
-            get
-            {
-                return this.Locations.Length > 0 ? this.Locations[0].Column : -1;
+                return (this.spans != null) && (this.spans.Length > 0);
             }
         }
 
@@ -127,27 +109,69 @@ namespace TestHelper
 
         public DiagnosticResult WithLocation(int line, int column)
         {
-            return this.WithLocation("Test0.cs", line, column);
+            return this.WithLocation(DefaultPath, line, column);
         }
 
         public DiagnosticResult WithLocation(string path, int line, int column)
         {
-            DiagnosticResult result = this;
-            Array.Resize(ref result.locations, (result.locations?.Length ?? 0) + 1);
-            result.locations[result.locations.Length - 1] = new DiagnosticResultLocation(path, line, column);
-            return result;
+            var linePosition = new LinePosition(line, column);
+
+            return this.AppendSpan(new FileLinePositionSpan(path, linePosition, linePosition));
+        }
+
+        public DiagnosticResult WithSpan(int startLine, int startColumn, int endLine, int endColumn)
+        {
+            return this.WithSpan(DefaultPath, startLine, startColumn, endLine, endColumn);
+        }
+
+        public DiagnosticResult WithSpan(string path, int startLine, int startColumn, int endLine, int endColumn)
+        {
+            return this.AppendSpan(new FileLinePositionSpan(path, new LinePosition(startLine, startColumn), new LinePosition(endLine, endColumn)));
         }
 
         public DiagnosticResult WithLineOffset(int offset)
         {
             DiagnosticResult result = this;
-            Array.Resize(ref result.locations, result.locations?.Length ?? 0);
-            for (int i = 0; i < result.locations.Length; i++)
+            Array.Resize(ref result.spans, result.spans?.Length ?? 0);
+            for (int i = 0; i < result.spans.Length; i++)
             {
-                result.locations[i].Line += offset;
+                var newStartLinePosition = new LinePosition(result.spans[i].StartLinePosition.Line + offset, result.spans[i].StartLinePosition.Character);
+                var newEndLinePosition = new LinePosition(result.spans[i].EndLinePosition.Line + offset, result.spans[i].EndLinePosition.Character);
+
+                result.spans[i] = new FileLinePositionSpan(result.spans[i].Path, newStartLinePosition, newEndLinePosition);
             }
 
             return result;
+        }
+
+        private DiagnosticResult AppendSpan(FileLinePositionSpan span)
+        {
+            FileLinePositionSpan[] newSpans;
+
+            if (this.spans != null)
+            {
+                newSpans = new FileLinePositionSpan[this.spans.Length + 1];
+                Array.Copy(this.spans, newSpans, this.spans.Length);
+                newSpans[this.spans.Length] = span;
+            }
+            else
+            {
+                newSpans = new FileLinePositionSpan[1]
+                {
+                    span,
+                };
+            }
+
+            // clone the object, so that the fluent syntax will work on immutable objects.
+            return new DiagnosticResult
+            {
+                Id = this.Id,
+                Message = this.message,
+                MessageFormat = this.MessageFormat,
+                MessageArguments = this.MessageArguments,
+                Severity = this.Severity,
+                Spans = newSpans,
+            };
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -209,6 +209,16 @@ namespace TestHelper
             return new DiagnosticResult(descriptor);
         }
 
+        protected DiagnosticResult CSharpCompilerError(string errorIdentifier, string message)
+        {
+            return new DiagnosticResult
+            {
+                Id = errorIdentifier,
+                Severity = DiagnosticSeverity.Error,
+                Message = message,
+            };
+        }
+
         /// <summary>
         /// Create a project using the input strings as sources.
         /// </summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1504UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1504UnitTests.cs
@@ -291,13 +291,7 @@ public class Foo
 }";
             DiagnosticResult[] expected =
             {
-                new DiagnosticResult()
-                {
-                    Id = "CS0501",
-                    Message = "'Foo.Prop.get' must declare a body because it is not marked abstract, extern, or partial",
-                    Severity = DiagnosticSeverity.Error,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 9) }
-                }
+                this.CSharpCompilerError("CS0501", "'Foo.Prop.get' must declare a body because it is not marked abstract, extern, or partial").WithLocation(6, 9),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1508UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1508UnitTests.cs
@@ -851,34 +851,10 @@ to determine the spacing with the close brace.
 
             DiagnosticResult[] expected =
             {
-                new DiagnosticResult
-                {
-                    Id = "CS1022",
-                    Severity = DiagnosticSeverity.Error,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 3, 28) },
-                    Message = "Type or namespace definition, or end-of-file expected"
-                },
-                new DiagnosticResult
-                {
-                    Id = "CS1513",
-                    Severity = DiagnosticSeverity.Error,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 3, 28) },
-                    Message = "} expected"
-                },
-                new DiagnosticResult
-                {
-                    Id = "CS1514",
-                    Severity = DiagnosticSeverity.Error,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 3, 28) },
-                    Message = "{ expected"
-                },
-                new DiagnosticResult
-                {
-                    Id = "CS1022",
-                    Severity = DiagnosticSeverity.Error,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 1) },
-                    Message = "Type or namespace definition, or end-of-file expected"
-                }
+                this.CSharpCompilerError("CS1022", "Type or namespace definition, or end-of-file expected").WithLocation(3, 28),
+                this.CSharpCompilerError("CS1513", "} expected").WithLocation(3, 28),
+                this.CSharpCompilerError("CS1514", "{ expected").WithLocation(3, 28),
+                this.CSharpCompilerError("CS1022", "Type or namespace definition, or end-of-file expected").WithLocation(6, 1),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/DebugMessagesUnitTestsBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/DebugMessagesUnitTestsBase.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Text;
     using TestHelper;
     using Xunit;
 
@@ -41,6 +42,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         [Fact]
         public async Task TestConstantMessage_Field_PassWrongTypeAsync()
         {
+            LinePosition linePosition = new LinePosition(4, 28);
             DiagnosticResult[] expected =
             {
                 new DiagnosticResult
@@ -48,7 +50,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
                     Id = "CS0029",
                     Message = "Cannot implicitly convert type 'int' to 'string'",
                     Severity = DiagnosticSeverity.Error,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 4, 28) }
+                    Spans = new[] { new FileLinePositionSpan("Test0.cs", linePosition, linePosition) }
                 }
             };
 
@@ -70,6 +72,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         [Fact]
         public async Task TestConstantMessage_Local_PassWrongTypeAsync()
         {
+            LinePosition linePosition = new LinePosition(6, 32);
             DiagnosticResult[] expected =
             {
                 new DiagnosticResult
@@ -77,7 +80,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
                     Id = "CS0029",
                     Message = "Cannot implicitly convert type 'int' to 'string'",
                     Severity = DiagnosticSeverity.Error,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 32) }
+                    Spans = new[] { new FileLinePositionSpan("Test0.cs", linePosition, linePosition) }
                 }
             };
 
@@ -99,6 +102,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         [Fact]
         public async Task TestConstantMessage_Inline_PassWrongTypeAsync()
         {
+            LinePosition linePosition = new LinePosition(6, 16 + this.MethodName.Length + this.InitialArguments.Sum(i => i.Length + ", ".Length));
             DiagnosticResult[] expected =
             {
                 new DiagnosticResult
@@ -106,7 +110,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
                     Id = "CS1503",
                     Message = $"Argument {1 + this.InitialArguments.Count()}: cannot convert from 'int' to 'string'",
                     Severity = DiagnosticSeverity.Error,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 16 + this.MethodName.Length + this.InitialArguments.Sum(i => i.Length + ", ".Length)) }
+                    Spans = new[] { new FileLinePositionSpan("Test0.cs", linePosition, linePosition) }
                 }
             };
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1404UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1404UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.CodeAnalysis.Text;
     using StyleCop.Analyzers.MaintainabilityRules;
     using TestHelper;
     using Xunit;
@@ -338,6 +339,7 @@ public class Foo
     }
 }";
 
+            var expectedLinePosition = new LinePosition(4, 82);
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(4, 66),
@@ -346,7 +348,7 @@ public class Foo
                     Id = "CS0029",
                     Message = "Cannot implicitly convert type 'int' to 'string'",
                     Severity = DiagnosticSeverity.Error,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 4, 82) }
+                    Spans = new[] { new FileLinePositionSpan("Test0.cs", expectedLinePosition, expectedLinePosition) }
                 }
             };
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1201UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1201UnitTests.cs
@@ -6,9 +6,12 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.CodeAnalysis.Text;
+
     using StyleCop.Analyzers.OrderingRules;
     using TestHelper;
     using Xunit;
@@ -270,22 +273,24 @@ public struct FooStruct { }
 ";
 
             // We don't care about the syntax errors.
+            var expectedLinePosition1 = new LinePosition(5, 5);
+            var expectedLinePosition2 = new LinePosition(6, 1);
             var expected = new[]
             {
-                 new DiagnosticResult
-                 {
-                     Id = "CS1585",
-                     Message = "Member modifier 'public' must precede the member type and name",
-                     Severity = DiagnosticSeverity.Error,
-                     Locations = new[] { new DiagnosticResultLocation("Test0.cs", 5, 5) }
-                 },
-                 new DiagnosticResult
-                 {
-                     Id = "CS1519",
-                     Message = "Invalid token '}' in class, struct, or interface member declaration",
-                     Severity = DiagnosticSeverity.Error,
-                     Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 1) }
-                 }
+                new DiagnosticResult
+                {
+                    Id = "CS1585",
+                    Message = "Member modifier 'public' must precede the member type and name",
+                    Severity = DiagnosticSeverity.Error,
+                    Spans = new[] { new FileLinePositionSpan("Test0.cs", expectedLinePosition1, expectedLinePosition1) }
+                },
+                new DiagnosticResult
+                {
+                    Id = "CS1519",
+                    Message = "Invalid token '}' in class, struct, or interface member declaration",
+                    Severity = DiagnosticSeverity.Error,
+                    Spans = new[] { new FileLinePositionSpan("Test0.cs", expectedLinePosition2, expectedLinePosition2) }
+                }
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
@@ -936,20 +936,8 @@ public class TestClass : TestInterface
             // We don't care about the syntax errors.
             var expected = new[]
             {
-                 new DiagnosticResult
-                 {
-                     Id = "CS1585",
-                     Message = "Member modifier 'public' must precede the member type and name",
-                     Severity = DiagnosticSeverity.Error,
-                     Locations = new[] { new DiagnosticResultLocation("Test0.cs", 5, 5) }
-                 },
-                 new DiagnosticResult
-                 {
-                     Id = "CS1519",
-                     Message = "Invalid token '}' in class, struct, or interface member declaration",
-                     Severity = DiagnosticSeverity.Error,
-                     Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 1) }
-                 }
+                this.CSharpCompilerError("CS1585", "Member modifier 'public' must precede the member type and name").WithLocation(5, 5),
+                this.CSharpCompilerError("CS1519", "Invalid token '}' in class, struct, or interface member declaration").WithLocation(6, 1),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -971,22 +959,10 @@ public class TestClass : TestInterface
 ";
 
             // We don't care about the syntax errors.
-            var expected = new[]
+            DiagnosticResult[] expected =
             {
-                 new DiagnosticResult
-                 {
-                     Id = "CS1585",
-                     Message = "Member modifier 'public' must precede the member type and name",
-                     Severity = DiagnosticSeverity.Error,
-                     Locations = new[] { new DiagnosticResultLocation("Test0.cs", 5, 5) }
-                 },
-                 new DiagnosticResult
-                 {
-                     Id = "CS1519",
-                     Message = "Invalid token '}' in class, struct, or interface member declaration",
-                     Severity = DiagnosticSeverity.Error,
-                     Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 1) }
-                 }
+                this.CSharpCompilerError("CS1585", "Member modifier 'public' must precede the member type and name").WithLocation(5, 5),
+                this.CSharpCompilerError("CS1519", "Invalid token '}' in class, struct, or interface member declaration").WithLocation(6, 1),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1204UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1204UnitTests.cs
@@ -576,22 +576,10 @@ public class TestClass : TestInterface
 ";
 
             // We don't care about the syntax errors.
-            var expected = new[]
+            DiagnosticResult[] expected =
             {
-                 new DiagnosticResult
-                 {
-                     Id = "CS1585",
-                     Message = "Member modifier 'public' must precede the member type and name",
-                     Severity = DiagnosticSeverity.Error,
-                     Locations = new[] { new DiagnosticResultLocation("Test0.cs", 5, 5) }
-                 },
-                 new DiagnosticResult
-                 {
-                     Id = "CS1519",
-                     Message = "Invalid token '}' in class, struct, or interface member declaration",
-                     Severity = DiagnosticSeverity.Error,
-                     Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 1) }
-                 }
+                this.CSharpCompilerError("CS1585", "Member modifier 'public' must precede the member type and name").WithLocation(5, 5),
+                this.CSharpCompilerError("CS1519", "Invalid token '}' in class, struct, or interface member declaration").WithLocation(6, 1),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1206UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1206UnitTests.cs
@@ -191,12 +191,9 @@ public class ExtendedClass : TestClass
     new public string
 }";
 
-            var expected = new DiagnosticResult
+            DiagnosticResult[] expected =
             {
-                Id = "CS1519",
-                Message = "Invalid token '}' in class, struct, or interface member declaration",
-                Severity = DiagnosticSeverity.Error,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 4, 1) }
+                this.CSharpCompilerError("CS1519", "Invalid token '}' in class, struct, or interface member declaration").WithLocation(4, 1),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1132UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1132UnitTests.cs
@@ -124,12 +124,9 @@ class Foo
     {declaration}
 }}";
 
-            DiagnosticResult expected = new DiagnosticResult
+            DiagnosticResult[] expected =
             {
-                Id = id,
-                Severity = DiagnosticSeverity.Error,
-                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 4, column) },
-                Message = message
+                this.CSharpCompilerError(id, message).WithLocation(4, column),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1000UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1000UnitTests.cs
@@ -852,13 +852,7 @@ class ClassName
 
             DiagnosticResult[] expected =
             {
-                new DiagnosticResult
-                {
-                    Id = "CS0742",
-                    Severity = DiagnosticSeverity.Error,
-                    Message = "A query body must end with a select clause or a group clause",
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 42) }
-                }
+                this.CSharpCompilerError("CS0742", "A query body must end with a select clause or a group clause").WithLocation(6, 42),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
@@ -193,13 +193,7 @@ class ClassName
 
             DiagnosticResult[] expected =
             {
-                new DiagnosticResult
-                {
-                    Id = "CS1003",
-                    Severity = DiagnosticSeverity.Error,
-                    Message = "Syntax error, ',' expected",
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 25) }
-                }
+                this.CSharpCompilerError("CS1003", "Syntax error, ',' expected").WithLocation(6, 25),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1002UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1002UnitTests.cs
@@ -406,13 +406,7 @@ class ClassName
 
             DiagnosticResult[] expected =
             {
-                new DiagnosticResult
-                {
-                    Id = "CS1002",
-                    Severity = DiagnosticSeverity.Error,
-                    Message = "; expected",
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 14) }
-                }
+                this.CSharpCompilerError("CS1002", "; expected").WithLocation(6, 14),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1007UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1007UnitTests.cs
@@ -76,13 +76,7 @@ class ClassName
 
             DiagnosticResult[] expected =
             {
-                new DiagnosticResult
-                {
-                    Id = "CS1003",
-                    Severity = DiagnosticSeverity.Error,
-                    Message = "Syntax error, 'operator' expected",
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 4, 28) }
-                }
+                this.CSharpCompilerError("CS1003", "Syntax error, 'operator' expected").WithLocation(4, 28),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1008UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1008UnitTests.cs
@@ -2026,13 +2026,7 @@ class ClassName
 
             DiagnosticResult[] expected =
             {
-                new DiagnosticResult
-                {
-                    Id = "CS1003",
-                    Severity = DiagnosticSeverity.Error,
-                    Message = "Syntax error, '(' expected",
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 5, 15) }
-                }
+                this.CSharpCompilerError("CS1003", "Syntax error, '(' expected").WithLocation(5, 15),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1009UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1009UnitTests.cs
@@ -850,13 +850,7 @@ class ClassName
 
             DiagnosticResult[] expected =
             {
-                new DiagnosticResult
-                {
-                    Id = "CS1026",
-                    Severity = DiagnosticSeverity.Error,
-                    Message = ") expected",
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 5, 16) }
-                }
+                this.CSharpCompilerError("CS1026", ") expected").WithLocation(5, 16),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1011UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1011UnitTests.cs
@@ -304,27 +304,9 @@ class ClassName
 
             DiagnosticResult[] expected =
             {
-                new DiagnosticResult
-                {
-                    Id = "CS0443",
-                    Severity = DiagnosticSeverity.Error,
-                    Message = "Syntax error; value expected",
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 28) }
-                },
-                new DiagnosticResult
-                {
-                    Id = "CS1003",
-                    Severity = DiagnosticSeverity.Error,
-                    Message = "Syntax error, ',' expected",
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 28) }
-                },
-                new DiagnosticResult
-                {
-                    Id = "CS1003",
-                    Severity = DiagnosticSeverity.Error,
-                    Message = "Syntax error, ']' expected",
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 28) }
-                }
+                this.CSharpCompilerError("CS0443", "Syntax error; value expected").WithLocation(6, 28),
+                this.CSharpCompilerError("CS1003", "Syntax error, ',' expected").WithLocation(6, 28),
+                this.CSharpCompilerError("CS1003", "Syntax error, ']' expected").WithLocation(6, 28),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1012UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1012UnitTests.cs
@@ -236,13 +236,7 @@ class ClassName
 
             DiagnosticResult[] expected =
             {
-                new DiagnosticResult
-                {
-                    Id = "CS1514",
-                    Severity = DiagnosticSeverity.Error,
-                    Message = "{ expected",
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 25) }
-                }
+                this.CSharpCompilerError("CS1514", "{ expected").WithLocation(6, 25),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1013UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1013UnitTests.cs
@@ -395,13 +395,7 @@ class ClassName
 
             DiagnosticResult[] expected =
             {
-                new DiagnosticResult
-                {
-                    Id = "CS1513",
-                    Severity = DiagnosticSeverity.Error,
-                    Message = "} expected",
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 3, 2) }
-                }
+                this.CSharpCompilerError("CS1513", "} expected").WithLocation(3, 2),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1015UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1015UnitTests.cs
@@ -384,13 +384,7 @@ class ClassName
 
             DiagnosticResult[] expected =
             {
-                new DiagnosticResult
-                {
-                    Id = "CS1003",
-                    Severity = DiagnosticSeverity.Error,
-                    Message = "Syntax error, '>' expected",
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 7, 35) }
-                }
+                this.CSharpCompilerError("CS1003", "Syntax error, '>' expected").WithLocation(7, 35),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1018UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1018UnitTests.cs
@@ -134,13 +134,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
 
             DiagnosticResult[] expected =
             {
-                new DiagnosticResult
-                {
-                    Id = "CS1031",
-                    Message = "Type expected",
-                    Severity = DiagnosticSeverity.Error,
-                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 2) }
-                }
+                this.CSharpCompilerError("CS1031", "Type expected").WithLocation(10, 2),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);


### PR DESCRIPTION
Fixes #625

Haven't added `.WithSingleTokenSpan()` because I can't really think of a proper way to do that at the moment.