### PR TITLE
Fix that SA1404 does not support escaped identifiers

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1404UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1404UnitTests.cs
@@ -68,6 +68,23 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
         }
 
         [Fact]
+        public async Task TestSuppressionWithEscapedIdentifierWithJustification()
+        {
+            var testCode = @"public class Foo
+{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(null, null, Justific\u0061tion = """")]
+    public void Bar()
+    {
+
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 66);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestSuppressionWithWhitespaceJustification()
         {
             var testCode = @"public class Foo

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1404CodeAnalysisSuppressionMustHaveJustification.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1404CodeAnalysisSuppressionMustHaveJustification.cs
@@ -74,7 +74,7 @@
                         foreach (var argument in attribute.ArgumentList.ChildNodes())
                         {
                             var attributeArgument = argument as AttributeArgumentSyntax;
-                            if (attributeArgument?.NameEquals?.Name?.ToString() == nameof(SuppressMessageAttribute.Justification))
+                            if (attributeArgument?.NameEquals?.Name?.Identifier.ValueText == nameof(SuppressMessageAttribute.Justification))
                             {
                                 // Check if the justification is not empty
 


### PR DESCRIPTION
Because everyone uses Justific\u0061tion