### PR TITLE
Implement proposed SA1028: NoTrailingWhitespace

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
@@ -184,6 +184,56 @@ more text
         }
 
         [Fact]
+        public async Task TrailingWhitespaceAfterDirectives()
+        {
+            string testCode = @"
+#define Zoot  
+#undef Zoot2  
+using System;  
+#if Foo  
+#elif Bar  
+#else  
+#endif 
+#warning Some warning  
+#region Some region  
+#endregion  
+";
+
+            string fixedCode = @"
+#define Zoot
+#undef Zoot2
+using System;
+#if Foo
+#elif Bar
+#else
+#endif
+#warning Some warning
+#region Some region
+#endregion
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(2, 13),
+                this.CSharpDiagnostic().WithLocation(3, 13),
+                this.CSharpDiagnostic().WithLocation(4, 14),
+                this.CSharpDiagnostic().WithLocation(5, 8),
+                this.CSharpDiagnostic().WithLocation(6, 10),
+                this.CSharpDiagnostic().WithLocation(7, 6),
+                this.CSharpDiagnostic().WithLocation(8, 7),
+                this.CSharpDiagnostic().WithLocation(9, 22),
+                this.CSharpDiagnostic().WithLocation(10, 20),
+                this.CSharpDiagnostic().WithLocation(11, 11),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None);
+
+            // We don't have code fixes available for directives yet.
+            ////await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
+        }
+
+        [Fact]
         public async Task NoTrailingWhitespaceAfterBlockComment()
         {
             string testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
@@ -1,0 +1,165 @@
+﻿namespace StyleCop.Analyzers.Test.SpacingRules
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.SpacingRules;
+    using TestHelper;
+    using Xunit;
+
+    /// <summary>
+    /// This class contains unit tests for <see cref="SA1028NoTrailingWhitespace"/> and
+    /// <see cref="SA1028CodeFixProvider"/>.
+    /// </summary>
+    public class SA1028UnitTests : CodeFixVerifier
+    {
+        [Fact]
+        public async Task TrailingWhitespaceAfterStatement()
+        {
+            string testCode = @"
+class ClassName
+{
+    void MethodName()
+    {
+        System.Console.WriteLine(); 
+    }
+}
+";
+
+            string fixedCode = @"
+class ClassName
+{
+    void MethodName()
+    {
+        System.Console.WriteLine();
+    }
+}
+";
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(6, 36),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TrailingWhitespaceAfterDeclaration()
+        {
+            string testCode = @"
+class ClassName 
+{
+}
+";
+
+            string fixedCode = @"
+class ClassName
+{
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(2, 16),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
+        }
+
+        [Fact(Skip = "Not yet passing.")]
+        public async Task TrailingWhitespaceAfterSingleLineComment()
+        {
+            string testCode = @"
+// hi there    
+";
+
+            string fixedCode = @"
+// hi there
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(2, 12),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
+        }
+
+        [Fact(Skip = "Not yet passing.")]
+        public async Task TrailingWhitespaceInsideMultiLineComment()
+        {
+            string testCode = @"/* 
+ foo   
+  bar   
+*/  
+";
+
+            string fixedCode = @"/*
+ foo
+  bar
+*/
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(1, 3),
+                this.CSharpDiagnostic().WithLocation(2, 4),
+                this.CSharpDiagnostic().WithLocation(3, 5),
+                this.CSharpDiagnostic().WithLocation(4, 3),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task TrailingWhitespaceWithinAndAfterHereString()
+        {
+            string testCode = @"
+class ClassName
+{
+    string foo = @""      
+more text    
+"";  
+}
+";
+
+            string fixedCode = @"
+class ClassName
+{
+    string foo = @""      
+more text    
+"";
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(6, 3),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new SA1028NoTrailingWhitespace();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new SA1028CodeFixProvider();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
@@ -234,6 +234,19 @@ using System;
         }
 
         [Fact]
+        public async Task TrailingWhitespaceFoundWithinFalseConditionalDirectiveBlocks()
+        {
+            string testCode = @"
+#if false
+using System;  
+#endif
+";
+
+            // Note: we verify that no diagnostics are produced inside non-compiled blocks
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        [Fact]
         public async Task NoTrailingWhitespaceAfterBlockComment()
         {
             string testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
@@ -72,7 +72,7 @@ class ClassName
             await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
         }
 
-        [Fact(Skip = "Not yet passing.")]
+        [Fact]
         public async Task TrailingWhitespaceAfterSingleLineComment()
         {
             string testCode = @"
@@ -93,7 +93,7 @@ class ClassName
             await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
         }
 
-        [Fact(Skip = "Not yet passing.")]
+        [Fact]
         public async Task TrailingWhitespaceInsideMultiLineComment()
         {
             string testCode = @"/* 
@@ -111,9 +111,38 @@ class ClassName
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(1, 3),
-                this.CSharpDiagnostic().WithLocation(2, 4),
-                this.CSharpDiagnostic().WithLocation(3, 5),
+                this.CSharpDiagnostic().WithLocation(2, 5),
+                this.CSharpDiagnostic().WithLocation(3, 6),
                 this.CSharpDiagnostic().WithLocation(4, 3),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
+        }
+
+        [Fact(Skip = "Not yet passing.")]
+        public async Task TrailingWhitespaceInsideXmlDocComment()
+        {
+            string testCode = @"
+/// <summary>  
+/// Some description    
+/// </summary>  
+class Foo { }
+";
+
+            string fixedCode = @"
+/// <summary>
+/// Some description
+/// </summary>
+class Foo { }
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(2, 14),
+                this.CSharpDiagnostic().WithLocation(3, 21),
+                this.CSharpDiagnostic().WithLocation(4, 15),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
@@ -150,6 +179,18 @@ more text
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None);
             await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task NoTrailingWhitespaceAfterBlockComment()
+        {
+            string testCode = @"
+class Program    /* some block comment that follows several spaces */
+{
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
         }
 
         protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
@@ -121,7 +121,7 @@ class ClassName
             await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
         }
 
-        [Fact(Skip = "Not yet passing.")]
+        [Fact]
         public async Task TrailingWhitespaceInsideXmlDocComment()
         {
             string testCode = @"
@@ -147,7 +147,9 @@ class Foo { }
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None);
-            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
+
+            // Enable this code fix when we have it working.
+            ////await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None);
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -226,6 +226,7 @@
     <Compile Include="SpacingRules\SA1007UnitTests.cs" />
     <Compile Include="SpacingRules\SA1021UnitTests.cs" />
     <Compile Include="SpacingRules\SA1022UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1028UnitTests.cs" />
     <Compile Include="Verifiers\CodeFixVerifier.cs" />
     <Compile Include="Verifiers\DiagnosticVerifier.cs" />
   </ItemGroup>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/DiagnosticVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/DiagnosticVerifier.cs
@@ -23,7 +23,10 @@ namespace TestHelper
         /// <returns>
         /// A new instance of the C# analyzer being tested.
         /// </returns>
-        protected abstract DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer();
+        protected virtual DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return null;
+        }
 
         /// <summary>
         /// Called to test a C# <see cref="DiagnosticAnalyzer"/> when applied on the single input source as a string.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/DiagnosticVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/DiagnosticVerifier.cs
@@ -23,10 +23,7 @@ namespace TestHelper
         /// <returns>
         /// A new instance of the C# analyzer being tested.
         /// </returns>
-        protected virtual DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
-        {
-            return null;
-        }
+        protected abstract DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer();
 
         /// <summary>
         /// Called to test a C# <see cref="DiagnosticAnalyzer"/> when applied on the single input source as a string.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerConstants.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerConstants.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers
 {
+    using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
 
     internal static class AnalyzerConstants
@@ -25,5 +26,7 @@
         /// to disable a diagnostic which is currently untested.
         /// </value>
         internal static bool DisabledNoTests { get; }
+
+        internal static Task CompletedTask { get; } = Task.FromResult(false);
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerConstants.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerConstants.cs
@@ -38,7 +38,5 @@
         /// to indicate that the diagnostic should be enabled by default.
         /// </value>
         internal static bool EnabledByDefault => true;
-
-        internal static Task CompletedTask { get; } = Task.FromResult(false);
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
@@ -41,13 +41,18 @@
             {
                 var diagnosticSpan = diagnostic.Location.SourceSpan;
                 var trivia = root.FindTrivia(diagnosticSpan.Start, findInsideTrivia: true);
-                if (trivia.Kind() != SyntaxKind.None) // exclude XmlText node till we have support for it.
+                switch (trivia.Kind())
                 {
-                    context.RegisterCodeFix(
-                        CodeAction.Create(
-                            "Remove trailing whitespace",
-                            ct => RemoveWhitespaceAsync(context.Document, diagnostic, ct)),
-                        diagnostic);
+                    case SyntaxKind.WhitespaceTrivia:
+                    case SyntaxKind.SingleLineCommentTrivia:
+                    case SyntaxKind.MultiLineCommentTrivia:
+                    case SyntaxKind.MultiLineDocumentationCommentTrivia:
+                        context.RegisterCodeFix(
+                            CodeAction.Create(
+                                "Remove trailing whitespace",
+                                ct => RemoveWhitespaceAsync(context.Document, diagnostic, ct)),
+                            diagnostic);
+                        break;
                 }
             }
         }
@@ -87,9 +92,7 @@
                     newRoot = root.ReplaceTrivia(trivia, newTrivia);
                     break;
                 default:
-                    Debug.Assert(false, "Unexpected this is.");
-                    newRoot = root;
-                    break;
+                    return document;
             }
 
             var newDocument = document.WithSyntaxRoot(newRoot);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Immutable;
     using System.Composition;
+    using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -10,7 +11,6 @@
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Text;
-
 
     /// <summary>
     /// Implements a code fix for <see cref="SA1028NoTrailingWhitespace"/>.
@@ -36,9 +36,9 @@
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)
         {
+            var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken);
             foreach (var diagnostic in context.Diagnostics)
             {
-                var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken);
                 var diagnosticSpan = diagnostic.Location.SourceSpan;
                 var trivia = root.FindTrivia(diagnosticSpan.Start, findInsideTrivia: true);
                 if (trivia.Kind() != SyntaxKind.None) // exclude XmlText node till we have support for it.
@@ -87,7 +87,9 @@
                     newRoot = root.ReplaceTrivia(trivia, newTrivia);
                     break;
                 default:
-                    throw new InvalidOperationException("Unexpected this is.");
+                    Debug.Assert(false, "Unexpected this is.");
+                    newRoot = root;
+                    break;
             }
 
             var newDocument = document.WithSyntaxRoot(newRoot);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
@@ -1,0 +1,67 @@
+﻿namespace StyleCop.Analyzers.SpacingRules
+{
+    using System;
+    using System.Collections.Immutable;
+    using System.Composition;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp;
+
+    /// <summary>
+    /// Implements a code fix for <see cref="SA1028NoTrailingWhitespace"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>To fix a violation of this rule, remove any whitespace at the end of a line of code.</para>
+    /// </remarks>
+    [ExportCodeFixProvider("WhitespaceDiagnosticCodeFixProvider", LanguageNames.CSharp), Shared]
+    public class SA1028CodeFixProvider : CodeFixProvider
+    {
+        private static readonly ImmutableArray<string> FixableDiagnostics =
+            ImmutableArray.Create(SA1028NoTrailingWhitespace.DiagnosticId);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+
+        /// <inheritdoc/>
+        public sealed override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        /// <inheritdoc/>
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        "Remove trailing whitespace",
+                        ct => RemoveWhitespaceAsync(context.Document, diagnostic, ct)),
+                    diagnostic);
+            }
+
+            return AnalyzerConstants.CompletedTask;
+        }
+
+        /// <summary>
+        /// Removes trailing whitespace.
+        /// </summary>
+        /// <param name="document">The document to be changed.</param>
+        /// <param name="diagnostic">The diagnostic to fix.</param>
+        /// <param name="cancellationToken">The cancellation token associated with the fix action.</param>
+        /// <returns>The transformed document.</returns>
+        private static async Task<Document> RemoveWhitespaceAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken);
+            var diagnosticSpan = diagnostic.Location.SourceSpan;
+            var trivia = root.FindTrivia(diagnosticSpan.Start, findInsideTrivia: true);
+            var newRoot = root.ReplaceTrivia(trivia, SyntaxTriviaList.Empty);
+
+            var newDocument = document.WithSyntaxRoot(newRoot);
+            return newDocument;
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028NoTrailingWhitespace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028NoTrailingWhitespace.cs
@@ -37,17 +37,14 @@
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/wiki/SA1028";
         private const bool IsEnabledByDefault = true;
 
-        private static DiagnosticDescriptor Rule { get; } = 
+        private static readonly DiagnosticDescriptor Descriptor =
             new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, IsEnabledByDefault, Description, HelpLink, customTags: new[] { WellKnownDiagnosticTags.Unnecessary });
 
+        private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
+            ImmutableArray.Create(Descriptor);
+
         /// <inheritdoc />
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
-        {
-            get
-            {
-                return ImmutableArray.Create(Rule);
-            }
-        }
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => SupportedDiagnosticsValue;
 
         /// <inheritdoc />
         public override void Initialize(AnalysisContext context)
@@ -104,7 +101,7 @@
 
                         if (reportWarning)
                         {
-                            context.ReportDiagnostic(Diagnostic.Create(Rule, trivia.GetLocation()));
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptor, trivia.GetLocation()));
                         }
 
                         break;
@@ -112,7 +109,7 @@
                         TextSpan trailingWhitespace = FindTrailingWhitespace(text, trivia.Span);
                         if (!trailingWhitespace.IsEmpty)
                         {
-                            context.ReportDiagnostic(Diagnostic.Create(Rule, Location.Create(context.Tree, trailingWhitespace)));
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.Create(context.Tree, trailingWhitespace)));
                         }
 
                         break;
@@ -124,7 +121,7 @@
                             trailingWhitespace = FindTrailingWhitespace(text, line.Span);
                             if (!trailingWhitespace.IsEmpty)
                             {
-                                context.ReportDiagnostic(Diagnostic.Create(Rule, Location.Create(context.Tree, trailingWhitespace)));
+                                context.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.Create(context.Tree, trailingWhitespace)));
                             }
 
                             if (line.EndIncludingLineBreak == text.Length)
@@ -151,7 +148,7 @@
                         trailingWhitespace = FindTrailingWhitespace(text, trivia.Span);
                         if (!trailingWhitespace.IsEmpty)
                         {
-                            context.ReportDiagnostic(Diagnostic.Create(Rule, Location.Create(context.Tree, trailingWhitespace)));
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.Create(context.Tree, trailingWhitespace)));
                         }
 
                         break;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028NoTrailingWhitespace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028NoTrailingWhitespace.cs
@@ -30,11 +30,15 @@
         /// The ID for diagnostics produced by the <see cref="SA1028NoTrailingWhitespace"/> analyzer.
         /// </summary>
         public const string DiagnosticId = "SA1028";
-        internal const string Title = "Code must not contain trailing whitespace";
-        internal const string MessageFormat = "Remove trailing whitespace";
-        internal const string Category = "Style";
+        private const string Title = "Code must not contain trailing whitespace";
+        private const string MessageFormat = "Remove trailing whitespace";
+        private const string Category = "Style";
+        private const string Description = "There should not be any whitespace at the end of a line of code.";
+        private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/wiki/SA1028";
+        private const bool IsEnabledByDefault = true;
 
-        internal static DiagnosticDescriptor Rule { get; } = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, customTags: new[] { WellKnownDiagnosticTags.Unnecessary });
+        private static DiagnosticDescriptor Rule { get; } = 
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, IsEnabledByDefault, Description, HelpLink, customTags: new[] { WellKnownDiagnosticTags.Unnecessary });
 
         /// <inheritdoc />
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
@@ -58,6 +62,7 @@
         private void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
         {
             var root = context.Tree.GetRoot(context.CancellationToken);
+            var text = root.GetText();
 
             foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
             {
@@ -104,7 +109,6 @@
 
                         break;
                     case SyntaxKind.SingleLineCommentTrivia:
-                        var text = root.GetText();
                         TextSpan trailingWhitespace = FindTrailingWhitespace(text, trivia.Span);
                         if (!trailingWhitespace.IsEmpty)
                         {
@@ -114,7 +118,6 @@
                         break;
                     case SyntaxKind.MultiLineCommentTrivia:
                     case SyntaxKind.SingleLineDocumentationCommentTrivia:
-                        text = root.GetText();
                         var line = text.Lines.GetLineFromPosition(trivia.Span.Start);
                         do
                         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028NoTrailingWhitespace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028NoTrailingWhitespace.cs
@@ -35,10 +35,9 @@
         private const string Category = "Style";
         private const string Description = "There should not be any whitespace at the end of a line of code.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/wiki/SA1028";
-        private const bool IsEnabledByDefault = true;
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, IsEnabledByDefault, Description, HelpLink, customTags: new[] { WellKnownDiagnosticTags.Unnecessary });
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink, customTags: new[] { WellKnownDiagnosticTags.Unnecessary });
 
         private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
             ImmutableArray.Create(Descriptor);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028NoTrailingWhitespace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028NoTrailingWhitespace.cs
@@ -138,6 +138,23 @@
                         while (line.End <= trivia.Span.End);
 
                         break;
+                    case SyntaxKind.IfDirectiveTrivia:
+                    case SyntaxKind.ElifDirectiveTrivia:
+                    case SyntaxKind.ElseDirectiveTrivia:
+                    case SyntaxKind.EndIfDirectiveTrivia:
+                    case SyntaxKind.DefineDirectiveTrivia:
+                    case SyntaxKind.UndefDirectiveTrivia:
+                    case SyntaxKind.WarningDirectiveTrivia:
+                    case SyntaxKind.ErrorDirectiveTrivia:
+                    case SyntaxKind.RegionDirectiveTrivia:
+                    case SyntaxKind.EndRegionDirectiveTrivia:
+                        trailingWhitespace = FindTrailingWhitespace(text, trivia.Span);
+                        if (!trailingWhitespace.IsEmpty)
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(Rule, Location.Create(context.Tree, trailingWhitespace)));
+                        }
+
+                        break;
                     default:
                         break;
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028NoTrailingWhitespace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028NoTrailingWhitespace.cs
@@ -1,0 +1,103 @@
+﻿namespace StyleCop.Analyzers.SpacingRules
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    /// <summary>
+    /// Discovers any C# lines of code with trailing whitespace.
+    /// </summary>
+    /// <remarks>
+    /// <para>A violation of this rule occurs whenever the code contains whitespace at the end of the line.</para>
+    ///
+    /// <para>Trailing whitespace causes unnecessary diffs in source control,
+    /// looks tacky in editors that show invisible whitespace as visible characters,
+    /// and is highlighted as an error in some configurations of git.</para>
+    ///
+    /// <para>For these reasons, trailing whitespace should be avoided.</para>
+    /// </remarks>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class SA1028NoTrailingWhitespace : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// The ID for diagnostics produced by the <see cref="SA1028NoTrailingWhitespace"/> analyzer.
+        /// </summary>
+        public const string DiagnosticId = "SA1028";
+        internal const string Title = "Code must not contain trailing whitespace";
+        internal const string MessageFormat = "Remove trailing whitespace";
+        internal const string Category = "Style";
+
+        internal static DiagnosticDescriptor Rule { get; } = new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, isEnabledByDefault: true, customTags: new[] { WellKnownDiagnosticTags.Unnecessary });
+
+        /// <inheritdoc />
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        {
+            get
+            {
+                return ImmutableArray.Create(Rule);
+            }
+        }
+
+        /// <inheritdoc />
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxTreeAction(this.HandleSyntaxTree);
+        }
+
+        /// <summary>
+        /// Scans an entire document for lines with trailing whitespace.
+        /// </summary>
+        /// <param name="context">The context that provides the document to scan.</param>
+        private void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
+        {
+            var root = context.Tree.GetRoot(context.CancellationToken);
+            foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
+            {
+                if (!trivia.IsKind(SyntaxKind.WhitespaceTrivia))
+                {
+                    continue;
+                }
+
+                bool reportWarning = false;
+                var token = trivia.Token;
+                SyntaxTriviaList triviaList;
+                if (token.LeadingTrivia.Contains(trivia))
+                {
+                    triviaList = token.LeadingTrivia;
+                }
+                else
+                {
+                    triviaList = token.TrailingTrivia;
+                }
+
+                bool foundWhitespace = false;
+                foreach (var innerTrivia in triviaList)
+                {
+                    if (!foundWhitespace)
+                    {
+                        if (innerTrivia.Equals(trivia))
+                            foundWhitespace = true;
+
+                        continue;
+                    }
+
+                    if (innerTrivia.IsKind(SyntaxKind.EndOfLineTrivia))
+                        reportWarning = true;
+
+                    break;
+                }
+
+                if (reportWarning)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Rule, trivia.GetLocation()));
+                }
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -265,6 +265,8 @@
     <Compile Include="SpacingRules\SA1026CodeFixProvider.cs" />
     <Compile Include="SpacingRules\SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation.cs" />
     <Compile Include="SpacingRules\SA1027TabsMustNotBeUsed.cs" />
+    <Compile Include="SpacingRules\SA1028CodeFixProvider.cs" />
+    <Compile Include="SpacingRules\SA1028NoTrailingWhitespace.cs" />
     <Compile Include="SpacingRules\SpacingExtensions.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This includes the analyzer, the code fix provider, and the tests.

Of notable mention is that IIRC the original StyleCop did not notice trailing whitespace at the end of a single line or multi-line comment. I took some extra trouble to fill that gap. I believe this will find *all* trailing whitespace. Although we often want to emulate legacy StyleCop behavior, I believe this is simply filling a bug in the original and I expect especially given the auto fix provider that folks can quickly upgrade their code if necessary when applying this rule.

Fix #729