### PR TITLE
Additional tests and fixes for SA1005

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1005UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1005UnitTests.cs
@@ -165,6 +165,22 @@
         }
 
         /// <summary>
+        /// Verify that a comment that starts with a forward slash not prefixed by a space does not trigger a diagnostic.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestForwardSlashNoSpace()
+        {
+            var testCode = @"//\whatever
+        public class SomeClass
+        {
+        }
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        /// <summary>
         /// Verify that an empty comment does not trigger a diagnostic.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1005UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1005UnitTests.cs
@@ -110,6 +110,127 @@
         }
 
         /// <summary>
+        /// Verify that multiple leading spaces in a file header do not trigger a diagnostic.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestMultipleLeadingSpacesInFileHeader()
+        {
+            var testCode = @"// --------------------------------------------------------------------------------------------------------------------
+// <copyright file=""SomeClass.cs"" company=""SomeCompany"">
+//   Copyright © 2015 Some Company.
+//   All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------------
+
+        public class SomeClass
+        {
+        }
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Verify that three leading slashes followed by a non-space character do not trigger
+        /// a diagnostic.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestThreeLeadingSlashes()
+        {
+            var testCode = @"///whatever
+        public class SomeClass
+        {
+        }
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Verify that two or more dashes at the start of a comment do not trigger a diagnostic.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestTwoDashes()
+        {
+            var testCode = @"//-----------------------
+        public class SomeClass
+        {
+        }
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Verify that an empty comment does not trigger a diagnostic.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestEmptyComment()
+        {
+            var testCode = @"//
+        public class SomeClass
+        {
+        }
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Verify that multiple leading spaces do not trigger a diagnostic on a comment that follows directly
+        /// after another single line comment.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestIndentedSecondCommentLine()
+        {
+            var testCode = @"// Some comment:
+        //     Some indented comment.
+        //         Even more indented comment.
+        public class SomeClass
+        {
+        }
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Verify that multiple leading spaces trigger a diagnostic on a comment that follows directly
+        /// after a blank line.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestIndentedFirstCommentLineAfterBlankLine()
+        {
+            var testCode = @"// Some comment:
+
+        //         Even more indented comment.
+        public class SomeClass
+        {
+        }
+";
+
+            var fixedTestCode = @"// Some comment:
+
+        // Even more indented comment.
+        public class SomeClass
+        {
+        }
+";
+
+            var expected = this.CSharpDiagnostic().WithLocation(3, 9);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode);
+        }
+
+        /// <summary>
         /// Verify that a commented code will not trigger a diagnostic.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005SingleLineCommentsMustBeginWithSingleSpace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005SingleLineCommentsMustBeginWithSingleSpace.cs
@@ -117,19 +117,25 @@
         private void HandleSingleLineCommentTrivia(SyntaxTreeAnalysisContext context, SyntaxTrivia trivia, bool isFirstSingleLineTrivia)
         {
             string text = trivia.ToFullString();
-            if (text.Equals("//"))
+            if (text.Equals(@"//"))
             {
                 return;
             }
 
             // special case: commented code
-            if (text.StartsWith("////", StringComparison.Ordinal))
+            if (text.StartsWith(@"////", StringComparison.Ordinal))
             {
                 return;
             }
 
             // Special case: multiple dashes at start of comment
-            if (text.StartsWith("//--", StringComparison.Ordinal))
+            if (text.StartsWith(@"//--", StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            // Special case: //\ negates spacing requirements
+            if (text.StartsWith(@"//\", StringComparison.Ordinal))
             {
                 return;
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005SingleLineCommentsMustBeginWithSingleSpace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005SingleLineCommentsMustBeginWithSingleSpace.cs
@@ -89,27 +89,27 @@
             {
                 switch (trivia.Kind())
                 {
-                    case SyntaxKind.SingleLineCommentTrivia:
-                        this.HandleSingleLineCommentTrivia(context, trivia, isFirstSingleLineTrivia);
-                        isFirstSingleLineTrivia = false;
-                        newLineCount = 0;
-                        break;
+                case SyntaxKind.SingleLineCommentTrivia:
+                    this.HandleSingleLineCommentTrivia(context, trivia, isFirstSingleLineTrivia);
+                    isFirstSingleLineTrivia = false;
+                    newLineCount = 0;
+                    break;
 
-                    case SyntaxKind.EndOfLineTrivia:
-                        if (++newLineCount == 2)
-                        {
-                            isFirstSingleLineTrivia = true;
-                            newLineCount = 0;
-                        }
-
-                        break;
-
-                    case SyntaxKind.WhitespaceTrivia:
-                        break;
-
-                    default:
+                case SyntaxKind.EndOfLineTrivia:
+                    if (++newLineCount == 2)
+                    {
                         isFirstSingleLineTrivia = true;
-                        break;
+                        newLineCount = 0;
+                    }
+
+                    break;
+
+                case SyntaxKind.WhitespaceTrivia:
+                    break;
+
+                default:
+                    isFirstSingleLineTrivia = true;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Now handles indented comments following a non-indented comment; comments starting with more than two dashes.

Modified diagnostic to address the above.

Fixes #715