### PR TITLE
Skip analyzing generated code in SA1205

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1205PartialElementsMustDeclareAccess.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1205PartialElementsMustDeclareAccess.cs
@@ -45,7 +45,7 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterSyntaxNodeAction(this.HandleElementDeclaration, SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration, SyntaxKind.InterfaceDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleElementDeclaration, SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration, SyntaxKind.InterfaceDeclaration);
         }
 
         private void HandleElementDeclaration(SyntaxNodeAnalysisContext context)


### PR DESCRIPTION
SA1205 missed the change to skip running on auto-generated code. This change corrects that.