### PR TITLE
Split SA1600, SA1601 and SA1602 into three rules each

### DIFF
--- a/SA16X0.txt
+++ b/SA16X0.txt
@@ -1,0 +1,36 @@
+# SA16X0
+
+<table>
+<tr>
+  <td>TypeName</td>
+  <td>SA16X0NonPrivateElementsMustBeDocumented</td>
+</tr>
+<tr>
+  <td>CheckId</td>
+  <td>SA16X0</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Documentation Rules</td>
+</tr>
+</table>
+
+## Cause
+
+A non-private, non-public C# code element is missing a documentation header.
+
+## Rule description
+
+C# syntax provides a mechanism for inserting documentation for classes and elements directly into the code, through the use of Xml documentation headers.
+For an introduction to these headers and a description of the header syntax, see the following article: http://msdn.microsoft.com/en-us/magazine/cc302121.aspx.
+
+A violation of this rule occurs if an element is completely missing a documentation header, or if the header is empty. In C# the following types of elements
+can have documentation headers: classes, constructors, delegates, enums, events, finalizers, indexers, interfaces, methods, properties, and structs.
+
+No violation of this rule occurs for public elements; these are covered by [CS1591](https://msdn.microsoft.com/en-us/library/zk18c1w9.aspx).
+This rule specializes [SA1600](http://www.stylecop.com/docs/SA1600.html), [SA1601](http://www.stylecop.com/docs/SA1601.html) and [SA1602](http://www.stylecop.com/docs/SA1602.html)
+for non-private, non-public elements only.
+
+## How to fix violations
+
+To fix a violation of this rule, add or fill in the documentation header for this element.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/DocumentationOptions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/DocumentationOptions.cs
@@ -1,0 +1,15 @@
+﻿namespace StyleCop.Analyzers.Test.DocumentationRules
+{
+    public enum DocumentationOptions
+    {
+        /// <summary>
+        /// Indicates that unit test code should contain sample documentation.
+        /// </summary>
+        WriteSampleDocumentation,
+
+        /// <summary>
+        /// Indicates that unit test code should not contain sample documentation.
+        /// </summary>
+        OmitSampleDocumentation
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/DocumentationRuleTestSampleCodeBuilder.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/DocumentationRuleTestSampleCodeBuilder.cs
@@ -130,7 +130,7 @@
             this.Write(";\r\n");
         }
 
-        public void WriteFinalizer(string name, DocumentationOptions documentationOptions, ExpectedResult expectError)
+        public void WriteDestructor(string name, DocumentationOptions documentationOptions, ExpectedResult expectError)
         {
             switch (documentationOptions)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/DocumentationRuleTestSampleCodeBuilder.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/DocumentationRuleTestSampleCodeBuilder.cs
@@ -1,0 +1,306 @@
+﻿namespace StyleCop.Analyzers.Test.DocumentationRules
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+
+    public sealed class DocumentationRuleTestSampleCodeBuilder : SampleCodeBuilder
+    {
+        private readonly ImmutableArray<string> diagnosticIds;
+
+        public DocumentationRuleTestSampleCodeBuilder()
+            : this(null)
+        {
+        }
+
+        public DocumentationRuleTestSampleCodeBuilder(IEnumerable<string> diagnosticIds)
+        {
+            this.diagnosticIds = diagnosticIds == null
+                ? ImmutableArray<string>.Empty
+                : diagnosticIds.Where(x => !string.IsNullOrEmpty(x)).Distinct(StringComparer.Ordinal).ToImmutableArray();
+        }
+
+        public void WriteClassStart(string name, DocumentationOptions documentationOptions, ExpectedResult expectError, params string[] modifiers)
+        {
+            this.WriteClassStart(name, documentationOptions, expectError, modifiers, null);
+        }
+
+        public void WriteClassStart(string name, DocumentationOptions documentationOptions, ExpectedResult expectError, string[] modifiers, string[] inherits)
+        {
+            switch (documentationOptions)
+            {
+                case DocumentationOptions.WriteSampleDocumentation:
+                    this.Write("/// <summary>\r\n/// Some class documentation.\r\n/// </summary>\r\n");
+                    break;
+            }
+
+            this.Write(ConcatModifiers(modifiers));
+            this.Write("class ");
+            this.Write(BuildSymbolWithPositionMarkers(name, expectError));
+
+            if (inherits != null && inherits.Any())
+            {
+                this.Write(" : ");
+                this.Write(string.Join(", ", inherits));
+            }
+
+            this.Write("\r\n");
+            this.WriteLine("{");
+
+            this.PushIndent();
+        }
+
+        public void WriteStructStart(string name, DocumentationOptions documentationOptions, ExpectedResult expectError, params string[] modifiers)
+        {
+            switch (documentationOptions)
+            {
+                case DocumentationOptions.WriteSampleDocumentation:
+                    this.Write("/// <summary>\r\n/// Some struct documentation.\r\n/// </summary>\r\n");
+                    break;
+            }
+
+            this.Write(ConcatModifiers(modifiers));
+            this.Write("struct ");
+            this.Write(BuildSymbolWithPositionMarkers(name, expectError));
+            this.Write("\r\n{\r\n");
+            this.PushIndent();
+        }
+
+        public void WriteEnumStart(string name, DocumentationOptions documentationOptions, ExpectedResult expectError, params string[] modifiers)
+        {
+            switch (documentationOptions)
+            {
+                case DocumentationOptions.WriteSampleDocumentation:
+                    this.Write("/// <summary>\r\n/// Some enum documentation.\r\n/// </summary>\r\n");
+                    break;
+            }
+
+            this.Write(ConcatModifiers(modifiers));
+            this.Write("enum ");
+            this.Write(BuildSymbolWithPositionMarkers(name, expectError));
+            this.Write("\r\n{\r\n");
+            this.PushIndent();
+        }
+
+        public void WriteInterfaceStart(string name, DocumentationOptions documentationOptions, ExpectedResult expectError, params string[] modifiers)
+        {
+            switch (documentationOptions)
+            {
+                case DocumentationOptions.WriteSampleDocumentation:
+                    this.Write("/// <summary>\r\n/// Some interface documentation.\r\n/// </summary>\r\n");
+                    break;
+            }
+
+            this.Write(ConcatModifiers(modifiers));
+            this.Write("interface ");
+            this.Write(BuildSymbolWithPositionMarkers(name, expectError));
+            this.Write("\r\n{\r\n");
+            this.PushIndent();
+        }
+
+        public void WriteConstructor(string name, DocumentationOptions documentationOptions, ExpectedResult expectError, params string[] modifiers)
+        {
+            switch (documentationOptions)
+            {
+                case DocumentationOptions.WriteSampleDocumentation:
+                    this.Write("/// <summary>\r\n/// Some constructor documentation.\r\n/// </summary>\r\n");
+                    break;
+            }
+
+            this.Write(ConcatModifiers(modifiers));
+            this.Write(BuildSymbolWithPositionMarkers(name, expectError));
+
+            this.Write("()\r\n{\r\n}\r\n");
+
+        }
+
+        public void WriteField(string name, DocumentationOptions documentationOptions, ExpectedResult expectError, params string[] modifiers)
+        {
+            switch (documentationOptions)
+            {
+                case DocumentationOptions.WriteSampleDocumentation:
+                    this.Write("/// <summary>\r\n/// Some field documentation.\r\n/// </summary>\r\n");
+                    break;
+            }
+
+            this.Write(ConcatModifiers(modifiers));
+            this.Write("object ");
+            this.Write(BuildSymbolWithPositionMarkers(name, expectError));
+            this.Write(";\r\n");
+        }
+
+        public void WriteFinalizer(string name, DocumentationOptions documentationOptions, ExpectedResult expectError)
+        {
+            switch (documentationOptions)
+            {
+                case DocumentationOptions.WriteSampleDocumentation:
+                    this.Write("/// <summary>\r\n/// Some finalizer documentation.\r\n/// </summary>\r\n");
+                    break;
+            }
+
+            this.Write("~");
+            this.Write(BuildSymbolWithPositionMarkers(name, expectError));
+            this.Write("()\r\n{\r\n}\r\n");
+        }
+
+        public void WriteIndexer(DocumentationOptions documentationOptions, ExpectedResult expectError, params string[] modifiers)
+        {
+            switch (documentationOptions)
+            {
+                case DocumentationOptions.WriteSampleDocumentation:
+                    this.Write("/// <summary>\r\n/// Some indexer documentation.\r\n/// </summary>\r\n/// <param name=\"" +
+                            "ix\">The index.</param>\r\n");
+                    break;
+            }
+
+            this.Write(ConcatModifiers(modifiers));
+            this.Write("object ");
+            this.Write(BuildSymbolWithPositionMarkers("this", expectError));
+            this.Write("[int ix]\r\n{\r\n\tget { return null; }\r\n}\r\n");
+        }
+
+        public void WriteDelegate(string name, DocumentationOptions documentationOptions, ExpectedResult expectError, params string[] modifiers)
+        {
+            switch (documentationOptions)
+            {
+                case DocumentationOptions.WriteSampleDocumentation:
+                    this.Write("/// <summary>\r\n/// Some delegate documentation.\r\n/// </summary>\r\n");
+                    break;
+            }
+
+            this.Write(ConcatModifiers(modifiers));
+            this.Write("delegate void ");
+            this.Write(BuildSymbolWithPositionMarkers(name, expectError));
+            this.Write("();\r\n");
+        }
+
+        public void WriteEvent(string name, DocumentationOptions documentationOptions, ExpectedResult expectError, params string[] modifiers)
+        {
+            switch (documentationOptions)
+            {
+                case DocumentationOptions.WriteSampleDocumentation:
+                    this.Write("/// <summary>\r\n/// Some event documentation.\r\n/// </summary>\r\n");
+                    break;
+            }
+
+            this.Write(ConcatModifiers(modifiers));
+            this.Write("event System.EventHandler ");
+            this.Write(BuildSymbolWithPositionMarkers(name, expectError));
+            this.Write(";\r\n");
+        }
+
+        public void WriteMethod(string name, DocumentationOptions documentationOptions, ExpectedResult expectError, params string[] modifiers)
+        {
+            switch (documentationOptions)
+            {
+                case DocumentationOptions.WriteSampleDocumentation:
+                    this.Write("/// <summary>\r\n/// Some method documentation.\r\n/// </summary>\r\n");
+                    break;
+            }
+
+            this.Write(ConcatModifiers(modifiers));
+            this.Write("void ");
+            this.Write(BuildSymbolWithPositionMarkers(name, expectError));
+            this.Write("()\r\n{\r\n}\r\n");
+        }
+
+        public void WriteProperty(string name, DocumentationOptions documentationOptions, ExpectedResult expectError, params string[] modifiers)
+        {
+            switch (documentationOptions)
+            {
+                case DocumentationOptions.WriteSampleDocumentation:
+                    this.Write("/// <summary>\r\n/// Some property documentation.\r\n/// </summary>\r\n");
+                    break;
+            }
+
+            this.Write(ConcatModifiers(modifiers));
+            this.Write("object ");
+            this.Write(BuildSymbolWithPositionMarkers(name, expectError));
+            this.Write("\r\n{\r\n\tget { return null; }\r\n\tset { }\r\n}\r\n");
+        }
+
+        public void WriteExplicitInterfaceProperty(string name, string interfaceName, DocumentationOptions documentationOptions, ExpectedResult expectedResult)
+        {
+            if (documentationOptions == DocumentationOptions.WriteSampleDocumentation)
+            {
+                this.WriteLine("/// <summary>");
+                this.WriteLine("/// Some summary.");
+                this.WriteLine("/// </summary>");
+            }
+
+            this.WriteLine($"string {interfaceName}.{BuildSymbolWithPositionMarkers(name, expectedResult)}");
+            this.WriteLine(string.Empty);
+            this.WriteLine("{");
+            this.PushIndent();
+            this.WriteLine("get { return null; }");
+            this.WriteLine("set { }");
+            this.PopIndent();
+            this.WriteLine("}");
+
+            this.WriteSuppressionStart();
+            this.WriteInterfaceStart(interfaceName, DocumentationOptions.OmitSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
+            this.WriteLine($"string {name} {{ get; set; }}");
+            this.WriteBlockEnd();
+            this.WriteSuppressionEnd();
+        }
+
+        private void WriteSuppressionStart()
+        {
+            using (this.SuppressIndent())
+            {
+                foreach (var diagnosticId in this.diagnosticIds)
+                {
+                    this.WriteLine($"#pragma warning disable {diagnosticId}");
+                }
+            }
+        }
+
+        private void WriteSuppressionEnd()
+        {
+            using (this.SuppressIndent())
+            {
+                foreach (var diagnosticId in this.diagnosticIds)
+                {
+                    this.WriteLine($"#pragma warning restore {diagnosticId}");
+                }
+            }
+        }
+
+        public void WriteBlockEnd()
+        {
+            this.PopIndent();
+            this.WriteLine("}");
+        }
+
+        public void WriteAutoGeneratedHeader()
+        {
+            this.Write(@"//------------------------------------------------------------------------------
+// <auto-generated>
+//     This code was generated by a tool.
+//     Runtime Version:4.0.30319.0
+//
+//     Changes to this file may cause incorrect behavior and will be lost if
+//     the code is regenerated.
+// </auto-generated>
+//------------------------------------------------------------------------------
+
+");
+        }
+
+        private static string ConcatModifiers(IEnumerable<string> modifiers)
+        {
+            if (modifiers == null || !modifiers.Any())
+            {
+                return string.Empty;
+            }
+
+            return string.Join(" ", modifiers) + " ";
+        }
+
+        private static string BuildSymbolWithPositionMarkers(string symbol, ExpectedResult writeMarkers)
+        {
+            return writeMarkers == ExpectedResult.Diagnostic ? string.Format("~~{0}~~", symbol) : symbol;
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/DocumentationRuleTestSampleCodeBuilder.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/DocumentationRuleTestSampleCodeBuilder.cs
@@ -112,7 +112,6 @@
             this.Write(BuildSymbolWithPositionMarkers(name, expectError));
 
             this.Write("()\r\n{\r\n}\r\n");
-
         }
 
         public void WriteField(string name, DocumentationOptions documentationOptions, ExpectedResult expectError, params string[] modifiers)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/ExpectedResult.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/ExpectedResult.cs
@@ -1,0 +1,15 @@
+﻿namespace StyleCop.Analyzers.Test.DocumentationRules
+{
+    public enum ExpectedResult
+    {
+        /// <summary>
+        /// No diagnostic is expected.
+        /// </summary>
+        NoDiagnostic,
+
+        /// <summary>
+        /// A diagnostic result is expected.
+        /// </summary>
+        Diagnostic
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
@@ -220,11 +220,11 @@
         [Theory]
         [InlineData(DocumentationOptions.WriteSampleDocumentation, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, DiagnosticId)]
-        public async Task TestFinalizerWithoutDocumentationAsync(DocumentationOptions options, string expectedDiagnosticId)
+        public async Task TestDestructorWithoutDocumentationAsync(DocumentationOptions options, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
             gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
-            gen.WriteFinalizer("TestClass", options, ExpectedResult.Diagnostic);
+            gen.WriteDestructor("TestClass", options, ExpectedResult.Diagnostic);
             gen.WriteBlockEnd();
 
             await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
@@ -1,411 +1,411 @@
-﻿namespace StyleCop.Analyzers.Test.DocumentationRules
-{
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis.Diagnostics;
-    using StyleCop.Analyzers.DocumentationRules;
-    using TestHelper;
-    using Xunit;
+﻿////namespace StyleCop.Analyzers.Test.DocumentationRules
+////{
+////    using System.Collections.Generic;
+////    using System.Linq;
+////    using System.Threading;
+////    using System.Threading.Tasks;
+////    using Microsoft.CodeAnalysis.Diagnostics;
+////    using StyleCop.Analyzers.DocumentationRules;
+////    using TestHelper;
+////    using Xunit;
 
-    /// <summary>
-    /// This class contains unit tests for <see cref="SA1600ElementsMustBeDocumented"/>.
-    /// </summary>
-    public class SA1600UnitTests : CodeFixVerifier
-    {
-        private const string DiagnosticId = SA1600ElementsMustBeDocumented.DiagnosticId;
-        private const string DiagnosticIdInternal = SA1600ElementsMustBeDocumented.DiagnosticIdInternal;
-        private const string DiagnosticIdPrivate = SA1600ElementsMustBeDocumented.DiagnosticIdPrivate;
-        private const string NoDiagnostic = null;
+////    /// <summary>
+////    /// This class contains unit tests for <see cref="SA1600ElementsMustBeDocumented"/>.
+////    /// </summary>
+////    public class SA1600UnitTests : CodeFixVerifier
+////    {
+////        private const string DiagnosticId = SA1600ElementsMustBeDocumented.DiagnosticIdPublic;
+////        private const string DiagnosticIdInternal = SA1600ElementsMustBeDocumented.DiagnosticIdInternal;
+////        private const string DiagnosticIdPrivate = SA1600ElementsMustBeDocumented.DiagnosticId;
+////        private const string NoDiagnostic = null;
 
-        [Fact]
-        public async Task TestEmptySourceAsync()
-        {
-            var testCode = string.Empty;
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-        }
+////        [Fact]
+////        public async Task TestEmptySourceAsync()
+////        {
+////            var testCode = string.Empty;
+////            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Fact]
-        public async Task TestClassWithEmptyDocumentationAsync()
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteLine(@"/// <summary>");
-            gen.WriteLine(@"/// </summary>");
-            gen.WriteClassStart("TestClass", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.Diagnostic, "public");
-            gen.WriteBlockEnd();
+////        [Fact]
+////        public async Task TestClassWithEmptyDocumentationAsync()
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteLine(@"/// <summary>");
+////            gen.WriteLine(@"/// </summary>");
+////            gen.WriteClassStart("TestClass", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.Diagnostic, "public");
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, DiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, DiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Theory]
-        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
-        public async Task TestClassAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteClassStart("TestClass", options, ExpectedResult.Diagnostic, modifiers);
-            gen.WriteBlockEnd();
+////        [Theory]
+////        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
+////        public async Task TestClassAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteClassStart("TestClass", options, ExpectedResult.Diagnostic, modifiers);
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Theory]
-        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
-        public async Task TestEnumAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteEnumStart("TestEnum", options, ExpectedResult.Diagnostic, modifiers);
-            gen.WriteBlockEnd();
+////        [Theory]
+////        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
+////        public async Task TestEnumAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteEnumStart("TestEnum", options, ExpectedResult.Diagnostic, modifiers);
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Theory]
-        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "public" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "internal" }, DiagnosticIdInternal)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, new[] { "public" }, DiagnosticIdInternal)]
-        public async Task TestNestedClassAsync(DocumentationOptions options, string[] parentModifiers, string[] modifiers, string expectedDiagnosticId)
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteClassStart("ParentClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, parentModifiers);
-            gen.WriteClassStart("TestClass", options, ExpectedResult.Diagnostic, modifiers);
-            gen.WriteBlockEnd();
-            gen.WriteBlockEnd();
+////        [Theory]
+////        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, new[] { "public" }, NoDiagnostic)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "public" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "internal" }, DiagnosticIdInternal)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, new[] { "public" }, DiagnosticIdInternal)]
+////        public async Task TestNestedClassAsync(DocumentationOptions options, string[] parentModifiers, string[] modifiers, string expectedDiagnosticId)
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteClassStart("ParentClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, parentModifiers);
+////            gen.WriteClassStart("TestClass", options, ExpectedResult.Diagnostic, modifiers);
+////            gen.WriteBlockEnd();
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Theory]
-        [InlineData(DocumentationOptions.WriteSampleDocumentation, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, DiagnosticId)]
-        public async Task TestExplicitInterfacePropertyImplementationAsync(DocumentationOptions options, string expectedDiagnosticId)
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder(new[] { DiagnosticId, DiagnosticIdInternal, DiagnosticIdPrivate });
-            gen.WriteClassStart("SomeClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, new[] { "public" }, new[] { "SomeClass.IInterface" });
-            gen.WriteExplicitInterfaceProperty("SomeProperty", "IInterface", options, ExpectedResult.Diagnostic);
-            gen.WriteBlockEnd();
+////        [Theory]
+////        [InlineData(DocumentationOptions.WriteSampleDocumentation, NoDiagnostic)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, DiagnosticId)]
+////        public async Task TestExplicitInterfacePropertyImplementationAsync(DocumentationOptions options, string expectedDiagnosticId)
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder(new[] { DiagnosticId, DiagnosticIdInternal, DiagnosticIdPrivate });
+////            gen.WriteClassStart("SomeClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, new[] { "public" }, new[] { "SomeClass.IInterface" });
+////            gen.WriteExplicitInterfaceProperty("SomeProperty", "IInterface", options, ExpectedResult.Diagnostic);
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Theory]
-        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
-        public async Task TestStructAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteStructStart("TestStruct", options, ExpectedResult.Diagnostic, modifiers);
-            gen.WriteBlockEnd();
+////        [Theory]
+////        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
+////        public async Task TestStructAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteStructStart("TestStruct", options, ExpectedResult.Diagnostic, modifiers);
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Theory]
-        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
-        public async Task TestEnumWithoutDocumentationAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteEnumStart("TestEnum", options, ExpectedResult.Diagnostic, modifiers);
-            gen.WriteBlockEnd();
+////        [Theory]
+////        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
+////        public async Task TestEnumWithoutDocumentationAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteEnumStart("TestEnum", options, ExpectedResult.Diagnostic, modifiers);
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Theory]
-        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
-        public async Task TestInterfaceAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteInterfaceStart("TestInterface", options, ExpectedResult.Diagnostic, modifiers);
-            gen.WriteBlockEnd();
+////        [Theory]
+////        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
+////        public async Task TestInterfaceAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteInterfaceStart("TestInterface", options, ExpectedResult.Diagnostic, modifiers);
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Theory]
-        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticIdPrivate)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
-        public async Task TestConstructorAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
-            gen.WriteConstructor("TestClass", options, ExpectedResult.Diagnostic, modifiers);
-            gen.WriteBlockEnd();
+////        [Theory]
+////        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticIdPrivate)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
+////        public async Task TestConstructorAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
+////            gen.WriteConstructor("TestClass", options, ExpectedResult.Diagnostic, modifiers);
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Theory]
-        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "private" }, DiagnosticIdPrivate)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "public" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "protected" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "protected", "internal" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "internal" }, DiagnosticIdInternal)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, new[] { "public" }, DiagnosticIdInternal)]
-        public async Task TestDelegateAsync(DocumentationOptions options, string[] ownerModifiers, string[] modifiers, string expectedDiagnosticId)
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, ownerModifiers);
-            gen.WriteDelegate("SomeDelegate", options, ExpectedResult.Diagnostic, modifiers);
-            gen.WriteBlockEnd();
+////        [Theory]
+////        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, new[] { "public" }, NoDiagnostic)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "private" }, DiagnosticIdPrivate)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "public" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "protected" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "protected", "internal" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "internal" }, DiagnosticIdInternal)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, new[] { "public" }, DiagnosticIdInternal)]
+////        public async Task TestDelegateAsync(DocumentationOptions options, string[] ownerModifiers, string[] modifiers, string expectedDiagnosticId)
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, ownerModifiers);
+////            gen.WriteDelegate("SomeDelegate", options, ExpectedResult.Diagnostic, modifiers);
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Theory]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, "public", "public", new[] { "public" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, "internal", "public", new[] { "public" }, DiagnosticIdInternal)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, "public", "private", new[] { "public" }, DiagnosticIdPrivate)]
-        public async Task TestNestedClassDelegateAsync(DocumentationOptions options, string outerClassModifier, string innerClassModifier, string[] modifiers, string expectedDiagnosticId)
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteClassStart("OuterClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, new[] { outerClassModifier });
-            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, new[] { innerClassModifier });
-            gen.WriteDelegate("SomeDelegate", options, ExpectedResult.Diagnostic, modifiers);
-            gen.WriteBlockEnd();
-            gen.WriteBlockEnd();
+////        [Theory]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, "public", "public", new[] { "public" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, "internal", "public", new[] { "public" }, DiagnosticIdInternal)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, "public", "private", new[] { "public" }, DiagnosticIdPrivate)]
+////        public async Task TestNestedClassDelegateAsync(DocumentationOptions options, string outerClassModifier, string innerClassModifier, string[] modifiers, string expectedDiagnosticId)
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteClassStart("OuterClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, new[] { outerClassModifier });
+////            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, new[] { innerClassModifier });
+////            gen.WriteDelegate("SomeDelegate", options, ExpectedResult.Diagnostic, modifiers);
+////            gen.WriteBlockEnd();
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Theory]
-        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticIdPrivate)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
-        public async Task TestEventAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
-            gen.WriteEvent("SomeEvent", options, ExpectedResult.Diagnostic, modifiers);
-            gen.WriteBlockEnd();
+////        [Theory]
+////        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticIdPrivate)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
+////        public async Task TestEventAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
+////            gen.WriteEvent("SomeEvent", options, ExpectedResult.Diagnostic, modifiers);
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Theory]
-        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticIdPrivate)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
-        public async Task TestFieldWithoutDocumentationAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
-            gen.WriteField("someField", options, ExpectedResult.Diagnostic, modifiers);
-            gen.WriteBlockEnd();
+////        [Theory]
+////        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticIdPrivate)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
+////        public async Task TestFieldWithoutDocumentationAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
+////            gen.WriteField("someField", options, ExpectedResult.Diagnostic, modifiers);
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Theory]
-        [InlineData(DocumentationOptions.WriteSampleDocumentation, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, DiagnosticId)]
-        public async Task TestDestructorWithoutDocumentationAsync(DocumentationOptions options, string expectedDiagnosticId)
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
-            gen.WriteDestructor("TestClass", options, ExpectedResult.Diagnostic);
-            gen.WriteBlockEnd();
+////        [Theory]
+////        [InlineData(DocumentationOptions.WriteSampleDocumentation, NoDiagnostic)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, DiagnosticId)]
+////        public async Task TestDestructorWithoutDocumentationAsync(DocumentationOptions options, string expectedDiagnosticId)
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
+////            gen.WriteDestructor("TestClass", options, ExpectedResult.Diagnostic);
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Theory]
-        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticIdPrivate)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
-        public async Task TestPublicIndexerWithoutDocumentationAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
-            gen.WriteIndexer(options, ExpectedResult.Diagnostic, modifiers);
-            gen.WriteBlockEnd();
+////        [Theory]
+////        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticIdPrivate)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
+////        public async Task TestPublicIndexerWithoutDocumentationAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
+////            gen.WriteIndexer(options, ExpectedResult.Diagnostic, modifiers);
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Theory]
-        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticIdPrivate)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
-        public async Task TestPublicMethodWithoutDocumentationAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
-            gen.WriteMethod("SomeMethod", options, ExpectedResult.Diagnostic, modifiers);
-            gen.WriteBlockEnd();
+////        [Theory]
+////        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticIdPrivate)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
+////        public async Task TestPublicMethodWithoutDocumentationAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
+////            gen.WriteMethod("SomeMethod", options, ExpectedResult.Diagnostic, modifiers);
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Theory]
-        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticIdPrivate)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, DiagnosticId)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
-        public async Task TestPublicPropertyWithoutDocumentationAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
-            gen.WriteProperty("SomeProperty", options, ExpectedResult.Diagnostic, modifiers);
-            gen.WriteBlockEnd();
+////        [Theory]
+////        [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticIdPrivate)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, DiagnosticId)]
+////        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticIdInternal)]
+////        public async Task TestPublicPropertyWithoutDocumentationAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
+////            gen.WriteProperty("SomeProperty", options, ExpectedResult.Diagnostic, modifiers);
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, expectedDiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        protected Task VerifyCSharpDiagnosticAsync(DocumentationRuleTestSampleCodeBuilder gen, string diagnosticId, CancellationToken cancellationToken)
-        {
-            var code = gen.GeneratedText;
+////        protected Task VerifyCSharpDiagnosticAsync(DocumentationRuleTestSampleCodeBuilder gen, string diagnosticId, CancellationToken cancellationToken)
+////        {
+////            var code = gen.GeneratedText;
 
-            var diagnostics = string.IsNullOrEmpty(diagnosticId)
-                ? EmptyDiagnosticResults
-                : gen.DiagnosticLocations.Select(x => this.CSharpDiagnostic(diagnosticId).WithLocation(x.Line, x.Column)).ToArray();
+////            var diagnostics = string.IsNullOrEmpty(diagnosticId)
+////                ? EmptyDiagnosticResults
+////                : gen.DiagnosticLocations.Select(x => this.CSharpDiagnostic(diagnosticId).WithLocation(x.Line, x.Column)).ToArray();
 
-            return this.VerifyCSharpDiagnosticAsync(code, diagnostics, cancellationToken);
-        }
+////            return this.VerifyCSharpDiagnosticAsync(code, diagnostics, cancellationToken);
+////        }
 
-        [Fact]
-        public async Task TestEmptyXmlCommentsAsync()
-        {
-            var testCodeWithEmptyDocumentation = @"    /// <summary>
-    /// </summary>
-public class OuterClass
-{
-}";
-            var testCodeWithDocumentation = @"    /// <summary>
-    /// A summary
-    /// </summary>
-public class OuterClass
-{
-}";
+////        [Fact]
+////        public async Task TestEmptyXmlCommentsAsync()
+////        {
+////            var testCodeWithEmptyDocumentation = @"    /// <summary>
+////    /// </summary>
+////public class OuterClass
+////{
+////}";
+////            var testCodeWithDocumentation = @"    /// <summary>
+////    /// A summary
+////    /// </summary>
+////public class OuterClass
+////{
+////}";
 
-            DiagnosticResult expected = this.CSharpDiagnostic(DiagnosticId).WithLocation(3, 14);
+////            DiagnosticResult expected = this.CSharpDiagnostic(DiagnosticId).WithLocation(3, 14);
 
-            await this.VerifyCSharpDiagnosticAsync(testCodeWithDocumentation, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpDiagnosticAsync(testCodeWithEmptyDocumentation, expected, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(testCodeWithDocumentation, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+////            await this.VerifyCSharpDiagnosticAsync(testCodeWithEmptyDocumentation, expected, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Fact]
-        public async Task TestCDataXmlCommentsAsync()
-        {
-            var testCodeWithEmptyDocumentation = @"/// <summary>
-    /// <![CDATA[]]>
-    /// </summary>
-public class OuterClass
-{
-}";
-            var testCodeWithDocumentation = @"    /// <summary>
-    /// <![CDATA[A summary.]]>
-    /// </summary>
-public class OuterClass
-{
-}";
+////        [Fact]
+////        public async Task TestCDataXmlCommentsAsync()
+////        {
+////            var testCodeWithEmptyDocumentation = @"/// <summary>
+////    /// <![CDATA[]]>
+////    /// </summary>
+////public class OuterClass
+////{
+////}";
+////            var testCodeWithDocumentation = @"    /// <summary>
+////    /// <![CDATA[A summary.]]>
+////    /// </summary>
+////public class OuterClass
+////{
+////}";
 
-            DiagnosticResult expected = this.CSharpDiagnostic(DiagnosticId).WithLocation(4, 14);
+////            DiagnosticResult expected = this.CSharpDiagnostic(DiagnosticId).WithLocation(4, 14);
 
-            await this.VerifyCSharpDiagnosticAsync(testCodeWithDocumentation, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpDiagnosticAsync(testCodeWithEmptyDocumentation, expected, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(testCodeWithDocumentation, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+////            await this.VerifyCSharpDiagnosticAsync(testCodeWithEmptyDocumentation, expected, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Fact]
-        public async Task TestEmptyElementXmlCommentsAsync()
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteLine(@"/// <inheritdoc />");
-            gen.WriteClassStart("TestClass", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
-            gen.WriteBlockEnd();
+////        [Fact]
+////        public async Task TestEmptyElementXmlCommentsAsync()
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteLine(@"/// <inheritdoc />");
+////            gen.WriteClassStart("TestClass", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, DiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, DiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Fact]
-        public async Task TestMultiLineDocumentationAsync()
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteLine(@"/**
- * <summary>This is a documentation comment summary.</summary>
- */");
-            gen.WriteClassStart("TestClass", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
-            gen.WriteLine(@"/**");
-            gen.WriteLine(@" * <summary>This is a documentation comment summary.</summary>");
-            gen.WriteLine(@" */");
-            gen.WriteMethod("SomeMethod", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
-            gen.WriteBlockEnd();
+////        [Fact]
+////        public async Task TestMultiLineDocumentationAsync()
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteLine(@"/**
+//// * <summary>This is a documentation comment summary.</summary>
+//// */");
+////            gen.WriteClassStart("TestClass", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
+////            gen.WriteLine(@"/**");
+////            gen.WriteLine(@" * <summary>This is a documentation comment summary.</summary>");
+////            gen.WriteLine(@" */");
+////            gen.WriteMethod("SomeMethod", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, DiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, DiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        /// <summary>
-        /// Verifies that we recognize the auto-generated xml element.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestSkipAutoGeneratedCodeAsync()
-        {
-            var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteAutoGeneratedHeader();
-            gen.WriteClassStart("TestClass", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
-            gen.WriteBlockEnd();
+////        /// <summary>
+////        /// Verifies that we recognize the auto-generated xml element.
+////        /// </summary>
+////        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+////        [Fact]
+////        public async Task TestSkipAutoGeneratedCodeAsync()
+////        {
+////            var gen = new DocumentationRuleTestSampleCodeBuilder();
+////            gen.WriteAutoGeneratedHeader();
+////            gen.WriteClassStart("TestClass", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
+////            gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, DiagnosticId, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(gen, DiagnosticId, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        /// <summary>
-        /// Verifies that we recognize the autogenerated xml element.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestSkipAutoGeneratedCode2Async()
-        {
-            var testCode = @"//------------------------------------------------------------------------------
-// <autogenerated>
-//     This code was generated by a tool.
-//     Runtime Version:4.0.30319.0
-//
-//     Changes to this file may cause incorrect behavior and will be lost if
-//     the code is regenerated.
-// </autogenerated>
-//------------------------------------------------------------------------------
+////        /// <summary>
+////        /// Verifies that we recognize the autogenerated xml element.
+////        /// </summary>
+////        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+////        [Fact]
+////        public async Task TestSkipAutoGeneratedCode2Async()
+////        {
+////            var testCode = @"//------------------------------------------------------------------------------
+////// <autogenerated>
+//////     This code was generated by a tool.
+//////     Runtime Version:4.0.30319.0
+//////
+//////     Changes to this file may cause incorrect behavior and will be lost if
+//////     the code is regenerated.
+////// </autogenerated>
+//////------------------------------------------------------------------------------
 
-public class OuterClass
-{
-    public void SomeMethod() { }
-}";
+////public class OuterClass
+////{
+////    public void SomeMethod() { }
+////}";
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
-        {
-            yield return new SA1600ElementsMustBeDocumented();
-        }
-    }
-}
+////        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+////        {
+////            yield return new SA1600ElementsMustBeDocumented();
+////        }
+////    }
+////}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
@@ -37,20 +37,22 @@ public partial {0} TypeName
         }
 
         [Theory]
-        [InlineData("class")]
-        [InlineData("struct")]
-        [InlineData("interface")]
-        public async Task TestPartialTypeWithoutDocumentationAsync(string typeKeyword)
+        [InlineData("class", "public", SA1601PartialElementsMustBeDocumented.DiagnosticId)]
+        [InlineData("class", "internal", SA1601PartialElementsMustBeDocumented.DiagnosticIdInternal)]
+        [InlineData("struct", "public", SA1601PartialElementsMustBeDocumented.DiagnosticId)]
+        [InlineData("struct", "public", SA1601PartialElementsMustBeDocumented.DiagnosticId)]
+        [InlineData("interface", "public", SA1601PartialElementsMustBeDocumented.DiagnosticId)]
+        public async Task TestPartialTypeWithoutDocumentationAsync(string typeKeyword, string typeModifier, string expectedDiagnosticId)
         {
             var testCode = @"
-public partial {0}
+{0} partial {1}
 TypeName
 {{
 }}";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 1);
+            DiagnosticResult expected = this.CSharpDiagnostic(expectedDiagnosticId).WithLocation(3, 1);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeKeyword), expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeModifier, typeKeyword), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
@@ -68,7 +70,7 @@ TypeName
 {{
 }}";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
+            DiagnosticResult expected = this.CSharpDiagnostic(SA1601PartialElementsMustBeDocumented.DiagnosticId).WithLocation(6, 1);
 
             await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeKeyword), expected, CancellationToken.None).ConfigureAwait(false);
         }
@@ -102,7 +104,7 @@ public partial class TypeName
     partial void MemberName();
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 18);
+            DiagnosticResult expected = this.CSharpDiagnostic(SA1601PartialElementsMustBeDocumented.DiagnosticIdPrivate).WithLocation(7, 18);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
@@ -122,7 +124,7 @@ public partial class TypeName
     partial void MemberName();
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 18);
+            DiagnosticResult expected = this.CSharpDiagnostic(SA1601PartialElementsMustBeDocumented.DiagnosticIdPrivate).WithLocation(10, 18);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
@@ -38,7 +38,7 @@ public partial {0} TypeName
 
         [Theory]
         [InlineData("class", "public", SA1601PartialElementsMustBeDocumented.DiagnosticId)]
-        [InlineData("class", "internal", SA1601PartialElementsMustBeDocumented.DiagnosticIdInternal)]
+        ////[InlineData("class", "internal", SA1601PartialElementsMustBeDocumented.DiagnosticIdInternal)]
         [InlineData("struct", "public", SA1601PartialElementsMustBeDocumented.DiagnosticId)]
         [InlineData("struct", "public", SA1601PartialElementsMustBeDocumented.DiagnosticId)]
         [InlineData("interface", "public", SA1601PartialElementsMustBeDocumented.DiagnosticId)]
@@ -92,42 +92,42 @@ public partial class TypeName
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestPartialMethodWithoutDocumentationAsync()
-        {
-            var testCode = @"
-/// <summary>
-/// Some Documentation
-/// </summary>
-public partial class TypeName
-{
-    partial void MemberName();
-}";
+////        [Fact]
+////        public async Task TestPartialMethodWithoutDocumentationAsync()
+////        {
+////            var testCode = @"
+/////// <summary>
+/////// Some Documentation
+/////// </summary>
+////public partial class TypeName
+////{
+////    partial void MemberName();
+////}";
 
-            DiagnosticResult expected = this.CSharpDiagnostic(SA1601PartialElementsMustBeDocumented.DiagnosticIdPrivate).WithLocation(7, 18);
+////            DiagnosticResult expected = this.CSharpDiagnostic(SA1601PartialElementsMustBeDocumented.DiagnosticIdPrivate).WithLocation(7, 18);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+////        }
 
-        [Fact]
-        public async Task TestPartialMethodWithEmptyDocumentationAsync()
-        {
-            var testCode = @"
-/// <summary>
-/// Some Documentation
-/// </summary>
-public partial class TypeName
-{
-    /// <summary>
-    /// 
-    /// </summary>
-    partial void MemberName();
-}";
+////        [Fact]
+////        public async Task TestPartialMethodWithEmptyDocumentationAsync()
+////        {
+////            var testCode = @"
+/////// <summary>
+/////// Some Documentation
+/////// </summary>
+////public partial class TypeName
+////{
+////    /// <summary>
+////    ///
+////    /// </summary>
+////    partial void MemberName();
+////}";
 
-            DiagnosticResult expected = this.CSharpDiagnostic(SA1601PartialElementsMustBeDocumented.DiagnosticIdPrivate).WithLocation(10, 18);
+////            DiagnosticResult expected = this.CSharpDiagnostic(SA1601PartialElementsMustBeDocumented.DiagnosticIdPrivate).WithLocation(10, 18);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
-        }
+////            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+////        }
 
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
@@ -13,6 +13,9 @@
     /// </summary>
     public class SA1601UnitTests : CodeFixVerifier
     {
+        private const string DiagnosticId = SA1601PartialElementsMustBeDocumented.DiagnosticId;
+        private const string NoDiagnostic = null;
+
         [Fact]
         public async Task TestEmptySourceAsync()
         {
@@ -37,12 +40,12 @@ public partial {0} TypeName
         }
 
         [Theory]
-        [InlineData("class", "public", SA1601PartialElementsMustBeDocumented.DiagnosticId)]
-        ////[InlineData("class", "internal", SA1601PartialElementsMustBeDocumented.DiagnosticIdInternal)]
-        [InlineData("struct", "public", SA1601PartialElementsMustBeDocumented.DiagnosticId)]
-        [InlineData("struct", "public", SA1601PartialElementsMustBeDocumented.DiagnosticId)]
-        [InlineData("interface", "public", SA1601PartialElementsMustBeDocumented.DiagnosticId)]
-        public async Task TestPartialTypeWithoutDocumentationAsync(string typeKeyword, string typeModifier, string expectedDiagnosticId)
+        [InlineData("class", "public")]
+        [InlineData("class", "internal")]
+        [InlineData("struct", "public")]
+        [InlineData("struct", "internal")]
+        [InlineData("interface", "public")]
+        public async Task TestPartialTypeWithoutDocumentationAsync(string typeKeyword, string typeModifier)
         {
             var testCode = @"
 {0} partial {1}
@@ -50,9 +53,7 @@ TypeName
 {{
 }}";
 
-            DiagnosticResult expected = this.CSharpDiagnostic(expectedDiagnosticId).WithLocation(3, 1);
-
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeModifier, typeKeyword), expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeModifier, typeKeyword), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
@@ -70,9 +71,7 @@ TypeName
 {{
 }}";
 
-            DiagnosticResult expected = this.CSharpDiagnostic(SA1601PartialElementsMustBeDocumented.DiagnosticId).WithLocation(6, 1);
-
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeKeyword), expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeKeyword), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -92,42 +91,44 @@ public partial class TypeName
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-////        [Fact]
-////        public async Task TestPartialMethodWithoutDocumentationAsync()
-////        {
-////            var testCode = @"
-/////// <summary>
-/////// Some Documentation
-/////// </summary>
-////public partial class TypeName
-////{
-////    partial void MemberName();
-////}";
+        [Fact]
+        public async Task TestPartialMethodWithoutDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Some Documentation
+/// </summary>
+public partial class TypeName
+{
+    partial void
+MemberName();
+}";
 
-////            DiagnosticResult expected = this.CSharpDiagnostic(SA1601PartialElementsMustBeDocumented.DiagnosticIdPrivate).WithLocation(7, 18);
+            DiagnosticResult expected = this.CSharpDiagnostic(DiagnosticId).WithLocation(8, 1);
 
-////            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
-////        }
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
 
-////        [Fact]
-////        public async Task TestPartialMethodWithEmptyDocumentationAsync()
-////        {
-////            var testCode = @"
-/////// <summary>
-/////// Some Documentation
-/////// </summary>
-////public partial class TypeName
-////{
-////    /// <summary>
-////    ///
-////    /// </summary>
-////    partial void MemberName();
-////}";
+        [Fact]
+        public async Task TestPartialMethodWithEmptyDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Some Documentation
+/// </summary>
+public partial class TypeName
+{
+    /// <summary>
+    ///
+    /// </summary>
+    partial void
+MemberName();
+}";
 
-////            DiagnosticResult expected = this.CSharpDiagnostic(SA1601PartialElementsMustBeDocumented.DiagnosticIdPrivate).WithLocation(10, 18);
+            DiagnosticResult expected = this.CSharpDiagnostic(DiagnosticId).WithLocation(11, 1);
 
-////            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
-////        }
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
 
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1602UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1602UnitTests.cs
@@ -37,18 +37,42 @@ enum TypeName
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestEnumWithoutDocumentationAsync()
+        [Theory]
+        [InlineData("public", SA1602EnumerationItemsMustBeDocumented.DiagnosticId)]
+        [InlineData("internal", SA1602EnumerationItemsMustBeDocumented.DiagnosticIdInternal)]
+        public async Task TestEnumWithoutDocumentationAsync(string enumModifier, string expectedDiagnosticId)
         {
             var testCode = @"
-enum TypeName
-{
+{0} enum TypeName
+{{
     Bar
-}";
+}}";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 5);
+            DiagnosticResult expected = this.CSharpDiagnostic(expectedDiagnosticId).WithLocation(4, 5);
 
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, enumModifier), expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("public", SA1602EnumerationItemsMustBeDocumented.DiagnosticId)]
+        [InlineData("protected internal", SA1602EnumerationItemsMustBeDocumented.DiagnosticId)]
+        [InlineData("protected internal", SA1602EnumerationItemsMustBeDocumented.DiagnosticId)]
+        [InlineData("internal", SA1602EnumerationItemsMustBeDocumented.DiagnosticIdInternal)]
+        [InlineData("private", SA1602EnumerationItemsMustBeDocumented.DiagnosticIdPrivate)]
+        public async Task TestNestedEnumWithoutDocumentationAsync(string enumModifier, string expectedDiagnosticId)
+        {
+            var testCode = @"
+public class OuterClass
+{{
+{0} enum TypeName
+{{
+    Bar
+}}
+}}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic(expectedDiagnosticId).WithLocation(6, 5);
+
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, enumModifier), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -58,7 +82,7 @@ enum TypeName
 /// <summary>
 /// Some Documentation
 /// </summary>
-enum TypeName
+public enum TypeName
 {
     /// <summary>
     /// 
@@ -66,7 +90,7 @@ enum TypeName
     Bar
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 5);
+            DiagnosticResult expected = this.CSharpDiagnostic(SA1602EnumerationItemsMustBeDocumented.DiagnosticId).WithLocation(10, 5);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1602UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1602UnitTests.cs
@@ -13,6 +13,9 @@
     /// </summary>
     public class SA1602UnitTests : CodeFixVerifier
     {
+        private const string DiagnosticId = SA1602EnumerationItemsMustBeDocumented.DiagnosticId;
+        private const string NoDiagnostic = null;
+
         [Fact]
         public async Task TestEmptySourceAsync()
         {
@@ -21,7 +24,7 @@
         }
 
         [Fact]
-        public async Task TestEnumWithDocumentationAsync()
+        public async Task TestEnumFieldWithDocumentationAsync()
         {
             var testCode = @"
 /// <summary>
@@ -38,9 +41,9 @@ enum TypeName
         }
 
         [Theory]
-        [InlineData("public", SA1602EnumerationItemsMustBeDocumented.DiagnosticId)]
-        [InlineData("internal", SA1602EnumerationItemsMustBeDocumented.DiagnosticIdInternal)]
-        public async Task TestEnumWithoutDocumentationAsync(string enumModifier, string expectedDiagnosticId)
+        [InlineData("public")]
+        [InlineData("internal")]
+        public async Task TestEnumFieldWithoutDocumentationAsync(string enumModifier)
         {
             var testCode = @"
 {0} enum TypeName
@@ -48,18 +51,16 @@ enum TypeName
     Bar
 }}";
 
-            DiagnosticResult expected = this.CSharpDiagnostic(expectedDiagnosticId).WithLocation(4, 5);
-
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, enumModifier), expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, enumModifier), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
-        [InlineData("public", SA1602EnumerationItemsMustBeDocumented.DiagnosticId)]
-        [InlineData("protected internal", SA1602EnumerationItemsMustBeDocumented.DiagnosticId)]
-        [InlineData("protected internal", SA1602EnumerationItemsMustBeDocumented.DiagnosticId)]
-        [InlineData("internal", SA1602EnumerationItemsMustBeDocumented.DiagnosticIdInternal)]
-        [InlineData("private", SA1602EnumerationItemsMustBeDocumented.DiagnosticIdPrivate)]
-        public async Task TestNestedEnumWithoutDocumentationAsync(string enumModifier, string expectedDiagnosticId)
+        [InlineData("public", NoDiagnostic)]
+        [InlineData("protected", NoDiagnostic)]
+        [InlineData("protected internal", NoDiagnostic)]
+        [InlineData("internal", NoDiagnostic)]
+        [InlineData("private", DiagnosticId)]
+        public async Task TestNestedEnumFieldWithoutDocumentationAsync(string enumModifier, string expectedDiagnosticId)
         {
             var testCode = @"
 public class OuterClass
@@ -70,13 +71,20 @@ public class OuterClass
 }}
 }}";
 
-            DiagnosticResult expected = this.CSharpDiagnostic(expectedDiagnosticId).WithLocation(6, 5);
+            if (expectedDiagnosticId == NoDiagnostic)
+            {
+                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, enumModifier), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            }
+            else
+            {
+                DiagnosticResult expected = this.CSharpDiagnostic(expectedDiagnosticId).WithLocation(6, 5);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, enumModifier), expected, CancellationToken.None).ConfigureAwait(false);
+                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, enumModifier), expected, CancellationToken.None).ConfigureAwait(false);
+            }
         }
 
         [Fact]
-        public async Task TestEnumWithEmptyDocumentationAsync()
+        public async Task TestEnumFieldWithEmptyDocumentationAsync()
         {
             var testCode = @"
 /// <summary>
@@ -90,9 +98,7 @@ public enum TypeName
     Bar
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic(SA1602EnumerationItemsMustBeDocumented.DiagnosticId).WithLocation(10, 5);
-
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA16X0UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA16X0UnitTests.cs
@@ -549,9 +549,16 @@ internal enum TypeName
     Bar
 }}";
 
-            DiagnosticResult expected = this.CSharpDiagnostic(expectedDiagnosticId).WithLocation(6, 5);
+            if (expectedDiagnosticId == NoDiagnostic)
+            {
+                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, enumModifier), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            }
+            else
+            {
+                DiagnosticResult expected = this.CSharpDiagnostic(expectedDiagnosticId).WithLocation(6, 5);
 
-            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, enumModifier), expected, CancellationToken.None).ConfigureAwait(false);
+                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, enumModifier), expected, CancellationToken.None).ConfigureAwait(false);
+            }
         }
 
         [Theory]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA16X0UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA16X0UnitTests.cs
@@ -10,11 +10,11 @@
     using Xunit;
 
     /// <summary>
-    /// This class contains unit tests for <see cref="SA1600ElementsMustBeDocumented"/>.
+    /// This class contains unit tests for <see cref="SA16X0InternalElementsMustBeDocumented"/>.
     /// </summary>
-    public class SA1600UnitTests : CodeFixVerifier
+    public class SA16X0UnitTests : CodeFixVerifier
     {
-        private const string DiagnosticId = SA1600ElementsMustBeDocumented.DiagnosticId;
+        private const string DiagnosticId = SA16X0InternalElementsMustBeDocumented.DiagnosticId;
         private const string NoDiagnostic = null;
 
         [Fact]
@@ -30,16 +30,16 @@
             var gen = new DocumentationRuleTestSampleCodeBuilder();
             gen.WriteLine(@"/// <summary>");
             gen.WriteLine(@"/// </summary>");
-            gen.WriteClassStart("TestClass", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.Diagnostic, "public");
+            gen.WriteClassStart("TestClass", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.Diagnostic, "internal");
             gen.WriteBlockEnd();
 
-            await this.VerifyCSharpDiagnosticAsync(gen, NoDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(gen, DiagnosticId, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
         [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, NoDiagnostic)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticId)]
         public async Task TestClassAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
@@ -52,7 +52,7 @@
         [Theory]
         [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, NoDiagnostic)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticId)]
         public async Task TestEnumAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
@@ -65,9 +65,9 @@
         [Theory]
         [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, new[] { "public" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "internal" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, new[] { "private" }, DiagnosticId)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "internal" }, DiagnosticId)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, new[] { "public" }, DiagnosticId)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, new[] { "private" }, NoDiagnostic)]
         public async Task TestNestedClassAsync(DocumentationOptions options, string[] parentModifiers, string[] modifiers, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
@@ -81,7 +81,7 @@
 
         [Theory]
         [InlineData(DocumentationOptions.WriteSampleDocumentation, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, DiagnosticId)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, NoDiagnostic)]
         public async Task TestExplicitInterfacePropertyImplementationAsync(DocumentationOptions options, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder(new[] { DiagnosticId });
@@ -95,7 +95,7 @@
         [Theory]
         [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, NoDiagnostic)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticId)]
         public async Task TestStructAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
@@ -108,7 +108,7 @@
         [Theory]
         [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, NoDiagnostic)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticId)]
         public async Task TestEnumWithoutDocumentationAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
@@ -121,7 +121,7 @@
         [Theory]
         [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, NoDiagnostic)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticId)]
         public async Task TestInterfaceAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
@@ -133,11 +133,11 @@
 
         [Theory]
         [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticId)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, NoDiagnostic)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticId)]
         public async Task TestConstructorAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
@@ -150,12 +150,12 @@
 
         [Theory]
         [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "private" }, DiagnosticId)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "private" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "public" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "protected" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "protected", "internal" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "internal" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, new[] { "public" }, NoDiagnostic)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, new[] { "internal" }, DiagnosticId)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, new[] { "public" }, DiagnosticId)]
         public async Task TestDelegateAsync(DocumentationOptions options, string[] ownerModifiers, string[] modifiers, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
@@ -168,8 +168,8 @@
 
         [Theory]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, "public", "public", new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, "internal", "public", new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, "public", "private", new[] { "public" }, DiagnosticId)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, "internal", "public", new[] { "public" }, DiagnosticId)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, "public", "private", new[] { "public" }, NoDiagnostic)]
         public async Task TestNestedClassDelegateAsync(DocumentationOptions options, string outerClassModifier, string innerClassModifier, string[] modifiers, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
@@ -184,11 +184,11 @@
 
         [Theory]
         [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticId)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, NoDiagnostic)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticId)]
         public async Task TestEventAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
@@ -201,11 +201,11 @@
 
         [Theory]
         [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticId)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, NoDiagnostic)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticId)]
         public async Task TestFieldWithoutDocumentationAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
@@ -218,11 +218,11 @@
 
         [Theory]
         [InlineData(DocumentationOptions.WriteSampleDocumentation, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, NoDiagnostic)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, DiagnosticId)]
         public async Task TestDestructorWithoutDocumentationAsync(DocumentationOptions options, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
-            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
+            gen.WriteClassStart("TestClass", DocumentationOptions.WriteSampleDocumentation, ExpectedResult.NoDiagnostic, "internal");
             gen.WriteDestructor("TestClass", options, ExpectedResult.Diagnostic);
             gen.WriteBlockEnd();
 
@@ -231,11 +231,11 @@
 
         [Theory]
         [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticId)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, NoDiagnostic)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticId)]
         public async Task TestPublicIndexerWithoutDocumentationAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
@@ -248,11 +248,11 @@
 
         [Theory]
         [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticId)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, NoDiagnostic)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticId)]
         public async Task TestPublicMethodWithoutDocumentationAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
@@ -265,11 +265,11 @@
 
         [Theory]
         [InlineData(DocumentationOptions.WriteSampleDocumentation, new[] { "public" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, DiagnosticId)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "private" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "public" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected" }, NoDiagnostic)]
         [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "protected", "internal" }, NoDiagnostic)]
-        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, NoDiagnostic)]
+        [InlineData(DocumentationOptions.OmitSampleDocumentation, new[] { "internal" }, DiagnosticId)]
         public async Task TestPublicPropertyWithoutDocumentationAsync(DocumentationOptions options, string[] modifiers, string expectedDiagnosticId)
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
@@ -296,20 +296,22 @@
         {
             var testCodeWithEmptyDocumentation = @"    /// <summary>
     /// </summary>
-public class OuterClass
+internal class
+OuterClass
 {
 }";
             var testCodeWithDocumentation = @"    /// <summary>
     /// A summary
     /// </summary>
-public class OuterClass
+internal class
+OuterClass
 {
 }";
 
-            ////DiagnosticResult expected = this.CSharpDiagnostic(NoDiagnostic).WithLocation(3, 14);
+            DiagnosticResult expected = this.CSharpDiagnostic(NoDiagnostic).WithLocation(4, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCodeWithDocumentation, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpDiagnosticAsync(testCodeWithEmptyDocumentation, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCodeWithEmptyDocumentation, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -318,28 +320,31 @@ public class OuterClass
             var testCodeWithEmptyDocumentation = @"/// <summary>
     /// <![CDATA[]]>
     /// </summary>
-public class OuterClass
+internal class
+OuterClass
 {
 }";
             var testCodeWithDocumentation = @"    /// <summary>
     /// <![CDATA[A summary.]]>
     /// </summary>
-public class OuterClass
+internal class
+OuterClass
 {
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic(DiagnosticId).WithLocation(4, 14);
+            DiagnosticResult expected = this.CSharpDiagnostic(DiagnosticId).WithLocation(5, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCodeWithDocumentation, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpDiagnosticAsync(testCodeWithEmptyDocumentation, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCodeWithEmptyDocumentation, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestEmptyElementXmlCommentsAsync()
         {
+            // A self-closing XML tag is permitted as an XML comment.
             var gen = new DocumentationRuleTestSampleCodeBuilder();
             gen.WriteLine(@"/// <inheritdoc />");
-            gen.WriteClassStart("TestClass", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
+            gen.WriteClassStart("TestClass", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.NoDiagnostic, "internal");
             gen.WriteBlockEnd();
 
             await this.VerifyCSharpDiagnosticAsync(gen, DiagnosticId, CancellationToken.None).ConfigureAwait(false);
@@ -352,7 +357,7 @@ public class OuterClass
             gen.WriteLine(@"/**
  * <summary>This is a documentation comment summary.</summary>
  */");
-            gen.WriteClassStart("TestClass", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
+            gen.WriteClassStart("TestClass", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.NoDiagnostic, "internal");
             gen.WriteLine(@"/**");
             gen.WriteLine(@" * <summary>This is a documentation comment summary.</summary>");
             gen.WriteLine(@" */");
@@ -371,7 +376,7 @@ public class OuterClass
         {
             var gen = new DocumentationRuleTestSampleCodeBuilder();
             gen.WriteAutoGeneratedHeader();
-            gen.WriteClassStart("TestClass", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.NoDiagnostic, "public");
+            gen.WriteClassStart("TestClass", DocumentationOptions.OmitSampleDocumentation, ExpectedResult.NoDiagnostic, "internal");
             gen.WriteBlockEnd();
 
             await this.VerifyCSharpDiagnosticAsync(gen, DiagnosticId, CancellationToken.None).ConfigureAwait(false);
@@ -394,7 +399,7 @@ public class OuterClass
 // </autogenerated>
 //------------------------------------------------------------------------------
 
-public class OuterClass
+internal class OuterClass
 {
     public void SomeMethod() { }
 }";
@@ -402,9 +407,211 @@ public class OuterClass
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("interface")]
+        public async Task TestPartialTypeWithDocumentationAsync(string typeKeyword)
+        {
+            var testCode = @"
+/// <summary>
+/// Some Documentation
+/// </summary>
+internal partial {0} TypeName
+{{
+}}";
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeKeyword), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("class", "public", NoDiagnostic)]
+        [InlineData("class", "internal", DiagnosticId)]
+        [InlineData("struct", "public", NoDiagnostic)]
+        [InlineData("struct", "internal", DiagnosticId)]
+        [InlineData("interface", "public", NoDiagnostic)]
+        [InlineData("interface", "internal", DiagnosticId)]
+        public async Task TestPartialTypeWithoutDocumentationAsync(string typeKeyword, string typeModifier, string expectedDiagnosticId)
+        {
+            var testCode = @"
+{0} partial {1}
+TypeName
+{{
+}}";
+
+            if (expectedDiagnosticId == NoDiagnostic)
+            {
+                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeModifier, typeKeyword), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            }
+            else
+            {
+                DiagnosticResult expected = this.CSharpDiagnostic(expectedDiagnosticId).WithLocation(3, 1);
+                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeModifier, typeKeyword), expected, CancellationToken.None).ConfigureAwait(false);
+            }
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("interface")]
+        public async Task TestPartialClassWithEmptyDocumentationAsync(string typeKeyword)
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+internal partial {0} 
+TypeName
+{{
+}}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic(DiagnosticId).WithLocation(6, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeKeyword), expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestPartialMethodWithDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Some Documentation
+/// </summary>
+internal partial class TypeName
+{
+    /// <summary>
+    /// Some Documentation
+    /// </summary>
+    partial void MemberName();
+}";
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestPartialMethodWithoutDocumentationAsync()
+        {
+            var testCode = @"
+        /// <summary>
+        /// Some Documentation
+        /// </summary>
+        internal partial class TypeName
+        {
+            partial void MemberName();
+        }";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestPartialMethodWithEmptyDocumentationAsync()
+        {
+            var testCode = @"
+        /// <summary>
+        /// Some Documentation
+        /// </summary>
+        public partial class TypeName
+        {
+            /// <summary>
+            ///
+            /// </summary>
+            partial void MemberName();
+        }";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestEnumFieldWithDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Some Documentation
+/// </summary>
+internal enum TypeName
+{
+    /// <summary>
+    /// Some Documentation
+    /// </summary>
+    Bar
+}";
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("public", NoDiagnostic)]
+        [InlineData("internal", DiagnosticId)]
+        public async Task TestEnumFieldWithoutDocumentationAsync(string enumModifier, string expectedDiagnosticId)
+        {
+            var testCode = @"/// <summary>
+/// Some text.
+/// </summary>
+{0} enum TypeName
+{{
+    Bar
+}}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic(expectedDiagnosticId).WithLocation(6, 5);
+
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, enumModifier), expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("public", NoDiagnostic)]
+        [InlineData("protected", NoDiagnostic)]
+        [InlineData("protected internal", NoDiagnostic)]
+        [InlineData("internal", DiagnosticId)]
+        [InlineData("private", NoDiagnostic)]
+        public async Task TestNestedEnumFieldWithoutDocumentationAsync(string enumModifier, string expectedDiagnosticId)
+        {
+            var testCode = @"/// <summary>
+/// Some text.
+/// </summary>
+public class OuterClass
+{{
+{0} enum
+TypeName
+{{
+    /// <summary>
+    /// The comments.
+    /// </summary>
+    Bar
+}}
+}}";
+
+            if (expectedDiagnosticId == NoDiagnostic)
+            {
+                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, enumModifier), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            }
+            else
+            {
+                DiagnosticResult expected = this.CSharpDiagnostic(expectedDiagnosticId).WithLocation(7, 1);
+
+                await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, enumModifier), expected, CancellationToken.None).ConfigureAwait(false);
+            }
+        }
+
+        [Fact]
+        public async Task TestEnumFieldWithEmptyDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Some Documentation
+/// </summary>
+internal enum TypeName
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    Bar
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic(DiagnosticId).WithLocation(10, 5);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            yield return new SA1600ElementsMustBeDocumented();
+            yield return new SA16X0InternalElementsMustBeDocumented();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SampleCodeBuilder.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SampleCodeBuilder.cs
@@ -1,0 +1,153 @@
+﻿namespace StyleCop.Analyzers.Test.DocumentationRules
+{
+    using System;
+    using System.Collections.Immutable;
+    using System.IO;
+    using System.Text;
+    using System.Text.RegularExpressions;
+    using TestHelper;
+
+    public abstract class SampleCodeBuilder
+    {
+        private const string Indent = @"    ";
+
+        private static readonly Regex DiagnosticMarkerPattern = new Regex(@"\~\~([^\~]*?)\~\~", RegexOptions.Compiled);
+
+        private readonly StringBuilder stringBuilder = new StringBuilder();
+
+        private ImmutableList<DiagnosticResultLocation> diagnosticLocations = ImmutableList<DiagnosticResultLocation>.Empty;
+
+        private int indentLevel;
+        private int linesWritten;
+        private int columnIndex;
+
+        public IImmutableList<DiagnosticResultLocation> DiagnosticLocations
+        {
+            get { return this.diagnosticLocations; }
+        }
+
+        public string GeneratedText
+        {
+            get { return this.stringBuilder.ToString(); }
+        }
+
+        public void Reset()
+        {
+            this.diagnosticLocations = ImmutableList<DiagnosticResultLocation>.Empty;
+            this.stringBuilder.Clear();
+            this.indentLevel = 0;
+            this.linesWritten = 0;
+            this.columnIndex = 0;
+        }
+
+        public void PushIndent()
+        {
+            ++this.indentLevel;
+        }
+
+        public void PopIndent()
+        {
+            --this.indentLevel;
+        }
+
+        public IDisposable SuppressIndent()
+        {
+            return new RestoreIndentDisposable(this);
+        }
+
+        public void WriteLine(string line)
+        {
+            StringReader reader = new StringReader(line);
+            string addLine = reader.ReadLine();
+            while (addLine != null)
+            {
+                if (this.columnIndex == 0)
+                {
+                    this.WriteIndent();
+                }
+
+                addLine = this.AddDiagnosticLocationsAndReturnPlainString(addLine);
+
+                this.stringBuilder.AppendLine(addLine);
+                this.columnIndex = 0;
+
+                addLine = reader.ReadLine();
+                ++this.linesWritten;
+            }
+        }
+
+        public void Write(string line)
+        {
+            string[] lines = line.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
+
+            for (int i = 0; i < lines.Length; i++)
+            {
+                if (this.columnIndex == 0)
+                {
+                    this.WriteIndent();
+                }
+
+                string addLine = lines[i];
+                addLine = this.AddDiagnosticLocationsAndReturnPlainString(addLine);
+
+                // Write line with markers removed to output.
+                this.stringBuilder.Append(addLine);
+                this.columnIndex += addLine.Length;
+
+                if (i < (lines.Length - 1))
+                {
+                    ++this.linesWritten;
+                    this.columnIndex = 0;
+                    this.stringBuilder.AppendLine();
+                }
+            }
+        }
+
+        private void WriteIndent()
+        {
+            for (int i = 0; i < this.indentLevel; i++)
+            {
+                this.stringBuilder.Append(Indent);
+                this.columnIndex += Indent.Length;
+            }
+        }
+
+        private string AddDiagnosticLocationsAndReturnPlainString(string textWithMarkers)
+        {
+            string addLine = textWithMarkers;
+
+            var markerMatch = DiagnosticMarkerPattern.Match(addLine);
+            while (markerMatch.Success)
+            {
+                // Add diagnostic location for the marker.
+                this.diagnosticLocations = this.diagnosticLocations.Add(
+                    new DiagnosticResultLocation(null, this.linesWritten + 1, markerMatch.Index + this.columnIndex + 1));
+
+                // Remove the marker from the line.
+                addLine = DiagnosticMarkerPattern.Replace(addLine, @"$1", 1);
+
+                markerMatch = DiagnosticMarkerPattern.Match(addLine);
+            }
+
+            return addLine;
+        }
+
+        private sealed class RestoreIndentDisposable : IDisposable
+        {
+            private int saved;
+            private SampleCodeBuilder restoreTo;
+
+            public RestoreIndentDisposable(SampleCodeBuilder builder)
+            {
+                this.restoreTo = builder;
+                this.saved = builder.indentLevel;
+                builder.indentLevel = 0;
+            }
+
+            public void Dispose()
+            {
+                this.restoreTo.indentLevel = this.saved;
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -124,6 +124,7 @@
     <Compile Include="DocumentationRules\DocumentationOptions.cs" />
     <Compile Include="DocumentationRules\DocumentationRuleTestSampleCodeBuilder.cs" />
     <Compile Include="DocumentationRules\ExpectedResult.cs" />
+    <Compile Include="DocumentationRules\SA16X0UnitTests.cs" />
     <Compile Include="DocumentationRules\SampleCodeBuilder.cs" />
     <Compile Include="DocumentationRules\SA1600UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1601UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -121,6 +121,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DocumentationRules\FileHeaderTestBase.cs" />
+    <Compile Include="DocumentationRules\DocumentationOptions.cs" />
+    <Compile Include="DocumentationRules\DocumentationRuleTestSampleCodeBuilder.cs" />
+    <Compile Include="DocumentationRules\ExpectedResult.cs" />
+    <Compile Include="DocumentationRules\SampleCodeBuilder.cs" />
     <Compile Include="DocumentationRules\SA1600UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1601UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1602UnitTests.cs" />
@@ -303,6 +307,9 @@
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc2\tools\analyzers\C#\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc2\tools\analyzers\C#\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-alpha010\tools\analyzers\C#\StyleCop.Analyzers.dll" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationAnalyzer.cs
@@ -36,7 +36,7 @@
 
             bool isNestedInClassOrStruct = this.IsNestedType(declaration);
 
-            if (declaration != null && !XmlCommentHelper.HasDocumentation(declaration))
+            if (declaration != null && !XmlCommentHelper.HasDocumentation(declaration) && !declaration.Modifiers.Any(SyntaxKind.PartialKeyword))
             {
                 var effective = EffectiveVisibilityHelper.ResolveVisibilityForChild(
                     EffectiveVisibilityHelper.EffectiveVisibility(declaration.Modifiers, isNestedInClassOrStruct ? SyntaxKind.PrivateKeyword : SyntaxKind.InternalKeyword),
@@ -65,7 +65,7 @@
                 defaultVisibility = SyntaxKind.PublicKeyword;
             }
 
-            if (declaration != null && !XmlCommentHelper.HasDocumentation(declaration))
+            if (declaration != null && !XmlCommentHelper.HasDocumentation(declaration) && !declaration.Modifiers.Any(SyntaxKind.PartialKeyword))
             {
                 var effective = EffectiveVisibilityHelper.ResolveVisibilityForChild(
                     EffectiveVisibilityHelper.EffectiveVisibility(declaration.Modifiers, defaultVisibility),
@@ -329,7 +329,7 @@
                 {
                     var effective = EffectiveVisibilityHelper.ResolveVisibilityForChild(SyntaxKind.PublicKeyword, enumMemberDeclaration.Parent as BaseTypeDeclarationSyntax);
 
-                    ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(SyntaxKind.PublicKeyword, context), enumMemberDeclaration.Identifier);
+                    ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(effective, context), enumMemberDeclaration.Identifier);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationAnalyzer.cs
@@ -290,7 +290,7 @@
                 {
                     if (!XmlCommentHelper.HasDocumentation(methodDeclaration))
                     {
-                        ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(SyntaxKind.PublicKeyword, context), methodDeclaration.Identifier);
+                        ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(SyntaxKind.PrivateKeyword, context), methodDeclaration.Identifier);
                     }
                 }
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationAnalyzer.cs
@@ -1,0 +1,342 @@
+﻿namespace StyleCop.Analyzers.DocumentationRules
+{
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
+
+    /// <summary>
+    /// Base class for rules that enforce the presence of XML documentation comments.
+    /// </summary>
+    public abstract class DocumentationAnalyzer : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// The identifier of the compiler diagnostic warning for missing XML documentation comments.
+        /// </summary>
+        protected const string CS1591DiagnosticId = @"CS1591";
+
+        /// <summary>
+        /// Gets the <see cref="DiagnosticDescriptor"/> to return for a rule violation with the specified
+        /// resolved visibility.
+        /// </summary>
+        /// <param name="visibility">The resolved visibility; one of <see cref="SyntaxKind.PublicKeyword"/>,
+        /// <see cref="SyntaxKind.InternalKeyword"/> or <see cref="SyntaxKind.PrivateKeyword"/>.</param>
+        /// <param name="context">The analysis context.</param>
+        /// <returns>The <see cref="DiagnosticDescriptor"/>, or <c>null</c> if no violation should be reported.</returns>
+        protected abstract DiagnosticDescriptor DescriptorFromEffectiveVisibility(SyntaxKind visibility, SyntaxNodeAnalysisContext context);
+
+        /// <summary>
+        /// Handles a type declaration.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        protected void HandleTypeDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            BaseTypeDeclarationSyntax declaration = context.Node as BaseTypeDeclarationSyntax;
+
+            bool isNestedInClassOrStruct = this.IsNestedType(declaration);
+
+            if (declaration != null && !XmlCommentHelper.HasDocumentation(declaration))
+            {
+                var effective = EffectiveVisibilityHelper.ResolveVisibilityForChild(
+                    EffectiveVisibilityHelper.EffectiveVisibility(declaration.Modifiers, isNestedInClassOrStruct ? SyntaxKind.PrivateKeyword : SyntaxKind.InternalKeyword),
+                    declaration.Parent as BaseTypeDeclarationSyntax);
+
+                ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(effective, context), declaration.Identifier);
+            }
+        }
+
+        /// <summary>
+        /// Handles a method declaration.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        protected void HandleMethodDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            MethodDeclarationSyntax declaration = context.Node as MethodDeclarationSyntax;
+            SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
+
+            if (this.IsInterfaceMemberDeclaration(declaration) || declaration.ExplicitInterfaceSpecifier != null)
+            {
+                defaultVisibility = SyntaxKind.PublicKeyword;
+            }
+
+            if (declaration != null && !XmlCommentHelper.HasDocumentation(declaration))
+            {
+                var effective = EffectiveVisibilityHelper.ResolveVisibilityForChild(
+                    EffectiveVisibilityHelper.EffectiveVisibility(declaration.Modifiers, defaultVisibility),
+                    declaration.Parent as BaseTypeDeclarationSyntax);
+
+                ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(effective, context), declaration.Identifier);
+            }
+        }
+
+        /// <summary>
+        /// Handles a constructor declaration.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        protected void HandleConstructorDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            ConstructorDeclarationSyntax declaration = context.Node as ConstructorDeclarationSyntax;
+
+            if (declaration != null && !XmlCommentHelper.HasDocumentation(declaration))
+            {
+                var effective = EffectiveVisibilityHelper.ResolveVisibilityForChild(
+                    EffectiveVisibilityHelper.EffectiveVisibility(declaration.Modifiers, SyntaxKind.PrivateKeyword),
+                    declaration.Parent as BaseTypeDeclarationSyntax);
+
+                ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(effective, context), declaration.Identifier);
+            }
+        }
+
+        /// <summary>
+        /// Handles a destructor declaration.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        protected void HandleDestructorDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            DestructorDeclarationSyntax declaration = context.Node as DestructorDeclarationSyntax;
+
+            if (declaration != null && !XmlCommentHelper.HasDocumentation(declaration))
+            {
+                var effective = EffectiveVisibilityHelper.ResolveVisibilityForChild(
+                    SyntaxKind.PublicKeyword,
+                    declaration.Parent as BaseTypeDeclarationSyntax);
+
+                ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(effective, context), declaration.Identifier);
+            }
+        }
+
+        /// <summary>
+        /// Handles a property declaration.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        protected void HandlePropertyDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            PropertyDeclarationSyntax declaration = context.Node as PropertyDeclarationSyntax;
+            SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
+
+            if (this.IsInterfaceMemberDeclaration(declaration) || declaration.ExplicitInterfaceSpecifier != null)
+            {
+                defaultVisibility = SyntaxKind.PublicKeyword;
+            }
+
+            if (declaration != null && !XmlCommentHelper.HasDocumentation(declaration))
+            {
+                var effective = EffectiveVisibilityHelper.ResolveVisibilityForChild(
+                    EffectiveVisibilityHelper.EffectiveVisibility(declaration.Modifiers, defaultVisibility),
+                    declaration.Parent as BaseTypeDeclarationSyntax);
+
+                ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(effective, context), declaration.Identifier);
+            }
+        }
+
+        /// <summary>
+        /// Handles an indexer declaration.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        protected void HandleIndexerDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            IndexerDeclarationSyntax declaration = context.Node as IndexerDeclarationSyntax;
+            SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
+
+            if (this.IsInterfaceMemberDeclaration(declaration) || declaration.ExplicitInterfaceSpecifier != null)
+            {
+                defaultVisibility = SyntaxKind.PublicKeyword;
+            }
+
+            if (declaration != null && !XmlCommentHelper.HasDocumentation(declaration))
+            {
+                var effective = EffectiveVisibilityHelper.ResolveVisibilityForChild(
+                    EffectiveVisibilityHelper.EffectiveVisibility(declaration.Modifiers, defaultVisibility),
+                    declaration.Parent as BaseTypeDeclarationSyntax);
+
+                ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(effective, context), declaration.ThisKeyword);
+            }
+        }
+
+        /// <summary>
+        /// Handles a field declaration.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        protected void HandleFieldDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            FieldDeclarationSyntax declaration = context.Node as FieldDeclarationSyntax;
+            var variableDeclaration = declaration?.Declaration;
+
+            if (variableDeclaration != null && !XmlCommentHelper.HasDocumentation(declaration))
+            {
+                var effective = EffectiveVisibilityHelper.ResolveVisibilityForChild(
+                    EffectiveVisibilityHelper.EffectiveVisibility(declaration.Modifiers, SyntaxKind.PrivateKeyword),
+                    declaration.Parent as BaseTypeDeclarationSyntax);
+
+                var diagnostic = this.DescriptorFromEffectiveVisibility(effective, context);
+
+                foreach (var variable in variableDeclaration.Variables)
+                {
+                    ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(effective, context), variable.Identifier);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handles a delegate declaration.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        protected void HandleDelegateDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            DelegateDeclarationSyntax declaration = context.Node as DelegateDeclarationSyntax;
+
+            bool isNestedInClassOrStruct = this.IsNestedType(declaration);
+
+            if (declaration != null && !XmlCommentHelper.HasDocumentation(declaration))
+            {
+                var effective = EffectiveVisibilityHelper.ResolveVisibilityForChild(
+                    EffectiveVisibilityHelper.EffectiveVisibility(declaration.Modifiers, isNestedInClassOrStruct ? SyntaxKind.PrivateKeyword : SyntaxKind.InternalKeyword),
+                    declaration.Parent as BaseTypeDeclarationSyntax);
+
+                ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(effective, context), declaration.Identifier);
+            }
+        }
+
+        /// <summary>
+        /// Handles an event declaration.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        protected void HandleEventDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            EventDeclarationSyntax declaration = context.Node as EventDeclarationSyntax;
+            SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
+
+            if (declaration.ExplicitInterfaceSpecifier != null)
+            {
+                defaultVisibility = SyntaxKind.PublicKeyword;
+            }
+
+            if (declaration != null && !XmlCommentHelper.HasDocumentation(declaration))
+            {
+                var effective = EffectiveVisibilityHelper.ResolveVisibilityForChild(
+                    EffectiveVisibilityHelper.EffectiveVisibility(declaration.Modifiers, defaultVisibility),
+                    declaration.Parent as BaseTypeDeclarationSyntax);
+
+                ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(effective, context), declaration.Identifier);
+            }
+        }
+
+        /// <summary>
+        /// Handles an event field declaration.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        protected void HandleEventFieldDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            EventFieldDeclarationSyntax declaration = context.Node as EventFieldDeclarationSyntax;
+            SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
+
+            if (this.IsInterfaceMemberDeclaration(declaration))
+            {
+                defaultVisibility = SyntaxKind.PublicKeyword;
+            }
+
+            var variableDeclaration = declaration?.Declaration;
+
+            if (variableDeclaration != null && !XmlCommentHelper.HasDocumentation(declaration))
+            {
+                var effective = EffectiveVisibilityHelper.ResolveVisibilityForChild(
+                    EffectiveVisibilityHelper.EffectiveVisibility(declaration.Modifiers, defaultVisibility),
+                    declaration.Parent as BaseTypeDeclarationSyntax);
+
+                var diagnostic = this.DescriptorFromEffectiveVisibility(effective, context);
+
+                foreach (var variable in variableDeclaration.Variables)
+                {
+                    ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(effective, context), variable.Identifier);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handles a partial type declaration.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        protected void HandlePartialTypeDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            TypeDeclarationSyntax typeDeclaration = context.Node as TypeDeclarationSyntax;
+            if (typeDeclaration != null)
+            {
+                if (typeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword))
+                {
+                    if (!XmlCommentHelper.HasDocumentation(typeDeclaration))
+                    {
+                        bool isNested = typeDeclaration.Parent is BaseTypeDeclarationSyntax;
+                        var effective = EffectiveVisibilityHelper.ResolveVisibilityForChild(
+                            EffectiveVisibilityHelper.EffectiveVisibility(typeDeclaration.Modifiers, isNested ? SyntaxKind.PrivateKeyword : SyntaxKind.InternalKeyword),
+                            typeDeclaration.Parent as BaseTypeDeclarationSyntax);
+
+                        ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(effective, context), typeDeclaration.Identifier);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handles a partial method declaration.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        protected void HandlePartialMethodDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            MethodDeclarationSyntax methodDeclaration = context.Node as MethodDeclarationSyntax;
+            if (methodDeclaration != null)
+            {
+                if (methodDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword))
+                {
+                    if (!XmlCommentHelper.HasDocumentation(methodDeclaration))
+                    {
+                        ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(SyntaxKind.PublicKeyword, context), methodDeclaration.Identifier);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handles an enumeration member.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        protected void HandleEnumMember(SyntaxNodeAnalysisContext context)
+        {
+            EnumMemberDeclarationSyntax enumMemberDeclaration = context.Node as EnumMemberDeclarationSyntax;
+            if (enumMemberDeclaration != null)
+            {
+                if (!XmlCommentHelper.HasDocumentation(enumMemberDeclaration))
+                {
+                    var effective = EffectiveVisibilityHelper.ResolveVisibilityForChild(SyntaxKind.PublicKeyword, enumMemberDeclaration.Parent as BaseTypeDeclarationSyntax);
+
+                    ReportDiagnostic(context, this.DescriptorFromEffectiveVisibility(SyntaxKind.PublicKeyword, context), enumMemberDeclaration.Identifier);
+                }
+            }
+        }
+
+        private static void ReportDiagnostic(SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor, SyntaxToken locationToken)
+        {
+            if (descriptor == null)
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(descriptor, locationToken.GetLocation()));
+        }
+
+        private bool IsNestedType(BaseTypeDeclarationSyntax typeDeclaration)
+        {
+            return typeDeclaration?.Parent is BaseTypeDeclarationSyntax;
+        }
+
+        private bool IsNestedType(DelegateDeclarationSyntax delegateDeclaration)
+        {
+            return delegateDeclaration?.Parent is BaseTypeDeclarationSyntax;
+        }
+
+        private bool IsInterfaceMemberDeclaration(SyntaxNode declaration)
+        {
+            return declaration?.Parent is InterfaceDeclarationSyntax;
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationAnalyzer.cs
@@ -55,7 +55,12 @@
             MethodDeclarationSyntax declaration = context.Node as MethodDeclarationSyntax;
             SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
 
-            if (this.IsInterfaceMemberDeclaration(declaration) || declaration.ExplicitInterfaceSpecifier != null)
+            if (declaration.ExplicitInterfaceSpecifier != null)
+            {
+                // Treat explicit interface implementation as private.
+                defaultVisibility = SyntaxKind.PrivateKeyword;
+            }
+            else if (this.IsInterfaceMemberDeclaration(declaration))
             {
                 defaultVisibility = SyntaxKind.PublicKeyword;
             }
@@ -115,7 +120,12 @@
             PropertyDeclarationSyntax declaration = context.Node as PropertyDeclarationSyntax;
             SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
 
-            if (this.IsInterfaceMemberDeclaration(declaration) || declaration.ExplicitInterfaceSpecifier != null)
+            if (declaration.ExplicitInterfaceSpecifier != null)
+            {
+                // Treat explicit interface implementation as private.
+                defaultVisibility = SyntaxKind.PrivateKeyword;
+            }
+            else if (this.IsInterfaceMemberDeclaration(declaration))
             {
                 defaultVisibility = SyntaxKind.PublicKeyword;
             }
@@ -139,7 +149,12 @@
             IndexerDeclarationSyntax declaration = context.Node as IndexerDeclarationSyntax;
             SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
 
-            if (this.IsInterfaceMemberDeclaration(declaration) || declaration.ExplicitInterfaceSpecifier != null)
+            if (declaration.ExplicitInterfaceSpecifier != null)
+            {
+                // Treat explicit interface implementation as private.
+                defaultVisibility = SyntaxKind.PrivateKeyword;
+            }
+            else if (this.IsInterfaceMemberDeclaration(declaration))
             {
                 defaultVisibility = SyntaxKind.PublicKeyword;
             }
@@ -208,6 +223,11 @@
             SyntaxKind defaultVisibility = SyntaxKind.PrivateKeyword;
 
             if (declaration.ExplicitInterfaceSpecifier != null)
+            {
+                // Treat explicit interface implementation as private.
+                defaultVisibility = SyntaxKind.PrivateKeyword;
+            }
+            else if (this.IsInterfaceMemberDeclaration(declaration))
             {
                 defaultVisibility = SyntaxKind.PublicKeyword;
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
@@ -86,7 +86,7 @@
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleTypeDeclaration, SyntaxKind.EnumDeclaration);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleMethodDeclaration, SyntaxKind.MethodDeclaration);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleConstructorDeclaration, SyntaxKind.ConstructorDeclaration);
-            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleFinalizerDeclaration, SyntaxKind.DestructorDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleDestructorDeclaration, SyntaxKind.DestructorDeclaration);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandlePropertyDeclaration, SyntaxKind.PropertyDeclaration);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleIndexerDeclaration, SyntaxKind.IndexerDeclaration);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleFieldDeclaration, SyntaxKind.FieldDeclaration);
@@ -163,7 +163,7 @@
             }
         }
 
-        private void HandleFinalizerDeclaration(SyntaxNodeAnalysisContext context)
+        private void HandleDestructorDeclaration(SyntaxNodeAnalysisContext context)
         {
             DestructorDeclarationSyntax declaration = context.Node as DestructorDeclarationSyntax;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
@@ -1,12 +1,13 @@
 ﻿namespace StyleCop.Analyzers.DocumentationRules
 {
-    using System.Collections.Immutable;
-    using System.Linq;
     using Helpers;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
-    using Microsoft.CodeAnalysis.Diagnostics;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using System;
+    using System.Collections.Immutable;
+    using System.Linq;
 
     /// <summary>
     /// A C# code element is missing a documentation header.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
@@ -77,7 +77,7 @@
                     : Descriptor;
 
             case SyntaxKind.InternalKeyword:
-                return (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA16X0NonPrivateElementsMustBeDocumented.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
+                return (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA16X0InternalElementsMustBeDocumented.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
                     ? null
                     : Descriptor;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1601PartialElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1601PartialElementsMustBeDocumented.cs
@@ -109,7 +109,7 @@
                     : Descriptor;
 
             case SyntaxKind.InternalKeyword:
-                return (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA16X0NonPrivateElementsMustBeDocumented.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
+                return (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA16X0InternalElementsMustBeDocumented.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
                     ? null
                     : Descriptor;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1602EnumerationItemsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1602EnumerationItemsMustBeDocumented.cs
@@ -39,18 +39,6 @@
         /// </summary>
         public const string DiagnosticId = "SA1602";
 
-        /// <summary>
-        /// The ID for diagnostics produced by the <see cref="SA1602EnumerationItemsMustBeDocumented"/> analyzer
-        /// for internal members.
-        /// </summary>
-        public const string DiagnosticIdInternal = "SA1602In";
-
-        /// <summary>
-        /// The ID for diagnostics produced by the <see cref="SA1602EnumerationItemsMustBeDocumented"/> analyzer
-        /// for private members.
-        /// </summary>
-        public const string DiagnosticIdPrivate = "SA1602Pr";
-
         private const string Title = "Enumeration items must be documented";
         private const string MessageFormat = "Enumeration items must be documented";
         private const string Category = "StyleCop.CSharp.DocumentationRules";
@@ -89,7 +77,7 @@
                     : Descriptor;
 
             case SyntaxKind.InternalKeyword:
-                return (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA16X0NonPrivateElementsMustBeDocumented.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
+                return (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA16X0InternalElementsMustBeDocumented.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
                     ? null
                     : Descriptor;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA16X0InternalElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA16X0InternalElementsMustBeDocumented.cs
@@ -22,16 +22,16 @@
     /// for non-private elements only.</para>
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SA16X0NonPrivateElementsMustBeDocumented : DocumentationAnalyzer
+    public class SA16X0InternalElementsMustBeDocumented : DocumentationAnalyzer
     {
         /// <summary>
-        /// The ID for diagnostics produced by the <see cref="SA16X0NonPrivateElementsMustBeDocumented"/> analyzer.
+        /// The ID for diagnostics produced by the <see cref="SA16X0InternalElementsMustBeDocumented"/> analyzer.
         /// </summary>
         public const string DiagnosticId = "SA16X0";
 
-        private const string Title = "Non-public elements must be documented";
-        private const string MessageFormat = "Non-public elements must be documented";
-        private const string Description = "A non-public C# code element is missing a documentation header.";
+        private const string Title = "Internal elements must be documented";
+        private const string MessageFormat = "Internal elements must be documented";
+        private const string Description = "An internal C# code element is missing a documentation header.";
 
         private const string Category = "StyleCop.CSharp.DocumentationRules";
         private static readonly string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA16X0.md";

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA16X0NonPrivateElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA16X0NonPrivateElementsMustBeDocumented.cs
@@ -1,13 +1,12 @@
 ﻿namespace StyleCop.Analyzers.DocumentationRules
 {
-    using System;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Diagnostics;
 
     /// <summary>
-    /// A C# code element is missing a documentation header.
+    /// A non-private C# code element is missing a documentation header.
     /// </summary>
     /// <remarks>
     /// <para>C# syntax provides a mechanism for inserting documentation for classes and elements directly into the
@@ -18,20 +17,24 @@
     /// <para>A violation of this rule occurs if an element is completely missing a documentation header, or if the
     /// header is empty. In C# the following types of elements can have documentation headers: classes, constructors,
     /// delegates, enums, events, finalizers, indexers, interfaces, methods, properties, and structs.</para>
+    /// <para>No violation of this rule occurs for public elements; these are covered by <see href="https://msdn.microsoft.com/en-us/library/zk18c1w9.aspx">CS1591</see>.
+    /// This rule specializes <see cref="SA1600ElementsMustBeDocumented"/>, <see cref="SA1601PartialElementsMustBeDocumented"/> and <see cref="SA1602EnumerationItemsMustBeDocumented"/>
+    /// for non-private elements only.</para>
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SA1600ElementsMustBeDocumented : DocumentationAnalyzer
+    public class SA16X0NonPrivateElementsMustBeDocumented : DocumentationAnalyzer
     {
         /// <summary>
-        /// The ID for diagnostics produced by the <see cref="SA1600ElementsMustBeDocumented"/> analyzer.
+        /// The ID for diagnostics produced by the <see cref="SA16X0NonPrivateElementsMustBeDocumented"/> analyzer.
         /// </summary>
-        public const string DiagnosticId = "SA1600";
+        public const string DiagnosticId = "SA16X0";
 
-        private const string Title = "Elements must be documented";
-        private const string MessageFormat = "Elements must be documented";
+        private const string Title = "Non-public elements must be documented";
+        private const string MessageFormat = "Non-public elements must be documented";
+        private const string Description = "A non-public C# code element is missing a documentation header.";
+
         private const string Category = "StyleCop.CSharp.DocumentationRules";
-        private const string Description = "A C# code element is missing a documentation header.";
-        private const string HelpLink = "http://www.stylecop.com/docs/SA1600.html";
+        private static readonly string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA16X0.md";
 
         private static readonly DiagnosticDescriptor Descriptor =
             new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
@@ -48,9 +51,10 @@
             }
         }
 
-        /// <inheritdoc/>
+        /// <inheritdoc />
         public override void Initialize(AnalysisContext context)
         {
+            // Complement of to SA1600.
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleTypeDeclaration, SyntaxKind.ClassDeclaration);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleTypeDeclaration, SyntaxKind.StructDeclaration);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleTypeDeclaration, SyntaxKind.InterfaceDeclaration);
@@ -64,29 +68,22 @@
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleDelegateDeclaration, SyntaxKind.DelegateDeclaration);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleEventDeclaration, SyntaxKind.EventDeclaration);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleEventFieldDeclaration, SyntaxKind.EventFieldDeclaration);
+
+            // Complement of SA1601.
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandlePartialTypeDeclaration, SyntaxKind.ClassDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandlePartialTypeDeclaration, SyntaxKind.InterfaceDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandlePartialTypeDeclaration, SyntaxKind.StructDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandlePartialMethodDeclaration, SyntaxKind.MethodDeclaration);
+
+            // Complement of SA1602.
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleEnumMember, SyntaxKind.EnumMemberDeclaration);
         }
 
         /// <inheritdoc/>
         protected override DiagnosticDescriptor DescriptorFromEffectiveVisibility(SyntaxKind visibility, SyntaxNodeAnalysisContext context)
         {
-            switch (visibility)
-            {
-            case SyntaxKind.PublicKeyword:
-                return (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(CS1591DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
-                    ? null
-                    : Descriptor;
-
-            case SyntaxKind.InternalKeyword:
-                return (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA16X0NonPrivateElementsMustBeDocumented.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
-                    ? null
-                    : Descriptor;
-
-            case SyntaxKind.PrivateKeyword:
-                return Descriptor;
-
-            default:
-                throw new ArgumentOutOfRangeException("visibility");
-            }
+            // Public is handled by CS1591 and private, by SA1600-SA1603.
+            return visibility == SyntaxKind.InternalKeyword ? Descriptor : null;
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/EffectiveVisibilityHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/EffectiveVisibilityHelper.cs
@@ -1,0 +1,107 @@
+﻿namespace StyleCop.Analyzers.Helpers
+{
+    using System;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+    /// <summary>
+    /// Contains helper methods for resolving the effective visibility of an element.
+    /// </summary>
+    public static class EffectiveVisibilityHelper
+    {
+        /// <summary>
+        /// Resolves a <see cref="SyntaxTokenList"/> to one of <see cref="SyntaxKind.PrivateKeyword"/>,
+        /// <see cref="SyntaxKind.InternalKeyword"/> or <see cref="SyntaxKind.PublicKeyword"/>.
+        /// </summary>
+        /// <param name="modifiers">The token list.</param>
+        /// <param name="defaultModifier">The default modifier if none are present in <paramref name="modifiers"/>.</param>
+        /// <returns>One of <see cref="SyntaxKind.PrivateKeyword"/>,
+        /// <see cref="SyntaxKind.InternalKeyword"/> or <see cref="SyntaxKind.PublicKeyword"/>.</returns>
+        /// <remarks>
+        /// <para>
+        /// Resolves a list of modifiers to the effective visibility that they represent from the standpoint
+        /// of the StyleCop documentation rules.
+        /// </para>
+        /// </remarks>
+        public static SyntaxKind EffectiveVisibility(SyntaxTokenList modifiers, SyntaxKind defaultModifier)
+        {
+            if (modifiers.Any(SyntaxKind.PrivateKeyword))
+            {
+                return SyntaxKind.PrivateKeyword;
+            }
+
+            if (modifiers.Any(SyntaxKind.ProtectedKeyword) || modifiers.Any(SyntaxKind.PublicKeyword))
+            {
+                return SyntaxKind.PublicKeyword;
+            }
+
+            if (modifiers.Any(SyntaxKind.InternalKeyword))
+            {
+                return SyntaxKind.InternalKeyword;
+            }
+
+            return defaultModifier;
+        }
+
+        /// <summary>
+        /// Resolves the visibility of an element in the context of its parent.
+        /// </summary>
+        /// <param name="startWith">The element's own visibility, which may be any of
+        /// <see cref="SyntaxKind.PrivateKeyword"/>,
+        /// <see cref="SyntaxKind.InternalKeyword"/> or <see cref="SyntaxKind.PublicKeyword"/>.</param>
+        /// <param name="parent">The element's parent.</param>
+        /// <returns>The resolved visibility.</returns>
+        public static SyntaxKind ResolveVisibilityForChild(SyntaxKind startWith, BaseTypeDeclarationSyntax parent)
+        {
+            var effective = startWith;
+
+            var current = parent;
+
+            while (current != null)
+            {
+                var newCurrent = current.Parent as BaseTypeDeclarationSyntax;
+
+                effective = ResolveVisibility(effective, EffectiveVisibility(current.Modifiers, newCurrent != null ? SyntaxKind.PrivateKeyword : SyntaxKind.InternalKeyword));
+
+                current = newCurrent;
+            }
+
+            return effective;
+        }
+
+        /// <summary>
+        /// Resolves the more restrictive of two <see cref="SyntaxKind"/> values that may be any of
+        /// <see cref="SyntaxKind.PrivateKeyword"/>,
+        /// <see cref="SyntaxKind.InternalKeyword"/> or <see cref="SyntaxKind.PublicKeyword"/>.
+        /// </summary>
+        /// <param name="left">The first value.</param>
+        /// <param name="right">The second value.</param>
+        /// <returns>The more restrictive of <paramref name="left"/> and <paramref name="right"/>.</returns>
+        private static SyntaxKind ResolveVisibility(SyntaxKind left, SyntaxKind right)
+        {
+            if (left != SyntaxKind.PrivateKeyword && left != SyntaxKind.InternalKeyword && left != SyntaxKind.PublicKeyword)
+            {
+                throw new ArgumentOutOfRangeException("left");
+            }
+
+            if (right != SyntaxKind.PrivateKeyword && right != SyntaxKind.InternalKeyword && right != SyntaxKind.PublicKeyword)
+            {
+                throw new ArgumentOutOfRangeException("right");
+            }
+
+            if (left == SyntaxKind.PrivateKeyword || right == SyntaxKind.PrivateKeyword)
+            {
+                return SyntaxKind.PrivateKeyword;
+            }
+
+            if (left == SyntaxKind.InternalKeyword || right == SyntaxKind.InternalKeyword)
+            {
+                return SyntaxKind.InternalKeyword;
+            }
+
+            return SyntaxKind.PublicKeyword;
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -114,6 +114,7 @@
     <Compile Include="DocumentationRules\StandardTextDiagnosticBase.cs" />
     <Compile Include="GeneratedCodeAnalysisExtensions.cs" />
     <Compile Include="Helpers\DocumentationCommentExtensions.cs" />
+    <Compile Include="Helpers\EffectiveVisibilityHelper.cs" />
     <Compile Include="Helpers\EnumerableHelpers.cs" />
     <Compile Include="Helpers\FileHeader.cs" />
     <Compile Include="Helpers\FileHeaderHelpers.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -112,7 +112,7 @@
     <Compile Include="DocumentationRules\SA1650ElementDocumentationMustBeSpelledCorrectly.cs" />
     <Compile Include="DocumentationRules\SA1651CodeFixProvider.cs" />
     <Compile Include="DocumentationRules\SA1651DoNotUsePlaceholderElements.cs" />
-    <Compile Include="DocumentationRules\SA16X0NonPrivateElementsMustBeDocumented.cs" />
+    <Compile Include="DocumentationRules\SA16X0InternalElementsMustBeDocumented.cs" />
     <Compile Include="DocumentationRules\StandardTextDiagnosticBase.cs" />
     <Compile Include="GeneratedCodeAnalysisExtensions.cs" />
     <Compile Include="Helpers\DocumentationCommentExtensions.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -46,6 +46,7 @@
   <ItemGroup>
     <Compile Include="AnalyzerConstants.cs" />
     <Compile Include="AnalyzerExtensions.cs" />
+    <Compile Include="DocumentationRules\DocumentationAnalyzer.cs" />
     <Compile Include="DocumentationRules\DocumentationResources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
@@ -111,6 +112,7 @@
     <Compile Include="DocumentationRules\SA1650ElementDocumentationMustBeSpelledCorrectly.cs" />
     <Compile Include="DocumentationRules\SA1651CodeFixProvider.cs" />
     <Compile Include="DocumentationRules\SA1651DoNotUsePlaceholderElements.cs" />
+    <Compile Include="DocumentationRules\SA16X0NonPrivateElementsMustBeDocumented.cs" />
     <Compile Include="DocumentationRules\StandardTextDiagnosticBase.cs" />
     <Compile Include="GeneratedCodeAnalysisExtensions.cs" />
     <Compile Include="Helpers\DocumentationCommentExtensions.cs" />

--- a/StyleCopAnalyzers.sln
+++ b/StyleCopAnalyzers.sln
@@ -39,6 +39,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentat
 		documentation\SA1519.md = documentation\SA1519.md
 		documentation\SA1520.md = documentation\SA1520.md
 		documentation\SA1651.md = documentation\SA1651.md
+		SA16X0.txt = SA16X0.txt
 		documentation\SX1309.md = documentation\SX1309.md
 		documentation\SX1309S.md = documentation\SX1309S.md
 	EndProjectSection


### PR DESCRIPTION
- For public, internal and private members. Added code to resolve visibility correctly in scope of parent type.
- Updated tests.

This is a first pass at trying to resolve #829 and #789. I'm sure this will generate some discussion, but hopefully it's a step in the right direction.

SA1600 has a completely new set of tests, and uses a crazy-new-test-code-generator.
There are, of necessity, new diagnostic IDs. These have the suffices "In" and "Pr".