### PR TITLE
Implemented diagnostic for SA1115: ParameterMustFollowComma.

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1115UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1115UnitTests.cs
@@ -87,6 +87,50 @@ string s)
         }
 
         [Fact]
+        public async Task TestConstructorInitializerEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+class Foo
+{
+    public Foo() : this(1,
+
+2) 
+    {
+    }
+
+    public Foo(int i, int z)
+    {
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestConstructorInitializerBaseEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+class FooParent
+{
+    public FooParent(int i, int j) {}
+}
+class Foo : FooParent
+{
+    public Foo(int i, int z) : base(i,
+
+z)
+    {
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestConstructorSecondParameterOnTheNextLine()
         {
             var testCode = @"
@@ -268,6 +312,31 @@ class Foo
         }
 
         [Fact]
+        public async Task TestIndexerCallInConditionalExpressionEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        var f = new Foo();
+        var b = f?[0,
+
+1];
+    }
+
+    public int this[int i, int j]
+    {
+        get { return 0; }
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestIndexerCallUsingThisEmptyLinesBetweenParameters()
         {
             var testCode = @"
@@ -306,6 +375,75 @@ class Foo
     public int this[int i, int j]
     {
         get { return 0; }
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestIndexerCallInConditionalExpressionSecondParameterOnTheNextLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        var f = new Foo();
+        var b = f?[0,
+1];
+    }
+
+    public int this[int i, int j]
+    {
+        get { return 0; }
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestIndexerCallInObjectInitializerBlankLineBetweenParameters()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        var f = new Foo() {[0,
+
+1] =3}; 
+    }
+
+    public int this[int i, int j]
+    {
+        get { return 0; }
+        set {}
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestIndexerCallInObjectInitializerSecondParameterOnTheNextLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        var f = new Foo() {[0,
+1] =3}; 
+    }
+
+    public int this[int i, int j]
+    {
+        get { return 0; }
+        set {}
     }
 }";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1115UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1115UnitTests.cs
@@ -1,4 +1,6 @@
-﻿namespace StyleCop.Analyzers.Test.ReadabilityRules
+﻿using System.Collections.Generic;
+
+namespace StyleCop.Analyzers.Test.ReadabilityRules
 {
     using System.Threading;
     using System.Threading.Tasks;
@@ -10,14 +12,14 @@
     public class SA1115UnitTests : CodeFixVerifier
     {
         [Fact]
-        public async Task TestEmptySource()
+        public async Task TestEmptySourceAsync()
         {
             var testCode = string.Empty;
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
-        public async Task TestMethodDeclarationEmptyLinesBetweenParameters()
+        public async Task TestMethodDeclarationEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 class Foo
@@ -39,7 +41,7 @@ int k)
         }
 
         [Fact]
-        public async Task TestMethodDeclarationSecondParameterOnTheNextLine()
+        public async Task TestMethodDeclarationSecondParameterOnTheNextLineAsync()
         {
             var testCode = @"
 class Foo
@@ -54,7 +56,7 @@ string s)
         }
 
         [Fact]
-        public async Task TestMethodDeclarationParametersAtTheSameLine()
+        public async Task TestMethodDeclarationParametersAtTheSameLineAsync()
         {
             var testCode = @"
 class Foo
@@ -68,7 +70,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestConstructorEmptyLinesBetweenParameters()
+        public async Task TestConstructorEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 class Foo
@@ -87,7 +89,7 @@ string s)
         }
 
         [Fact]
-        public async Task TestConstructorInitializerEmptyLinesBetweenParameters()
+        public async Task TestConstructorInitializerEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 class Foo
@@ -109,7 +111,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestConstructorInitializerBaseEmptyLinesBetweenParameters()
+        public async Task TestConstructorInitializerBaseEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 class FooParent
@@ -131,7 +133,7 @@ z)
         }
 
         [Fact]
-        public async Task TestConstructorSecondParameterOnTheNextLine()
+        public async Task TestConstructorSecondParameterOnTheNextLineAsync()
         {
             var testCode = @"
 class Foo
@@ -146,7 +148,7 @@ string s)
         }
 
         [Fact]
-        public async Task TestConstructorParametersAtTheSameLine()
+        public async Task TestConstructorParametersAtTheSameLineAsync()
         {
             var testCode = @"
 class Foo
@@ -160,7 +162,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestMethodCallEmptyLinesBetweenParameters()
+        public async Task TestMethodCallEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 class Foo
@@ -183,7 +185,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestMethodCallSecondParameterOnTheNextLine()
+        public async Task TestMethodCallSecondParameterOnTheNextLineAsync()
         {
             var testCode = @"
 class Foo
@@ -203,7 +205,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestMethodCallParametersAtTheSameLine()
+        public async Task TestMethodCallParametersAtTheSameLineAsync()
         {
             var testCode = @"
 class Foo
@@ -222,7 +224,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestConstructorCallEmptyLinesBetweenParameters()
+        public async Task TestConstructorCallEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 class Foo
@@ -248,7 +250,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestConstructorCallSecondParameterOnTheNextLine()
+        public async Task TestConstructorCallSecondParameterOnTheNextLineAsync()
         {
             var testCode = @"
 class Foo
@@ -269,7 +271,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestConstructorCallParametersAtTheSameLine()
+        public async Task TestConstructorCallParametersAtTheSameLineAsync()
         {
             var testCode = @"
 class Foo
@@ -288,7 +290,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestIndexerCallEmptyLinesBetweenParameters()
+        public async Task TestIndexerCallEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 class Foo
@@ -312,7 +314,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestIndexerCallInConditionalExpressionEmptyLinesBetweenParameters()
+        public async Task TestIndexerCallInConditionalExpressionEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 class Foo
@@ -337,7 +339,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestIndexerCallUsingThisEmptyLinesBetweenParameters()
+        public async Task TestIndexerCallUsingThisEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 class Foo
@@ -361,7 +363,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestIndexerCallSecondParameterOnTheNextLine()
+        public async Task TestIndexerCallSecondParameterOnTheNextLineAsync()
         {
             var testCode = @"
 class Foo
@@ -382,7 +384,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestIndexerCallInConditionalExpressionSecondParameterOnTheNextLine()
+        public async Task TestIndexerCallInConditionalExpressionSecondParameterOnTheNextLineAsync()
         {
             var testCode = @"
 class Foo
@@ -404,7 +406,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestIndexerCallInObjectInitializerBlankLineBetweenParameters()
+        public async Task TestIndexerCallInObjectInitializerBlankLineBetweenParametersAsync()
         {
             var testCode = @"
 class Foo
@@ -429,7 +431,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestIndexerCallInObjectInitializerSecondParameterOnTheNextLine()
+        public async Task TestIndexerCallInObjectInitializerSecondParameterOnTheNextLineAsync()
         {
             var testCode = @"
 class Foo
@@ -451,7 +453,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestIndexerCallParametersAtTheSameLine()
+        public async Task TestIndexerCallParametersAtTheSameLineAsync()
         {
             var testCode = @"
 class Foo
@@ -471,7 +473,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestIndexerDeclarationEmptyLinesBetweenParameters()
+        public async Task TestIndexerDeclarationEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 class Foo
@@ -490,7 +492,7 @@ int j]
         }
 
         [Fact]
-        public async Task TestIndexerDeclarationSecondParameterOnTheNextLine()
+        public async Task TestIndexerDeclarationSecondParameterOnTheNextLineAsync()
         {
             var testCode = @"
 class Foo
@@ -506,7 +508,7 @@ int j]
         }
 
         [Fact]
-        public async Task TestIndexerDeclarationParametersAtTheSameLine()
+        public async Task TestIndexerDeclarationParametersAtTheSameLineAsync()
         {
             var testCode = @"
 class Foo
@@ -521,7 +523,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestArrayCreationEmptyLinesBetweenParameters()
+        public async Task TestArrayCreationEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 class Foo
@@ -540,7 +542,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestArrayCreationSecondParameterOnTheNextLine()
+        public async Task TestArrayCreationSecondParameterOnTheNextLineAsync()
         {
             var testCode = @"
 class Foo
@@ -556,7 +558,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestArrayCreationParametersAtTheSameLine()
+        public async Task TestArrayCreationParametersAtTheSameLineAsync()
         {
             var testCode = @"
 class Foo
@@ -571,7 +573,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestArrayCallEmptyLinesBetweenParameters()
+        public async Task TestArrayCallEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 class Foo
@@ -591,7 +593,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestArrayCallSecondParameterOnTheNextLine()
+        public async Task TestArrayCallSecondParameterOnTheNextLineAsync()
         {
             var testCode = @"
 class Foo
@@ -608,7 +610,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestArrayCallParametersAtTheSameLine()
+        public async Task TestArrayCallParametersAtTheSameLineAsync()
         {
             var testCode = @"
 class Foo
@@ -624,7 +626,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestAttributeEmptyLinesBetweenParameters()
+        public async Task TestAttributeEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 [System.AttributeUsage(System.AttributeTargets.Class)]
@@ -648,7 +650,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestAttributeSecondParameterOnTheNextLine()
+        public async Task TestAttributeSecondParameterOnTheNextLineAsync()
         {
             var testCode = @"
 [System.AttributeUsage(System.AttributeTargets.Class)]
@@ -669,7 +671,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestAttributeParametersAtTheSameLine()
+        public async Task TestAttributeParametersAtTheSameLineAsync()
         {
             var testCode = @"
 [System.AttributeUsage(System.AttributeTargets.Class)]
@@ -689,7 +691,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestAttributeListEmptyLinesBetweenParameters()
+        public async Task TestAttributeListEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true)]
@@ -710,7 +712,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestAttributeListSecondParameterOnTheNextLine()
+        public async Task TestAttributeListSecondParameterOnTheNextLineAsync()
         {
             var testCode = @"
 [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true)]
@@ -728,7 +730,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestAttributeListParametersAtTheSameLine()
+        public async Task TestAttributeListParametersAtTheSameLineAsync()
         {
             var testCode = @"
 [System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true)]
@@ -745,7 +747,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestAnonymousMethodDeclarationEmptyLinesBetweenParameters()
+        public async Task TestAnonymousMethodDeclarationEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 class Foo
@@ -769,7 +771,7 @@ int h)
         }
 
         [Fact]
-        public async Task TestAnonymousMethodDeclarationSecondParameterOnTheNextLine()
+        public async Task TestAnonymousMethodDeclarationSecondParameterOnTheNextLineAsync()
         {
             var testCode = @"
 class Foo
@@ -788,7 +790,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestAnonymousMethodDeclarationParametersAtTheSameLine()
+        public async Task TestAnonymousMethodDeclarationParametersAtTheSameLineAsync()
         {
             var testCode = @"
 class Foo
@@ -803,7 +805,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestLambdaEmptyLinesBetweenParameters()
+        public async Task TestLambdaEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 class Foo
@@ -829,7 +831,7 @@ z) => {};
         }
 
         [Fact]
-        public async Task TestLambdaExplicitParametersTypesEmptyLinesBetweenParameters()
+        public async Task TestLambdaExplicitParametersTypesEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 class Foo
@@ -855,7 +857,7 @@ int z) => {};
         }
 
         [Fact]
-        public async Task TestLambdaSecondParameterOnTheNextLine()
+        public async Task TestLambdaSecondParameterOnTheNextLineAsync()
         {
             var testCode = @"
 class Foo
@@ -873,7 +875,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestLambdaParametersAtTheSameLine()
+        public async Task TestLambdaParametersAtTheSameLineAsync()
         {
             var testCode = @"
 class Foo
@@ -888,7 +890,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestDelegateDeclarationEmptyLinesBetweenParameters()
+        public async Task TestDelegateDeclarationEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 class Foo
@@ -908,7 +910,7 @@ int z);
         }
 
         [Fact]
-        public async Task TestDelegateDeclarationSecondParameterOnTheNextLine()
+        public async Task TestDelegateDeclarationSecondParameterOnTheNextLineAsync()
         {
             var testCode = @"
 class Foo
@@ -922,7 +924,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestDelegateDeclarationParametersAtTheSameLine()
+        public async Task TestDelegateDeclarationParametersAtTheSameLineAsync()
         {
             var testCode = @"
 class Foo
@@ -934,7 +936,7 @@ class Foo
         }
 
         [Fact]
-        public async Task TestOperatorOverloadEmptyLinesBetweenParameters()
+        public async Task TestOperatorOverloadEmptyLinesBetweenParametersAsync()
         {
             var testCode = @"
 public class Foo
@@ -953,7 +955,7 @@ Foo b)
         }
 
         [Fact]
-        public async Task TestOperatorOverloadSecondParameterOnTheNextLine()
+        public async Task TestOperatorOverloadSecondParameterOnTheNextLineAsync()
         {
             var testCode = @"
 public class Foo
@@ -969,7 +971,7 @@ public class Foo
         }
 
         [Fact]
-        public async Task TestOperatorOverloadParametersAtTheSameLine()
+        public async Task TestOperatorOverloadParametersAtTheSameLineAsync()
         {
             var testCode = @"
 public class Foo
@@ -983,9 +985,9 @@ public class Foo
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
-            return new SA1115ParameterMustFollowComma();
+            yield return new SA1115ParameterMustFollowComma();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1115UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1115UnitTests.cs
@@ -1,0 +1,853 @@
+﻿namespace StyleCop.Analyzers.Test.ReadabilityRules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.ReadabilityRules;
+    using TestHelper;
+    using Xunit;
+
+    public class SA1115UnitTests : CodeFixVerifier
+    {
+        [Fact]
+        public async Task TestEmptySource()
+        {
+            var testCode = string.Empty;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMethodDeclarationEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar(int i, int z,
+
+string s,
+
+int j,
+int k)
+    {
+    }
+}";
+
+            DiagnosticResult expected1 = this.CSharpDiagnostic().WithLocation(6, 1);
+            DiagnosticResult expected2 = this.CSharpDiagnostic().WithLocation(8, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, new []{ expected1, expected2 }, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMethodDeclarationSecondParameterOnTheNextLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar(int i,
+string s)
+    {
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMethodDeclarationParametersAtTheSameLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar(int i, string s)
+    {
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestConstructorEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+class Foo
+{
+    public Foo(int i, int z,
+
+
+string s)
+    {
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestConstructorSecondParameterOnTheNextLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public Foo(int i,
+string s)
+    {
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestConstructorParametersAtTheSameLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public Foo(int i, string s)
+    {
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMethodCallEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar(int i, int z)
+    {
+    }
+
+    public void Baz()
+    {
+        Bar(1,
+
+2);
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(12, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMethodCallSecondParameterOnTheNextLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar(int i, int z)
+    {
+    }
+
+    public void Baz()
+    {
+        Bar(1,
+            2);
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMethodCallParametersAtTheSameLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar(int i, int z)
+    {
+    }
+
+    public void Baz()
+    {
+        Bar(1, 2);
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestConstructorCallEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+class Foo
+{
+    public Foo(int i, int z, int j)
+    {
+    }
+
+    public void Baz()
+    {
+        var f = new Foo(1,
+
+2,
+
+3);
+    }
+}";
+
+            DiagnosticResult expected1 = this.CSharpDiagnostic().WithLocation(12, 1);
+            DiagnosticResult expected2 = this.CSharpDiagnostic().WithLocation(14, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, new [] { expected1, expected2 }, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestConstructorCallSecondParameterOnTheNextLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public Foo(int i, int z, int j)
+    {
+    }
+
+    public void Baz()
+    {
+        var f = new Foo(1,
+                        2,
+                        3);
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestConstructorCallParametersAtTheSameLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public Foo(int i, int z, int j)
+    {
+    }
+
+    public void Baz()
+    {
+        var f = new Foo(1, 2, 3);
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestIndexerCallEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        var b = new Foo()[0,
+
+1];
+    }
+
+    public int this[int i, int j]
+    {
+        get { return 0; }
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestIndexerCallUsingThisEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        var b = this[0,
+
+1];
+    }
+
+    public int this[int i, int j]
+    {
+        get { return 0; }
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestIndexerCallSecondParameterOnTheNextLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        var b = new Foo()[0,
+1];
+    }
+
+    public int this[int i, int j]
+    {
+        get { return 0; }
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestIndexerCallParametersAtTheSameLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        var b = new Foo()[0, 1];
+    }
+
+    public int this[int i, int j]
+    {
+        get { return 0; }
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestIndexerDeclarationEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+class Foo
+{
+    public int this[int i, 
+
+int j]
+    {
+        get { return 0; }
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestIndexerDeclarationSecondParameterOnTheNextLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public int this[int i, 
+int j]
+    {
+        get { return 0; }
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestIndexerDeclarationParametersAtTheSameLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public int this[int i, int j]
+    {
+        get { return 0; }
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestArrayCreationEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        int[,] numbers = new int[3, 
+
+2] { {1, 2}, {3, 4}, {5, 6} };
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestArrayCreationSecondParameterOnTheNextLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        int[,] numbers = new int[3, 
+                                 2] { {1, 2}, {3, 4}, {5, 6} };
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestArrayCreationParametersAtTheSameLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        int[,] numbers = new int[3, 2] { {1, 2}, {3, 4}, {5, 6} };
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestArrayCallEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        int[,] numbers = { {1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10} };
+        numbers[1, 
+
+1] = 5;
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestArrayCallSecondParameterOnTheNextLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        int[,] numbers = { {1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10} };
+        numbers[1, 
+                1] = 5;
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestArrayCallParametersAtTheSameLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        int[,] numbers = { {1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10} };
+        numbers[1, 1] = 5;
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestAttributeEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+[System.AttributeUsage(System.AttributeTargets.Class)]
+public class MyAttribute : System.Attribute
+{
+    public MyAttribute(int a, int b)
+    {
+    }
+}
+
+[MyAttribute(1,
+
+2)]
+class Foo
+{
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(12, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestAttributeSecondParameterOnTheNextLine()
+        {
+            var testCode = @"
+[System.AttributeUsage(System.AttributeTargets.Class)]
+public class MyAttribute : System.Attribute
+{
+    public MyAttribute(int a, int b)
+    {
+    }
+}
+
+[MyAttribute(1,
+             2)]
+class Foo
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestAttributeParametersAtTheSameLine()
+        {
+            var testCode = @"
+[System.AttributeUsage(System.AttributeTargets.Class)]
+public class MyAttribute : System.Attribute
+{
+    public MyAttribute(int a, int b)
+    {
+    }
+}
+
+[MyAttribute(1, 2)]
+class Foo
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestAttributeListEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+[System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true)]
+public class MyAttribute : System.Attribute
+{
+}
+
+[MyAttribute,
+
+MyAttribute]
+class Foo
+{
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestAttributeListSecondParameterOnTheNextLine()
+        {
+            var testCode = @"
+[System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true)]
+public class MyAttribute : System.Attribute
+{
+}
+
+[MyAttribute,
+MyAttribute]
+class Foo
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestAttributeListParametersAtTheSameLine()
+        {
+            var testCode = @"
+[System.AttributeUsage(System.AttributeTargets.Class, AllowMultiple = true)]
+public class MyAttribute : System.Attribute
+{
+}
+
+[MyAttribute, MyAttribute]
+class Foo
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestAnonymousMethodDeclarationEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        System.Action<int, int, int, int> a = delegate(int i,
+
+int j,
+int z,
+
+int h) 
+{};
+    }
+}";
+
+            DiagnosticResult expected1 = this.CSharpDiagnostic().WithLocation(8, 1);
+            DiagnosticResult expected2 = this.CSharpDiagnostic().WithLocation(11, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, new[] { expected1, expected2 }, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestAnonymousMethodDeclarationSecondParameterOnTheNextLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        System.Action<int, int, int, int> a = delegate(int i,
+                                                        int j,
+                                                        int z,
+                                                        int h) 
+                                                        {};
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestAnonymousMethodDeclarationParametersAtTheSameLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        System.Action<int, int, int, int> a = delegate(int i, int j, int z, int h) {};
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestLambdaEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        System.Action<int, int, int, int> a = (i,
+
+
+j,
+
+k,
+
+z) => {};
+    }
+}";
+
+            DiagnosticResult expected1 = this.CSharpDiagnostic().WithLocation(9, 1);
+            DiagnosticResult expected2 = this.CSharpDiagnostic().WithLocation(11, 1);
+            DiagnosticResult expected3 = this.CSharpDiagnostic().WithLocation(13, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, new[] { expected1, expected2, expected3 }, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestLambdaExplicitParametersTypesEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        System.Action<int, int, int, int> a = (int i,
+
+
+int j,
+
+int k,
+
+int z) => {};
+    }
+}";
+
+            DiagnosticResult expected1 = this.CSharpDiagnostic().WithLocation(9, 1);
+            DiagnosticResult expected2 = this.CSharpDiagnostic().WithLocation(11, 1);
+            DiagnosticResult expected3 = this.CSharpDiagnostic().WithLocation(13, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, new[] { expected1, expected2, expected3 }, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestLambdaSecondParameterOnTheNextLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        System.Action<int, int, int, int> a = (int i,
+                                                int j,
+                                                int k,
+                                                int z) => {};
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestLambdaParametersAtTheSameLine()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        System.Action<int, int, int, int> a = (int i, int j, int k, int z) => {};
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestDelegateDeclarationEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+class Foo
+{
+    delegate void Del(int i,
+
+int j,
+
+
+int z);
+}";
+
+            DiagnosticResult expected1 = this.CSharpDiagnostic().WithLocation(6, 1);
+            DiagnosticResult expected2 = this.CSharpDiagnostic().WithLocation(9, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, new[] { expected1, expected2 }, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestDelegateDeclarationSecondParameterOnTheNextLine()
+        {
+            var testCode = @"
+class Foo
+{
+    delegate void Del(int i,
+                        int j,
+                        int z);
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestDelegateDeclarationParametersAtTheSameLine()
+        {
+            var testCode = @"
+class Foo
+{
+    delegate void Del(int i, int j, int z);
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestOperatorOverloadEmptyLinesBetweenParameters()
+        {
+            var testCode = @"
+public class Foo
+{
+    public static Foo operator +(Foo a, 
+
+Foo b)
+    {
+        return new Foo();
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestOperatorOverloadSecondParameterOnTheNextLine()
+        {
+            var testCode = @"
+public class Foo
+{
+    public static Foo operator +(Foo a, 
+                                 Foo b)
+    {
+        return new Foo();
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestOperatorOverloadParametersAtTheSameLine()
+        {
+            var testCode = @"
+public class Foo
+{
+    public static Foo operator +(Foo a, Foo b)
+    {
+        return new Foo();
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected override DiagnosticAnalyzer GetCSharpDiagnosticAnalyzer()
+        {
+            return new SA1115ParameterMustFollowComma();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -253,6 +253,7 @@
     <Compile Include="ReadabilityRules\SA1113UnitTests.cs" />
     <Compile Include="ReadabilityRules\SA1114UnitTests.cs" />
     <Compile Include="ReadabilityRules\SA1118UnitTests.cs" />
+    <Compile Include="ReadabilityRules\SA1115UnitTests.cs" />
     <Compile Include="ReadabilityRules\SA1121UnitTests.cs" />
     <Compile Include="ReadabilityRules\SA1122UnitTests.cs" />
     <Compile Include="ReadabilityRules\SA1123UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.Designer.cs
@@ -494,7 +494,7 @@ namespace StyleCop.Analyzers.ReadabilityRules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to .
+        ///   Looks up a localized string similar to The parameter must begin on the line after the previous parameter..
         /// </summary>
         internal static string SA1115MessageFormat {
             get {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.resx
@@ -262,7 +262,7 @@
     <value>A parameter within a C# method or indexer call or declaration does not begin on the same line as the previous parameter, or on the next line.</value>
   </data>
   <data name="SA1115MessageFormat" xml:space="preserve">
-    <value />
+    <value>The parameter must begin on the line after the previous parameter.</value>
   </data>
   <data name="SA1115Title" xml:space="preserve">
     <value>Parameter must follow comma</value>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1115ParameterMustFollowComma.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1115ParameterMustFollowComma.cs
@@ -65,8 +65,7 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleMethodDeclaration, SyntaxKind.MethodDeclaration);
-            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleConstructorDeclaration, SyntaxKind.ConstructorDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleBaseMethodDeclaration, SyntaxKind.ConstructorDeclaration, SyntaxKind.MethodDeclaration, SyntaxKind.OperatorDeclaration);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleInvocation, SyntaxKind.InvocationExpression);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleObjectCreation, SyntaxKind.ObjectCreationExpression);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleIndexerDeclaration, SyntaxKind.IndexerDeclaration);
@@ -77,7 +76,6 @@
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleAnonymousMethod, SyntaxKind.AnonymousMethodExpression);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleLambda, SyntaxKind.ParenthesizedLambdaExpression);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleDelegateDeclaration, SyntaxKind.DelegateDeclaration);
-            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleOperatorDeclaration, SyntaxKind.OperatorDeclaration);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleConstructorInitializer, SyntaxKind.BaseConstructorInitializer, SyntaxKind.ThisConstructorInitializer);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleElementBinding, SyntaxKind.ElementBindingExpression);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleImpliticElementAccess, SyntaxKind.ImplicitElementAccess);
@@ -102,13 +100,6 @@
             var constructorInitializer = (ConstructorInitializerSyntax) context.Node;
 
             AnalyzeArgumentList(context, constructorInitializer.ArgumentList);
-        }
-
-        private void HandleOperatorDeclaration(SyntaxNodeAnalysisContext context)
-        {
-            var operatorDeclaration = (OperatorDeclarationSyntax) context.Node;
-
-            AnalyzeParameterList(context, operatorDeclaration.ParameterList);
         }
 
         private void HandleDelegateDeclaration(SyntaxNodeAnalysisContext context)
@@ -237,18 +228,11 @@
             AnalyzeArgumentList(context, invocation.ArgumentList);
         }
 
-        private void HandleConstructorDeclaration(SyntaxNodeAnalysisContext context)
+        private void HandleBaseMethodDeclaration(SyntaxNodeAnalysisContext context)
         {
-            var constructorDeclaration = (ConstructorDeclarationSyntax) context.Node;
+            var constructorDeclaration = (BaseMethodDeclarationSyntax) context.Node;
 
             AnalyzeParameterList(context, constructorDeclaration.ParameterList);
-        }
-
-        private void HandleMethodDeclaration(SyntaxNodeAnalysisContext context)
-        {
-            var methodDeclaration = (MethodDeclarationSyntax)context.Node;
-
-            AnalyzeParameterList(context, methodDeclaration.ParameterList);
         }
 
         private static void AnalyzeArgumentList(SyntaxNodeAnalysisContext context, BaseArgumentListSyntax argumentListSyntax)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1115ParameterMustFollowComma.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1115ParameterMustFollowComma.cs
@@ -65,19 +65,19 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterSyntaxNodeAction(this.HandleMethodDeclaration, SyntaxKind.MethodDeclaration);
-            context.RegisterSyntaxNodeAction(this.HandleConstructorDeclaration, SyntaxKind.ConstructorDeclaration);
-            context.RegisterSyntaxNodeAction(this.HandleInvocation, SyntaxKind.InvocationExpression);
-            context.RegisterSyntaxNodeAction(this.HandleObjectCreation, SyntaxKind.ObjectCreationExpression);
-            context.RegisterSyntaxNodeAction(this.HandleIndexerDeclaration, SyntaxKind.IndexerDeclaration);
-            context.RegisterSyntaxNodeAction(this.HandleElementAccess, SyntaxKind.ElementAccessExpression);
-            context.RegisterSyntaxNodeAction(this.HandleArrayCreation, SyntaxKind.ArrayCreationExpression);
-            context.RegisterSyntaxNodeAction(this.HandleAttribute, SyntaxKind.Attribute);
-            context.RegisterSyntaxNodeAction(this.HandleAttributeList, SyntaxKind.AttributeList);
-            context.RegisterSyntaxNodeAction(this.HandleAnonymousMethod, SyntaxKind.AnonymousMethodExpression);
-            context.RegisterSyntaxNodeAction(this.HandleLambda, SyntaxKind.ParenthesizedLambdaExpression);
-            context.RegisterSyntaxNodeAction(this.HandleDelegateDeclaration, SyntaxKind.DelegateDeclaration);
-            context.RegisterSyntaxNodeAction(this.HandleOperatorDeclaration, SyntaxKind.OperatorDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleMethodDeclaration, SyntaxKind.MethodDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleConstructorDeclaration, SyntaxKind.ConstructorDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleInvocation, SyntaxKind.InvocationExpression);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleObjectCreation, SyntaxKind.ObjectCreationExpression);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleIndexerDeclaration, SyntaxKind.IndexerDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleElementAccess, SyntaxKind.ElementAccessExpression);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleArrayCreation, SyntaxKind.ArrayCreationExpression);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleAttribute, SyntaxKind.Attribute);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleAttributeList, SyntaxKind.AttributeList);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleAnonymousMethod, SyntaxKind.AnonymousMethodExpression);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleLambda, SyntaxKind.ParenthesizedLambdaExpression);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleDelegateDeclaration, SyntaxKind.DelegateDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleOperatorDeclaration, SyntaxKind.OperatorDeclaration);
         }
 
         private void HandleOperatorDeclaration(SyntaxNodeAnalysisContext context)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1115ParameterMustFollowComma.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1115ParameterMustFollowComma.cs
@@ -78,6 +78,30 @@
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleLambda, SyntaxKind.ParenthesizedLambdaExpression);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleDelegateDeclaration, SyntaxKind.DelegateDeclaration);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleOperatorDeclaration, SyntaxKind.OperatorDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleConstructorInitializer, SyntaxKind.BaseConstructorInitializer, SyntaxKind.ThisConstructorInitializer);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleElementBinding, SyntaxKind.ElementBindingExpression);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleImpliticElementAccess, SyntaxKind.ImplicitElementAccess);
+        }
+
+        private void HandleImpliticElementAccess(SyntaxNodeAnalysisContext context)
+        {
+            var implicitElementAccess = (ImplicitElementAccessSyntax)context.Node;
+
+            AnalyzeArgumentList(context, implicitElementAccess.ArgumentList);
+        }
+
+        private void HandleElementBinding(SyntaxNodeAnalysisContext context)
+        {
+            var elementBinding = (ElementBindingExpressionSyntax) context.Node;
+
+            AnalyzeArgumentList(context, elementBinding.ArgumentList);
+        }
+
+        private void HandleConstructorInitializer(SyntaxNodeAnalysisContext context)
+        {
+            var constructorInitializer = (ConstructorInitializerSyntax) context.Node;
+
+            AnalyzeArgumentList(context, constructorInitializer.ArgumentList);
         }
 
         private void HandleOperatorDeclaration(SyntaxNodeAnalysisContext context)


### PR DESCRIPTION
Fixes #49.

Similarly to other readability rules, I extended it so it analyzes additional kinds.