### PR TITLE
Enable the batch fixer for SA1651 (DoNotUsePlaceholderElements)

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1651CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1651CodeFixProvider.cs
@@ -31,8 +31,7 @@
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
         {
-            // Require users review each removal of placeholder tags.
-            return null;
+            return WellKnownFixAllProviders.BatchFixer;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
In the initial implementation of SA1651, the batch fixer was explicitly disabled in order to require users manually review each placeholder tag for accuracy. This limitation is not required, because even with the batch fixer enabled, there are three other points where manual review is involved:

1. The UI for fixing multiple instances shows a list of changes that will occur, and allows the user to deselect items which should not be changed.
2. When committing changes to source control.
3. During the code review process for the team maintaining the affected code.

Disabling the batch fixer serves only to slow down the process of correcting multiple instances of this violation. This pull request enables the batch fixer for the SA1651 code fix provider.