### PR TITLE
Implement new diagnostic SA1519 CurlyBrackets and SA1520 UseCurlyBracketsConsistently

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1503UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1503UnitTests.cs
@@ -240,14 +240,15 @@ public class Foo
     public void Bar(int i)
     {
         if (i == 0)
-        {
             Debug.Assert(true);
-        }
         else
             Debug.Assert(false);
     }
 }";
 
+            // While it looks like only one instance is fixed, what actually happened is fixing the first warning caused
+            // the second warning to change from SA1503 to SA1520. Since the testing framework is only testing SA1503,
+            // from its perspective all warnings have been corrected so it stops iterating.
             var fixedTestCode = @"using System.Diagnostics;
 public class Foo
 {
@@ -258,13 +259,11 @@ public class Foo
             Debug.Assert(true);
         }
         else
-        {
             Debug.Assert(false);
-        }
     }
 }";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1519UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1519UnitTests.cs
@@ -1,0 +1,627 @@
+﻿namespace StyleCop.Analyzers.Test.LayoutRules
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.LayoutRules;
+    using TestHelper;
+    using Xunit;
+
+    public class SA1519UnitTests : CodeFixVerifier
+    {
+        /// <summary>
+        /// Gets the statements that will be used in the theory test cases.
+        /// </summary>
+        /// <value>
+        /// The statements that will be used in the theory test cases.
+        /// </value>
+        public static IEnumerable<object[]> TestStatements
+        {
+            get
+            {
+                yield return new[] { "if (i == 0)" };
+                yield return new[] { "while (i == 0)" };
+                yield return new[] { "for (var j = 0; j < i; j++)" };
+                yield return new[] { "foreach (var j in new[] { 1, 2, 3 })" };
+            }
+        }
+
+        /// <summary>
+        /// Verifies that the analyzer will properly handle an empty source.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestEmptySourceAsync()
+        {
+            var testCode = string.Empty;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that a statement followed by a single-line statement without curly braces will not produce a
+        /// warning.
+        /// </summary>
+        /// <param name="statementText">The source code for the first part of a compound statement whose child can be
+        /// either a statement block or a single statement.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(TestStatements))]
+        public async Task TestSingleLineStatementWithoutCurlyBracketsAsync(string statementText)
+        {
+            await this.VerifyCSharpDiagnosticAsync(this.GenerateSingleLineTestStatement(statementText), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that a statement followed by a multi-line statement without curly braces will produce a warning.
+        /// </summary>
+        /// <param name="statementText">The source code for the first part of a compound statement whose child can be
+        /// either a statement block or a single statement.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(TestStatements))]
+        public async Task TestMultiLineStatementWithoutCurlyBracketsAsync(string statementText)
+        {
+            var expected = this.CSharpDiagnostic().WithLocation(7, 13);
+            await this.VerifyCSharpDiagnosticAsync(this.GenerateMultiLineTestStatement(statementText), expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that a <c>do</c> statement followed by a single-line statement without curly braces will not
+        /// produce a warning.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestSingleLineDoStatementAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        do
+            Debug.Assert(true);
+        while (false);
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that a <c>do</c> statement followed by a multi-line statement without curly braces will produce a
+        /// warning, and the code fix for this warning results in valid code.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestMultiLineDoStatementAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        do
+            Debug.Assert(
+                true);
+        while (false);
+    }
+}";
+            var fixedCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        do
+        {
+            Debug.Assert(
+                true);
+        }
+        while (false);
+    }
+}";
+
+            var expected = this.CSharpDiagnostic().WithLocation(7, 13);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that a statement followed by a block with curly braces will produce no diagnostics results.
+        /// </summary>
+        /// <param name="statementText">The source code for the first part of a compound statement whose child can be
+        /// either a statement block or a single statement.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(TestStatements))]
+        public async Task TestStatementWithCurlyBracketsAsync(string statementText)
+        {
+            await this.VerifyCSharpDiagnosticAsync(this.GenerateFixedTestStatement(statementText), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that an if / else statement followed by a single-line statement without curly braces will not
+        /// produce a warning.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestSingleLineIfElseStatementWithoutCurlyBracketsAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            Debug.Assert(true);
+        else
+            Debug.Assert(false);
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that an if / else statement followed by a multi-line statement without curly braces will produce a
+        /// warning.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestMultiLineIfElseStatementWithoutCurlyBracketsAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            Debug.Assert(
+                true);
+        else
+            Debug.Assert(
+                false);
+    }
+}";
+
+            var expected = new[]
+            {
+                this.CSharpDiagnostic().WithLocation(7, 13),
+                this.CSharpDiagnostic().WithLocation(10, 13)
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that an if statement followed by a block with curly braces will produce no diagnostics results.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestIfElseStatementWithCurlyBracketsAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+        {
+            Debug.Assert(true);
+        }
+        else
+        {
+            Debug.Assert(false);
+        }
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that an if statement followed by a else if, followed by an else statement, all blocks with curly
+        /// braces will produce no diagnostics results.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestIfElseIfElseStatementWithCurlyBracketsAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+        {
+            Debug.Assert(true);
+        }
+        else if (i == 1)
+        {
+            Debug.Assert(false);
+        }
+        else
+        {
+            Debug.Assert(true);
+        }
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that nested if statements followed by a single-line statement without curly braces will produce
+        /// no diagnostics.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestMultipleSingleLineIfStatementsWithoutCurlyBracketsAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0) if (i == 0) Debug.Assert(true);
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that nested if statements followed by a multi-line statement without curly braces will produce
+        /// warnings.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestMultipleMultiLineIfStatementsWithoutCurlyBracketsAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0) if (i == 0) Debug.Assert(
+            true);
+    }
+}";
+
+            var expected = new[]
+            {
+                this.CSharpDiagnostic().WithLocation(6, 21),
+                this.CSharpDiagnostic().WithLocation(6, 33)
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will work properly for a statement.
+        /// </summary>
+        /// <param name="statementText">The source code for the first part of a compound statement whose child can be
+        /// either a statement block or a single statement.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(TestStatements))]
+        private async Task TestCodeFixForStatementAsync(string statementText)
+        {
+            await this.VerifyCSharpFixAsync(this.GenerateMultiLineTestStatement(statementText), this.GenerateFixedTestStatement(statementText)).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will work properly for an if .. else statement.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestCodeFixProviderForIfStatementAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            Debug.Assert(
+                true);
+        else if (i == 3)
+            Debug.Assert(false);
+        else
+            Debug.Assert(false);
+    }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+        {
+            Debug.Assert(
+                true);
+        }
+        else if (i == 3)
+            Debug.Assert(false);
+        else
+            Debug.Assert(false);
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will work properly for an if .. else statement.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestCodeFixProviderForElseIfStatementAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            Debug.Assert(true);
+        else if (i == 3)
+            Debug.Assert(
+                false);
+        else
+            Debug.Assert(false);
+    }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            Debug.Assert(true);
+        else if (i == 3)
+        {
+            Debug.Assert(
+                false);
+        }
+        else
+            Debug.Assert(false);
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will work properly for an if .. else statement.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestCodeFixProviderForElseStatementAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            Debug.Assert(true);
+        else if (i == 3)
+            Debug.Assert(false);
+        else
+            Debug.Assert(
+                false);
+    }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            Debug.Assert(true);
+        else if (i == 3)
+            Debug.Assert(false);
+        else
+        {
+            Debug.Assert(
+                false);
+        }
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will properly handle alternate indentations.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/660")]
+        public async Task TestCodeFixProviderWithAlternateIndentationAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+ public void Bar(int i)
+ {
+  if (i == 0)
+   Debug.Assert(
+    true);
+ }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+ public void Bar(int i)
+ {
+  if (i == 0)
+  {
+   Debug.Assert(
+    true);
+  }
+ }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will work properly handle non-whitespace trivia.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestCodeFixProviderWithNonWhitespaceTriviaAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+#pragma warning restore
+        if (i == 0)
+            Debug.Assert(
+                true);
+    }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+#pragma warning restore
+        if (i == 0)
+        {
+            Debug.Assert(
+                true);
+        }
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will work properly handle multiple cases of missing brackets.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestCodeFixProviderWithMultipleNestingsAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0) if (i == 0) Debug.Assert(
+            true);
+    }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+        {
+            if (i == 0)
+            {
+                Debug.Assert(
+            true);
+            }
+        }
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will not perform a code fix when statement contains a preprocessor directive.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestCodeFixWithPreprocessorDirectivesAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (true)
+#if !DEBUG
+            Debug.WriteLine(
+                ""Foobar"");
+#endif
+        Debug.WriteLine(""Foobar 2"");
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, testCode).ConfigureAwait(false);
+        }
+
+        private string GenerateSingleLineTestStatement(string statementText)
+        {
+            var testCodeFormat = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        #STATEMENT#
+            Debug.Assert(true);
+    }
+}";
+            return testCodeFormat.Replace("#STATEMENT#", statementText);
+        }
+
+        private string GenerateMultiLineTestStatement(string statementText)
+        {
+            var testCodeFormat = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        #STATEMENT#
+            Debug.Assert(
+                true);
+    }
+}";
+            return testCodeFormat.Replace("#STATEMENT#", statementText);
+        }
+
+        private string GenerateFixedTestStatement(string statementText)
+        {
+            var fixedTestCodeFormat = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        #STATEMENT#
+        {
+            Debug.Assert(
+                true);
+        }
+    }
+}";
+            return fixedTestCodeFormat.Replace("#STATEMENT#", statementText);
+        }
+
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new SA1519CurlyBrackets();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new SA1503CodeFixProvider();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1520UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1520UnitTests.cs
@@ -1,0 +1,485 @@
+﻿namespace StyleCop.Analyzers.Test.LayoutRules
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.LayoutRules;
+    using TestHelper;
+    using Xunit;
+
+    public class SA1520UnitTests : CodeFixVerifier
+    {
+        /// <summary>
+        /// Verifies that the analyzer will properly handle an empty source.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestEmptySourceAsync()
+        {
+            var testCode = string.Empty;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that an if / else statement followed by a single-line statement without curly braces will not
+        /// produce a warning.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestSingleLineIfElseStatementWithoutCurlyBracketsAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            Debug.Assert(true);
+        else
+            Debug.Assert(false);
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that an if / else statement followed by a multi-line statement without curly braces will not
+        /// produce a warning.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestMultiLineIfElseStatementWithoutCurlyBracketsAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            Debug.Assert(
+                true);
+        else
+            Debug.Assert(
+                false);
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that an if statement followed by a block with curly braces will produce no diagnostics results.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestIfElseStatementWithCurlyBracketsAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+        {
+            Debug.Assert(true);
+        }
+        else
+        {
+            Debug.Assert(false);
+        }
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that an if statement followed by a else if, followed by an else statement, all blocks with curly
+        /// braces will produce no diagnostics results.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestIfElseIfElseStatementWithCurlyBracketsAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+        {
+            Debug.Assert(true);
+        }
+        else if (i == 1)
+        {
+            Debug.Assert(false);
+        }
+        else
+        {
+            Debug.Assert(true);
+        }
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that nested if statements followed by a single-line statement without curly braces will produce
+        /// no diagnostics.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestMultipleSingleLineIfStatementsWithoutCurlyBracketsAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0) if (i == 0) Debug.Assert(true);
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that nested if statements followed by a multi-line statement without curly braces will not produce
+        /// warnings.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestMultipleMultiLineIfStatementsWithoutCurlyBracketsAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0) if (i == 0) Debug.Assert(
+            true);
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will work properly for an if .. else statement.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestCodeFixProviderForIfStatementAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            Debug.Assert(true);
+        else if (i == 3)
+        {
+            Debug.Assert(false);
+        }
+        else
+        {
+            Debug.Assert(false);
+        }
+    }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+        {
+            Debug.Assert(true);
+        }
+        else if (i == 3)
+        {
+            Debug.Assert(false);
+        }
+        else
+        {
+            Debug.Assert(false);
+        }
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will work properly for an if .. else statement.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestCodeFixProviderForElseIfStatementAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+        {
+            Debug.Assert(true);
+        }
+        else if (i == 3)
+            Debug.Assert(false);
+        else
+        {
+            Debug.Assert(false);
+        }
+    }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+        {
+            Debug.Assert(true);
+        }
+        else if (i == 3)
+        {
+            Debug.Assert(false);
+        }
+        else
+        {
+            Debug.Assert(false);
+        }
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will work properly for an if .. else statement.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestCodeFixProviderForElseStatementAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+        {
+            Debug.Assert(true);
+        }
+        else if (i == 3)
+        {
+            Debug.Assert(false);
+        }
+        else
+            Debug.Assert(false);
+    }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+        {
+            Debug.Assert(true);
+        }
+        else if (i == 3)
+        {
+            Debug.Assert(false);
+        }
+        else
+        {
+            Debug.Assert(false);
+        }
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will properly handle alternate indentations.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/660")]
+        public async Task TestCodeFixProviderWithAlternateIndentationAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+ public void Bar(int i)
+ {
+  if (i == 0)
+   Debug.Assert(true);
+  else
+  {
+   Debug.Assert(false);
+  }
+ }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+ public void Bar(int i)
+ {
+  if (i == 0)
+  {
+   Debug.Assert(true);
+  }
+  else
+  {
+   Debug.Assert(false);
+  }
+ }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will work properly handle non-whitespace trivia.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestCodeFixProviderWithNonWhitespaceTriviaAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+#pragma warning restore
+        if (i == 0)
+            Debug.Assert(true);
+        else
+        {
+            Debug.Assert(false);
+        }
+    }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+#pragma warning restore
+        if (i == 0)
+        {
+            Debug.Assert(true);
+        }
+        else
+        {
+            Debug.Assert(false);
+        }
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will work properly handle multiple cases of missing brackets.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestCodeFixProviderWithMultipleNestingsAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            Debug.Assert(true);
+        else if (i == 3)
+        {
+            Debug.Assert(false);
+        }
+        else if (i == 4)
+            Debug.Assert(false);
+        else
+            Debug.Assert(false);
+    }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+        {
+            Debug.Assert(true);
+        }
+        else if (i == 3)
+        {
+            Debug.Assert(false);
+        }
+        else if (i == 4)
+        {
+            Debug.Assert(false);
+        }
+        else
+        {
+            Debug.Assert(false);
+        }
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will not perform a code fix when statement contains a preprocessor directive.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestCodeFixWithPreprocessorDirectivesAsync()
+        {
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (true)
+#if !DEBUG
+            Debug.WriteLine(""Foobar"");
+#endif
+        else
+        {
+            Debug.WriteLine(""Foobar 2"");
+        }
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, testCode).ConfigureAwait(false);
+        }
+
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new SA1520UseCurlyBracketsConsistently();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new SA1503CodeFixProvider();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -188,6 +188,7 @@
     <Compile Include="LayoutRules\SA1517UnitTests.cs" />
     <Compile Include="LayoutRules\SA1518UnitTests.cs" />
     <Compile Include="LayoutRules\SA1519UnitTests.cs" />
+    <Compile Include="LayoutRules\SA1520UnitTests.cs" />
     <Compile Include="MaintainabilityRules\DebugMessagesUnitTestsBase.cs" />
     <Compile Include="MaintainabilityRules\FileMayOnlyContainTestBase.cs" />
     <Compile Include="MaintainabilityRules\SA1119UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -187,6 +187,7 @@
     <Compile Include="LayoutRules\SA1516UnitTests.cs" />
     <Compile Include="LayoutRules\SA1517UnitTests.cs" />
     <Compile Include="LayoutRules\SA1518UnitTests.cs" />
+    <Compile Include="LayoutRules\SA1519UnitTests.cs" />
     <Compile Include="MaintainabilityRules\DebugMessagesUnitTestsBase.cs" />
     <Compile Include="MaintainabilityRules\FileMayOnlyContainTestBase.cs" />
     <Compile Include="MaintainabilityRules\SA1119UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CodeFixProvider.cs
@@ -22,7 +22,7 @@
     public class SA1503CodeFixProvider : CodeFixProvider
     {
         private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1503CurlyBracketsMustNotBeOmitted.DiagnosticId, SA1519CurlyBrackets.DiagnosticId);
+            ImmutableArray.Create(SA1503CurlyBracketsMustNotBeOmitted.DiagnosticId, SA1519CurlyBrackets.DiagnosticId, SA1520UseCurlyBracketsConsistently.DiagnosticId);
 
         /// <inheritdoc/>
         public override ImmutableArray<string> FixableDiagnosticIds

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CodeFixProvider.cs
@@ -22,7 +22,7 @@
     public class SA1503CodeFixProvider : CodeFixProvider
     {
         private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1503CurlyBracketsMustNotBeOmitted.DiagnosticId);
+            ImmutableArray.Create(SA1503CurlyBracketsMustNotBeOmitted.DiagnosticId, SA1519CurlyBrackets.DiagnosticId);
 
         /// <inheritdoc/>
         public override ImmutableArray<string> FixableDiagnosticIds

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CurlyBracketsMustNotBeOmitted.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CurlyBracketsMustNotBeOmitted.cs
@@ -106,10 +106,13 @@
                 }
             }
 
-            if (clauses.OfType<BlockSyntax>().Any())
+            if (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA1520UseCurlyBracketsConsistently.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
             {
-                // inconsistencies will be reported as SA1520
-                return;
+                // inconsistencies will be reported as SA1520, as long as it's not suppressed
+                if (clauses.OfType<BlockSyntax>().Any())
+                {
+                    return;
+                }
             }
 
             foreach (StatementSyntax clause in clauses)
@@ -161,12 +164,15 @@
                 return;
             }
 
-            Location location = childStatement.GetLocation();
-            FileLinePositionSpan lineSpan = location.GetLineSpan();
-            if (lineSpan.StartLinePosition.Line != lineSpan.EndLinePosition.Line)
+            if (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA1519CurlyBrackets.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
             {
-                // diagnostics for multi-line statements is handled by SA1519
-                return;
+                // diagnostics for multi-line statements is handled by SA1519, as long as it's not suppressed
+                Location location = childStatement.GetLocation();
+                FileLinePositionSpan lineSpan = location.GetLineSpan();
+                if (lineSpan.StartLinePosition.Line != lineSpan.EndLinePosition.Line)
+                {
+                    return;
+                }
             }
 
             context.ReportDiagnostic(Diagnostic.Create(Descriptor, childStatement.GetLocation()));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1519CurlyBrackets.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1519CurlyBrackets.cs
@@ -7,58 +7,35 @@
     using Microsoft.CodeAnalysis.Diagnostics;
 
     /// <summary>
-    /// The opening and closing curly brackets for a C# statement have been omitted.
+    /// The opening and closing curly brackets for a multi-line C# statement have been omitted.
     /// </summary>
     /// <remarks>
-    /// <para>A violation of this rule occurs when the opening and closing curly brackets for a statement have been
-    /// omitted. In C#, some types of statements may optionally include curly brackets. Examples include <c>if</c>,
-    /// <c>while</c>, and <c>for</c> statements. For example, an if-statement may be written without curly
+    /// <para>A violation of this rule occurs when the opening and closing curly brackets for a multi-line statement
+    /// have been omitted. In C#, some types of statements may optionally include curly brackets. Examples include
+    /// <c>if</c>, <c>while</c>, and <c>for</c> statements. For example, an if-statement may be written without curly
     /// brackets:</para>
     ///
     /// <code language="csharp">
     /// if (true)
-    ///     return this.value;
+    ///     return
+    ///         this.value;
     /// </code>
     ///
-    /// <para>Although this is legal in C#, StyleCop always requires the curly brackets to be present, to increase the
-    /// readability and maintainability of the code.</para>
-    ///
-    /// <para>When the curly brackets are omitted, it is possible to introduce an error in the code by inserting an
-    /// additional statement beneath the if-statement. For example:</para>
-    ///
-    /// <code language="csharp">
-    /// if (true)
-    ///     this.value = 2;
-    ///     return this.value;
-    /// </code>
-    ///
-    /// <para>Glancing at this code, it appears as if both the assignment statement and the return statement are
-    /// children of the if-statement. In fact, this is not true. Only the assignment statement is a child of the
-    /// if-statement, and the return statement will always execute regardless of the outcome of the if-statement.</para>
-    ///
-    /// <para>StyleCop always requires the opening and closing curly brackets to be present, to prevent these kinds of
-    /// errors:</para>
-    ///
-    /// <code language="csharp">
-    /// if (true)
-    /// {
-    ///     this.value = 2;
-    ///     return this.value;
-    /// }
-    /// </code>
+    /// <para>Although this is legal in C#, StyleCop requires the curly brackets to be present when the statement spans
+    /// multiple lines, to increase the readability and maintainability of the code.</para>
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class SA1503CurlyBracketsMustNotBeOmitted : DiagnosticAnalyzer
+    public class SA1519CurlyBrackets : DiagnosticAnalyzer
     {
         /// <summary>
-        /// The ID for diagnostics produced by the <see cref="SA1503CurlyBracketsMustNotBeOmitted"/> analyzer.
+        /// The ID for diagnostics produced by the <see cref="SA1519CurlyBrackets"/> analyzer.
         /// </summary>
-        public const string DiagnosticId = "SA1503";
+        public const string DiagnosticId = "SA1519";
         private const string Title = "Curly brackets must not be omitted";
         private const string MessageFormat = "Curly brackets must not be omitted";
         private const string Category = "StyleCop.CSharp.LayoutRules";
         private const string Description = "The opening and closing curly brackets for a C# statement have been omitted.";
-        private const string HelpLink = "http://www.stylecop.com/docs/SA1503.html";
+        private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1519.md";
 
         private static readonly DiagnosticDescriptor Descriptor =
             new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
@@ -148,9 +125,8 @@
 
             Location location = childStatement.GetLocation();
             FileLinePositionSpan lineSpan = location.GetLineSpan();
-            if (lineSpan.StartLinePosition.Line != lineSpan.EndLinePosition.Line)
+            if (lineSpan.StartLinePosition.Line == lineSpan.EndLinePosition.Line)
             {
-                // diagnostics for multi-line statements is handled by SA1519
                 return;
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1520UseCurlyBracketsConsistently.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1520UseCurlyBracketsConsistently.cs
@@ -1,0 +1,122 @@
+﻿namespace StyleCop.Analyzers.LayoutRules
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    /// <summary>
+    /// The opening and closing curly brackets of a chained <c>if</c>/<c>else if</c>/<c>else</c> construct were included
+    /// for some clauses, but omitted for others.
+    /// </summary>
+    /// <remarks>
+    /// <para>A violation of this rule occurs when the opening and closing curly brackets for a chained statement have
+    /// been included for some clauses but omitted for others. In C#, some types of statements may optionally include
+    /// curly brackets. For example, an <c>if</c>-statement may be written with inconsistent curly brackets:</para>
+    ///
+    /// <code language="csharp">
+    /// if (true)
+    ///     return this.value;
+    /// else
+    /// {
+    ///     return that.value.
+    /// }
+    /// </code>
+    ///
+    /// <para>Although this is legal in C#, StyleCop requires the curly brackets to be present for all clauses of a
+    /// chained <c>if</c>/<c>else if</c>/<c>else</c> construct when brackets are included for any clause, to increase
+    /// the readability and maintainability of the code.</para>
+    /// </remarks>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class SA1520UseCurlyBracketsConsistently : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// The ID for diagnostics produced by the <see cref="SA1520UseCurlyBracketsConsistently"/> analyzer.
+        /// </summary>
+        public const string DiagnosticId = "SA1520";
+        private const string Title = "Use curly brackets consistently";
+        private const string MessageFormat = "Use curly brackets consistently";
+        private const string Category = "StyleCop.CSharp.LayoutRules";
+        private const string Description = "The opening and closing curly brackets of a chained if/else if/else construct were included for some clauses, but omitted for others.";
+        private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1520.md";
+
+        private static readonly DiagnosticDescriptor Descriptor =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+
+        private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
+            ImmutableArray.Create(Descriptor);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        {
+            get
+            {
+                return SupportedDiagnosticsValue;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleIfStatement, SyntaxKind.IfStatement);
+        }
+
+        private void HandleIfStatement(SyntaxNodeAnalysisContext context)
+        {
+            var ifStatement = (IfStatementSyntax)context.Node;
+            if (ifStatement.Parent.IsKind(SyntaxKind.ElseClause))
+            {
+                // this will be analyzed as a clause of the outer if statement
+                return;
+            }
+
+            List<StatementSyntax> clauses = new List<StatementSyntax>();
+            for (IfStatementSyntax current = ifStatement; current != null; current = current.Else?.Statement as IfStatementSyntax)
+            {
+                clauses.Add(current.Statement);
+                if (current.Else != null && !(current.Else.Statement is IfStatementSyntax))
+                {
+                    clauses.Add(current.Else.Statement);
+                }
+            }
+
+            if (clauses.All(i => i is BlockSyntax))
+            {
+                // consistent inclusion of braces
+                return;
+            }
+
+            if (!clauses.OfType<BlockSyntax>().Any())
+            {
+                // consistent lack of braces
+                return;
+            }
+
+            foreach (StatementSyntax clause in clauses)
+            {
+                this.CheckChildStatement(context, clause);
+            }
+        }
+
+        private void CheckChildStatement(SyntaxNodeAnalysisContext context, StatementSyntax childStatement)
+        {
+            if (childStatement is BlockSyntax)
+            {
+                return;
+            }
+
+            Location location = childStatement.GetLocation();
+            FileLinePositionSpan lineSpan = location.GetLineSpan();
+            if (lineSpan.StartLinePosition.Line != lineSpan.EndLinePosition.Line)
+            {
+                // diagnostics for multi-line statements is handled by SA1519
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, childStatement.GetLocation()));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1520UseCurlyBracketsConsistently.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1520UseCurlyBracketsConsistently.cs
@@ -108,12 +108,15 @@
                 return;
             }
 
-            Location location = childStatement.GetLocation();
-            FileLinePositionSpan lineSpan = location.GetLineSpan();
-            if (lineSpan.StartLinePosition.Line != lineSpan.EndLinePosition.Line)
+            if (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA1519CurlyBrackets.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
             {
-                // diagnostics for multi-line statements is handled by SA1519
-                return;
+                // diagnostics for multi-line statements is handled by SA1519, as long as it's not suppressed
+                Location location = childStatement.GetLocation();
+                FileLinePositionSpan lineSpan = location.GetLineSpan();
+                if (lineSpan.StartLinePosition.Line != lineSpan.EndLinePosition.Line)
+                {
+                    return;
+                }
             }
 
             context.ReportDiagnostic(Diagnostic.Create(Descriptor, childStatement.GetLocation()));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -156,6 +156,7 @@
     <Compile Include="LayoutRules\SA1517CodeMustNotContainBlankLinesAtStartOfFile.cs" />
     <Compile Include="LayoutRules\SA1518CodeFixProvider.cs" />
     <Compile Include="LayoutRules\SA1518CodeMustNotContainBlankLinesAtEndOfFile.cs" />
+    <Compile Include="LayoutRules\SA1519CurlyBrackets.cs" />
     <Compile Include="MaintainabilityRules\MaintainabilityResources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -157,6 +157,7 @@
     <Compile Include="LayoutRules\SA1518CodeFixProvider.cs" />
     <Compile Include="LayoutRules\SA1518CodeMustNotContainBlankLinesAtEndOfFile.cs" />
     <Compile Include="LayoutRules\SA1519CurlyBrackets.cs" />
+    <Compile Include="LayoutRules\SA1520UseCurlyBracketsConsistently.cs" />
     <Compile Include="MaintainabilityRules\MaintainabilityResources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>

--- a/StyleCopAnalyzers.sln
+++ b/StyleCopAnalyzers.sln
@@ -36,6 +36,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentat
 		documentation\SA1028.md = documentation\SA1028.md
 		documentation\SA1216.md = documentation\SA1216.md
 		documentation\SA1217.md = documentation\SA1217.md
+		documentation\SA1519.md = documentation\SA1519.md
 		documentation\SA1651.md = documentation\SA1651.md
 		documentation\SX1309.md = documentation\SX1309.md
 		documentation\SX1309S.md = documentation\SX1309S.md

--- a/StyleCopAnalyzers.sln
+++ b/StyleCopAnalyzers.sln
@@ -37,6 +37,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentat
 		documentation\SA1216.md = documentation\SA1216.md
 		documentation\SA1217.md = documentation\SA1217.md
 		documentation\SA1519.md = documentation\SA1519.md
+		documentation\SA1520.md = documentation\SA1520.md
 		documentation\SA1651.md = documentation\SA1651.md
 		documentation\SX1309.md = documentation\SX1309.md
 		documentation\SX1309S.md = documentation\SX1309S.md

--- a/documentation/SA1519.md
+++ b/documentation/SA1519.md
@@ -1,0 +1,49 @@
+﻿# SA1519
+
+<table>
+<tr>
+  <td>TypeName</td>
+  <td>SA1519CurlyBrackets</td>
+</tr>
+<tr>
+  <td>CheckId</td>
+  <td>SA1519</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Layout Rules</td>
+</tr>
+</table>
+
+## Cause
+
+The opening and closing curly brackets for a multi-line C# statement have been omitted.
+
+## Rule description
+
+A violation of this rule occurs when the opening and closing curly brackets for a multi-line statement have been
+omitted. In C#, some types of statements may optionally include curly brackets. Examples include `if`, `while`, and
+`for` statements. For example, an `if`-statement may be written without curly brackets:
+
+```csharp
+if (true)
+    return
+        this.value;
+```
+
+Although this is legal in C#, StyleCop requires the curly brackets to be present when the statement spans multiple
+lines, to increase the readability and maintainability of the code.
+
+## How to fix violations
+
+To fix a violation of this rule, the violating statement will be converted to a block statement.
+
+## How to suppress violations
+
+```csharp
+if (true)
+#pragma warning disable SA1519 // Curly brackets
+    return
+        this.value;
+#pragma warning restore SA1519 // Curly brackets
+```

--- a/documentation/SA1520.md
+++ b/documentation/SA1520.md
@@ -1,0 +1,57 @@
+﻿# SA1520
+
+<table>
+<tr>
+  <td>TypeName</td>
+  <td>SA1520UseCurlyBracketsConsistently</td>
+</tr>
+<tr>
+  <td>CheckId</td>
+  <td>SA1520</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Layout Rules</td>
+</tr>
+</table>
+
+## Cause
+
+The opening and closing curly brackets of a chained `if`/`else if`/`else` construct were included for some clauses, but
+omitted for others.
+
+## Rule description
+
+A violation of this rule occurs when the opening and closing curly brackets for a chained statement have been included
+for some clauses but omitted for others. In C#, some types of statements may optionally include curly brackets. For
+example, an `if`-statement may be written with inconsistent curly brackets:
+
+```csharp
+if (true)
+    return this.value;
+else
+{
+    return that.value.
+}
+```
+
+Although this is legal in C#, StyleCop requires the curly brackets to be present for all clauses of a chained `if`/`else
+if`/`else` construct when brackets are included for any clause, to increase the readability and maintainability of the
+code.
+
+## How to fix violations
+
+To fix a violation of this rule, the violating statement will be converted to a block statement.
+
+## How to suppress violations
+
+```csharp
+if (true)
+#pragma warning disable SA1520 // Use curly brackets consistently
+    return this.value;
+#pragma warning restore SA1520 // Use curly brackets consistently
+else
+{
+    return that.value.
+}
+```


### PR DESCRIPTION
The SA1519 rule still needs a good name, but everything else should be in place. :smile: 

I updated SA1503 to not report warnings that are now reported as SA1519 or SA1520.

Fixes #716
Fixes #717 