### PR TITLE
Fix that SA1304 is reported for accessible fields

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1304UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1304UnitTests.cs
@@ -21,21 +21,13 @@
         [Fact]
         public async Task TestPublicReadonlyFieldStartingWithLowerCaseAsync()
         {
+            // Should be reported by SA1307 instead
             var testCode = @"public class Foo
 {
     public readonly string bar = ""baz"";
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 28);
-
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
-
-            var fixedCode = @"public class Foo
-{
-    public readonly string Bar = ""baz"";
-}";
-
-            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -57,20 +49,13 @@
     protected readonly string bar = ""baz"";
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 31);
-
-            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
-
-            var fixedCode = @"public class Foo
-{
-    protected readonly string Bar = ""baz"";
-}";
-            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestProtectedReadonlyFieldStartingWithUpperCaseAsync()
         {
+            // Should be reported by SA1307 instead
             var testCode = @"public class Foo
 {
     protected readonly string Bar = ""baz"";

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1304NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1304NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter.cs
@@ -78,6 +78,17 @@
                 return;
             }
 
+            if (!syntax.Modifiers.Any(SyntaxKind.InternalKeyword))
+            {
+                // SA1307 is taken precedence here. SA1307 should be reported if the field is accessible.
+                // So if SA1307 is enabled this diagnostic will only be reported for internal fields.
+                if (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions
+                    .GetValueOrDefault(SA1307AccessibleFieldsMustBeginWithUpperCaseLetter.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
+                {
+                    return;
+                }
+            }
+
             var variables = syntax.Declaration?.Variables;
             if (variables == null)
             {


### PR DESCRIPTION
We should make it possible to test if the diagnostic works if SA1307 is disabled. I dont think our testing framework currently supports that.

Fixes #574.