### PR TITLE
Disable alternative rules by default

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerConstants.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerConstants.cs
@@ -38,7 +38,7 @@
         /// to indicate that the diagnostic is disabled by default because it is an alternative to a reference StyleCop
         /// rule.
         /// </value>
-        internal static bool DisabledAlternative => true;
+        internal static bool DisabledAlternative => false;
 
         /// <summary>
         /// Gets a reference value which can be passed to


### PR DESCRIPTION
I unintentionally enabled alternative rules by default when I was looking for a solution for #841. This pull request corrects that mistake.