### PR TITLE
Restrict the set of files which is excluded by filename

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/GeneratedCodeAnalysisExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/GeneratedCodeAnalysisExtensions.cs
@@ -184,7 +184,7 @@ namespace StyleCop.Analyzers
         {
             return Regex.IsMatch(
                 Path.GetFileName(filePath),
-                @"(^service|^TemporaryGeneratedFile_.*|^assemblyinfo|^assemblyattributes|\.(g\.i|g|designer|generated|assemblyattributes))\.(cs|vb)$",
+                @"\.designer\.cs$",
                 RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
         }
     }


### PR DESCRIPTION
This change removes the automatic exclusion for all filenames where no specific example of this requirement could be found. The code generators for the files that are not eligible for analysis use `<auto-generated>` (or `<autogenerated>`) in the generated code, which causes the exclusion to occur by content instead.

Fixes #848
Fixes #849
Fixes #850
Fixes #851
Fixes #854