### PR TITLE
Fix that SA1612 does not take order into account

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1612ElementParameterDocumentationMustMatchElementParameters.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1612ElementParameterDocumentationMustMatchElementParameters.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.DocumentationRules
 {
+    using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
     using Microsoft.CodeAnalysis;
@@ -36,11 +37,17 @@
         private const string Description = "The documentation describing the parameters to a C# method, constructor, delegate or indexer element does not match the actual parameters on the element.";
         private const string HelpLink = "http://www.stylecop.com/docs/SA1612.html";
 
-        private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+        private const string MissingParamForDocumentationMessageFormat = "The parameter '{0}' does not exist.";
+        private const string ParamWrongOrderMessageFormat = "The parameter documentation for '{0}' should be at position {1}.";
+
+        private static readonly DiagnosticDescriptor MissingParameterDescriptor =
+            new DiagnosticDescriptor(DiagnosticId, Title, MissingParamForDocumentationMessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+
+        private static readonly DiagnosticDescriptor OrderDescriptor =
+                   new DiagnosticDescriptor(DiagnosticId, Title, ParamWrongOrderMessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
         private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
-            ImmutableArray.Create(Descriptor);
+            ImmutableArray.Create(MissingParameterDescriptor);
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
@@ -54,71 +61,86 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleXmlElement, SyntaxKind.XmlElement);
-            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleXmlEmptyElement, SyntaxKind.XmlEmptyElement);
+            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleDocumentationTrivia, SyntaxKind.SingleLineDocumentationCommentTrivia);
         }
 
-        private void HandleXmlElement(SyntaxNodeAnalysisContext context)
+        private void HandleDocumentationTrivia(SyntaxNodeAnalysisContext context)
         {
-            XmlElementSyntax emptyElement = context.Node as XmlElementSyntax;
+            DocumentationCommentTriviaSyntax syntax = context.Node as DocumentationCommentTriviaSyntax;
 
-            var name = emptyElement?.StartTag?.Name;
+            // Find the type parameters of the parent node
+            IEnumerable<string> parentParametersEnumerable = GetParentParameters(syntax);
 
-            HandleElement(context, emptyElement, name, emptyElement?.StartTag?.GetLocation());
-        }
-
-        private void HandleXmlEmptyElement(SyntaxNodeAnalysisContext context)
-        {
-            XmlEmptyElementSyntax emptyElement = context.Node as XmlEmptyElementSyntax;
-
-            var name = emptyElement?.Name;
-
-            HandleElement(context, emptyElement, name, emptyElement?.GetLocation());
-        }
-
-        private static void HandleElement(SyntaxNodeAnalysisContext context, XmlNodeSyntax element, XmlNameSyntax name, Location alternativeDiagnosticLocation)
-        {
-            if (string.Equals(name.ToString(), XmlCommentHelper.ParamXmlTag))
+            if (parentParametersEnumerable == null)
             {
-                var nameAttribute = XmlCommentHelper.GetFirstAttributeOrDefault<XmlNameAttributeSyntax>(element);
+                return;
+            }
 
-                // Make sure we ignore violations that should be reported by SA1613 instead.
-                if (!string.IsNullOrWhiteSpace(nameAttribute?.Identifier?.Identifier.ValueText) && ParentElementHasParameter(element, nameAttribute.Identifier.Identifier.ValueText) == false)
-                {
-                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, nameAttribute?.Identifier?.GetLocation() ?? alternativeDiagnosticLocation));
-                }
+            ImmutableArray<string> parentParameters = parentParametersEnumerable.ToImmutableArray();
+
+            ImmutableArray<XmlNodeSyntax> nodes = syntax.Content
+                .Where(node => string.Equals(GetName(node)?.ToString(), XmlCommentHelper.ParamXmlTag))
+                .ToImmutableArray();
+
+            for (int i = 0; i < nodes.Length; i++)
+            {
+                HandleElement(context, nodes[i], parentParameters, i, GetName(nodes[i])?.GetLocation());
+            }
+        }
+
+        private static XmlNameSyntax GetName(XmlNodeSyntax element)
+        {
+            return (element as XmlElementSyntax)?.StartTag?.Name
+                ?? (element as XmlEmptyElementSyntax)?.Name;
+        }
+
+        private static void HandleElement(SyntaxNodeAnalysisContext context, XmlNodeSyntax element, ImmutableArray<string> parentParameters, int index, Location alternativeDiagnosticLocation)
+        {
+            var nameAttribute = XmlCommentHelper.GetFirstAttributeOrDefault<XmlNameAttributeSyntax>(element);
+
+            // Make sure we ignore violations that should be reported by SA1613 instead.
+            if (string.IsNullOrWhiteSpace(nameAttribute?.Identifier?.Identifier.ValueText))
+            {
+                return;
+            }
+
+            if (!parentParameters.Contains(nameAttribute.Identifier.Identifier.ValueText))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(MissingParameterDescriptor, nameAttribute?.Identifier?.GetLocation() ?? alternativeDiagnosticLocation, nameAttribute.Identifier.Identifier.ValueText));
+            }
+            else if (parentParameters.Length <= index || parentParameters[index] != nameAttribute.Identifier.Identifier.ValueText)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(OrderDescriptor, nameAttribute?.Identifier?.GetLocation() ?? alternativeDiagnosticLocation,
+                    nameAttribute.Identifier.Identifier.ValueText, parentParameters.IndexOf(nameAttribute.Identifier.Identifier.ValueText) + 1));
             }
         }
 
         /// <summary>
         /// Checks if the given <see cref="SyntaxNode"/> has a <see cref="BaseMethodDeclarationSyntax"/>, <see cref="IndexerDeclarationSyntax"/> or a <see cref="DelegateDeclarationSyntax"/>
-        /// as one of its parent. If it finds one of those three with a valid parameter list it returns whether or not there is a parameter called <paramref name="parameterName"/>.
+        /// as one of its parent. If it finds one of those three with a valid type parameter list it returns a <see cref="IEnumerable{T}"/> containing the names of all parameters.
         /// </summary>
         /// <param name="node">The node the analysis should start at.</param>
-        /// <param name="parameterName">The parameter name that should be checked</param>
         /// <returns>
-        /// true, if one parent is a <see cref="BaseMethodDeclarationSyntax"/>, <see cref="IndexerDeclarationSyntax"/> or a <see cref="DelegateDeclarationSyntax"/> with a parameter called <paramref name="parameterName"/>.
-        /// false, if one parent is a <see cref="BaseMethodDeclarationSyntax"/>, <see cref="IndexerDeclarationSyntax"/> or a <see cref="DelegateDeclarationSyntax"/> without a parameter called <paramref name="parameterName"/>.
-        /// null if no parent could be found or invalid syntax is detected.
+        /// A <see cref="IEnumerable{T}"/> containing all parameters or null, of no valid parent could be found.
         /// </returns>
-        private static bool? ParentElementHasParameter(SyntaxNode node, string parameterName)
+        private static IEnumerable<string> GetParentParameters(SyntaxNode node)
         {
-            var methodParent = node.FirstAncestorOrSelf<BaseMethodDeclarationSyntax>();
+            var methodParent = node.FirstAncestorOrSelf<MethodDeclarationSyntax>();
             if (methodParent != null)
             {
-                return methodParent.ParameterList?.Parameters.Any(x => x.Identifier.ValueText == parameterName);
-            }
-
-            var indexerParent = node.FirstAncestorOrSelf<IndexerDeclarationSyntax>();
-            if (indexerParent != null)
-            {
-                return indexerParent.ParameterList?.Parameters.Any(x => x.Identifier.ValueText == parameterName);
+                return methodParent.ParameterList?.Parameters.Select(x => x.Identifier.ValueText) ?? Enumerable.Empty<string>();
             }
 
             var delegateParent = node.FirstAncestorOrSelf<DelegateDeclarationSyntax>();
             if (delegateParent != null)
             {
-                return delegateParent.ParameterList?.Parameters.Any(x => x.Identifier.ValueText == parameterName);
+                return delegateParent.ParameterList?.Parameters.Select(x => x.Identifier.ValueText) ?? Enumerable.Empty<string>();
+            }
+
+            var indexerParent = node.FirstAncestorOrSelf<IndexerDeclarationSyntax>();
+            if (indexerParent != null)
+            {
+                return indexerParent.ParameterList?.Parameters.Select(x => x.Identifier.ValueText) ?? Enumerable.Empty<string>();
             }
 
             return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1612ElementParameterDocumentationMustMatchElementParameters.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1612ElementParameterDocumentationMustMatchElementParameters.cs
@@ -32,7 +32,6 @@
         /// </summary>
         public const string DiagnosticId = "SA1612";
         private const string Title = "Element parameter documentation must match element parameters";
-        private const string MessageFormat = "Element parameter documentation must match element parameters";
         private const string Category = "StyleCop.CSharp.DocumentationRules";
         private const string Description = "The documentation describing the parameters to a C# method, constructor, delegate or indexer element does not match the actual parameters on the element.";
         private const string HelpLink = "http://www.stylecop.com/docs/SA1612.html";


### PR DESCRIPTION
Fixes #867.

The implementation for this rule is now symmetric to the one I did for SA1620.