### PR TITLE
Fix exception in SA1619

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -65,6 +65,8 @@ namespace TestHelper
             }
 
             var supportedDiagnosticsSpecificOptions = new Dictionary<string, ReportDiagnostic>();
+            // Report exceptions during the analysis process as errors
+            supportedDiagnosticsSpecificOptions.Add("AD0001", ReportDiagnostic.Error);
             foreach (var analyzer in analyzers)
             {
                 foreach (var diagnostic in analyzer.SupportedDiagnostics)
@@ -87,7 +89,9 @@ namespace TestHelper
                 var compilerDiagnostics = compilation.GetDiagnostics(cancellationToken);
                 var compilerErrors = compilerDiagnostics.Where(i => i.Severity == DiagnosticSeverity.Error);
                 var diags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
-                foreach (var diag in diags.Concat(compilerErrors))
+                var allDiagnostics = await compilationWithAnalyzers.GetAllDiagnosticsAsync().ConfigureAwait(false);
+                var failureDiagnostics = allDiagnostics.Where(diagnostic => diagnostic.Id == "AD0001");
+                foreach (var diag in diags.Concat(compilerErrors).Concat(failureDiagnostics))
                 {
                     if (diag.Location == Location.None || diag.Location.IsInMetadata)
                     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1619GenericTypeParametersMustBeDocumentedPartialClass.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1619GenericTypeParametersMustBeDocumentedPartialClass.cs
@@ -111,6 +111,12 @@
         {
             TypeDeclarationSyntax typeDeclaration = (TypeDeclarationSyntax)context.Node;
 
+            if (typeDeclaration.TypeParameterList == null)
+            {
+                // We are only interested in generic types
+                return;
+            }
+
             if (!typeDeclaration.Modifiers.Any(SyntaxKind.PartialKeyword))
             {
                 return;


### PR DESCRIPTION
This change includes two parts:

* Pass through diagnostic AD0001 as an error during testing This change ensures exceptions thrown during the evaluation of a test are properly detected by the test infrastructure.
* (In progress) Fixes #888