### PR TITLE
Update to the latest release (alpha 8) of StyleCop.Analyzers

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1616UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1616UnitTests.cs
@@ -136,6 +136,7 @@ $$
             var expected = this.CSharpDiagnostic().WithLocation(10, 8);
 
             await this.VerifyCSharpDiagnosticAsync(testCode.Replace("$$", declaration), expected, CancellationToken.None).ConfigureAwait(false);
+
             // The code fix does not alter this case.
             await this.VerifyCSharpFixAsync(testCode.Replace("$$", declaration), testCode.Replace("$$", declaration), cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
@@ -160,6 +161,7 @@ $$
             var expected = this.CSharpDiagnostic().WithLocation(10, 8);
 
             await this.VerifyCSharpDiagnosticAsync(testCode.Replace("$$", declaration), expected, CancellationToken.None).ConfigureAwait(false);
+
             // The code fix does not alter this case.
             await this.VerifyCSharpFixAsync(testCode.Replace("$$", declaration), testCode.Replace("$$", declaration), cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
@@ -184,6 +186,7 @@ $$
             var expected = this.CSharpDiagnostic().WithLocation(10, 8);
 
             await this.VerifyCSharpDiagnosticAsync(testCode.Replace("$$", declaration), expected, CancellationToken.None).ConfigureAwait(false);
+
             // The code fix does not alter this case.
             await this.VerifyCSharpFixAsync(testCode.Replace("$$", declaration), testCode.Replace("$$", declaration), cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -65,8 +65,6 @@ namespace TestHelper
             }
 
             var supportedDiagnosticsSpecificOptions = new Dictionary<string, ReportDiagnostic>();
-            // Report exceptions during the analysis process as errors
-            supportedDiagnosticsSpecificOptions.Add("AD0001", ReportDiagnostic.Error);
             foreach (var analyzer in analyzers)
             {
                 foreach (var diagnostic in analyzer.SupportedDiagnostics)
@@ -75,6 +73,9 @@ namespace TestHelper
                     supportedDiagnosticsSpecificOptions[diagnostic.Id] = ReportDiagnostic.Default;
                 }
             }
+
+            // Report exceptions during the analysis process as errors
+            supportedDiagnosticsSpecificOptions.Add("AD0001", ReportDiagnostic.Error);
 
             var diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
             foreach (var project in projects)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Classes.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Classes.cs
@@ -113,15 +113,20 @@
             {
                 // InvalidClass1
                 this.CSharpDiagnostic().WithLocation(3, 32),
+
                 // InvalidClass2
                 this.CSharpDiagnostic().WithLocation(6, 32),
+
                 // InvalidClass3
                 this.CSharpDiagnostic().WithLocation(10, 32),
                 this.CSharpDiagnostic().WithLocation(11, 27),
+
                 // InvalidClass4
                 this.CSharpDiagnostic().WithLocation(13, 32),
+
                 // InvalidClass5
                 this.CSharpDiagnostic().WithLocation(18, 27),
+
                 // InvalidClass6
                 this.CSharpDiagnostic().WithLocation(21, 5)
             };

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Constructors.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Constructors.cs
@@ -133,15 +133,20 @@ public class Foo
             {
                 // Invalid constructor #1
                 this.CSharpDiagnostic().WithLocation(6, 18),
+
                 // Invalid constructor #2
                 this.CSharpDiagnostic().WithLocation(10, 24),
+
                 // Invalid constructor #3
                 this.CSharpDiagnostic().WithLocation(15, 24),
                 this.CSharpDiagnostic().WithLocation(16, 25),
+
                 // Invalid constructor #4
                 this.CSharpDiagnostic().WithLocation(19, 25),
+
                 // Invalid constructor #5
                 this.CSharpDiagnostic().WithLocation(25, 25),
+
                 // Invalid constructor #6
                 this.CSharpDiagnostic().WithLocation(29, 5)
             };

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Delegates.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Delegates.cs
@@ -243,28 +243,39 @@ public class Foo
             {
                 // Invalid delegate #1
                 this.CSharpDiagnostic().WithLocation(14, 37),
+
                 // Invalid delegate #2
                 this.CSharpDiagnostic().WithLocation(18, 37),
+
                 // Invalid delegate #3
                 this.CSharpDiagnostic().WithLocation(23, 37),
                 this.CSharpDiagnostic().WithLocation(24, 29),
+
                 // Invalid delegate #4
                 this.CSharpDiagnostic().WithLocation(27, 37),
+
                 // Invalid delegate #5
                 this.CSharpDiagnostic().WithLocation(33, 29),
+
                 // Invalid delegate #6
                 this.CSharpDiagnostic().WithLocation(37, 9),
+
                 // Invalid delegate #7
                 this.CSharpDiagnostic().WithLocation(41, 34),
+
                 // Invalid delegate #8
                 this.CSharpDiagnostic().WithLocation(45, 34),
+
                 // Invalid delegate #9
                 this.CSharpDiagnostic().WithLocation(50, 34),
                 this.CSharpDiagnostic().WithLocation(51, 29),
+
                 // Invalid delegate #10
                 this.CSharpDiagnostic().WithLocation(54, 34),
+
                 // Invalid delegate #11
                 this.CSharpDiagnostic().WithLocation(60, 29),
+
                 // Invalid delegate #12
                 this.CSharpDiagnostic().WithLocation(64, 9)
             };

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Destructors.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Destructors.cs
@@ -184,15 +184,20 @@ public class Foo
             {
                 // Invalid destructor #1
                 this.CSharpDiagnostic().WithLocation(8, 23),
+
                 // Invalid destructor #2
                 this.CSharpDiagnostic().WithLocation(15, 23),
+
                 // Invalid destructor #3
                 this.CSharpDiagnostic().WithLocation(23, 23),
                 this.CSharpDiagnostic().WithLocation(24, 29),
+
                 // Invalid destructor #4
                 this.CSharpDiagnostic().WithLocation(30, 23),
+
                 // Invalid destructor #5
                 this.CSharpDiagnostic().WithLocation(39, 29),
+
                 // Invalid destructor #6
                 this.CSharpDiagnostic().WithLocation(46, 9)
             };

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.DoWhiles.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.DoWhiles.cs
@@ -248,35 +248,48 @@
             {
                 // Invalid do ... while #1
                 this.CSharpDiagnostic().WithLocation(10, 9),
+
                 // Invalid do ... while #2
                 this.CSharpDiagnostic().WithLocation(13, 12),
+
                 // Invalid do ... while #3
                 this.CSharpDiagnostic().WithLocation(18, 12),
                 this.CSharpDiagnostic().WithLocation(19, 9),
+
                 // Invalid do ... while #4
                 this.CSharpDiagnostic().WithLocation(25, 9),
+
                 // Invalid do ... while #5
                 this.CSharpDiagnostic().WithLocation(30, 20),
+
                 // Invalid do ... while #6
                 this.CSharpDiagnostic().WithLocation(36, 20),
+
                 // Invalid do ... while #7
                 this.CSharpDiagnostic().WithLocation(40, 9),
+
                 // Invalid do ... while #8
                 this.CSharpDiagnostic().WithLocation(46, 9),
                 this.CSharpDiagnostic().WithLocation(47, 9),
+
                 // Invalid do ... while #9
                 this.CSharpDiagnostic().WithLocation(50, 12),
+
                 // Invalid do ... while #10
                 this.CSharpDiagnostic().WithLocation(56, 12),
                 this.CSharpDiagnostic().WithLocation(58, 9),
+
                 // Invalid do ... while #11
                 this.CSharpDiagnostic().WithLocation(61, 12),
                 this.CSharpDiagnostic().WithLocation(62, 20),
+
                 // Invalid do ... while #12
                 this.CSharpDiagnostic().WithLocation(66, 12),
                 this.CSharpDiagnostic().WithLocation(67, 20),
+
                 // Invalid do ... while #13
                 this.CSharpDiagnostic().WithLocation(70, 12),
+
                 // Invalid do ... while #14
                 this.CSharpDiagnostic().WithLocation(75, 12),
                 this.CSharpDiagnostic().WithLocation(76, 9)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Enums.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Enums.cs
@@ -110,15 +110,20 @@
             {
                 // InvalidEnum1
                 this.CSharpDiagnostic().WithLocation(3, 30),
+
                 // InvalidEnum2
                 this.CSharpDiagnostic().WithLocation(6, 30),
+
                 // InvalidEnum3
                 this.CSharpDiagnostic().WithLocation(10, 30),
                 this.CSharpDiagnostic().WithLocation(11, 14),
+
                 // InvalidEnum4
                 this.CSharpDiagnostic().WithLocation(13, 30),
+
                 // InvalidEnum5
                 this.CSharpDiagnostic().WithLocation(18, 14),
+
                 // InvalidEnum6
                 this.CSharpDiagnostic().WithLocation(21, 5)
             };

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Events.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Events.cs
@@ -243,20 +243,25 @@ public class Foo
                 // Invalid event #1
                 this.CSharpDiagnostic().WithLocation(10, 13),
                 this.CSharpDiagnostic().WithLocation(14, 16),
+
                 // Invalid event #2
                 this.CSharpDiagnostic().WithLocation(22, 13),
                 this.CSharpDiagnostic().WithLocation(23, 33),
                 this.CSharpDiagnostic().WithLocation(25, 16),
                 this.CSharpDiagnostic().WithLocation(26, 33),
+
                 // Invalid event #3
                 this.CSharpDiagnostic().WithLocation(32, 13),
                 this.CSharpDiagnostic().WithLocation(35, 16),
+
                 // Invalid event #4
                 this.CSharpDiagnostic().WithLocation(44, 33),
                 this.CSharpDiagnostic().WithLocation(48, 33),
+
                 // Invalid event #5
                 this.CSharpDiagnostic().WithLocation(55, 9),
                 this.CSharpDiagnostic().WithLocation(59, 9),
+
                 // Invalid event #6 (Only report once for accessor statement on a single line)
                 this.CSharpDiagnostic().WithLocation(67, 9),
                 this.CSharpDiagnostic().WithLocation(70, 9)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Ifs.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Ifs.cs
@@ -199,15 +199,20 @@
             {
                 // Invalid if #1
                 this.CSharpDiagnostic().WithLocation(8, 21),
+
                 // Invalid if #2
                 this.CSharpDiagnostic().WithLocation(12, 21),
+
                 // Invalid if #3
                 this.CSharpDiagnostic().WithLocation(17, 21),
                 this.CSharpDiagnostic().WithLocation(18, 20),
+
                 // Invalid if #4
                 this.CSharpDiagnostic().WithLocation(21, 21),
+
                 // Invalid if #5
                 this.CSharpDiagnostic().WithLocation(27, 20),
+
                 // Invalid if #6
                 this.CSharpDiagnostic().WithLocation(31, 9)
             };
@@ -342,15 +347,20 @@
             {
                 // Invalid if ... else #1
                 this.CSharpDiagnostic().WithLocation(11, 14),
+
                 // Invalid if ... else #2
                 this.CSharpDiagnostic().WithLocation(18, 14),
+
                 // Invalid if ... else #3
                 this.CSharpDiagnostic().WithLocation(26, 14),
                 this.CSharpDiagnostic().WithLocation(27, 20),
+
                 // Invalid if ... else #4
                 this.CSharpDiagnostic().WithLocation(33, 14),
+
                 // Invalid if ... else #5
                 this.CSharpDiagnostic().WithLocation(42, 20),
+
                 // Invalid if ... else #6
                 this.CSharpDiagnostic().WithLocation(49, 9)
             };

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Indexers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Indexers.cs
@@ -298,32 +298,42 @@
                 // Invalid indexer #1
                 this.CSharpDiagnostic().WithLocation(8, 13),
                 this.CSharpDiagnostic().WithLocation(12, 13),
+
                 // Invalid indexer #2
                 this.CSharpDiagnostic().WithLocation(20, 13),
                 this.CSharpDiagnostic().WithLocation(21, 31),
                 this.CSharpDiagnostic().WithLocation(23, 13),
                 this.CSharpDiagnostic().WithLocation(24, 32),
+
                 // Invalid indexer #3
                 this.CSharpDiagnostic().WithLocation(30, 13),
                 this.CSharpDiagnostic().WithLocation(33, 13),
+
                 // Invalid indexer #4
                 this.CSharpDiagnostic().WithLocation(42, 31),
                 this.CSharpDiagnostic().WithLocation(46, 32),
+
                 // Invalid indexer #5
                 this.CSharpDiagnostic().WithLocation(53, 9),
                 this.CSharpDiagnostic().WithLocation(57, 9),
+
                 // Invalid indexer #6 (Only report once for accessor statements on a single line)
                 this.CSharpDiagnostic().WithLocation(65, 9),
                 this.CSharpDiagnostic().WithLocation(68, 9),
+
                 // Invalid indexer #7
                 this.CSharpDiagnostic().WithLocation(72, 34),
+
                 // Invalid indexer #8
                 this.CSharpDiagnostic().WithLocation(77, 35),
                 this.CSharpDiagnostic().WithLocation(78, 35),
+
                 // Invalid indexer #9
                 this.CSharpDiagnostic().WithLocation(81, 34),
+
                 // Invalid indexer #10
                 this.CSharpDiagnostic().WithLocation(87, 35),
+
                 // Invalid indexer #11
                 this.CSharpDiagnostic().WithLocation(91, 5)
             };

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Interfaces.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Interfaces.cs
@@ -113,15 +113,20 @@
             {
                 // InvalidInterface1
                 this.CSharpDiagnostic().WithLocation(3, 40),
+
                 // InvalidInterface2
                 this.CSharpDiagnostic().WithLocation(6, 40),
+
                 // InvalidInterface3
                 this.CSharpDiagnostic().WithLocation(10, 40),
                 this.CSharpDiagnostic().WithLocation(11, 21),
+
                 // InvalidInterface4
                 this.CSharpDiagnostic().WithLocation(13, 40),
+
                 // InvalidInterface5
                 this.CSharpDiagnostic().WithLocation(18, 21),
+
                 // InvalidInterface6
                 this.CSharpDiagnostic().WithLocation(21, 5)
             };

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.LambdaExpressions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.LambdaExpressions.cs
@@ -238,28 +238,39 @@ public class Foo
             {
                 // Invalid lambda expression #1
                 this.CSharpDiagnostic().WithLocation(12, 30),
+
                 // Invalid lambda expression #2
                 this.CSharpDiagnostic().WithLocation(16, 30),
+
                 // Invalid lambda expression #3
                 this.CSharpDiagnostic().WithLocation(21, 30),
                 this.CSharpDiagnostic().WithLocation(22, 29),
+
                 // Invalid lambda expression #4
                 this.CSharpDiagnostic().WithLocation(25, 30),
+
                 // Invalid lambda expression #5
                 this.CSharpDiagnostic().WithLocation(31, 29),
+
                 // Invalid lambda expression #6
                 this.CSharpDiagnostic().WithLocation(35, 9),
+
                 // Invalid lambda expression #7
                 this.CSharpDiagnostic().WithLocation(39, 31),
+
                 // Invalid lambda expression #8
                 this.CSharpDiagnostic().WithLocation(43, 31),
+
                 // Invalid lambda expression #9
                 this.CSharpDiagnostic().WithLocation(48, 31),
                 this.CSharpDiagnostic().WithLocation(49, 29),
+
                 // Invalid lambda expression #10
                 this.CSharpDiagnostic().WithLocation(52, 31),
+
                 // Invalid lambda expression #11
                 this.CSharpDiagnostic().WithLocation(58, 29),
+
                 // Invalid lambda expression #12
                 this.CSharpDiagnostic().WithLocation(62, 9)
             };

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Methods.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Methods.cs
@@ -133,15 +133,20 @@ public class Foo
             {
                 // Invalid method #1
                 this.CSharpDiagnostic().WithLocation(6, 27),
+
                 // Invalid method #2
                 this.CSharpDiagnostic().WithLocation(10, 27),
+
                 // Invalid method #3
                 this.CSharpDiagnostic().WithLocation(15, 27),
                 this.CSharpDiagnostic().WithLocation(16, 25),
+
                 // Invalid method #4
                 this.CSharpDiagnostic().WithLocation(19, 27),
+
                 // Invalid method #5
                 this.CSharpDiagnostic().WithLocation(25, 25),
+
                 // Invalid method #6
                 this.CSharpDiagnostic().WithLocation(29, 5)
             };

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Namespaces.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Namespaces.cs
@@ -104,15 +104,20 @@ namespace InvalidNamespace6
             {
                 // InvalidNamespace1
                 this.CSharpDiagnostic().WithLocation(1, 29),
+
                 // InvalidNamespace2
                 this.CSharpDiagnostic().WithLocation(4, 29),
+
                 // InvalidNamespace3
                 this.CSharpDiagnostic().WithLocation(8, 29),
                 this.CSharpDiagnostic().WithLocation(9, 19),
+
                 // InvalidNamespace4
                 this.CSharpDiagnostic().WithLocation(11, 29),
+
                 // InvalidNamespace5
                 this.CSharpDiagnostic().WithLocation(16, 19),
+
                 // InvalidNamespace6
                 this.CSharpDiagnostic().WithLocation(19, 1)
             };

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.ObjectInitializers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.ObjectInitializers.cs
@@ -372,32 +372,40 @@ public class Foo
                 this.CSharpDiagnostic().WithLocation(14, 32),
                 this.CSharpDiagnostic().WithLocation(14, 34),
                 this.CSharpDiagnostic().WithLocation(14, 36),
+
                 // Invalid object initializer #2
                 this.CSharpDiagnostic().WithLocation(18, 5),
                 this.CSharpDiagnostic().WithLocation(19, 9),
                 this.CSharpDiagnostic().WithLocation(21, 13),
+
                 // Invalid object initializer #3
                 this.CSharpDiagnostic().WithLocation(28, 41),
                 this.CSharpDiagnostic().WithLocation(29, 21),
                 this.CSharpDiagnostic().WithLocation(31, 28),
+
                 // Invalid object initializer #4
                 this.CSharpDiagnostic().WithLocation(49, 36),
                 this.CSharpDiagnostic().WithLocation(49, 38),
                 this.CSharpDiagnostic().WithLocation(49, 40),
+
                 // Invalid object initializer #5
                 this.CSharpDiagnostic().WithLocation(53, 9),
                 this.CSharpDiagnostic().WithLocation(54, 13),
                 this.CSharpDiagnostic().WithLocation(56, 17),
+
                 // Invalid object initializer #6
                 this.CSharpDiagnostic().WithLocation(63, 31),
                 this.CSharpDiagnostic().WithLocation(64, 25),
                 this.CSharpDiagnostic().WithLocation(66, 32),
+
                 // Invalid object initializer #7
                 this.CSharpDiagnostic().WithLocation(79, 32),
                 this.CSharpDiagnostic().WithLocation(79, 34),
+
                 // Invalid object initializer #8
                 this.CSharpDiagnostic().WithLocation(83, 9),
                 this.CSharpDiagnostic().WithLocation(85, 13),
+
                 // Invalid object initializer #9
                 this.CSharpDiagnostic().WithLocation(90, 29),
                 this.CSharpDiagnostic().WithLocation(92, 34)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Properties.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Properties.cs
@@ -359,38 +359,51 @@ public class Foo
                 // Invalid property #1
                 this.CSharpDiagnostic().WithLocation(10, 13),
                 this.CSharpDiagnostic().WithLocation(14, 13),
+
                 // Invalid property #2
                 this.CSharpDiagnostic().WithLocation(22, 13),
                 this.CSharpDiagnostic().WithLocation(23, 31),
                 this.CSharpDiagnostic().WithLocation(25, 13),
                 this.CSharpDiagnostic().WithLocation(26, 32),
+
                 // Invalid property #3
                 this.CSharpDiagnostic().WithLocation(32, 13),
                 this.CSharpDiagnostic().WithLocation(35, 13),
+
                 // Invalid property #4
                 this.CSharpDiagnostic().WithLocation(44, 31),
                 this.CSharpDiagnostic().WithLocation(48, 32),
+
                 // Invalid property #5
                 this.CSharpDiagnostic().WithLocation(55, 9),
                 this.CSharpDiagnostic().WithLocation(59, 9),
+
                 // Invalid property #6 (Only report once for accessor statements on a single line)
                 this.CSharpDiagnostic().WithLocation(67, 9),
                 this.CSharpDiagnostic().WithLocation(70, 9),
+
                 // Invalid property #7
                 this.CSharpDiagnostic().WithLocation(76, 35),
+
                 // Invalid property #8
                 this.CSharpDiagnostic().WithLocation(79, 27),
+
                 // Invalid property #9
                 this.CSharpDiagnostic().WithLocation(84, 27),
                 this.CSharpDiagnostic().WithLocation(85, 35),
+
                 // Invalid property #10
                 this.CSharpDiagnostic().WithLocation(88, 28),
+
                 // Invalid property #11
                 this.CSharpDiagnostic().WithLocation(93, 5),
+
                 // Invalid property #12
                 this.CSharpDiagnostic().WithLocation(101, 11),
+
                 // Invalid property #13
                 this.CSharpDiagnostic().WithLocation(104, 45),
+
                 // Invalid property #14
                 this.CSharpDiagnostic().WithLocation(111, 45)
             };

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Structs.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Structs.cs
@@ -113,15 +113,20 @@
             {
                 // InvalidStruct1
                 this.CSharpDiagnostic().WithLocation(3, 34),
+
                 // InvalidStruct2
                 this.CSharpDiagnostic().WithLocation(6, 34),
+
                 // InvalidStruct3
                 this.CSharpDiagnostic().WithLocation(10, 34),
                 this.CSharpDiagnostic().WithLocation(11, 27),
+
                 // InvalidStruct4
                 this.CSharpDiagnostic().WithLocation(13, 34),
+
                 // InvalidStruct5
                 this.CSharpDiagnostic().WithLocation(18, 27),
+
                 // InvalidStruct6
                 this.CSharpDiagnostic().WithLocation(21, 5)
             };

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.TryCatchFinallys.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.TryCatchFinallys.cs
@@ -256,10 +256,12 @@ public class Foo
                 this.CSharpDiagnostic().WithLocation(10, 13),
                 this.CSharpDiagnostic().WithLocation(12, 27),
                 this.CSharpDiagnostic().WithLocation(14, 17),
+
                 // Invalid try ... catch ... finally #2
                 this.CSharpDiagnostic().WithLocation(18, 13),
                 this.CSharpDiagnostic().WithLocation(21, 27),
                 this.CSharpDiagnostic().WithLocation(24, 17),
+
                 // Invalid try ... catch ... finally #3
                 this.CSharpDiagnostic().WithLocation(29, 13),
                 this.CSharpDiagnostic().WithLocation(30, 21),
@@ -267,14 +269,17 @@ public class Foo
                 this.CSharpDiagnostic().WithLocation(32, 21),
                 this.CSharpDiagnostic().WithLocation(33, 17),
                 this.CSharpDiagnostic().WithLocation(34, 21),
+
                 // Invalid try ... catch ... finally #4
                 this.CSharpDiagnostic().WithLocation(37, 13),
                 this.CSharpDiagnostic().WithLocation(39, 27),
                 this.CSharpDiagnostic().WithLocation(41, 17),
+
                 // Invalid try ... catch ... finally #5
                 this.CSharpDiagnostic().WithLocation(47, 21),
                 this.CSharpDiagnostic().WithLocation(50, 21),
                 this.CSharpDiagnostic().WithLocation(53, 21),
+
                 // Invalid try ... catch ... finally #6
                 this.CSharpDiagnostic().WithLocation(57, 9),
                 this.CSharpDiagnostic().WithLocation(60, 9),

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1513UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1513UnitTests.cs
@@ -450,16 +450,22 @@ public class Foo
             {
                 // Invalid #1
                 this.CSharpDiagnostic().WithLocation(17, 10),
+
                 // Invalid #2
                 this.CSharpDiagnostic().WithLocation(25, 6),
+
                 // Invalid #3
                 this.CSharpDiagnostic().WithLocation(35, 14),
+
                 // Invalid #4
                 this.CSharpDiagnostic().WithLocation(45, 10),
+
                 // Invalid #5
                 this.CSharpDiagnostic().WithLocation(52, 10),
+
                 // Invalid #6
                 this.CSharpDiagnostic().WithLocation(65, 14),
+
                 // Invalid #7
                 this.CSharpDiagnostic().WithLocation(73, 14)
             };

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1516UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1516UnitTests.cs
@@ -170,7 +170,6 @@ namespace Foot
         public async Task HasEmptyLineWorksCorrectlyAsync()
         {
             // This test increases code coverage in SA1516ElementsMustBeSeparatedByBlankLine.HasEmptyLine
-
             var testCode = @"using System;
 
 namespace Foo
@@ -195,7 +194,6 @@ namespace Foo
         public async Task GetDiagnosticLocationWorksCorrectlyAsync()
         {
             // This test increases code coverage in SA1516ElementsMustBeSeparatedByBlankLine.GetDiagnosticLocation
-
             var testCode = @"using System;
 
 namespace Foo

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1201UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1201UnitTests.cs
@@ -214,6 +214,7 @@ public struct FooStruct { }
     public string
 }
 ";
+
             // We don't care about the syntax errors.
             var expected = new[]
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1000UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1000UnitTests.cs
@@ -467,7 +467,6 @@ select x;";
         {
             // There is no way to have a 'yield' keyword which is not followed by a space. All we need to do is verify
             // that no diagnostic is reported for its use with a space.
-
             string statementWithSpace = @"yield return 3;";
             await this.TestKeywordStatementAsync(statementWithSpace, EmptyDiagnosticResults, statementWithSpace, returnType: "IEnumerable<int>").ConfigureAwait(false);
         }
@@ -477,7 +476,6 @@ select x;";
         {
             // There is no way to have a 'yield' keyword which is not followed by a space. All we need to do is verify
             // that no diagnostic is reported for its use with a space.
-
             string statementWithSpace = @"yield break;";
             await this.TestKeywordStatementAsync(statementWithSpace, EmptyDiagnosticResults, statementWithSpace, returnType: "IEnumerable<int>").ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -289,7 +289,7 @@
     <Analyzer Include="..\..\packages\AsyncUsageAnalyzers.1.0.0-alpha001\tools\analyzers\AsyncUsageAnalyzers.dll" />
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc2\tools\analyzers\C#\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc2\tools\analyzers\C#\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-alpha007\tools\analyzers\C#\StyleCop.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-alpha008\tools\analyzers\C#\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/packages.config
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-rc2" targetFramework="net45" userInstalled="true" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-rc2" targetFramework="net45" userInstalled="true" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" userInstalled="true" />
-  <package id="StyleCop.Analyzers" version="1.0.0-alpha007" targetFramework="net45" userInstalled="true" />
+  <package id="StyleCop.Analyzers" version="1.0.0-alpha008" targetFramework="net45" userInstalled="true" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net45" userInstalled="true" />
   <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net45" userInstalled="true" />
   <package id="xunit" version="2.0.0" targetFramework="net45" userInstalled="true" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.ruleset
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.ruleset
@@ -103,7 +103,6 @@
     <Rule Id="SA1408" Action="Error" />
     <Rule Id="SA1410" Action="Error" />
     <Rule Id="SA1411" Action="Error" />
-    <Rule Id="SA1512" Action="Hidden" />
     <Rule Id="SA1515" Action="Hidden" />
     <Rule Id="SA1600" Action="None" />
     <Rule Id="SA1603" Action="Error" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.ruleset
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.ruleset
@@ -103,7 +103,6 @@
     <Rule Id="SA1408" Action="Error" />
     <Rule Id="SA1410" Action="Error" />
     <Rule Id="SA1411" Action="Error" />
-    <Rule Id="SA1515" Action="Hidden" />
     <Rule Id="SA1600" Action="None" />
     <Rule Id="SA1603" Action="Error" />
     <Rule Id="SA1633" Action="Hidden" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.ruleset
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.ruleset
@@ -107,6 +107,7 @@
     <Rule Id="SA1515" Action="Hidden" />
     <Rule Id="SA1600" Action="None" />
     <Rule Id="SA1603" Action="Error" />
+    <Rule Id="SA1633" Action="Hidden" />
     <Rule Id="SA1642" Action="Error" />
     <Rule Id="SA1643" Action="Error" />
   </Rules>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
@@ -244,15 +244,18 @@
 
         private bool NeedsComment(SyntaxTokenList modifiers, SyntaxKind defaultModifier)
         {
-
-            return (modifiers.Any(SyntaxKind.PublicKeyword)
+            if (!(modifiers.Any(SyntaxKind.PublicKeyword)
                 || modifiers.Any(SyntaxKind.ProtectedKeyword)
                 || modifiers.Any(SyntaxKind.InternalKeyword)
                 || defaultModifier == SyntaxKind.PublicKeyword
                 || defaultModifier == SyntaxKind.ProtectedKeyword
-                || defaultModifier == SyntaxKind.InternalKeyword)
-                // Ignore partial classes because they get reported as SA1601
-                && !modifiers.Any(SyntaxKind.PartialKeyword);
+                || defaultModifier == SyntaxKind.InternalKeyword))
+            {
+                return false;
+            }
+
+            // Also ignore partial classes because they get reported as SA1601
+            return !modifiers.Any(SyntaxKind.PartialKeyword);
         }
 
         private bool IsNestedType(BaseTypeDeclarationSyntax typeDeclaration)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -156,9 +156,9 @@
 
             for (int i = 0; i < list.SeparatorCount; i++)
             {
-                var separator = list.GetSeparator(i);
                 // Make sure the parameter list looks nice
                 // Cannot use ReplaceSeparator due to dotnet/roslyn#2630: https://github.com/dotnet/roslyn/issues/2630
+                var separator = list.GetSeparator(i);
                 list = SyntaxFactory.SeparatedList<TypeSyntax>(list.GetWithSeparators().Replace(separator, separator.WithTrailingTrivia(SyntaxFactory.Space)));
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/StandardTextDiagnosticBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/StandardTextDiagnosticBase.cs
@@ -161,6 +161,7 @@
             {
                 var genericNameArgumentNames = genericName.TypeArgumentList.Arguments.Cast<SimpleNameSyntax>().Select(p => p.Identifier.ToString());
                 var classParameterNames = typeParameterList?.Parameters.Select(p => p.Identifier.ToString()) ?? Enumerable.Empty<string>();
+
                 // Make sure the names match up
                 return genericNameArgumentNames.SequenceEqual(classParameterNames);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1500CurlyBracketsForMultiLineStatementsMustNotShareLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1500CurlyBracketsForMultiLineStatementsMustNotShareLine.cs
@@ -191,6 +191,7 @@
                 if (previousToken.GetLocation().GetLineSpan().StartLinePosition.Line == line)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));
+
                     // no need to report more than one instance for this token
                     return;
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1404CodeAnalysisSuppressionMustHaveJustification.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1404CodeAnalysisSuppressionMustHaveJustification.cs
@@ -77,7 +77,6 @@
                             if (attributeArgument?.NameEquals?.Name?.Identifier.ValueText == nameof(SuppressMessageAttribute.Justification))
                             {
                                 // Check if the justification is not empty
-
                                 var value = context.SemanticModel.GetConstantValue(attributeArgument.Expression);
 
                                 // If value does not have a value the expression is not constant -> Compilation error

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407ArithmeticExpressionsMustDeclarePrecedence.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407ArithmeticExpressionsMustDeclarePrecedence.cs
@@ -84,7 +84,6 @@
                 if (binSyntax.Left is BinaryExpressionSyntax)
                 {
                     // Check if the operations are of the same kind
-
                     var left = (BinaryExpressionSyntax)binSyntax.Left;
 
                     if (!this.IsSameFamily(binSyntax.OperatorToken, left.OperatorToken))
@@ -96,7 +95,6 @@
                 if (binSyntax.Right is BinaryExpressionSyntax)
                 {
                     // Check if the operations are of the same kind
-
                     var right = (BinaryExpressionSyntax)binSyntax.Right;
 
                     if (!this.IsSameFamily(binSyntax.OperatorToken, right.OperatorToken))

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1408ConditionalExpressionsMustDeclarePrecedence.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1408ConditionalExpressionsMustDeclarePrecedence.cs
@@ -91,7 +91,6 @@
                 if (binSyntax.Left is BinaryExpressionSyntax)
                 {
                     // Check if the operations are of the same kind
-
                     var left = (BinaryExpressionSyntax)binSyntax.Left;
                     if (left.OperatorToken.IsKind(SyntaxKind.AmpersandAmpersandToken) || left.OperatorToken.IsKind(SyntaxKind.BarBarToken))
                     {
@@ -106,7 +105,6 @@
                 if (binSyntax.Right is BinaryExpressionSyntax)
                 {
                     // Check if the operations are of the same kind
-
                     var right = (BinaryExpressionSyntax)binSyntax.Right;
                     if (right.OperatorToken.IsKind(SyntaxKind.AmpersandAmpersandToken) || right.OperatorToken.IsKind(SyntaxKind.BarBarToken))
                     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SystemDiagnosticsDebugDiagnosticBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SystemDiagnosticsDebugDiagnosticBase.cs
@@ -47,6 +47,7 @@
                             if (messageParameter?.Expression != null)
                             {
                                 Optional<object> constantValue = context.SemanticModel.GetConstantValue(messageParameter.Expression);
+
                                 // Report a diagnostic if the message is constant and null or whitespace
                                 if (constantValue.HasValue && string.IsNullOrWhiteSpace(constantValue.Value as string))
                                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
@@ -58,7 +58,6 @@
         {
             // Note: Interfaces are handled by SA1302
             // Note: Fields are handled by SA1303 through SA1311
-
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleNamespaceDeclarationSyntax, SyntaxKind.NamespaceDeclaration);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleClassDeclarationSyntax, SyntaxKind.ClassDeclaration);
             context.RegisterSyntaxNodeActionHonorExclusions(this.HandleEnumDeclarationSyntax, SyntaxKind.EnumDeclaration);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121UseBuiltInTypeAlias.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121UseBuiltInTypeAlias.cs
@@ -243,7 +243,6 @@
         {
             // The only time a type name can appear as an argument is for the invocation expression created for the
             // nameof keyword. This assumption is the foundation of the following simple analysis algorithm.
-
             if (identifierNameSyntax.Parent == null)
             {
                 return false;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005SingleLineCommentsMustBeginWithSingleSpace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005SingleLineCommentsMustBeginWithSingleSpace.cs
@@ -143,7 +143,6 @@
 
             // No need to handle documentation comments ("///") because they're not
             // reported as SingleLineCommentTrivia.
-
             int spaceCount = 0;
             for (int i = 2; (i < text.Length) && (text[i] == ' '); i++)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
@@ -122,6 +122,7 @@
                 case SyntaxKind.WhileKeyword:
                     allowLeadingNoSpace = false;
                     allowLeadingSpace = true;
+
                     // allow these to be reported as SA1000
                     reportPrecedingError = false;
                     break;
@@ -135,6 +136,7 @@
                 case SyntaxKind.UncheckedKeyword:
                     allowLeadingNoSpace = true;
                     allowLeadingSpace = false;
+
                     // allow these to be reported as SA1000
                     reportPrecedingError = false;
                     break;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
@@ -128,12 +128,14 @@
 
             case SyntaxKind.PlusToken:
                 precedesStickyCharacter = nextToken.Parent.IsKind(SyntaxKind.UnaryPlusExpression);
+
                 // this will be reported as SA1022
                 suppressFollowingSpaceError = true;
                 break;
 
             case SyntaxKind.MinusToken:
                 precedesStickyCharacter = nextToken.Parent.IsKind(SyntaxKind.UnaryMinusExpression);
+
                 // this will be reported as SA1021
                 suppressFollowingSpaceError = true;
                 break;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010OpeningSquareBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010OpeningSquareBracketsMustBeSpacedCorrectly.cs
@@ -94,6 +94,7 @@
             {
                 SyntaxToken precedingToken = token.GetPreviousToken();
                 precededBySpace = precedingToken.HasTrailingTrivia;
+
                 // ignore if handled by SA1026
                 ignorePrecedingSpaceProblem = precededBySpace && precedingToken.IsKind(SyntaxKind.NewKeyword);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -389,7 +389,7 @@
     <Analyzer Include="..\..\packages\AsyncUsageAnalyzers.1.0.0-alpha001\tools\analyzers\AsyncUsageAnalyzers.dll" />
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc2\tools\analyzers\C#\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc2\tools\analyzers\C#\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-alpha007\tools\analyzers\C#\StyleCop.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-alpha008\tools\analyzers\C#\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="DocumentationRules\DocumentationResources.resx">

--- a/StyleCop.Analyzers/StyleCop.Analyzers/packages.config
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-rc2" targetFramework="portable-net45+win8" userInstalled="true" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable-net45+win8" userInstalled="true" />
   <package id="NuGet.CommandLine" version="2.8.3" targetFramework="portable45-net45+win8" userInstalled="true" />
-  <package id="StyleCop.Analyzers" version="1.0.0-alpha007" targetFramework="portable45-net45+win8" userInstalled="true" />
+  <package id="StyleCop.Analyzers" version="1.0.0-alpha008" targetFramework="portable45-net45+win8" userInstalled="true" />
   <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="portable-net45+win8" userInstalled="true" />
   <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="portable-net45+win8" userInstalled="true" />
   <package id="Tvl.NuGet.BuildTasks" version="1.0.0-alpha002" targetFramework="portable45-net45+win8" userInstalled="true" />


### PR DESCRIPTION
Notes:

* SA1512 is now enabled (bugs fixed during the Alpha 8 release allowed this)
* SA1515 is now enabled (bugs fixed during the Alpha 8 release allowed this)
* SA1633 is disabled (we haven't settled on a specific file header at this point, plus I don't want to enable it prior to a code fix being available)
