### PR TITLE
Update AsyncUsageAnalyzers dependency

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -298,7 +298,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\..\packages\AsyncUsageAnalyzers.1.0.0-alpha001\tools\analyzers\AsyncUsageAnalyzers.dll" />
+    <Analyzer Include="..\..\packages\AsyncUsageAnalyzers.1.0.0-alpha002\tools\analyzers\AsyncUsageAnalyzers.dll" />
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc2\tools\analyzers\C#\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc2\tools\analyzers\C#\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-alpha010\tools\analyzers\C#\StyleCop.Analyzers.dll" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/packages.config
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AsyncUsageAnalyzers" version="1.0.0-alpha001" targetFramework="net45" userInstalled="true" />
+  <package id="AsyncUsageAnalyzers" version="1.0.0-alpha002" targetFramework="net45" userInstalled="true" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0-rc2" targetFramework="net45" userInstalled="true" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-rc2" targetFramework="net45" userInstalled="true" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0-rc2" targetFramework="net45" userInstalled="true" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -395,7 +395,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\..\packages\AsyncUsageAnalyzers.1.0.0-alpha001\tools\analyzers\AsyncUsageAnalyzers.dll" />
+    <Analyzer Include="..\..\packages\AsyncUsageAnalyzers.1.0.0-alpha002\tools\analyzers\AsyncUsageAnalyzers.dll" />
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc2\tools\analyzers\C#\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc2\tools\analyzers\C#\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-alpha010\tools\analyzers\C#\StyleCop.Analyzers.dll" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/packages.config
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AsyncUsageAnalyzers" version="1.0.0-alpha001" targetFramework="portable45-net45+win8" userInstalled="true" />
+  <package id="AsyncUsageAnalyzers" version="1.0.0-alpha002" targetFramework="portable45-net45+win8" userInstalled="true" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0-rc2" targetFramework="portable-net45+win8" userInstalled="true" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-rc2" targetFramework="portable-net45+win8" userInstalled="true" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0-rc2" targetFramework="portable-net45+win8" userInstalled="true" />


### PR DESCRIPTION
This corrects the error reported in the IDE for the `SpecializedTasks.CompletedTask` getter.

Specifically a case of this issue: DotNetAnalyzers/AsyncUsageAnalyzers#21.