### PR TITLE
SA1206 rule implementation

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1206UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1206UnitTests.cs
@@ -1,0 +1,225 @@
+﻿namespace StyleCop.Analyzers.Test.OrderingRules
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.OrderingRules;
+    using TestHelper;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for <see cref="SA1206DeclarationKeywordsMustFollowOrder"/>.
+    /// </summary>
+    public class SA1206UnitTests : CodeFixVerifier
+    {
+        [Fact]
+        public async Task TestEmptySourceAsync()
+        {
+            var testCode = string.Empty;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestKeywordsInClassDeclarationAsync()
+        {
+            var testCode = @"abstract public class T
+{
+}
+";
+            var expected = this.CSharpDiagnostic().WithLocation(1, 10).WithArguments("access modifier", "other");
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestKeywordsWithExpressionBodiedMemberAndAsyncKeywordAsync()
+        {
+            var testCode = @"public class Test
+{
+    async static public void GetResult() => new object();
+}";
+            DiagnosticResult[] expected = new[]
+            {
+                this.CSharpDiagnostic().WithLocation(3, 11).WithArguments("static", "other"),
+                this.CSharpDiagnostic().WithLocation(3, 18).WithArguments("access modifier", "static"),
+                this.CSharpDiagnostic().WithLocation(3, 18).WithArguments("access modifier", "other")
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestKeywordsInClassMembersAsync()
+        {
+            var testCode = @"public class TestClass
+{
+    public static extern void FirstMethod();
+    virtual public void SecondMethod() {}
+    static public void ThirdMethod() {}
+    protected virtual new void FourthMethod() {}
+    virtual new internal async protected void FifthMethod() { }
+    public new static void SixthMethod() {}
+    new static public string FirstProperty { get; set; }
+    virtual public event System.EventHandler Changed;
+    extern public int this[int index] { get; set; }
+    extern public void ExternMethodOne();
+    extern static void ExternMethodTwo();
+    volatile internal static bool Test;
+    public readonly string Field = string.Empty;
+}";
+
+            DiagnosticResult[] expected = new[]
+            {
+                this.CSharpDiagnostic().WithLocation(4, 13).WithArguments("access modifier", "other"),
+                this.CSharpDiagnostic().WithLocation(5, 12).WithArguments("access modifier", "static"),
+                this.CSharpDiagnostic().WithLocation(7, 17).WithArguments("access modifier", "other"),
+                this.CSharpDiagnostic().WithLocation(7, 32).WithArguments("access modifier", "other"),
+                this.CSharpDiagnostic().WithLocation(8, 16).WithArguments("static", "other"),
+                this.CSharpDiagnostic().WithLocation(9, 9).WithArguments("static", "other"),
+                this.CSharpDiagnostic().WithLocation(9, 16).WithArguments("access modifier", "static"),
+                this.CSharpDiagnostic().WithLocation(9, 16).WithArguments("access modifier", "other"),
+                this.CSharpDiagnostic().WithLocation(10, 13).WithArguments("access modifier", "other"),
+                this.CSharpDiagnostic().WithLocation(11, 12).WithArguments("access modifier", "other"),
+                this.CSharpDiagnostic().WithLocation(12, 12).WithArguments("access modifier", "other"),
+                this.CSharpDiagnostic().WithLocation(13, 12).WithArguments("static", "other"),
+                this.CSharpDiagnostic().WithLocation(14, 14).WithArguments("access modifier", "other"),
+                this.CSharpDiagnostic().WithLocation(14, 23).WithArguments("static", "other")
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("struct")]
+        [InlineData("interface")]
+        [InlineData("enum")]
+        public async Task TestNewKeywordWithinNestedTypeDeclarationsAsync(string type)
+        {
+            var testCode = @"public class TestClass
+{
+    protected " + type + @" Nested
+    {
+    }
+}
+
+public class ExtendedTestClass : TestClass
+{
+    new protected " + type + @" Nested
+    {
+    }
+}";
+            var expected = this.CSharpDiagnostic().WithLocation(10, 9).WithArguments("access modifier", "other");
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestHidedNestedDelegateDeclarationAsync()
+        {
+            var testCode = @"public class TestClass
+{
+    protected delegate void SomeDelegate(int a);
+}
+
+public class ExtendedTestClass : TestClass
+{
+    new protected delegate void SomeDelegate(int a);
+}";
+            var expected = this.CSharpDiagnostic().WithLocation(8, 9).WithArguments("access modifier", "other");
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestWithNewKeywordWithConstantAsync()
+        {
+            var testCode = @"public class TestClass
+{
+    public const string Empty = """";
+}
+
+public class ExtendedClass : TestClass
+{
+    new public const string Empty = """";
+}";
+            var expected = this.CSharpDiagnostic().WithLocation(8, 9).WithArguments("access modifier", "other");
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestKeywordsWithOperatorDeclarationsAsync()
+        {
+            var testCode = @"public class Number
+{
+    extern public static Number operator ++(Number n);
+    extern static public Number operator %(Number left, Number right);
+    public extern static explicit operator Number(int n);
+}";
+            DiagnosticResult[] expected = new[]
+            {
+                this.CSharpDiagnostic().WithLocation(3, 12).WithArguments("access modifier", "other"),
+                this.CSharpDiagnostic().WithLocation(3, 19).WithArguments("static", "other"),
+                this.CSharpDiagnostic().WithLocation(4, 12).WithArguments("static", "other"),
+                this.CSharpDiagnostic().WithLocation(4, 19).WithArguments("access modifier", "static"),
+                this.CSharpDiagnostic().WithLocation(4, 19).WithArguments("access modifier", "other"),
+                this.CSharpDiagnostic().WithLocation(5, 19).WithArguments("static", "other")
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestWithUnsafeKeywordAndFixedAsync()
+        {
+            var testCode = @"unsafe public struct SomeClass
+{   
+    unsafe public fixed int x[5];
+}";
+            DiagnosticResult[] expected = new[]
+            {
+                this.CSharpDiagnostic().WithLocation(1, 8).WithArguments("access modifier", "other"),
+                this.CSharpDiagnostic().WithLocation(3, 12).WithArguments("access modifier", "other")
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestWithIncompleteMembersAsync()
+        {
+            var testCode = @"public class Test
+{
+    new public string
+}";
+
+            var expected = new DiagnosticResult
+            {
+                Id = "CS1519",
+                Message = "Invalid token '}' in class, struct, or interface member declaration",
+                Severity = DiagnosticSeverity.Error,
+                Locations = new[] { new DiagnosticResultLocation("Test0.cs", 4, 1) }
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestWithPartialKeywordAsync()
+        {
+            var testCode = @"abstract partial class AbstractClass
+{
+    static partial void PartialTest();
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new SA1206DeclarationKeywordsMustFollowOrder();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -240,6 +240,7 @@
     <Compile Include="OrderingRules\SA1200UnitTests.cs" />
     <Compile Include="OrderingRules\SA1201UnitTests.cs" />
     <Compile Include="OrderingRules\SA1205UnitTests.cs" />
+    <Compile Include="OrderingRules\SA1206UnitTests.cs" />
     <Compile Include="OrderingRules\SA1208UnitTests.cs" />
     <Compile Include="OrderingRules\SA1209UnitTests.cs" />
     <Compile Include="OrderingRules\SA1210UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1206DeclarationKeywordsMustFollowOrder.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1206DeclarationKeywordsMustFollowOrder.cs
@@ -2,6 +2,8 @@
 {
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
 
     /// <summary>
@@ -31,16 +33,39 @@
         /// </summary>
         public const string DiagnosticId = "SA1206";
         private const string Title = "Declaration keywords must follow order";
-        private const string MessageFormat = "TODO: Message format";
+        private const string MessageFormat = "The {0} keyword must come before the '{1}' keyword in the element declaration.";
         private const string Category = "StyleCop.CSharp.OrderingRules";
         private const string Description = "The keywords within the declaration of an element do not follow a standard ordering scheme.";
         private const string HelpLink = "http://www.stylecop.com/docs/SA1206.html";
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledNoTests, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
         private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
             ImmutableArray.Create(Descriptor);
+
+        /// <summary>
+        /// Represents modifier type for implementing SA1206 rule
+        /// </summary>
+        private enum ModifierType
+        {
+            /// <summary>
+            /// Represents default value
+            /// </summary>
+            None,
+            /// <summary>
+            /// Represents any of access modifiers i.e public, protected, internal, private
+            /// </summary>
+            Access,
+            /// <summary>
+            /// Represents static modifier
+            /// </summary>
+            Static,
+            /// <summary>
+            /// Represents other modifiers i.e partial, virtual, abstract, override, extern, unsafe, new, async, const, sealed, readonly, volatile, fixed
+            /// </summary>
+            Other
+        }
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
@@ -54,7 +79,177 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            // TODO: Implement analysis
+            context.RegisterSyntaxNodeActionHonorExclusions(HandleDeclaration, SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration, SyntaxKind.InterfaceDeclaration,
+                SyntaxKind.EnumDeclaration, SyntaxKind.DelegateDeclaration, SyntaxKind.FieldDeclaration, SyntaxKind.MethodDeclaration,
+                SyntaxKind.PropertyDeclaration, SyntaxKind.EventDeclaration, SyntaxKind.EventFieldDeclaration, SyntaxKind.IndexerDeclaration,
+                SyntaxKind.OperatorDeclaration, SyntaxKind.ConversionOperatorDeclaration, SyntaxKind.ConstructorDeclaration);
         }
+
+        private static void HandleDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var modifiers = GetModifiersFromDeclaration(context.Node);
+            CheckModifiersOrderAndReportDiagnostics(context, modifiers);
+        }
+
+        private static SyntaxTokenList GetModifiersFromDeclaration(SyntaxNode node)
+        {
+            SyntaxTokenList result = default(SyntaxTokenList);
+
+            switch (node.Kind())
+            {
+                case SyntaxKind.ClassDeclaration:
+                case SyntaxKind.StructDeclaration:
+                case SyntaxKind.InterfaceDeclaration:
+                    result = ((BaseTypeDeclarationSyntax)node).Modifiers;
+                    break;
+                case SyntaxKind.EnumDeclaration:
+                    result = ((EnumDeclarationSyntax)node).Modifiers;
+                    break;
+                case SyntaxKind.DelegateDeclaration:
+                    result = ((DelegateDeclarationSyntax)node).Modifiers;
+                    break;
+                case SyntaxKind.FieldDeclaration:
+                case SyntaxKind.EventFieldDeclaration:
+                    result = ((BaseFieldDeclarationSyntax)node).Modifiers;
+                    break;
+                case SyntaxKind.PropertyDeclaration:
+                case SyntaxKind.EventDeclaration:
+                case SyntaxKind.IndexerDeclaration:
+                    result = ((BasePropertyDeclarationSyntax)node).Modifiers;
+                    break;
+                case SyntaxKind.MethodDeclaration:
+                case SyntaxKind.ConstructorDeclaration:
+                case SyntaxKind.OperatorDeclaration:
+                case SyntaxKind.ConversionOperatorDeclaration:
+                    result = ((BaseMethodDeclarationSyntax)node).Modifiers;
+                    break;
+            }
+
+            return result;
+        }
+
+        private static void CheckModifiersOrderAndReportDiagnostics(SyntaxNodeAnalysisContext context, SyntaxTokenList modifiers)
+        {
+            var previousModifierType = ModifierType.None;
+            var otherModifiersAppearEarlier = false;
+
+            foreach (var modifier in modifiers)
+            {
+                var currentModifierType = GetModifierType(modifier);
+
+                if (CompareModifiersType(currentModifierType, previousModifierType) < 0)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, modifier.GetLocation(), GetModifierTypeText(currentModifierType), GetModifierTypeText(previousModifierType)));
+                }
+
+                if (AccessOrStaticModifierNotFollowingOtherModifier(currentModifierType, previousModifierType) && otherModifiersAppearEarlier)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, modifier.GetLocation(), GetModifierTypeText(currentModifierType), GetModifierTypeText(ModifierType.Other)));
+                }
+
+                if (!otherModifiersAppearEarlier)
+                {
+                    otherModifiersAppearEarlier = currentModifierType == ModifierType.Other;
+                }
+
+                previousModifierType = currentModifierType;
+            }
+        }
+
+        private static ModifierType GetModifierType(SyntaxToken modifier)
+        {
+            var result = default(ModifierType);
+
+            switch (modifier.Kind())
+            {
+                case SyntaxKind.PublicKeyword:
+                case SyntaxKind.ProtectedKeyword:
+                case SyntaxKind.InternalKeyword:
+                case SyntaxKind.PrivateKeyword:
+                    result = ModifierType.Access;
+                    break;
+                case SyntaxKind.StaticKeyword:
+                    result = ModifierType.Static;
+                    break;
+                case SyntaxKind.VirtualKeyword:
+                case SyntaxKind.AbstractKeyword:
+                case SyntaxKind.OverrideKeyword:
+                case SyntaxKind.ExternKeyword:
+                case SyntaxKind.UnsafeKeyword:
+                case SyntaxKind.NewKeyword:
+                case SyntaxKind.SealedKeyword:
+                case SyntaxKind.ReadOnlyKeyword:
+                case SyntaxKind.VolatileKeyword:
+                case SyntaxKind.FixedKeyword:
+                case SyntaxKind.ConstKeyword:
+                case SyntaxKind.AsyncKeyword:
+                case SyntaxKind.PartialKeyword:
+                    result = ModifierType.Other;
+                    break;
+            }
+
+            return result;
+        }
+
+        private static int CompareModifiersType(ModifierType first, ModifierType second)
+        {
+            const int lessThan = -1;
+            const int greaterThan = 1;
+
+            var result = 0;
+
+            if (first == second)
+            {
+                result = 0;
+            }
+            else if (first == ModifierType.None)
+            {
+                result = lessThan;
+            }
+            else if (second == ModifierType.None)
+            {
+                result = greaterThan;
+            }
+            else if (first == ModifierType.Access && (second == ModifierType.Static || second == ModifierType.Other))
+            {
+                result = lessThan;
+            }
+            else if (first == ModifierType.Static && second == ModifierType.Other)
+            {
+                result = lessThan;
+            }
+            else if (first == ModifierType.Static && second == ModifierType.Access)
+            {
+                result = greaterThan;
+            }
+            else if (first == ModifierType.Other && (second == ModifierType.Static || second == ModifierType.Access))
+            {
+                result = greaterThan;
+            }
+
+            return result;
+        }
+
+        private static string GetModifierTypeText(ModifierType modifierType)
+        {
+            var result = string.Empty;
+
+            switch (modifierType)
+            {
+                case ModifierType.Access:
+                    result = "access modifier";
+                    break;
+                case ModifierType.Static:
+                    result = "static";
+                    break;
+                case ModifierType.Other:
+                    result = "other";
+                    break;
+            }
+
+            return result;
+        }
+
+        private static bool AccessOrStaticModifierNotFollowingOtherModifier(ModifierType current, ModifierType previous) => (current == ModifierType.Access || current == ModifierType.Static) && previous != ModifierType.Other;
     }
 }


### PR DESCRIPTION
Fixes #66 

This is implementation of SA1206 rule

Implementation return diagnostics as orginal StyleCop.
But there are a slight differences :
* location of diagnostic is set to location of modifier, instead of start of line containing declaration
* if there are more than one access modifier diagnostics are reported seperately for those access modifiers