### PR TITLE
Fix SA1119 for rc3

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerExtensions.cs
@@ -64,5 +64,24 @@ namespace StyleCop.Analyzers
                 },
                 syntaxKinds);
         }
+
+        internal static void RegisterSyntaxNodeActionHonorExclusions<TLanguageKindEnum>(this CompilationStartAnalysisContext context, Action<SyntaxNodeAnalysisContext> action, params TLanguageKindEnum[] syntaxKinds) where TLanguageKindEnum : struct
+        {
+            context.RegisterSyntaxNodeAction(
+                c =>
+                {
+                    if (c.IsGenerated())
+                    {
+                        return;
+                    }
+
+                    // Honor the containing document item's ExcludeFromStylecop=True
+                    // MSBuild metadata, if analyzers have access to it.
+                    //// TODO: code here
+
+                    action(c);
+                },
+                syntaxKinds);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119StatementMustNotUseUnnecessaryParenthesis.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119StatementMustNotUseUnnecessaryParenthesis.cs
@@ -58,7 +58,7 @@
             new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
         private static readonly DiagnosticDescriptor ParenthesisDescriptor =
-            new DiagnosticDescriptor(ParenthesesDiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Hidden, false, Description, HelpLink, customTags: new[] { WellKnownDiagnosticTags.Unnecessary, WellKnownDiagnosticTags.NotConfigurable });
+            new DiagnosticDescriptor(ParenthesesDiagnosticId, Title, MessageFormat, Category, DiagnosticSeverity.Hidden, AnalyzerConstants.EnabledByDefault, Description, HelpLink, customTags: new[] { WellKnownDiagnosticTags.Unnecessary, WellKnownDiagnosticTags.NotConfigurable });
 
         private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
             ImmutableArray.Create(Descriptor, ParenthesisDescriptor);
@@ -75,7 +75,16 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterSyntaxNodeActionHonorExclusions(this.HandleParenthesizedExpression, SyntaxKind.ParenthesizedExpression);
+            context.RegisterCompilationStartAction(startContext =>
+            {
+                // Only register the syntax node action if the diagnostic is enabled. This is important because
+                // otherwise the diagnostic for fading out the parenthesis is still active, even if the main diagnostic
+                // is disabled
+                if (startContext.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(Descriptor.Id) != Microsoft.CodeAnalysis.ReportDiagnostic.Suppress)
+                {
+                    startContext.RegisterSyntaxNodeActionHonorExclusions(this.HandleParenthesizedExpression, SyntaxKind.ParenthesizedExpression);
+                }
+            });
         }
 
         private void HandleParenthesizedExpression(SyntaxNodeAnalysisContext context)


### PR DESCRIPTION
Fixes #929. I verified that this works in rc3 as well as rc2. I would like to implement tests that verify that the parenthesis diagnostic is not reported if the main diagnostic is suppressed, but I need #522 for that.