### PR TITLE
Introduce GetReplacementToken helper for Dictionary

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DictionaryHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DictionaryHelper.cs
@@ -1,0 +1,23 @@
+﻿namespace StyleCop.Analyzers.Helpers
+{
+    using System.Collections.Generic;
+    using Microsoft.CodeAnalysis;
+
+    internal static class DictionaryHelper
+    {
+        /// <summary>
+        /// This helper method allow us avoid closure allocations when used with SyntaxNode.ReplaceTokens and etc.
+        /// </summary>
+        /// <param name="replacements">Dictionary with key value pairs {token to replace, replacement token}.</param>
+        /// <param name="original">The token to replace. This argument used for getting replacement token from dictionary.</param>
+        /// <param name="couldBeRewritten">The token to replace which could be rewritten. We ignore this argument.</param>
+        /// <returns>Returns replacement token from dicionary.</returns>
+        internal static SyntaxToken GetReplacementToken(
+            this Dictionary<SyntaxToken, SyntaxToken> replacements,
+            SyntaxToken original,
+            SyntaxToken couldBeRewritten)
+        {
+            return replacements[original];
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DocumentationCommentExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DocumentationCommentExtensions.cs
@@ -241,7 +241,7 @@
                 replacements[pair.Value] = pair.Value.WithLeadingTrivia(pair.Value.LeadingTrivia.InsertRange(0, pair.Key.TrailingTrivia));
             }
 
-            return node.ReplaceTokens(replacements.Keys, (originalToken, rewrittenToken) => replacements[originalToken]);
+            return node.ReplaceTokens(replacements.Keys, replacements.GetReplacementToken);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1505CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1505CodeFixProvider.cs
@@ -76,7 +76,7 @@
                 [nextToken] = nextToken.WithLeadingTrivia(triviaList.Skip(lastEndOfLineIndex + 1))
             };
 
-            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, (t1, t2) => replaceMap[t1]);
+            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, replaceMap.GetReplacementToken);
             return document.WithSyntaxRoot(newSyntaxRoot);
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1508CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1508CodeFixProvider.cs
@@ -85,7 +85,7 @@
                 [closeBraceToken] = closeBraceToken.WithLeadingTrivia(triviaList.Skip(firstLeadingWhitespace))
             };
 
-            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, (t1, t2) => replaceMap[t1]);
+            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, replaceMap.GetReplacementToken);
             return document.WithSyntaxRoot(newSyntaxRoot);
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1102CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1102CodeFixProvider.cs
@@ -59,7 +59,7 @@
                 [token] = token.WithLeadingTrivia(indentationTrivia)
             };
 
-            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, (t1, t2) => replaceMap[t1]).WithoutFormatting();
+            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, replaceMap.GetReplacementToken).WithoutFormatting();
             return document.WithSyntaxRoot(newSyntaxRoot);
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1103CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1103CodeFixProvider.cs
@@ -96,7 +96,7 @@
                 replaceMap.Add(token, token.WithLeadingTrivia());
             }
 
-            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, (t1, t2) => replaceMap[t1]).WithoutFormatting();
+            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, replaceMap.GetReplacementToken).WithoutFormatting();
             return document.WithSyntaxRoot(newSyntaxRoot);
         }
 
@@ -126,7 +126,7 @@
                 }
             }
 
-            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, (t1, t2) => replaceMap[t1]).WithoutFormatting();
+            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, replaceMap.GetReplacementToken).WithoutFormatting();
             return document.WithSyntaxRoot(newSyntaxRoot);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1104SA1105CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1104SA1105CodeFixProvider.cs
@@ -61,7 +61,7 @@
                 [token] = token.WithLeadingTrivia(indentationTrivia)
             };
 
-            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, (t1, t2) => replaceMap[t1]).WithoutFormatting();
+            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, replaceMap.GetReplacementToken).WithoutFormatting();
             return document.WithSyntaxRoot(newSyntaxRoot);
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
@@ -101,7 +101,7 @@
                 replacements[token] = corrected;
             }
 
-            var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
+            var transformed = root.ReplaceTokens(replacements.Keys, replacements.GetReplacementToken);
             return Task.FromResult(document.WithSyntaxRoot(transformed));
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002CodeFixProvider.cs
@@ -94,7 +94,7 @@
                 replacements[token] = corrected;
             }
 
-            var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
+            var transformed = root.ReplaceTokens(replacements.Keys, replacements.GetReplacementToken);
             Document updatedDocument = document.WithSyntaxRoot(transformed);
 
             return updatedDocument;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
@@ -106,7 +106,7 @@
                 replacements[token] = correctedOperatorNoSpace;
             }
 
-            var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
+            var transformed = root.ReplaceTokens(replacements.Keys, replacements.GetReplacementToken);
             Document updatedDocument = document.WithSyntaxRoot(transformed);
 
             return Task.FromResult(updatedDocument);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008CodeFixProvider.cs
@@ -110,7 +110,7 @@
                 return document;
             }
 
-            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, (t1, t2) => replaceMap[t1]);
+            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, replaceMap.GetReplacementToken);
             return document.WithSyntaxRoot(newSyntaxRoot);
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
@@ -111,7 +111,7 @@
                 return Task.FromResult(document);
             }
 
-            var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
+            var transformed = root.ReplaceTokens(replacements.Keys, replacements.GetReplacementToken);
             Document updatedDocument = document.WithSyntaxRoot(transformed);
 
             return Task.FromResult(updatedDocument);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
@@ -11,6 +11,7 @@
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// Implements a code fix for <see cref="SA1018NullableTypeSymbolsMustNotBePrecededBySpace"/>.
@@ -93,7 +94,7 @@
                 [questionToken] = questionToken.WithLeadingTrivia()
             };
 
-            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, (t1, t2) => replaceMap[t1]);
+            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, replaceMap.GetReplacementToken);
             return document.WithSyntaxRoot(newSyntaxRoot);
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021CodeFixProvider.cs
@@ -96,7 +96,7 @@
                 replacements.Add(token, corrected);
             }
 
-            var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
+            var transformed = root.ReplaceTokens(replacements.Keys, replacements.GetReplacementToken);
             Document updatedDocument = document.WithSyntaxRoot(transformed);
 
             return Task.FromResult(updatedDocument);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022CodeFixProvider.cs
@@ -96,7 +96,7 @@
                 replacements.Add(token, corrected);
             }
 
-            var transformed = root.ReplaceTokens(replacements.Keys, (original, maybeRewritten) => replacements[original]);
+            var transformed = root.ReplaceTokens(replacements.Keys, replacements.GetReplacementToken);
             Document updatedDocument = document.WithSyntaxRoot(transformed);
 
             return Task.FromResult(updatedDocument);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Helpers\NameSyntaxHelpers.cs" />
     <Compile Include="Helpers\RenameHelper.cs" />
     <Compile Include="Helpers\SpecializedTasks.cs" />
+    <Compile Include="Helpers\DictionaryHelper.cs" />
     <Compile Include="Helpers\TokenHelpers.cs" />
     <Compile Include="Helpers\TriviaHelper.cs" />
     <Compile Include="Helpers\UsingDirectiveSyntaxHelpers.cs" />


### PR DESCRIPTION
This helper method allow us avoid closure allocations when used with SyntaxNode.ReplaceTokens and etc.