### PR TITLE
Add a equivalence key to all code actions

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1609SA1610CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1609SA1610CodeFixProvider.cs
@@ -50,7 +50,7 @@
                 }
 
                 string description = DocumentationResources.SA1609SA1610CodeFix;
-                context.RegisterCodeFix(CodeAction.Create(description, cancellationToken => this.GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(description, cancellationToken => this.GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken), equivalenceKey: nameof(SA1609SA1610CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1615SA1616CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1615SA1616CodeFixProvider.cs
@@ -50,7 +50,7 @@
                 }
 
                 string description = "Document return value";
-                context.RegisterCodeFix(CodeAction.Create(description, cancellationToken => this.GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(description, cancellationToken => this.GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken), equivalenceKey: nameof(SA1615SA1616CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1617CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1617CodeFixProvider.cs
@@ -39,7 +39,7 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(DocumentationResources.SA1617CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(DocumentationResources.SA1617CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1617CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -56,7 +56,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(DocumentationResources.SA1642SA1643CodeFix, token => GetTransformedDocumentAsync(context.Document, root, node)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(DocumentationResources.SA1642SA1643CodeFix, token => GetTransformedDocumentAsync(context.Document, root, node), equivalenceKey: nameof(SA1642SA1643CodeFixProvider)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1651CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1651CodeFixProvider.cs
@@ -65,7 +65,7 @@
                 }
 
                 string description = DocumentationResources.SA1651CodeFix;
-                context.RegisterCodeFix(CodeAction.Create(description, cancellationToken => this.GetTransformedDocumentAsync(context.Document, xmlElementSyntax, cancellationToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(description, cancellationToken => this.GetTransformedDocumentAsync(context.Document, xmlElementSyntax, cancellationToken), equivalenceKey: nameof(SA1651CodeFixProvider)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1500CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1500CodeFixProvider.cs
@@ -45,7 +45,7 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1500CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1500CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1500CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501CodeFixProvider.cs
@@ -37,7 +37,7 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1501CodeFix, cancellationToken => this.GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1501CodeFix, cancellationToken => this.GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken), equivalenceKey: nameof(SA1501CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1502CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1502CodeFixProvider.cs
@@ -37,7 +37,7 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1502CodeFix, token => this.GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1502CodeFix, token => this.GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1502CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CodeFixProvider.cs
@@ -58,7 +58,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1503CodeFix, token => GetTransformedDocumentAsync(context.Document, syntaxRoot, node, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1503CodeFix, token => GetTransformedDocumentAsync(context.Document, syntaxRoot, node, token), equivalenceKey: nameof(SA1503CodeFixProvider)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1505CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1505CodeFixProvider.cs
@@ -36,7 +36,7 @@
         {
             foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1505CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1505CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1505CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1506CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1506CodeFixProvider.cs
@@ -35,7 +35,7 @@
         {
             foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1506CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1506CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1506CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1507CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1507CodeFixProvider.cs
@@ -35,7 +35,7 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1507CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1507CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1507CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1508CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1508CodeFixProvider.cs
@@ -36,7 +36,7 @@
         {
             foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1508CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1508CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1508CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1509CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1509CodeFixProvider.cs
@@ -39,7 +39,8 @@
                 context.RegisterCodeFix(
                     CodeAction.Create(
                         LayoutResources.SA1509CodeFix,
-                        token => this.GetTransformedDocumentAsync(context.Document, diagnostic, token)),
+                        token => this.GetTransformedDocumentAsync(context.Document, diagnostic, token),
+                        equivalenceKey: nameof(SA1509CodeFixProvider)),
                     diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1510CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1510CodeFixProvider.cs
@@ -34,7 +34,7 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1510CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1510CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1510CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1511CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1511CodeFixProvider.cs
@@ -34,7 +34,7 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1511CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1511CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1511CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1512CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1512CodeFixProvider.cs
@@ -35,7 +35,7 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1512CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1512CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1512CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513CodeFixProvider.cs
@@ -38,7 +38,7 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1513CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1513CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1513CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1514CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1514CodeFixProvider.cs
@@ -35,7 +35,7 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1514CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1514CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1514CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515CodeFixProvider.cs
@@ -35,7 +35,7 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1515CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1515CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1515CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1516CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1516CodeFixProvider.cs
@@ -41,7 +41,7 @@
                 var leadingTrivia = node?.GetLeadingTrivia();
                 if (leadingTrivia != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1516CodeFix, token => GetTransformedDocumentAsync(context, syntaxRoot, node, (SyntaxTriviaList)leadingTrivia)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1516CodeFix, token => GetTransformedDocumentAsync(context, syntaxRoot, node, (SyntaxTriviaList)leadingTrivia), equivalenceKey: nameof(SA1516CodeFixProvider)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1517CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1517CodeFixProvider.cs
@@ -35,7 +35,7 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1517CodeFix, token => GetTransformedDocumentAsync(context.Document, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1517CodeFix, token => GetTransformedDocumentAsync(context.Document, token), equivalenceKey: nameof(SA1517CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1518CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1518CodeFixProvider.cs
@@ -35,7 +35,7 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1518CodeFix, token => GetTransformedDocumentAsync(context.Document, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1518CodeFix, token => GetTransformedDocumentAsync(context.Document, token), equivalenceKey: nameof(SA1518CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
@@ -55,7 +55,7 @@
 
                 if (syntax != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create(MaintainabilityResources.SA1119CodeFix, token => GetTransformedDocumentAsync(context.Document, root, syntax)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create(MaintainabilityResources.SA1119CodeFix, token => GetTransformedDocumentAsync(context.Document, root, syntax), equivalenceKey: nameof(SA1119CodeFixProvider)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
@@ -57,7 +57,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(MaintainabilityResources.SA1400CodeFix, token => GetTransformedDocumentAsync(context.Document, root, declarationNode)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(MaintainabilityResources.SA1400CodeFix, token => GetTransformedDocumentAsync(context.Document, root, declarationNode), equivalenceKey: nameof(SA1400CodeFixProvider)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1402CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1402CodeFixProvider.cs
@@ -45,7 +45,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(MaintainabilityResources.SA1402CodeFix, cancellationToken => GetTransformedSolutionAsync(context.Document, diagnostic, cancellationToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(MaintainabilityResources.SA1402CodeFix, cancellationToken => GetTransformedSolutionAsync(context.Document, diagnostic, cancellationToken), equivalenceKey: nameof(SA1402CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
@@ -53,7 +53,7 @@
                 BinaryExpressionSyntax syntax = node as BinaryExpressionSyntax;
                 if (syntax != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create(MaintainabilityResources.SA1407SA1408CodeFix, token => GetTransformedDocumentAsync(context.Document, root, syntax)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create(MaintainabilityResources.SA1407SA1408CodeFix, token => GetTransformedDocumentAsync(context.Document, root, syntax), equivalenceKey: nameof(SA1407SA1408CodeFixProvider)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1410SA1411CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1410SA1411CodeFixProvider.cs
@@ -56,7 +56,7 @@
 
                 if (node != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create(MaintainabilityResources.SA1410SA1411CodeFix, token => GetTransformedDocumentAsync(context.Document, root, node)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create(MaintainabilityResources.SA1410SA1411CodeFix, token => GetTransformedDocumentAsync(context.Document, root, node), equivalenceKey: nameof(SA1410SA1411CodeFixProvider)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1304SA1311CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1304SA1311CodeFixProvider.cs
@@ -74,7 +74,7 @@
                         newName = newName + Suffix;
                     }
 
-                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.SA1304SA1311CodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.SA1304SA1311CodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken), equivalenceKey: nameof(SA1304SA1311CodeFixProvider)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1306CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1306CodeFixProvider.cs
@@ -53,7 +53,7 @@
                 if (!string.IsNullOrEmpty(token.ValueText))
                 {
                     var newName = char.ToLower(token.ValueText[0]) + token.ValueText.Substring(1);
-                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.SA1306CodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.SA1306CodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken), equivalenceKey: nameof(SA1306CodeFixProvider)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1307CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1307CodeFixProvider.cs
@@ -52,7 +52,7 @@
                 if (!string.IsNullOrEmpty(token.ValueText))
                 {
                     var newName = char.ToUpper(token.ValueText[0]) + token.ValueText.Substring(1);
-                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.SA1307CodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.SA1307CodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken), equivalenceKey: nameof(SA1307CodeFixProvider)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1308CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1308CodeFixProvider.cs
@@ -78,7 +78,7 @@
                 if (!string.IsNullOrEmpty(token.ValueText))
                 {
                     var newName = token.ValueText.Substring(numberOfCharsToRemove);
-                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.SA1308CodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.SA1308CodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken), equivalenceKey: nameof(SA1308CodeFixProvider)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1309CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1309CodeFixProvider.cs
@@ -61,7 +61,7 @@
                         continue;
                     }
 
-                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.SA1309CodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.SA1309CodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken), equivalenceKey: nameof(SA1309CodeFixProvider)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1310CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1310CodeFixProvider.cs
@@ -55,7 +55,7 @@
                 string proposedName = BuildProposedName(currentName);
                 if (proposedName != currentName)
                 {
-                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.SA1310CodeFix, proposedName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, proposedName, cancellationToken)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.SA1310CodeFix, proposedName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, proposedName, cancellationToken), equivalenceKey: nameof(SA1310CodeFixProvider)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SX1309CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SX1309CodeFixProvider.cs
@@ -55,7 +55,7 @@
                 if (!string.IsNullOrEmpty(token.ValueText))
                 {
                     string newName = '_' + token.ValueText;
-                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.SX1309CodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.SX1309CodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken), equivalenceKey: nameof(SA1309CodeFixProvider)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1205CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1205CodeFixProvider.cs
@@ -36,7 +36,7 @@
         {
             foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(OrderingResources.SA1205CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(OrderingResources.SA1205CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1205CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionCodeFixProvider.cs
@@ -43,7 +43,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create("Remove region", token => GetTransformedDocumentAsync(context.Document, diagnostic)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create("Remove region", token => GetTransformedDocumentAsync(context.Document, diagnostic), equivalenceKey: nameof(RemoveRegionCodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
@@ -50,7 +50,7 @@
                     return;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1100CodeFix, token => GetTransformedDocumentAsync(context.Document, root, node)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1100CodeFix, token => GetTransformedDocumentAsync(context.Document, root, node), equivalenceKey: nameof(SA1100CodeFixProvider)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
@@ -51,7 +51,7 @@
                     return;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1101CodeFix, token => GetTransformedDocumentAsync(context.Document, root, diagnostic, node)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1101CodeFix, token => GetTransformedDocumentAsync(context.Document, root, diagnostic, node), equivalenceKey: nameof(SA1101CodeFixProvider)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1103CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1103CodeFixProvider.cs
@@ -44,10 +44,10 @@
 
                 if (queryExpression.DescendantTrivia().All(AcceptableSingleLineTrivia))
                 {
-                    context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1103CodeFixSingleLine, token => GetTransformedDocumentFromSingleLineAsync(context.Document, diagnostic, token)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1103CodeFixSingleLine, token => GetTransformedDocumentFromSingleLineAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1103CodeFixProvider)), diagnostic);
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1103CodeFixMultipleLines, token => GetTransformedDocumentForMultipleLinesAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1103CodeFixMultipleLines, token => GetTransformedDocumentForMultipleLinesAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1103CodeFixProvider)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1104SA1105CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1104SA1105CodeFixProvider.cs
@@ -37,7 +37,7 @@
         {
             foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1104SA1105CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1104SA1105CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1104SA1105CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1107CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1107CodeFixProvider.cs
@@ -50,7 +50,7 @@
 
                 if (node?.Parent as BlockSyntax != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1107CodeFix, token => GetTransformedDocumentAsync(context.Document, root, node)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1107CodeFix, token => GetTransformedDocumentAsync(context.Document, root, node), equivalenceKey: nameof(SA1107CodeFixProvider)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
@@ -65,7 +65,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1121CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1121CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1121CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
@@ -57,7 +57,7 @@
                 var node = root?.FindNode(diagnostic.Location.SourceSpan, findInsideTrivia: true, getInnermostNodeForTie: true);
                 if (node != null && node.IsKind(SyntaxKind.StringLiteralExpression))
                 {
-                    context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1122CodeFix, token => GetTransformedDocumentAsync(context.Document, root, node)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1122CodeFix, token => GetTransformedDocumentAsync(context.Document, root, node), equivalenceKey: nameof(SA1122CodeFixProvider)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000CodeFixProvider.cs
@@ -49,7 +49,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1000CodeFix, t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1000CodeFix, t => GetTransformedDocumentAsync(context.Document, root, token), equivalenceKey: nameof(SA1000CodeFixProvider)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
@@ -51,7 +51,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1001CodeFix, t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1001CodeFix, t => GetTransformedDocumentAsync(context.Document, root, token), equivalenceKey: nameof(SA1001CodeFixProvider)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002CodeFixProvider.cs
@@ -44,7 +44,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1002CodeFix, t => GetTransformedDocumentAsync(context.Document, diagnostic, t)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1002CodeFix, t => GetTransformedDocumentAsync(context.Document, diagnostic, t), equivalenceKey: nameof(SA1002CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
@@ -42,7 +42,7 @@
             {
                 if (diagnostic.Properties.ContainsKey(SA1003SymbolsMustBeSpacedCorrectly.CodeFixAction))
                 {
-                    context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1003CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1003CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1003CodeFixProvider)), diagnostic);
                 }
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1004CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1004CodeFixProvider.cs
@@ -43,7 +43,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1004CodeFix, token => GetTransformedDocumentAsync(context.Document, root, diagnostic)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1004CodeFix, token => GetTransformedDocumentAsync(context.Document, root, diagnostic), equivalenceKey: nameof(SA1004CodeFixProvider)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
@@ -50,7 +50,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1005CodeFix, t => GetTransformedDocumentAsync(context.Document, root, trivia)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1005CodeFix, t => GetTransformedDocumentAsync(context.Document, root, trivia), equivalenceKey: nameof(SA1005CodeFixProvider)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1006CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1006CodeFixProvider.cs
@@ -49,7 +49,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1006CodeFix, t => GetTransformedDocumentAsync(context.Document, root, keywordToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1006CodeFix, t => GetTransformedDocumentAsync(context.Document, root, keywordToken), equivalenceKey: nameof(SA1006CodeFixProvider)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1007CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1007CodeFixProvider.cs
@@ -53,7 +53,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1007CodeFix, t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1007CodeFix, t => GetTransformedDocumentAsync(context.Document, root, token), equivalenceKey: nameof(SA1007CodeFixProvider)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008CodeFixProvider.cs
@@ -36,7 +36,7 @@
         {
             foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
             {
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1008CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1008CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1008CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010CodeFixProvider.cs
@@ -46,7 +46,8 @@
 
                 context.RegisterCodeFix(
                     CodeAction.Create(SpacingResources.SA1010CodeFix,
-                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken)),
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        equivalenceKey: nameof(SA1010CodeFixProvider)),
                         diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
@@ -51,7 +51,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1011CodeFix, t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1011CodeFix, t => GetTransformedDocumentAsync(context.Document, root, token), equivalenceKey: nameof(SA1011ClosingSquareBracketsMustBeSpacedCorrectly)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016CodeFixProvider.cs
@@ -43,7 +43,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1016CodeFix, cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1016CodeFix, cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken), equivalenceKey: nameof(SA1016CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017CodeFixProvider.cs
@@ -43,7 +43,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1017CodeFix, cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1017CodeFix, cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken), equivalenceKey: nameof(SA1017CodeFixProvider)), diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
@@ -58,7 +58,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1018CodeFix, cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1018CodeFix, cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken), equivalenceKey: nameof(SA1018CodeFixProvider)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021CodeFixProvider.cs
@@ -52,7 +52,7 @@
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1021CodeFix, t => GetTransformedDocumentAsync(context.Document, root, token)), diagnostic);
+                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1021CodeFix, t => GetTransformedDocumentAsync(context.Document, root, token), equivalenceKey: nameof(SA1021CodeFixProvider)), diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
@@ -50,7 +50,8 @@
                     context.RegisterCodeFix(
                         CodeAction.Create(
                             SpacingResources.SA1028CodeFix,
-                            ct => RemoveWhitespaceAsync(context.Document, diagnostic, ct)),
+                            ct => RemoveWhitespaceAsync(context.Document, diagnostic, ct),
+                            equivalenceKey: nameof(SA1028CodeFixProvider)),
                         diagnostic);
                     break;
                 default:
@@ -61,7 +62,8 @@
                         context.RegisterCodeFix(
                             CodeAction.Create(
                                 SpacingResources.SA1028CodeFix,
-                                ct => RemoveWhitespaceAsync(context.Document, diagnostic, ct)),
+                                ct => RemoveWhitespaceAsync(context.Document, diagnostic, ct),
+                                equivalenceKey: nameof(SA1028CodeFixProvider)),
                             diagnostic);
                         break;
                     }


### PR DESCRIPTION
A roslyn analyzer will complain in rc3 if the equivalence key is not set. I set it to the concatenation of all diagnostic ids the code fix can fix. I don't think we have a code fix where we want to do it differently.