### PR TITLE
Implement a fix all provider for removing region directives

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1123UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1123UnitTests.cs
@@ -41,6 +41,7 @@
 }";
 
             await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            await this.VerifyCSharpFixAllFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -139,6 +140,44 @@
 }";
 
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestFixAllProviderAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    void MethodName()
+    {
+        #region Foo
+        #region Foo
+        #region Foo
+        #endregion
+        #endregion
+        #endregion
+        #region Foo
+        #region Foo
+        #region Foo
+        // Test
+        #endregion
+        #endregion
+        #endregion
+    }
+}
+";
+
+            string fixedCode = @"
+class ClassName
+{
+    void MethodName()
+    {
+        // Test
+    }
+}
+";
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAllFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1124UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1124UnitTests.cs
@@ -77,6 +77,7 @@
 }";
 
             await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            await this.VerifyCSharpFixAllFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -113,6 +114,7 @@
 }";
 
             await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            await this.VerifyCSharpFixAllFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -141,6 +143,7 @@
 }";
 
             await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            await this.VerifyCSharpFixAllFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -169,6 +172,7 @@
 }";
 
             await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            await this.VerifyCSharpFixAllFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -197,6 +201,7 @@
 }";
 
             await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            await this.VerifyCSharpFixAllFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DocumentBasedFixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DocumentBasedFixAllProvider.cs
@@ -1,0 +1,66 @@
+﻿namespace StyleCop.Analyzers.Helpers
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+
+    /// <summary>
+    /// Provides a base class to write a <see cref="FixAllProvider"/> that fixes documents independently.
+    /// </summary>
+    internal abstract class DocumentBasedFixAllProvider : FixAllProvider
+    {
+        protected abstract string CodeActionTitle { get; }
+
+        public override async Task<CodeAction> GetFixAsync(FixAllContext fixAllContext)
+        {
+            switch (fixAllContext.Scope)
+            {
+            case FixAllScope.Document:
+                var newRoot = await this.FixAllInDocumentAsync(fixAllContext, fixAllContext.Document).ConfigureAwait(false);
+                return CodeAction.Create(this.CodeActionTitle, token => Task.FromResult(fixAllContext.Document.WithSyntaxRoot(newRoot)));
+
+            case FixAllScope.Project:
+                Solution solution = await this.GetProjectFixesAsync(fixAllContext, fixAllContext.Project).ConfigureAwait(false);
+                return CodeAction.Create(this.CodeActionTitle, token => Task.FromResult(solution));
+
+            case FixAllScope.Solution:
+                var newSolution = fixAllContext.Solution;
+                var projectIds = newSolution.ProjectIds;
+                for (int i = 0; i < projectIds.Count; i++)
+                {
+                    newSolution = await this.GetProjectFixesAsync(fixAllContext, newSolution.GetProject(projectIds[i])).ConfigureAwait(false);
+                }
+
+                return CodeAction.Create(this.CodeActionTitle, token => Task.FromResult(newSolution));
+
+            case FixAllScope.Custom:
+            default:
+                return null;
+            }
+        }
+
+        private async Task<Solution> GetProjectFixesAsync(FixAllContext fixAllContext, Project project)
+        {
+            Solution solution = project.Solution;
+            var oldDocuments = project.Documents.ToImmutableArray();
+            List<Task<SyntaxNode>> newDocuments = new List<Task<SyntaxNode>>(oldDocuments.Length);
+            foreach (var document in oldDocuments)
+            {
+                newDocuments.Add(this.FixAllInDocumentAsync(fixAllContext, document));
+            }
+
+            for (int i = 0; i < oldDocuments.Length; i++)
+            {
+                var newDocumentRoot = await newDocuments[i].ConfigureAwait(false);
+                solution = solution.WithDocumentSyntaxRoot(oldDocuments[i].Id, newDocumentRoot);
+            }
+
+            return solution;
+        }
+
+        protected abstract Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document);
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionCodeFixProvider.cs
@@ -30,7 +30,7 @@
         public override FixAllProvider GetFixAllProvider()
         {
             // The batch fixer does not do a very good job if regions are stacked in each other
-            return CustomFixAllProviders.BatchFixer;
+            return new RemoveRegionFixAllProvider();
         }
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionFixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionFixAllProvider.cs
@@ -2,10 +2,10 @@
 {
     using System.Linq;
     using System.Threading.Tasks;
+    using Helpers;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
-    using Helpers;
 
     internal sealed class RemoveRegionFixAllProvider : DocumentBasedFixAllProvider
     {
@@ -13,24 +13,16 @@
 
         protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
         {
-            try
-            {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
-                SyntaxNode root = await document.GetSyntaxRootAsync().ConfigureAwait(false);
+            var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+            SyntaxNode root = await document.GetSyntaxRootAsync().ConfigureAwait(false);
 
-                var nodesToRemove = diagnostics.Select(d => root.FindNode(d.Location.SourceSpan, findInsideTrivia: true))
-                    .Where(node => node != null && !node.IsMissing)
-                    .OfType<RegionDirectiveTriviaSyntax>()
-                    .SelectMany(node => node.GetRelatedDirectives())
-                    .Where(node => !node.IsMissing);
+            var nodesToRemove = diagnostics.Select(d => root.FindNode(d.Location.SourceSpan, findInsideTrivia: true))
+                .Where(node => node != null && !node.IsMissing)
+                .OfType<RegionDirectiveTriviaSyntax>()
+                .SelectMany(node => node.GetRelatedDirectives())
+                .Where(node => !node.IsMissing);
 
-                return root.RemoveNodes(nodesToRemove, SyntaxRemoveOptions.AddElasticMarker);
-            }
-            catch (System.Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine(ex);
-                return null;
-            }
+            return root.RemoveNodes(nodesToRemove, SyntaxRemoveOptions.AddElasticMarker);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionFixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionFixAllProvider.cs
@@ -1,0 +1,36 @@
+﻿namespace StyleCop.Analyzers.ReadabilityRules
+{
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Helpers;
+
+    internal sealed class RemoveRegionFixAllProvider : DocumentBasedFixAllProvider
+    {
+        protected override string CodeActionTitle => "Remove region";
+
+        protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+        {
+            try
+            {
+                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                SyntaxNode root = await document.GetSyntaxRootAsync().ConfigureAwait(false);
+
+                var nodesToRemove = diagnostics.Select(d => root.FindNode(d.Location.SourceSpan, findInsideTrivia: true))
+                    .Where(node => node != null && !node.IsMissing)
+                    .OfType<RegionDirectiveTriviaSyntax>()
+                    .SelectMany(node => node.GetRelatedDirectives())
+                    .Where(node => !node.IsMissing);
+
+                return root.RemoveNodes(nodesToRemove, SyntaxRemoveOptions.AddElasticMarker);
+            }
+            catch (System.Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(ex);
+                return null;
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1107FixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1107FixAllProvider.cs
@@ -1,64 +1,18 @@
 ﻿namespace StyleCop.Analyzers.ReadabilityRules
 {
-    using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CodeActions;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Editing;
+    using StyleCop.Analyzers.Helpers;
 
-    internal class SA1107FixAllProvider : FixAllProvider
+    internal class SA1107FixAllProvider : DocumentBasedFixAllProvider
     {
-        public override async Task<CodeAction> GetFixAsync(FixAllContext fixAllContext)
-        {
-            switch (fixAllContext.Scope)
-            {
-            case FixAllScope.Document:
-                var newRoot = await this.FixAllInDocumentAsync(fixAllContext, fixAllContext.Document).ConfigureAwait(false);
-                return CodeAction.Create(ReadabilityResources.SA1107CodeFix, token => Task.FromResult(fixAllContext.Document.WithSyntaxRoot(newRoot)));
+        protected override string CodeActionTitle => ReadabilityResources.SA1107CodeFix;
 
-            case FixAllScope.Project:
-                Solution solution = await this.GetProjectFixesAsync(fixAllContext, fixAllContext.Project).ConfigureAwait(false);
-                return CodeAction.Create(ReadabilityResources.SA1107CodeFix, token => Task.FromResult(solution));
-
-            case FixAllScope.Solution:
-                var newSolution = fixAllContext.Solution;
-                var projectIds = newSolution.ProjectIds;
-                for (int i = 0; i < projectIds.Count; i++)
-                {
-                    newSolution = await this.GetProjectFixesAsync(fixAllContext, newSolution.GetProject(projectIds[i])).ConfigureAwait(false);
-                }
-
-                return CodeAction.Create(ReadabilityResources.SA1107CodeFix, token => Task.FromResult(newSolution));
-
-            case FixAllScope.Custom:
-            default:
-                return null;
-            }
-        }
-
-        private async Task<Solution> GetProjectFixesAsync(FixAllContext fixAllContext, Project project)
-        {
-            Solution solution = project.Solution;
-            var oldDocuments = project.Documents.ToImmutableArray();
-            List<Task<SyntaxNode>> newDocuments = new List<Task<SyntaxNode>>(oldDocuments.Length);
-            foreach (var document in oldDocuments)
-            {
-                newDocuments.Add(this.FixAllInDocumentAsync(fixAllContext, document));
-            }
-
-            for (int i = 0; i < oldDocuments.Length; i++)
-            {
-                var newDocumentRoot = await newDocuments[i].ConfigureAwait(false);
-                solution = solution.WithDocumentSyntaxRoot(oldDocuments[i].Id, newDocumentRoot);
-            }
-
-            return solution;
-        }
-
-        private async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+        protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
         {
             DocumentEditor editor = await DocumentEditor.CreateAsync(document, fixAllContext.CancellationToken).ConfigureAwait(false);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -201,6 +201,7 @@
     <Compile Include="MaintainabilityRules\SA1407ArithmeticExpressionsMustDeclarePrecedence.cs" />
     <Compile Include="MaintainabilityRules\SA1407SA1408CodeFixProvider.cs" />
     <Compile Include="Helpers\DocumentBasedFixAllProvider.cs" />
+    <Compile Include="ReadabilityRules\RemoveRegionFixAllProvider.cs" />
     <Compile Include="MaintainabilityRules\SA1407SA1408FixAllProvider.cs" />
     <Compile Include="MaintainabilityRules\SA1408ConditionalExpressionsMustDeclarePrecedence.cs" />
     <Compile Include="MaintainabilityRules\SA1409RemoveUnnecessaryCode.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -200,6 +200,7 @@
     <Compile Include="MaintainabilityRules\SA1406DebugFailMustProvideMessageText.cs" />
     <Compile Include="MaintainabilityRules\SA1407ArithmeticExpressionsMustDeclarePrecedence.cs" />
     <Compile Include="MaintainabilityRules\SA1407SA1408CodeFixProvider.cs" />
+    <Compile Include="Helpers\DocumentBasedFixAllProvider.cs" />
     <Compile Include="MaintainabilityRules\SA1407SA1408FixAllProvider.cs" />
     <Compile Include="MaintainabilityRules\SA1408ConditionalExpressionsMustDeclarePrecedence.cs" />
     <Compile Include="MaintainabilityRules\SA1409RemoveUnnecessaryCode.cs" />


### PR DESCRIPTION
While testing I discovered that the BatchFixer screws up when multiple regions are close together.