### PR TITLE
Fix for issue #958. SA1001 reported for multidimensional array

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
@@ -133,6 +133,24 @@
             await this.TestCommaInStatementOrDeclAsync(statement, expected, fixedStatement).ConfigureAwait(false);
         }
 
+        [Fact]
+        public async Task TestCommaFollowedByBracketInArrayDeclAsync()
+        {
+            string statement = @"int[,] myArray;";
+            await this.TestCommaInStatementOrDeclAsync(statement, EmptyDiagnosticResults, statement).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestSpaceBeforeCommaFollowedByBracketInArrayDeclAsync()
+        {
+            string statement = @"int[, ,] myArray;";
+            string fixedStatement = @"int[,,] myArray;";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 19);
+
+            await this.TestCommaInStatementOrDeclAsync(statement, expected, fixedStatement).ConfigureAwait(false);
+        }
+
         private Task TestCommaInStatementOrDeclAsync(string originalStatement, DiagnosticResult expected, string fixedStatement)
         {
             return this.TestCommaInStatementOrDeclAsync(originalStatement, new[] { expected }, fixedStatement);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CodeFixProvider.cs
@@ -75,9 +75,9 @@
             else
             {
                 SyntaxToken nextToken = token.GetNextToken();
-                if (nextToken.IsKind(SyntaxKind.CommaToken) || nextToken.IsKind(SyntaxKind.GreaterThanToken))
+                if (nextToken.IsKind(SyntaxKind.CommaToken) || nextToken.IsKind(SyntaxKind.GreaterThanToken) || nextToken.IsKind(SyntaxKind.CloseBracketToken))
                 {
-                    // make an exception for things like typeof(Func<,>) and typeof(Func<,,>)
+                    // make an exception for things like typeof(Func<,>), typeof(Func<,,>) and int[,] myArray
                     missingFollowingSpace = false;
                 }
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CommasMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CommasMustBeSpacedCorrectly.cs
@@ -88,9 +88,9 @@
             else
             {
                 SyntaxToken nextToken = token.GetNextToken();
-                if (nextToken.IsKind(SyntaxKind.CommaToken) || nextToken.IsKind(SyntaxKind.GreaterThanToken))
+                if (nextToken.IsKind(SyntaxKind.CommaToken) || nextToken.IsKind(SyntaxKind.GreaterThanToken) || nextToken.IsKind(SyntaxKind.CloseBracketToken))
                 {
-                    // make an exception for things like typeof(Func<,>) and typeof(Func<,,>)
+                    // make an exception for things like typeof(Func<,>), typeof(Func<,,>) and int[,] myArray
                     missingFollowingSpace = false;
                 }
             }


### PR DESCRIPTION
Fix for issue #958. A warning was being raised when a multidimensional array was declared. Also implement code fix if spaces are found around comma in a multidimensional array declaration.