### PR TITLE
Remove unnecessary Location allocations

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
@@ -173,7 +173,7 @@
             {
                 if (!XmlCommentHelper.HasDocumentation(declaration))
                 {
-                    var locations = variableDeclaration.Variables.Select(v => v.Identifier.GetLocation()).ToArray();
+                    var locations = variableDeclaration.Variables.Select(v => v.Identifier.GetLocation());
                     foreach (var location in locations)
                     {
                         context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));
@@ -232,7 +232,7 @@
             {
                 if (!XmlCommentHelper.HasDocumentation(declaration))
                 {
-                    var locations = variableDeclaration.Variables.Select(v => v.Identifier.GetLocation()).ToArray();
+                    var locations = variableDeclaration.Variables.Select(v => v.Identifier.GetLocation());
                     foreach (var location in locations)
                     {
                         context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/LocationHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/LocationHelpers.cs
@@ -8,13 +8,53 @@
     internal static class LocationHelpers
     {
         /// <summary>
+        /// Gets the location in terms of path, line and column for a given token.
+        /// </summary>
+        /// <param name="token">The token to use.</param>
+        /// <returns>The location in terms of path, line and column for a given token.</returns>
+        internal static FileLinePositionSpan GetLineSpan(this SyntaxToken token)
+        {
+            return token.SyntaxTree.GetLineSpan(token.Span);
+        }
+
+        /// <summary>
+        /// Gets the location in terms of path, line and column for a given node.
+        /// </summary>
+        /// <param name="node">The node to use.</param>
+        /// <returns>The location in terms of path, line and column for a given node.</returns>
+        internal static FileLinePositionSpan GetLineSpan(this SyntaxNode node)
+        {
+            return node.SyntaxTree.GetLineSpan(node.Span);
+        }
+
+        /// <summary>
+        /// Gets the location in terms of path, line and column for a given trivia.
+        /// </summary>
+        /// <param name="trivia">The trivia to use.</param>
+        /// <returns>The location in terms of path, line and column for a given trivia.</returns>
+        internal static FileLinePositionSpan GetLineSpan(this SyntaxTrivia trivia)
+        {
+            return trivia.SyntaxTree.GetLineSpan(trivia.Span);
+        }
+
+        /// <summary>
+        /// Gets the location in terms of path, line and column for a given node or token.
+        /// </summary>
+        /// <param name="nodeOrToken">The trivia to use.</param>
+        /// <returns>The location in terms of path, line and column for a given node or token.</returns>
+        internal static FileLinePositionSpan GetLineSpan(this SyntaxNodeOrToken nodeOrToken)
+        {
+            return nodeOrToken.SyntaxTree.GetLineSpan(nodeOrToken.Span);
+        }
+
+        /// <summary>
         /// Gets the line on which the given token occurs.
         /// </summary>
         /// <param name="token">The token to use.</param>
         /// <returns>The line on which the given token occurs.</returns>
         internal static int GetLine(this SyntaxToken token)
         {
-            return token.GetLocation().GetLineSpan().StartLinePosition.Line;
+            return token.GetLineSpan().StartLinePosition.Line;
         }
 
         /// <summary>
@@ -24,7 +64,7 @@
         /// <returns>The line on which the given node ends.</returns>
         internal static int GetEndLine(this SyntaxNode node)
         {
-            return node.GetLocation().GetLineSpan().EndLinePosition.Line;
+            return node.GetLineSpan().EndLinePosition.Line;
         }
 
         /// <summary>
@@ -34,7 +74,7 @@
         /// <returns>True, if the node spans multiple source text lines.</returns>
         internal static bool SpansMultipleLines(this SyntaxNode node)
         {
-            var lineSpan = node.GetLocation().GetLineSpan();
+            var lineSpan = node.GetLineSpan();
 
             return lineSpan.StartLinePosition.Line < lineSpan.EndLinePosition.Line;
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1500CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1500CodeFixProvider.cs
@@ -56,7 +56,7 @@
             var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
 
             var curlyBracketToken = syntaxRoot.FindToken(diagnostic.Location.SourceSpan.Start);
-            var curlyBracketLine = curlyBracketToken.GetLocation().GetLineSpan().StartLinePosition.Line;
+            var curlyBracketLine = curlyBracketToken.GetLineSpan().StartLinePosition.Line;
             var curlyBracketReplacementToken = curlyBracketToken;
 
             var indentationOptions = IndentationOptions.FromDocument(document);
@@ -80,7 +80,7 @@
             else
             {
                 // Check if we need to apply a fix before the curly bracket
-                if (previousToken.GetLocation().GetLineSpan().StartLinePosition.Line == curlyBracketLine)
+                if (previousToken.GetLineSpan().StartLinePosition.Line == curlyBracketLine)
                 {
                     var sharedTrivia = curlyBracketReplacementToken.LeadingTrivia.WithoutTrailingWhitespace();
                     var previousTokenNewTrailingTrivia = previousToken.TrailingTrivia
@@ -95,7 +95,7 @@
 
                 // Check if we need to apply a fix after the curly bracket
                 // if a closing curly bracket is followed by a semi-colon or closing paren, no fix is needed.
-                if ((nextToken.GetLocation().GetLineSpan().StartLinePosition.Line == curlyBracketLine) &&
+                if ((nextToken.GetLineSpan().StartLinePosition.Line == curlyBracketLine) &&
                     (!curlyBracketToken.IsKind(SyntaxKind.CloseBraceToken) || !IsValidFollowingToken(nextToken)))
                 {
                     var sharedTrivia = nextToken.LeadingTrivia.WithoutTrailingWhitespace();
@@ -167,7 +167,7 @@
                 }
             }
 
-            return curlyBracketToken.GetLocation().GetLineSpan().StartLinePosition.Line == token.GetLocation().GetLineSpan().StartLinePosition.Line;
+            return curlyBracketToken.GetLineSpan().StartLinePosition.Line == token.GetLineSpan().StartLinePosition.Line;
         }
 
         private static bool IsValidFollowingToken(SyntaxToken nextToken)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1500CurlyBracketsForMultiLineStatementsMustNotShareLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1500CurlyBracketsForMultiLineStatementsMustNotShareLine.cs
@@ -5,6 +5,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// The opening or closing curly bracket within a C# statement, element, or expression is not placed on its own
@@ -169,9 +170,9 @@
             }
         }
 
-        private static int? GetStartLine(SyntaxToken token)
+        private static int GetStartLine(SyntaxToken token)
         {
-            return token.GetLocation()?.GetLineSpan().StartLinePosition.Line;
+            return token.GetLineSpan().StartLinePosition.Line;
         }
 
         private void CheckCurlyBracketToken(SyntaxNodeAnalysisContext context, SyntaxToken token)
@@ -181,15 +182,14 @@
                 return;
             }
 
-            Location location = token.GetLocation();
-            int line = location.GetLineSpan().StartLinePosition.Line;
+            int line = token.GetLineSpan().StartLinePosition.Line;
 
             SyntaxToken previousToken = token.GetPreviousToken();
             if (!previousToken.IsMissing)
             {
-                if (previousToken.GetLocation().GetLineSpan().StartLinePosition.Line == line)
+                if (previousToken.GetLineSpan().StartLinePosition.Line == line)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation()));
 
                     // no need to report more than one instance for this token
                     return;
@@ -206,14 +206,17 @@
                 case SyntaxKind.SemicolonToken:
                     // these are allowed to appear on the same line
                     return;
+                case SyntaxKind.None:
+                    // last token of this file
+                    return;
 
                 default:
-                    break;
+                break;
                 }
 
-                if (nextToken.GetLocation().GetLineSpan().StartLinePosition.Line == line)
+                if (nextToken.GetLineSpan().StartLinePosition.Line == line)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation()));
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501CodeFixProvider.cs
@@ -62,8 +62,8 @@
         {
             var parentLastToken = block.OpenBraceToken.GetPreviousToken();
 
-            var parentEndLine = parentLastToken.GetLocation().GetLineSpan().EndLinePosition.Line;
-            var blockStartLine = block.OpenBraceToken.GetLocation().GetLineSpan().StartLinePosition.Line;
+            var parentEndLine = parentLastToken.GetLineSpan().EndLinePosition.Line;
+            var blockStartLine = block.OpenBraceToken.GetLineSpan().StartLinePosition.Line;
 
             var newParentLastToken = parentLastToken;
             if (parentEndLine == blockStartLine)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1502CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1502CodeFixProvider.cs
@@ -112,8 +112,8 @@
             var tokenSubstitutions = new Dictionary<SyntaxToken, SyntaxToken>();
 
             var parentLastToken = openBraceToken.GetPreviousToken();
-            var parentEndLine = parentLastToken.GetLocation().GetLineSpan().EndLinePosition.Line;
-            var blockStartLine = openBraceToken.GetLocation().GetLineSpan().StartLinePosition.Line;
+            var parentEndLine = parentLastToken.GetLineSpan().EndLinePosition.Line;
+            var blockStartLine = openBraceToken.GetLineSpan().StartLinePosition.Line;
 
             // reformat parent if it is on the same line as the block.
             if (parentEndLine == blockStartLine)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1502ElementMustNotBeOnASingleLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1502ElementMustNotBeOnASingleLine.cs
@@ -6,6 +6,7 @@
     using Microsoft.CodeAnalysis.Diagnostics;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// A C# element containing opening and closing curly brackets is written completely on a single line.
@@ -107,8 +108,8 @@
 
         private static void CheckViolation(SyntaxNodeAnalysisContext context, SyntaxToken openBraceToken, SyntaxToken closeBraceToken)
         {
-            var openingBraceLineSpan = openBraceToken.GetLocation().GetLineSpan();
-            var closingBraceLineSpan = closeBraceToken.GetLocation().GetLineSpan();
+            var openingBraceLineSpan = openBraceToken.GetLineSpan();
+            var closingBraceLineSpan = closeBraceToken.GetLineSpan();
 
             if (openingBraceLineSpan.EndLinePosition.Line == closingBraceLineSpan.StartLinePosition.Line)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CurlyBracketsMustNotBeOmitted.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CurlyBracketsMustNotBeOmitted.cs
@@ -7,6 +7,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// The opening and closing curly brackets for a C# statement have been omitted.
@@ -166,8 +167,7 @@
             if (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA1519CurlyBracketsMustNotBeOmittedFromMultiLineChildStatement.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
             {
                 // diagnostics for multi-line statements is handled by SA1519, as long as it's not suppressed
-                Location location = childStatement.GetLocation();
-                FileLinePositionSpan lineSpan = location.GetLineSpan();
+                FileLinePositionSpan lineSpan = childStatement.GetLineSpan();
                 if (lineSpan.StartLinePosition.Line != lineSpan.EndLinePosition.Line)
                 {
                     return;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1504AllAccessorsMustBeSingleLineOrMultiLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1504AllAccessorsMustBeSingleLineOrMultiLine.cs
@@ -7,6 +7,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// Within a C# property, indexer or event, at least one of the child accessors is written on a single line, and at
@@ -114,7 +115,7 @@
 
             foreach (var accessorDeclarationSyntax in accessors)
             {
-                var fileLinePositionSpan = accessorDeclarationSyntax.GetLocation().GetLineSpan();
+                var fileLinePositionSpan = accessorDeclarationSyntax.GetLineSpan();
 
                 if (fileLinePositionSpan.StartLinePosition.Line == fileLinePositionSpan.EndLinePosition.Line)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1505OpeningCurlyBracketsMustNotBeFollowedByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1505OpeningCurlyBracketsMustNotBeFollowedByBlankLine.cs
@@ -5,6 +5,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// An opening curly bracket within a C# element, statement, or expression is followed by a blank line.
@@ -147,7 +148,7 @@
 
         private static int GetLine(SyntaxToken token)
         {
-            return token.GetLocation().GetLineSpan().StartLinePosition.Line;
+            return token.GetLineSpan().StartLinePosition.Line;
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1508ClosingCurlyBracketsMustNotBePrecededByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1508ClosingCurlyBracketsMustNotBePrecededByBlankLine.cs
@@ -5,6 +5,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// A closing curly bracket within a C# element, statement, or expression is preceded by a blank line.
@@ -111,7 +112,7 @@
         private void AnalyzeCloseBrace(SyntaxNodeAnalysisContext context, SyntaxToken closeBraceToken)
         {
             var previousToken = closeBraceToken.GetPreviousToken();
-            if ((closeBraceToken.GetLocation().GetLineSpan().StartLinePosition.Line - previousToken.GetLocation().GetLineSpan().EndLinePosition.Line) < 2)
+            if ((closeBraceToken.GetLineSpan().StartLinePosition.Line - previousToken.GetLineSpan().EndLinePosition.Line) < 2)
             {
                 // there will be no blank lines when the closing brace and the preceding token are not at least two lines apart.
                 return;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1509CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1509CodeFixProvider.cs
@@ -68,13 +68,13 @@
         {
             var result = new List<SyntaxTrivia>();
 
-            var lineOfOpenBrace = openBrace.GetLocation().GetLineSpan().StartLinePosition.Line;
+            var lineOfOpenBrace = openBrace.GetLineSpan().StartLinePosition.Line;
             var lineToCheck = lineOfOpenBrace - 1;
 
             while (lineToCheck > -1)
             {
                 var trivias = openBrace.LeadingTrivia
-                    .Where(t => t.GetLocation().GetLineSpan().StartLinePosition.Line == lineToCheck)
+                    .Where(t => t.GetLineSpan().StartLinePosition.Line == lineToCheck)
                     .ToList();
                 var endOfLineTrivia = trivias.Where(t => t.IsKind(SyntaxKind.EndOfLineTrivia)).ToList();
                 if (endOfLineTrivia.Any() && trivias.Except(endOfLineTrivia).All(t => t.IsKind(SyntaxKind.WhitespaceTrivia)))

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513ClosingCurlyBracketMustBeFollowedByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513ClosingCurlyBracketMustBeFollowedByBlankLine.cs
@@ -8,6 +8,7 @@
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using Microsoft.CodeAnalysis.Text;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// A closing curly bracket within a C# element, statement, or expression is not followed by a blank line.
@@ -230,7 +231,7 @@
             private bool IsOnSameLineAsOpeningBrace(SyntaxToken closeBrace)
             {
                 var matchingOpenBrace = this.curlyBracketsStack.Peek();
-                return matchingOpenBrace.GetLocation().GetLineSpan().EndLinePosition.Line == closeBrace.GetLocation().GetLineSpan().StartLinePosition.Line;
+                return matchingOpenBrace.GetLineSpan().EndLinePosition.Line == closeBrace.GetLineSpan().StartLinePosition.Line;
             }
 
             private bool StartsWithDirectiveTrivia(SyntaxTriviaList triviaList)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1516ElementsMustBeSeparatedByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1516ElementsMustBeSeparatedByBlankLine.cs
@@ -199,7 +199,7 @@
 
         private static bool IsMultiline(SyntaxNode node)
         {
-            var lineSpan = node.GetLocation().GetLineSpan();
+            var lineSpan = node.GetLineSpan();
 
             return lineSpan.StartLinePosition.Line != lineSpan.EndLinePosition.Line;
         }
@@ -227,8 +227,6 @@
 
         private static Location GetDiagnosticLocation(SyntaxNode node)
         {
-            Location nodeLocation = node.GetLocation();
-
             if (node.HasLeadingTrivia)
             {
                 return node.GetLeadingTrivia()[0].GetLocation();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1519CurlyBracketsMustNotBeOmittedFromMultiLineChildStatement.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1519CurlyBracketsMustNotBeOmittedFromMultiLineChildStatement.cs
@@ -5,6 +5,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// The opening and closing curly brackets for a multi-line C# statement have been omitted.
@@ -122,8 +123,7 @@
                 return;
             }
 
-            Location location = childStatement.GetLocation();
-            FileLinePositionSpan lineSpan = location.GetLineSpan();
+            FileLinePositionSpan lineSpan = childStatement.GetLineSpan();
             if (lineSpan.StartLinePosition.Line == lineSpan.EndLinePosition.Line)
             {
                 return;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1520UseCurlyBracketsConsistently.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1520UseCurlyBracketsConsistently.cs
@@ -7,6 +7,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// The opening and closing curly brackets of a chained <c>if</c>/<c>else if</c>/<c>else</c> construct were included
@@ -110,8 +111,7 @@
             if (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA1519CurlyBracketsMustNotBeOmittedFromMultiLineChildStatement.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
             {
                 // diagnostics for multi-line statements is handled by SA1519, as long as it's not suppressed
-                Location location = childStatement.GetLocation();
-                FileLinePositionSpan lineSpan = location.GetLineSpan();
+                FileLinePositionSpan lineSpan = childStatement.GetLineSpan();
                 if (lineSpan.StartLinePosition.Line != lineSpan.EndLinePosition.Line)
                 {
                     return;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1410SA1411CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1410SA1411CodeFixProvider.cs
@@ -73,7 +73,7 @@
             var newSyntaxRoot = root.RemoveNode(node, SyntaxRemoveOptions.KeepNoTrivia);
 
             // The removing operation has not changed the location of the previous token
-            var newPreviousToken = newSyntaxRoot.FindToken(previousToken.GetLocation().SourceSpan.Start);
+            var newPreviousToken = newSyntaxRoot.FindToken(previousToken.Span.Start);
 
             var newTrailingTrivia = newPreviousToken.TrailingTrivia.AddRange(firstToken.GetAllTrivia()).AddRange(lastToken.GetAllTrivia());
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1214StaticReadonlyElementsMustAppearBeforeStaticNonReadonlyElements.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1214StaticReadonlyElementsMustAppearBeforeStaticNonReadonlyElements.cs
@@ -6,6 +6,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// A static readonly element is positioned beneath a static non-readonly element of the same type.
@@ -70,7 +71,7 @@
                 return;
             }
 
-            var firstNonReadonlyFieldLocation = firstNonReadonlyField.GetLocation().GetLineSpan();
+            var firstNonReadonlyFieldLocation = firstNonReadonlyField.GetLineSpan();
             if (!firstNonReadonlyFieldLocation.IsValid)
             {
                 return;
@@ -78,12 +79,12 @@
 
             var readonlyFieldLocations =
                 staticFields.Where(f => f.Modifiers.Any(SyntaxKind.ReadOnlyKeyword))
-                    .Where(f => f.GetLocation().GetLineSpan().IsValid)
+                    .Where(f => f.GetLineSpan().IsValid)
                     .Where(f => f.Declaration != null && f.Declaration.Variables.Any())
                     .Select(f => new
                     {
-                        FieldLocation = f.GetLocation(),
-                        FieldEndLinePosition = f.GetLocation().GetLineSpan().EndLinePosition
+                        FieldDeclaration = f,
+                        FieldEndLinePosition = f.GetLineSpan().EndLinePosition
                     })
                     .ToList();
 
@@ -91,7 +92,7 @@
             {
                 if (firstNonReadonlyFieldLocation.EndLinePosition < location.FieldEndLinePosition)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, location.FieldLocation));
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, location.FieldDeclaration.GetLocation()));
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1103CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1103CodeFixProvider.cs
@@ -60,7 +60,7 @@
                 return true;
 
             case SyntaxKind.MultiLineCommentTrivia:
-                var lineSpan = trivia.GetLocation().GetLineSpan();
+                var lineSpan = trivia.GetLineSpan();
                 return lineSpan.StartLinePosition.Line == lineSpan.EndLinePosition.Line;
 
             default:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1107CodeMustNotContainMultipleStatementsOnOneLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1107CodeMustNotContainMultipleStatementsOnOneLine.cs
@@ -5,6 +5,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// The C# code contains more than one statement on a single line.
@@ -53,17 +54,17 @@
 
             if (block != null && block.Statements.Any())
             {
-                Location previousStatementLocation = block.Statements[0].GetLocation();
-                Location currentStatementLocation;
+                FileLinePositionSpan previousStatementLocation = block.Statements[0].GetLineSpan();
+                FileLinePositionSpan currentStatementLocation;
 
                 for (int i = 1; i < block.Statements.Count; i++)
                 {
-                    currentStatementLocation = block.Statements[i].GetLocation();
+                    currentStatementLocation = block.Statements[i].GetLineSpan();
 
-                    if (previousStatementLocation.GetLineSpan().EndLinePosition.Line
-                        == currentStatementLocation.GetLineSpan().StartLinePosition.Line)
+                    if (previousStatementLocation.EndLinePosition.Line
+                        == currentStatementLocation.StartLinePosition.Line)
                     {
-                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, currentStatementLocation));
+                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, block.Statements[i].GetLocation()));
                     }
 
                     previousStatementLocation = currentStatementLocation;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA110xQueryClauses.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA110xQueryClauses.cs
@@ -112,17 +112,17 @@
 
                 // The node before the query clause may encompass the entire query clause,
                 // so we need to use the token within that node for the line determination.
-                var location1 = !(parent1 is QueryContinuationSyntax) ? parent1.GetLocation() : token1.GetLocation();
-                var location2 = parent2.GetLocation();
+                var location1 = !(parent1 is QueryContinuationSyntax) ? parent1.GetLineSpan() : token1.GetLineSpan();
+                var location2 = parent2.GetLineSpan();
 
-                if (((location2.GetLineSpan().StartLinePosition.Line - location1.GetLineSpan().EndLinePosition.Line) > 1)
+                if (((location2.StartLinePosition.Line - location1.EndLinePosition.Line) > 1)
                     && isEnabledSA1102
                     && !token2.LeadingTrivia.Any(trivia => trivia.IsDirective))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(SA1102Descriptor, token2.GetLocation()));
                 }
 
-                var onSameLine = location1.GetLineSpan().EndLinePosition.Line == location2.GetLineSpan().StartLinePosition.Line;
+                var onSameLine = location1.EndLinePosition.Line == location2.StartLinePosition.Line;
 
                 if (onSameLine
                     && isEnabledSA1104

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1110OpeningParenthesisMustBeOnDeclarationLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1110OpeningParenthesisMustBeOnDeclarationLine.cs
@@ -6,6 +6,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// The opening parenthesis or bracket in a call to a C# method or indexer, or the declaration of a method or
@@ -293,27 +294,25 @@
 
         private static void CheckIfLocationOfIdentifierNameAndOpenTokenAreTheSame(SyntaxNodeAnalysisContext context, SyntaxToken openToken, SyntaxToken identifierToken)
         {
-            var identifierLine = identifierToken.GetLocation().GetLineSpan();
-            var openParenLocation = openToken.GetLocation();
-            var openParenLine = openParenLocation.GetLineSpan();
+            var identifierLine = identifierToken.GetLineSpan();
+            var openParenLine = openToken.GetLineSpan();
             if (identifierLine.IsValid &&
                 openParenLine.IsValid &&
                 openParenLine.StartLinePosition.Line != identifierLine.StartLinePosition.Line)
             {
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, openParenLocation));
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, openToken.GetLocation()));
             }
         }
 
         private static void CheckIfLocationOfExpressionAndOpenTokenAreTheSame(SyntaxNodeAnalysisContext context, SyntaxToken openToken, ExpressionSyntax expression)
         {
-            var identifierLine = expression.GetLocation().GetLineSpan();
-            var openParenLocation = openToken.GetLocation();
-            var openParenLine = openParenLocation.GetLineSpan();
+            var identifierLine = expression.GetLineSpan();
+            var openParenLine = openToken.GetLineSpan();
             if (identifierLine.IsValid &&
                 openParenLine.IsValid &&
                 openParenLine.StartLinePosition.Line != identifierLine.StartLinePosition.Line)
             {
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, openParenLocation));
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, openToken.GetLocation()));
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1111ClosingParenthesisMustBeOnLineOfLastParameter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1111ClosingParenthesisMustBeOnLineOfLastParameter.cs
@@ -5,6 +5,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// The closing parenthesis or bracket in a call to a C# method or indexer, or the declaration of a method or
@@ -331,14 +332,13 @@
         private static void CheckIfLocationOfLastArgumentOrParameterAndCloseTokenAreTheSame(SyntaxNodeAnalysisContext context,
        CSharpSyntaxNode parameterOrArgument, SyntaxToken closeToken)
         {
-            var lastParameterLine = parameterOrArgument.GetLocation().GetLineSpan();
-            var closeParenLocation = closeToken.GetLocation();
-            var closeParenLine = closeParenLocation.GetLineSpan();
+            var lastParameterLine = parameterOrArgument.GetLineSpan();
+            var closeParenLine = closeToken.GetLineSpan();
             if (lastParameterLine.IsValid &&
                 closeParenLine.IsValid &&
                 closeParenLine.StartLinePosition.Line != lastParameterLine.EndLinePosition.Line)
             {
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, closeParenLocation));
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, closeToken.GetLocation()));
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1112ClosingParenthesisMustBeOnLineOfOpeningParenthesis.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1112ClosingParenthesisMustBeOnLineOfOpeningParenthesis.cs
@@ -6,6 +6,7 @@
     using Microsoft.CodeAnalysis.Diagnostics;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// The closing parenthesis or bracket in a call to a C# method or indexer, or the declaration of a method or
@@ -126,14 +127,13 @@
         private static void CheckIfLocationOfOpenAndCloseTokensAreTheSame(SyntaxNodeAnalysisContext context,
             SyntaxToken openToken, SyntaxToken closeToken)
         {
-            var closeParenLocation = closeToken.GetLocation();
-            var closeParenLine = closeParenLocation.GetLineSpan();
-            var openParenLine = openToken.GetLocation().GetLineSpan();
+            var closeParenLine = closeToken.GetLineSpan();
+            var openParenLine = openToken.GetLineSpan();
             if (closeParenLine.IsValid &&
                 openParenLine.IsValid &&
                 openParenLine.StartLinePosition.Line != closeParenLine.StartLinePosition.Line)
             {
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, closeParenLocation));
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, closeToken.GetLocation()));
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1113CommaMustBeOnSameLineAsPreviousParameter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1113CommaMustBeOnSameLineAsPreviousParameter.cs
@@ -238,10 +238,9 @@
                         return;
                     }
 
-                    var location = nodeOrToken.GetLocation();
-                    if (previousNode.GetEndLine() < location.GetLineSpan().StartLinePosition.Line)
+                    if (previousNode.GetEndLine() < nodeOrToken.GetLineSpan().StartLinePosition.Line)
                     {
-                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));
+                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, nodeOrToken.GetLocation()));
                     }
                 }
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1114ParameterListMustFollowDeclaration.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1114ParameterListMustFollowDeclaration.cs
@@ -5,6 +5,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// The start of the parameter list for a method or indexer call or declaration does not begin on the same line as
@@ -192,13 +193,13 @@
 
                 var firstSize = arrayRankSpecifierSyntax.Sizes[0];
 
-                var firstSizeLineSpan = firstSize.GetLocation().GetLineSpan();
+                var firstSizeLineSpan = firstSize.GetLineSpan();
                 if (!firstSizeLineSpan.IsValid)
                 {
                     return;
                 }
 
-                var openBracketLineSpan = openBracketToken.GetLocation().GetLineSpan();
+                var openBracketLineSpan = openBracketToken.GetLineSpan();
                 if (!openBracketLineSpan.IsValid)
                 {
                     return;
@@ -224,13 +225,13 @@
 
             var firstAttribute = attributesList.Attributes[0];
 
-            var firstAttributeLineSpan = firstAttribute.GetLocation().GetLineSpan();
+            var firstAttributeLineSpan = firstAttribute.GetLineSpan();
             if (!firstAttributeLineSpan.IsValid)
             {
                 return;
             }
 
-            var openBracketLineSpan = openBracketToken.GetLocation().GetLineSpan();
+            var openBracketLineSpan = openBracketToken.GetLineSpan();
             if (!openBracketLineSpan.IsValid)
             {
                 return;
@@ -255,13 +256,13 @@
 
             var firstArgument = argumentListSyntax.Arguments[0];
 
-            var firstArgumentLineSpan = firstArgument.GetLocation().GetLineSpan();
+            var firstArgumentLineSpan = firstArgument.GetLineSpan();
             if (!firstArgumentLineSpan.IsValid)
             {
                 return;
             }
 
-            var openBracketLineSpan = openBracketToken.GetLocation().GetLineSpan();
+            var openBracketLineSpan = openBracketToken.GetLineSpan();
             if (!openBracketLineSpan.IsValid)
             {
                 return;
@@ -286,13 +287,13 @@
 
             var firstArgument = argumentListSyntax.Arguments[0];
 
-            var firstArgumentLineSpan = firstArgument.GetLocation().GetLineSpan();
+            var firstArgumentLineSpan = firstArgument.GetLineSpan();
             if (!firstArgumentLineSpan.IsValid)
             {
                 return;
             }
 
-            var openParenLineSpan = argumentListSyntax.OpenParenToken.GetLocation().GetLineSpan();
+            var openParenLineSpan = argumentListSyntax.OpenParenToken.GetLineSpan();
             if (!openParenLineSpan.IsValid)
             {
                 return;
@@ -317,13 +318,13 @@
 
             var firstArgument = argumentListSyntax.Arguments[0];
 
-            var firstArgumentLineSpan = firstArgument.GetLocation().GetLineSpan();
+            var firstArgumentLineSpan = firstArgument.GetLineSpan();
             if (!firstArgumentLineSpan.IsValid)
             {
                 return;
             }
 
-            var openParenLineSpan = openParenToken.GetLocation().GetLineSpan();
+            var openParenLineSpan = openParenToken.GetLineSpan();
             if (!openParenLineSpan.IsValid)
             {
                 return;
@@ -348,13 +349,13 @@
 
             var firstParameter = parameterListSyntax.Parameters[0];
 
-            var firstParameterLineSpan = firstParameter.GetLocation().GetLineSpan();
+            var firstParameterLineSpan = firstParameter.GetLineSpan();
             if (!firstParameterLineSpan.IsValid)
             {
                 return;
             }
 
-            var openBracketLineSpan = openBracketToken.GetLocation().GetLineSpan();
+            var openBracketLineSpan = openBracketToken.GetLineSpan();
             if (!openBracketLineSpan.IsValid)
             {
                 return;
@@ -379,13 +380,13 @@
 
             var firstParameter = parameterListSyntax.Parameters[0];
 
-            var firstParameterLineSpan = firstParameter.GetLocation().GetLineSpan();
+            var firstParameterLineSpan = firstParameter.GetLineSpan();
             if (!firstParameterLineSpan.IsValid)
             {
                 return;
             }
 
-            var openParenLineSpan = parameterListSyntax.OpenParenToken.GetLocation().GetLineSpan();
+            var openParenLineSpan = parameterListSyntax.OpenParenToken.GetLineSpan();
             if (!openParenLineSpan.IsValid)
             {
                 return;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1115ParameterMustFollowComma.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1115ParameterMustFollowComma.cs
@@ -5,6 +5,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// A parameter within a C# method or indexer call or declaration does not begin on the same line as the previous
@@ -131,11 +132,11 @@
                 return;
             }
 
-            var previousLine = attributeList.Attributes[0].GetLocation().GetLineSpan().EndLinePosition.Line;
+            var previousLine = attributeList.Attributes[0].GetLineSpan().EndLinePosition.Line;
             for (int i = 1; i < attributeList.Attributes.Count; i++)
             {
                 var currentAttribute = attributeList.Attributes[i];
-                var lineSpan = currentAttribute.GetLocation().GetLineSpan();
+                var lineSpan = currentAttribute.GetLineSpan();
                 var currentLine = lineSpan.StartLinePosition.Line;
                 if (currentLine - previousLine > 1)
                 {
@@ -156,11 +157,11 @@
                 return;
             }
 
-            var previousLine = attribute.ArgumentList.Arguments[0].GetLocation().GetLineSpan().EndLinePosition.Line;
+            var previousLine = attribute.ArgumentList.Arguments[0].GetLineSpan().EndLinePosition.Line;
             for (int i = 1; i < attribute.ArgumentList.Arguments.Count; i++)
             {
                 var currentArgument = attribute.ArgumentList.Arguments[i];
-                var lineSpan = currentArgument.GetLocation().GetLineSpan();
+                var lineSpan = currentArgument.GetLineSpan();
                 var currentLine = lineSpan.StartLinePosition.Line;
                 if (currentLine - previousLine > 1)
                 {
@@ -186,11 +187,11 @@
                     continue;
                 }
 
-                var previousLine = rankSpecifier.Sizes[0].GetLocation().GetLineSpan().EndLinePosition.Line;
+                var previousLine = rankSpecifier.Sizes[0].GetLineSpan().EndLinePosition.Line;
                 for (int i = 1; i < rankSpecifier.Sizes.Count; i++)
                 {
                     var currentSize = rankSpecifier.Sizes[i];
-                    var lineSpan = currentSize.GetLocation().GetLineSpan();
+                    var lineSpan = currentSize.GetLineSpan();
                     var currentLine = lineSpan.StartLinePosition.Line;
                     if (currentLine - previousLine > 1)
                     {
@@ -245,11 +246,11 @@
                 return;
             }
 
-            var previousLine = argumentListSyntax.Arguments[0].GetLocation().GetLineSpan().EndLinePosition.Line;
+            var previousLine = argumentListSyntax.Arguments[0].GetLineSpan().EndLinePosition.Line;
             for (int i = 1; i < argumentListSyntax.Arguments.Count; i++)
             {
                 var currentArgument = argumentListSyntax.Arguments[i];
-                var lineSpan = currentArgument.GetLocation().GetLineSpan();
+                var lineSpan = currentArgument.GetLineSpan();
                 var currentLine = lineSpan.StartLinePosition.Line;
                 if (currentLine - previousLine > 1)
                 {
@@ -268,11 +269,11 @@
                 return;
             }
 
-            var previousLine = parameterListSyntax.Parameters[0].GetLocation().GetLineSpan().EndLinePosition.Line;
+            var previousLine = parameterListSyntax.Parameters[0].GetLineSpan().EndLinePosition.Line;
             for (int i = 1; i < parameterListSyntax.Parameters.Count; i++)
             {
                 var currentParameter = parameterListSyntax.Parameters[i];
-                var lineSpan = currentParameter.GetLocation().GetLineSpan();
+                var lineSpan = currentParameter.GetLineSpan();
                 var currentLine = lineSpan.StartLinePosition.Line;
                 if (currentLine - previousLine > 1)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1118ParameterMustNotSpanMultipleLines.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1118ParameterMustNotSpanMultipleLines.cs
@@ -6,6 +6,7 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// A parameter to a C# method or indexer, other than the first parameter, spans across multiple lines.
@@ -121,7 +122,7 @@
 
         private bool CheckIfArgumentIsMultiline(CSharpSyntaxNode argument)
         {
-            var lineSpan = argument.GetLocation().GetLineSpan();
+            var lineSpan = argument.GetLineSpan();
             return lineSpan.EndLinePosition.Line > lineSpan.StartLinePosition.Line;
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
@@ -100,7 +100,7 @@
             var leadingTriviaList = prevToken.TrailingTrivia.AddRange(token.LeadingTrivia);
 
             var isFirstOnLine = false;
-            if (prevToken.GetLocation().GetLineSpan().EndLinePosition.Line < token.GetLocation().GetLineSpan().StartLinePosition.Line)
+            if (prevToken.GetLineSpan().EndLinePosition.Line < token.GetLineSpan().StartLinePosition.Line)
             {
                 var done = false;
                 for (var i = leadingTriviaList.Count - 1; !done && (i >= 0); i--)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1025CodeMustNotContainMultipleWhitespaceInARow.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1025CodeMustNotContainMultipleWhitespaceInARow.cs
@@ -72,7 +72,7 @@
                 return;
             }
 
-            if (trivia.GetLocation()?.GetMappedLineSpan().StartLinePosition.Character == 0)
+            if (trivia.SyntaxTree.GetMappedLineSpan(trivia.Span).StartLinePosition.Character == 0)
             {
                 return;
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1027CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1027CodeFixProvider.cs
@@ -51,7 +51,7 @@
 
             var stringBuilder = new StringBuilder();
 
-            var column = violatingTrivia.GetLocation().GetLineSpan().StartLinePosition.Character;
+            var column = violatingTrivia.GetLineSpan().StartLinePosition.Character;
             foreach (var c in violatingTrivia.ToFullString())
             {
                 if (c == '\t')

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
@@ -96,9 +96,8 @@
                 break;
             case SyntaxKind.MultiLineCommentTrivia:
             case SyntaxKind.MultiLineDocumentationCommentTrivia:
-                var triviaLocation = trivia.GetLocation();
                 string oldTriviaContent = trivia.ToFullString();
-                TextSpan diagnosticSpanWithinTrivia = TextSpan.FromBounds(diagnosticSpan.Start - triviaLocation.SourceSpan.Start, diagnosticSpan.End - triviaLocation.SourceSpan.Start);
+                TextSpan diagnosticSpanWithinTrivia = TextSpan.FromBounds(diagnosticSpan.Start - trivia.Span.Start, diagnosticSpan.End - trivia.Span.Start);
                 newTriviaContent = string.Concat(
                     oldTriviaContent.Substring(0, diagnosticSpanWithinTrivia.Start),
                     oldTriviaContent.Substring(diagnosticSpanWithinTrivia.End));


### PR DESCRIPTION
The most allocated object in our source is SourceLocation. I looked through our source and we allocate locations when we actually just want the line span. I removed these allocations.