### PR TITLE
Don't use semantics for SA1121 if they are not necessary

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/SyntaxTriviaHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/SyntaxTriviaHelpers.cs
@@ -1,0 +1,54 @@
+﻿namespace StyleCop.Analyzers.Helpers
+{
+    using System.Linq;
+    using System.Runtime.CompilerServices;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Foo = Microsoft.CodeAnalysis.CSharp;
+
+    internal static class SyntaxTreeHelpers
+    {
+        /// <summary>
+        /// A cache of the result of computing whether a document has using alias directives.
+        /// </summary>
+        /// <remarks>
+        /// This allows many analyzers that run on every token in the file to avoid checking
+        /// the same state in the document repeatedly.
+        /// </remarks>
+        private static readonly ConditionalWeakTable<SyntaxTree, StrongBox<bool?>> UsingAliasPresentCheck
+            = new ConditionalWeakTable<SyntaxTree, StrongBox<bool?>>();
+
+        internal static bool ContainsUsingAlias(this SyntaxTree tree)
+        {
+            if (tree == null)
+            {
+                return false;
+            }
+
+            StrongBox<bool?> cachedResult = UsingAliasPresentCheck.GetOrCreateValue(tree);
+            if (cachedResult.Value.HasValue)
+            {
+                return cachedResult.Value.Value;
+            }
+
+            bool hasUsingAlias = ContainsUsingAliasNoCache(tree);
+
+            // Update the strongbox's value with our computed result.
+            // This doesn't change the strongbox reference, and its presence in the
+            // ConditionalWeakTable is already assured, so we're updating in-place.
+            // In the event of a race condition with another thread that set the value,
+            // we'll just be re-setting it to the same value.
+            cachedResult.Value = hasUsingAlias;
+
+            return hasUsingAlias;
+        }
+
+        private static bool ContainsUsingAliasNoCache(SyntaxTree tree)
+        {
+            var nodes = tree.GetRoot().DescendantNodes(node => node.IsKind(SyntaxKind.CompilationUnit) || node.IsKind(SyntaxKind.NamespaceDeclaration));
+
+            return nodes.OfType<UsingDirectiveSyntax>().Any(x => x.Alias != null);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/SyntaxTriviaHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/SyntaxTriviaHelpers.cs
@@ -5,7 +5,6 @@
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
-    using Foo = Microsoft.CodeAnalysis.CSharp;
 
     internal static class SyntaxTreeHelpers
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121UseBuiltInTypeAlias.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121UseBuiltInTypeAlias.cs
@@ -6,6 +6,8 @@
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
+
 
     /// <summary>
     /// The code uses one of the basic C# types, but does not use the built-in alias for the type.
@@ -185,6 +187,34 @@
             if (identifierNameSyntax.FirstAncestorOrSelf<UsingDirectiveSyntax>() != null)
             {
                 return;
+            }
+
+            // Most source files will not have any using alias directives. Then we don't have to use semantics
+            // if the identifier name doesn't match the name of a special type
+            if (!identifierNameSyntax.SyntaxTree.ContainsUsingAlias())
+            {
+                switch (identifierNameSyntax.Identifier.Text)
+                {
+                case nameof(Boolean):
+                case nameof(Byte):
+                case nameof(Char):
+                case nameof(Decimal):
+                case nameof(Double):
+                case nameof(Int16):
+                case nameof(Int32):
+                case nameof(Int64):
+                case nameof(Object):
+                case nameof(SByte):
+                case nameof(Single):
+                case nameof(String):
+                case nameof(UInt16):
+                case nameof(UInt32):
+                case nameof(UInt64):
+                    break;
+
+                default:
+                    return;
+                }
             }
 
             SemanticModel semanticModel = context.SemanticModel;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Helpers\NameSyntaxHelpers.cs" />
     <Compile Include="Helpers\RenameHelper.cs" />
     <Compile Include="Helpers\SpecializedTasks.cs" />
+    <Compile Include="Helpers\SyntaxTriviaHelpers.cs" />
     <Compile Include="Helpers\TokenHelpers.cs" />
     <Compile Include="Helpers\TriviaHelper.cs" />
     <Compile Include="Helpers\UsingDirectiveSyntaxHelpers.cs" />


### PR DESCRIPTION
This diagnostic was one of our slowest. Now you have to search for it in a performance report.