### PR TITLE
Fix that the SA1011 CF removes a space after a array rank specifier

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011CodeFixProvider.cs
@@ -94,6 +94,10 @@
                     ignoreTrailingWhitespace = nextToken.Parent.IsKind(SyntaxKind.ConditionalAccessExpression);
                     break;
 
+                case SyntaxKind.IdentifierToken:
+                    ignoreTrailingWhitespace = token.Parent.IsKind(SyntaxKind.ArrayRankSpecifier);
+                    break;
+
                 default:
                     ignoreTrailingWhitespace = false;
                     break;


### PR DESCRIPTION
Fixes #959