### PR TITLE
Fix that SA1121 is not reported when built in types are used as generic parameters in usings

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121UseBuiltInTypeAlias.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121UseBuiltInTypeAlias.cs
@@ -183,7 +183,8 @@
                 break;
             }
 
-            if (identifierNameSyntax.FirstAncestorOrSelf<UsingDirectiveSyntax>() != null)
+            if (identifierNameSyntax.FirstAncestorOrSelf<UsingDirectiveSyntax>() != null
+                && identifierNameSyntax.FirstAncestorOrSelf<TypeArgumentListSyntax>() == null)
             {
                 return;
             }


### PR DESCRIPTION
Fixes #969.