### PR TITLE
Unit tests for attribute brackets analyzers

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1016UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1016UnitTests.cs
@@ -58,7 +58,7 @@ class ClassName5<[
     MyAttribute] T>
 {
     [return: MyAttribute]
-    int MethodName([MyAttribute] int x) { return 0; }
+    int [ ] MethodName([MyAttribute] int x) { return new int [ 3 ]; }
 }
 
 [System.AttributeUsage(System.AttributeTargets.All)]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1016UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1016UnitTests.cs
@@ -1,0 +1,124 @@
+﻿namespace StyleCop.Analyzers.Test.SpacingRules
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.SpacingRules;
+    using TestHelper;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for <see cref="SA1016OpeningAttributeBracketsMustBeSpacedCorrectly"/>.
+    /// </summary>
+    public class SA1016UnitTests : CodeFixVerifier
+    {
+        /// <summary>
+        /// Verifies that the analyzer will properly handle an empty source.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestEmptySourceAsync()
+        {
+            var testCode = string.Empty;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the analyzer will properly valid bracket placement.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestValidBracketsAsync()
+        {
+            var testCode = @"
+[System.Obsolete]
+class ClassName
+{
+}
+
+[
+System.Obsolete]
+class ClassName2
+{
+}
+
+[ // Comment
+System.Obsolete]
+class ClassName3
+{
+}
+
+class ClassName4<[MyAttribute] T>
+{
+}
+
+class ClassName5<[
+    MyAttribute] T>
+{
+    [return: MyAttribute]
+    int MethodName([MyAttribute] int x) { return 0; }
+}
+
+[System.AttributeUsage(System.AttributeTargets.All)]
+sealed class MyAttribute : System.Attribute { }
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the analyzer will properly report invalid bracket placements.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestInvalidBracketsAsync()
+        {
+            var testCode = @"
+[ System.Obsolete]
+class ClassName
+{
+}
+
+[  System.Obsolete]
+class ClassName2
+{
+}
+";
+            var fixedCode = @"
+[System.Obsolete]
+class ClassName
+{
+}
+
+[System.Obsolete]
+class ClassName2
+{
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(2, 1),
+                this.CSharpDiagnostic().WithLocation(7, 1),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new SA1016OpeningAttributeBracketsMustBeSpacedCorrectly();
+        }
+
+        /// <inheritdoc/>
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new SA1016CodeFixProvider();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1016UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1016UnitTests.cs
@@ -54,7 +54,12 @@ class ClassName4<[MyAttribute] T>
 {
 }
 
-class ClassName5<[
+[/*comment*/System.Obsolete]
+class ClassName5
+{
+}
+
+class ClassName6<[
     MyAttribute] T>
 {
     [return: MyAttribute]
@@ -85,6 +90,11 @@ class ClassName
 class ClassName2
 {
 }
+
+[ /*comment*/ System.Obsolete]
+class ClassName3
+{
+}
 ";
             var fixedCode = @"
 [System.Obsolete]
@@ -96,12 +106,18 @@ class ClassName
 class ClassName2
 {
 }
+
+[/*comment*/System.Obsolete]
+class ClassName3
+{
+}
 ";
 
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(2, 1),
                 this.CSharpDiagnostic().WithLocation(7, 1),
+                this.CSharpDiagnostic().WithLocation(12, 1),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1017UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1017UnitTests.cs
@@ -41,13 +41,18 @@ class ClassName
 
 [System.Obsolete
 ]
-class ClassName3
+class ClassName2
 {
 }
 
 [System.Obsolete
  ]
-class ClassName4
+class ClassName3
+{
+}
+
+[System.Obsolete /*comment*/]
+class ClassNam4
 {
 }
 
@@ -86,6 +91,11 @@ class ClassName
 class ClassName2
 {
 }
+
+[System.Obsolete /*comment*/ ]
+class ClassNam3
+{
+}
 ";
             var fixedCode = @"
 [System.Obsolete]
@@ -97,12 +107,18 @@ class ClassName
 class ClassName2
 {
 }
+
+[System.Obsolete/*comment*/]
+class ClassNam3
+{
+}
 ";
 
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(2, 18),
                 this.CSharpDiagnostic().WithLocation(7, 19),
+                this.CSharpDiagnostic().WithLocation(12, 30),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1017UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1017UnitTests.cs
@@ -1,0 +1,124 @@
+﻿namespace StyleCop.Analyzers.Test.SpacingRules
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.SpacingRules;
+    using TestHelper;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for <see cref="SA1017ClosingAttributeBracketsMustBeSpacedCorrectly"/>.
+    /// </summary>
+    public class SA1017UnitTests : CodeFixVerifier
+    {
+        /// <summary>
+        /// Verifies that the analyzer will properly handle an empty source.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestEmptySourceAsync()
+        {
+            var testCode = string.Empty;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the analyzer will properly valid bracket placement.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestValidBracketsAsync()
+        {
+            var testCode = @"
+[System.Obsolete]
+class ClassName
+{
+}
+
+[System.Obsolete
+]
+class ClassName3
+{
+}
+
+[System.Obsolete
+ ]
+class ClassName4
+{
+}
+
+class ClassName5<[MyAttribute] T>
+{
+}
+
+class ClassName6<[MyAttribute
+] T>
+{
+    [return: MyAttribute]
+    int MethodName([MyAttribute] int x) { return 0; }
+}
+
+[System.AttributeUsage(System.AttributeTargets.All)]
+sealed class MyAttribute : System.Attribute { }
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the analyzer will properly report invalid bracket placements.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestInvalidBracketsAsync()
+        {
+            var testCode = @"
+[System.Obsolete ]
+class ClassName
+{
+}
+
+[System.Obsolete  ]
+class ClassName2
+{
+}
+";
+            var fixedCode = @"
+[System.Obsolete]
+class ClassName
+{
+}
+
+[System.Obsolete]
+class ClassName2
+{
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(2, 18),
+                this.CSharpDiagnostic().WithLocation(7, 19),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new SA1017ClosingAttributeBracketsMustBeSpacedCorrectly();
+        }
+
+        /// <inheritdoc/>
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new SA1017CodeFixProvider();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1017UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1017UnitTests.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.SpacingRules;
@@ -107,6 +108,49 @@ class ClassName2
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMissingBracketTokenAsync()
+        {
+            var testCode = @"
+class ClassName
+{
+    void MethodName()
+    {
+        int[] x = new int[3;
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                new DiagnosticResult()
+                {
+                    Id = "CS1003",
+                    Message = "Syntax error, ',' expected",
+                    Severity = DiagnosticSeverity.Error,
+                },
+                new DiagnosticResult()
+                {
+                    Id = "CS0443",
+                    Message = "Syntax error; value expected",
+                    Severity = DiagnosticSeverity.Error,
+                },
+                new DiagnosticResult()
+                {
+                    Id = "CS1003",
+                    Message = "Syntax error, ']' expected",
+                    Severity = DiagnosticSeverity.Error,
+                }
+            };
+
+            for (int i = 0; i < expected.Length; i++)
+            {
+                expected[i] = expected[i].WithLocation(6, 28);
+            }
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -284,6 +284,7 @@
     <Compile Include="SpacingRules\SA1008UnitTests.cs" />
     <Compile Include="SpacingRules\SA1010UnitTests.cs" />
     <Compile Include="SpacingRules\SA1016UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1017UnitTests.cs" />
     <Compile Include="SpacingRules\SA1018UnitTests.cs" />
     <Compile Include="SpacingRules\SA1021UnitTests.cs" />
     <Compile Include="SpacingRules\SA1022UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -283,6 +283,7 @@
     <Compile Include="SpacingRules\SA1007UnitTests.cs" />
     <Compile Include="SpacingRules\SA1008UnitTests.cs" />
     <Compile Include="SpacingRules\SA1010UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1016UnitTests.cs" />
     <Compile Include="SpacingRules\SA1018UnitTests.cs" />
     <Compile Include="SpacingRules\SA1021UnitTests.cs" />
     <Compile Include="SpacingRules\SA1022UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016OpeningAttributeBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016OpeningAttributeBracketsMustBeSpacedCorrectly.cs
@@ -4,6 +4,8 @@
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
+
 
     /// <summary>
     /// An opening attribute bracket within a C# element is not spaced correctly.
@@ -78,7 +80,17 @@
                 return;
             }
 
-            if (!token.HasTrailingTrivia || token.TrailingTrivia.Any(SyntaxKind.EndOfLineTrivia))
+            if (token.IsLastInLine())
+            {
+                return;
+            }
+
+            if (!token.HasTrailingTrivia)
+            {
+                return;
+            }
+
+            if (!token.TrailingTrivia[0].IsKind(SyntaxKind.WhitespaceTrivia))
             {
                 return;
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016OpeningAttributeBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016OpeningAttributeBracketsMustBeSpacedCorrectly.cs
@@ -46,10 +46,10 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterSyntaxTreeActionHonorExclusions(this.HandleSyntaxTree);
+            context.RegisterSyntaxTreeActionHonorExclusions(HandleSyntaxTree);
         }
 
-        private void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
+        private static void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
         {
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
@@ -57,7 +57,7 @@
                 switch (token.Kind())
                 {
                 case SyntaxKind.OpenBracketToken:
-                    this.HandleOpenBracketToken(context, token);
+                    HandleOpenBracketToken(context, token);
                     break;
 
                 default:
@@ -66,7 +66,7 @@
             }
         }
 
-        private void HandleOpenBracketToken(SyntaxTreeAnalysisContext context, SyntaxToken token)
+        private static void HandleOpenBracketToken(SyntaxTreeAnalysisContext context, SyntaxToken token)
         {
             if (token.IsMissing)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016OpeningAttributeBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1016OpeningAttributeBracketsMustBeSpacedCorrectly.cs
@@ -29,7 +29,7 @@
         private static readonly string HelpLink = "http://www.stylecop.com/docs/SA1016.html";
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.SpacingRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledNoTests, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.SpacingRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
         private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
             ImmutableArray.Create(Descriptor);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017ClosingAttributeBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017ClosingAttributeBracketsMustBeSpacedCorrectly.cs
@@ -46,10 +46,10 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            context.RegisterSyntaxTreeActionHonorExclusions(this.HandleSyntaxTree);
+            context.RegisterSyntaxTreeActionHonorExclusions(HandleSyntaxTree);
         }
 
-        private void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
+        private static void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
         {
             SyntaxNode root = context.Tree.GetCompilationUnitRoot(context.CancellationToken);
             foreach (var token in root.DescendantTokens())
@@ -57,7 +57,7 @@
                 switch (token.Kind())
                 {
                 case SyntaxKind.CloseBracketToken:
-                    this.HandleCloseBracketToken(context, token);
+                    HandleCloseBracketToken(context, token);
                     break;
 
                 default:
@@ -66,7 +66,7 @@
             }
         }
 
-        private void HandleCloseBracketToken(SyntaxTreeAnalysisContext context, SyntaxToken token)
+        private static void HandleCloseBracketToken(SyntaxTreeAnalysisContext context, SyntaxToken token)
         {
             if (token.IsMissing)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017ClosingAttributeBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017ClosingAttributeBracketsMustBeSpacedCorrectly.cs
@@ -89,6 +89,11 @@
                 return;
             }
 
+            if (!precedingToken.TrailingTrivia.Last().IsKind(SyntaxKind.WhitespaceTrivia))
+            {
+                return;
+            }
+
             // Closing attribute brackets must not be preceded by a space.
             context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation()));
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017ClosingAttributeBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017ClosingAttributeBracketsMustBeSpacedCorrectly.cs
@@ -4,6 +4,7 @@
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// A closing attribute bracket within a C# element is not spaced correctly.
@@ -78,9 +79,8 @@
             }
 
             bool hasPrecedingSpace = false;
-            if (!token.HasLeadingTrivia)
+            if (!token.IsFirstInLine())
             {
-                // only the first token on the line has leading trivia, and those are ignored
                 SyntaxToken precedingToken = token.GetPreviousToken();
                 if (precedingToken.HasTrailingTrivia)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017ClosingAttributeBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017ClosingAttributeBracketsMustBeSpacedCorrectly.cs
@@ -28,7 +28,7 @@
         private static readonly string HelpLink = "http://www.stylecop.com/docs/SA1017.html";
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.SpacingRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledNoTests, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.SpacingRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
         private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
             ImmutableArray.Create(Descriptor);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017ClosingAttributeBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1017ClosingAttributeBracketsMustBeSpacedCorrectly.cs
@@ -78,21 +78,19 @@
                 return;
             }
 
-            bool hasPrecedingSpace = false;
-            if (!token.IsFirstInLine())
+            if (token.IsFirstInLine())
             {
-                SyntaxToken precedingToken = token.GetPreviousToken();
-                if (precedingToken.HasTrailingTrivia)
-                {
-                    hasPrecedingSpace = true;
-                }
+                return;
             }
 
-            if (hasPrecedingSpace)
+            SyntaxToken precedingToken = token.GetPreviousToken();
+            if (!precedingToken.HasTrailingTrivia)
             {
-                // Closing attribute brackets must not be preceded by a space.
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation()));
+                return;
             }
+
+            // Closing attribute brackets must not be preceded by a space.
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation()));
         }
     }
 }


### PR DESCRIPTION
* Unit tests for SA1016 (OpeningAttributeBracketsMustBeSpacedCorrectly), fixes #202, fixes #268
* Unit tests for SA1017 (ClosingAttributeBracketsMustBeSpacedCorrectly), fixes #203, fixes #269
* Fix a bug in SA1017 when the closing bracket appears in the first column of a new line
* A bit of code cleanup

:memo: If you want any of this moved to its own pull request, please let me know.