### PR TITLE
SA1207 analyzer added for issue #67.

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1207UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1207UnitTests.cs
@@ -1,0 +1,130 @@
+﻿namespace StyleCop.Analyzers.Test.OrderingRules
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.OrderingRules;
+    using TestHelper;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for the <see cref="SA1207ProtectedMustComeBeforeInternal"/> class.
+    /// </summary>
+    public class SA1207UnitTests : CodeFixVerifier
+    {
+        private const string TestCodeTemplate = @"
+public class Foo
+{
+    $$
+}
+";
+
+        public static IEnumerable<object[]> ValidDeclarations
+        {
+            get
+            {
+                return
+                    from accessModifier in ValidAccessModifiers
+                    from declaration in DeclarationsWithoutAccessModifier
+                    select new object[] { accessModifier + " " + declaration };
+            }
+        }
+
+        public static IEnumerable<object[]> InvalidDeclarations
+        {
+            get
+            {
+                return
+                    from accessModifier in InvalidAccessModifiers
+                    from declarationWithoutAccessModifier in DeclarationsWithoutAccessModifier
+                    select new object[] { accessModifier + " " + declarationWithoutAccessModifier };
+            }
+        }
+
+        private static IEnumerable<string> ValidAccessModifiers
+        {
+            get
+            {
+                yield return string.Empty;
+                yield return "protected";
+                yield return "internal";
+                yield return "protected internal";
+            }
+        }
+
+        private static IEnumerable<string> InvalidAccessModifiers
+        {
+            get
+            {
+                yield return "internal protected";
+            }
+        }
+
+        private static IEnumerable<string> DeclarationsWithoutAccessModifier
+        {
+            get
+            {
+                yield return "class Bar {}";
+                yield return "delegate void Bar();";
+                yield return "event System.Action Bar { add {} remove {} }";
+                yield return "event System.Action Bar;";
+                yield return "int Bar;";
+                yield return "int this[int index] { get { return 0; } }";
+                yield return "interface Bar {}";
+                yield return "void Bar() {}";
+                yield return "int Bar { get; set; }";
+                yield return "struct Bar {}";
+            }
+        }
+
+        /// <summary>
+        /// Verify that the analyzer accepts an empty source.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestEmptySourceAsync()
+        {
+            var testCode = string.Empty;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that a valid declaration will not produce a diagnostic.
+        /// </summary>
+        /// <param name="declaration">The declaration to verify.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(ValidDeclarations))]
+        public async Task TestValidDeclarationAsync(string declaration)
+        {
+            var testCode = TestCodeTemplate.Replace("$$", declaration);
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that an invalid type declaration will produce a diagnostic.
+        /// </summary>
+        /// <param name="declaration">The declaration to verify.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(InvalidDeclarations))]
+        public async Task TestInvalidDeclarationAsync(string declaration)
+        {
+            var testCode = TestCodeTemplate.Replace("$$", declaration);
+            ////var fixedTestCode = FixedTestCodeTemplate.Replace("##", "internal").Replace("$$", declaration);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, this.CSharpDiagnostic().WithLocation(4, 14), CancellationToken.None).ConfigureAwait(false);
+            ////await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new SA1207ProtectedMustComeBeforeInternal();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -228,6 +228,7 @@
     <Compile Include="OrderingRules\SA1201UnitTests.cs" />
     <Compile Include="OrderingRules\SA1205UnitTests.cs" />
     <Compile Include="OrderingRules\SA1206UnitTests.cs" />
+    <Compile Include="OrderingRules\SA1207UnitTests.cs" />
     <Compile Include="OrderingRules\SA1208UnitTests.cs" />
     <Compile Include="OrderingRules\SA1209UnitTests.cs" />
     <Compile Include="OrderingRules\SA1210UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1207ProtectedMustComeBeforeInternal.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1207ProtectedMustComeBeforeInternal.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Diagnostics;
 
     /// <summary>
@@ -24,12 +25,12 @@
         /// </summary>
         public const string DiagnosticId = "SA1207";
         private const string Title = "Protected must come before internal";
-        private const string MessageFormat = "TODO: Message format";
+        private const string MessageFormat = "The keyword 'protected' must come before 'internal'.";
         private const string Description = "The keyword 'protected' is positioned after the keyword 'internal' within the declaration of a protected internal C# element.";
         private const string HelpLink = "http://www.stylecop.com/docs/SA1207.html";
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.OrderingRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledNoTests, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.OrderingRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
         private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
             ImmutableArray.Create(Descriptor);
@@ -46,7 +47,43 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            // TODO: Implement analysis
+            context.RegisterSyntaxNodeActionHonorExclusions(
+                HandleDeclaration,
+                SyntaxKind.ClassDeclaration,
+                SyntaxKind.DelegateDeclaration,
+                SyntaxKind.EventDeclaration,
+                SyntaxKind.EventFieldDeclaration,
+                SyntaxKind.FieldDeclaration,
+                SyntaxKind.IndexerDeclaration,
+                SyntaxKind.InterfaceDeclaration,
+                SyntaxKind.MethodDeclaration,
+                SyntaxKind.PropertyDeclaration,
+                SyntaxKind.StructDeclaration);
+        }
+
+        private static void HandleDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var childTokens = context.Node?.ChildTokens();
+            if (childTokens == null)
+            {
+                return;
+            }
+
+            bool internalKeywordFound = false;
+            foreach (var childToken in childTokens)
+            {
+                if (childToken.IsKind(SyntaxKind.InternalKeyword))
+                {
+                    internalKeywordFound = true;
+                    continue;
+                }
+
+                if (childToken.IsKind(SyntaxKind.ProtectedKeyword) && internalKeywordFound)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, childToken.GetLocation()));
+                    break;
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
A new pull request for SA1207 analyzer, because I figured out how to link it to my branch.
Proposed changes have been made.
Code fix has been removed. This way the analyzer can be integrated earlier.
See also related pull request (from different branch) https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/1010.

Fix #67