### PR TITLE
Fix that SA1005 is reported for documentation is documentation parsing is disabled

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1005UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1005UnitTests.cs
@@ -309,7 +309,7 @@ public class Bar
             Solution solution = base.CreateSolution(projectId, language);
             Project project = solution.GetProject(projectId);
 
-            return solution.WithProjectParseOptions(projectId, project.ParseOptions.WithDocumentationMode(DocumentationMode.None));
+            return solution.WithProjectParseOptions(projectId, project.ParseOptions.WithDocumentationMode(this.documentationMode));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1005UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1005UnitTests.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.SpacingRules;
@@ -14,6 +15,8 @@
     /// </summary>
     public class SA1005UnitTests : CodeFixVerifier
     {
+        private DocumentationMode documentationMode = DocumentationMode.Diagnose;
+
         /// <summary>
         /// Verifies that the analyzer will properly handle an empty source.
         /// </summary>
@@ -267,6 +270,28 @@
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verify that the diagnostic is not reported for documentation comments
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestDocumentationAsync()
+        {
+            var testCode = @"/// <summary>
+/// Some text
+/// </summary>
+public class Bar
+{
+}
+";
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+
+            // Verify that this works if the project was configured to treat documentation comments as regular comments
+            this.documentationMode = DocumentationMode.None;
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
         /// <inheritdoc/>
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
@@ -277,6 +302,14 @@
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new SA1005CodeFixProvider();
+        }
+
+        protected override Solution CreateSolution(ProjectId projectId, string language)
+        {
+            Solution solution = base.CreateSolution(projectId, language);
+            Project project = solution.GetProject(projectId);
+
+            return solution.WithProjectParseOptions(projectId, project.ParseOptions.WithDocumentationMode(DocumentationMode.None));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005SingleLineCommentsMustBeginWithSingleSpace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005SingleLineCommentsMustBeginWithSingleSpace.cs
@@ -122,8 +122,8 @@
                 return;
             }
 
-            // special case: commented code
-            if (text.StartsWith(@"////", StringComparison.Ordinal))
+            // special case: commented code or documentation if the parsers documentation mode is DocumentationMode.None
+            if (text.StartsWith(@"///", StringComparison.Ordinal))
             {
                 return;
             }


### PR DESCRIPTION
Fixes #1012. 
I also implemented a regression test.