### PR TITLE
Diagnostic unit tests: SA1019 (MemberAccessSymbolsMustBeSpacedCorrectly)

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1019UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1019UnitTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -19,6 +20,19 @@
     public class SA1019UnitTests : CodeFixVerifier
     {
         /// <summary>
+        /// The members access operators to test.
+        /// </summary>
+        /// <value>The members access operators to test.</value>
+        public static IEnumerable<object[]> Operators
+        {
+            get
+            {
+                yield return new object[] { "." };
+                yield return new object[] { "?." };
+            }
+        }
+
+        /// <summary>
         /// Verifies that the analyzer will properly handle an empty source.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -30,72 +44,122 @@
         }
 
         /// <summary>
-        /// Asserts that a space before a period member access symbol reports correctly.
+        /// Asserts that a space before a member access operator reports correctly.
         /// </summary>
+        /// <param name="op">The member access operator.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestSpaceBeforeDotAsync()
+        [Theory]
+        [MemberData(nameof(Operators))]
+        public async Task TestSpaceBeforeOperatorAsync(string op)
         {
-            string template = this.GetTemplate(" .");
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(16, 27).WithArguments(".", "preceded");
+            string template = this.GetTemplate($" {op}");
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(16, 27).WithArguments(op[0], "preceded");
             await this.VerifyCSharpDiagnosticAsync(template, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Asserts that a space after a period member access symbol reports correctly.
+        /// Asserts that a space after a member access operator reports correctly.
         /// </summary>
+        /// <param name="op">The member access operator.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestSpaceAfterDotAsync()
+        [Theory]
+        [MemberData(nameof(Operators))]
+        public async Task TestSpaceAfterOperatorAsync(string op)
         {
-            string template = this.GetTemplate(". ");
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(16, 26).WithArguments(".", "followed");
+            string template = this.GetTemplate($"{op} ");
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(16, 25 + op.Length).WithArguments(op.Last(), "followed");
             await this.VerifyCSharpDiagnosticAsync(template, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Asserts that a space before a null conditional access symbol reports correctly.
+        /// Asserts that a member access operator at the end of a line does not report.
         /// </summary>
+        /// <param name="op">The member access operator.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestSpaceBeforeNullConditionalAsync()
+        [Theory]
+        [MemberData(nameof(Operators))]
+        public async Task TestOperatorAtEndOfLineDoesNotReportAsync(string op)
         {
-            string template = this.GetTemplate(" ?.");
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(16, 27).WithArguments("?", "preceded");
-            await this.VerifyCSharpDiagnosticAsync(template, expected, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Asserts that a space after a null conditional access symbol reports correctly.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestSpaceAfterNullConditionalAsync()
-        {
-            string template = this.GetTemplate("?. ");
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(16, 27).WithArguments(".", "followed");
-            await this.VerifyCSharpDiagnosticAsync(template, expected, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Asserts that a dot at the end of a line does not report.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestDotAtEndOfLineDoesNotReportAsync()
-        {
-            string template = this.GetTemplate($".{Environment.NewLine}");
+            string template = this.GetTemplate($"{op}{Environment.NewLine}");
             await this.VerifyCSharpDiagnosticAsync(template, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// Asserts that a dot at the start of a line does not report.
+        /// Asserts that a member access operator at the start of a line does not report.
         /// </summary>
+        /// <param name="op">The member access operator.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestDotAtStartOfLineDoesNotReportAsync()
+        [Theory]
+        [MemberData(nameof(Operators))]
+        public async Task TestOperatorAtStartOfLineDoesNotReportAsync(string op)
         {
-            string template = this.GetTemplate($"{Environment.NewLine}.");
+            string template = this.GetTemplate($"{Environment.NewLine}{op}");
+            await this.VerifyCSharpDiagnosticAsync(template, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asserts that block comments either side of the operator does not report a diagnostic.
+        /// </summary>
+        /// <param name="op">The member access operator.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(Operators))]
+        public async Task TestBlockCommentsEitherSideOfOperatorDoesNotReportAsync(string op)
+        {
+            string template = this.GetTemplate($"/**/{op}/**/");
+            await this.VerifyCSharpDiagnosticAsync(template, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asserts that a comment on the line preceding the operator does not report.
+        /// </summary>
+        /// <param name="op">The member access operator.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(Operators))]
+        public async Task TestCommentOnLinePrecedingOperatorDoesNotReportAsync(string op)
+        {
+            string template = this.GetTemplate($"// This is a comment{Environment.NewLine}{op}");
+            await this.VerifyCSharpDiagnosticAsync(template, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asserts that a comment on the line following the operator does not report.
+        /// </summary>
+        /// <param name="op">The member access operator.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(Operators))]
+        public async Task TestCommentOnLineFollowingOperatorDoesNotReportAsync(string op)
+        {
+            string template = this.GetTemplate($"{op}{Environment.NewLine}// This is a comment{Environment.NewLine}");
+            await this.VerifyCSharpDiagnosticAsync(template, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asserts that a comment on the same line as the operator separated by whitespace does report a diagnostic.
+        /// </summary>
+        /// <param name="op">The member access operator.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(Operators))]
+        public async Task TestCommentOnSameLineSeparatedByWhitespaceReportsAsync(string op)
+        {
+            string template = this.GetTemplate($"{op} // This is a comment{Environment.NewLine}");
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(16, 25 + op.Length).WithArguments(".", "followed");
+            await this.VerifyCSharpDiagnosticAsync(template, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asserts that a comment on the same line as and immediately after the operator does report a diagnostic.
+        /// </summary>
+        /// <param name="op">The member access operator.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(Operators))]
+        public async Task TestCommentOnSameLineImmediatelyAfterOperatorDoesNotReportsAsync(string op)
+        {
+            string template = this.GetTemplate($"{op}// This is a comment{Environment.NewLine}");
             await this.VerifyCSharpDiagnosticAsync(template, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1019UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1019UnitTests.cs
@@ -1,0 +1,169 @@
+﻿namespace StyleCop.Analyzers.Test.SpacingRules
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    using StyleCop.Analyzers.SpacingRules;
+
+    using TestHelper;
+
+    using Xunit;
+
+    /// <summary>
+    /// This class contains unit tests for the <see cref="SA1019MemberAccessSymbolsMustBeSpacedCorrectly"/> class.
+    /// </summary>
+    public class SA1019UnitTests : CodeFixVerifier
+    {
+        /// <summary>
+        /// Verifies that the analyzer will properly handle an empty source.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestEmptySourceAsync()
+        {
+            var testCode = string.Empty;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asserts that a space before a period member access symbol reports correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestSpaceBeforeDotAsync()
+        {
+            string template = this.GetTemplate(" .");
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(16, 27).WithArguments(".", "preceded");
+            await this.VerifyCSharpDiagnosticAsync(template, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asserts that a space after a period member access symbol reports correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestSpaceAfterDotAsync()
+        {
+            string template = this.GetTemplate(". ");
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(16, 26).WithArguments(".", "followed");
+            await this.VerifyCSharpDiagnosticAsync(template, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asserts that a space before a null conditional access symbol reports correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestSpaceBeforeNullConditionalAsync()
+        {
+            string template = this.GetTemplate(" ?.");
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(16, 27).WithArguments("?", "preceded");
+            await this.VerifyCSharpDiagnosticAsync(template, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asserts that a space after a null conditional access symbol reports correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestSpaceAfterNullConditionalAsync()
+        {
+            string template = this.GetTemplate("?. ");
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(16, 27).WithArguments(".", "followed");
+            await this.VerifyCSharpDiagnosticAsync(template, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asserts that a dot at the end of a line does not report.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestDotAtEndOfLineDoesNotReportAsync()
+        {
+            string template = this.GetTemplate($".{Environment.NewLine}");
+            await this.VerifyCSharpDiagnosticAsync(template, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asserts that a dot at the start of a line does not report.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestDotAtStartOfLineDoesNotReportAsync()
+        {
+            string template = this.GetTemplate($"{Environment.NewLine}.");
+            await this.VerifyCSharpDiagnosticAsync(template, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asserts that a ternary operator does not report.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestTernaryDoesNotReportAsync()
+        {
+            string template =
+
+@"namespace SA1019
+{
+    class Test
+    {
+        public void TestMethod()
+        {
+            var number = true ? 1 : 2;
+        }
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(template, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Gets the C# analyzers being tested
+        /// </summary>
+        /// <returns>
+        /// New instances of all the C# analyzers being tested.
+        /// </returns>
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new SA1019MemberAccessSymbolsMustBeSpacedCorrectly();
+        }
+
+        /// <summary>
+        /// Retrieves the template used for testing.
+        /// </summary>
+        /// <param name="accessSymbol">The access symbol to use, including any spacing or newline characters.</param>
+        /// <returns>The template to be tested.</returns>
+        private string GetTemplate(string accessSymbol)
+        {
+
+            string template =
+
+@"namespace SA1019 
+{{     
+    class Foo
+    {{
+        public bool Bar() 
+        {{
+            return true;
+        }}
+    }}
+
+    class Test
+    {{
+        public void TestMethod()
+        {{
+            var foo = new Foo();
+            var bar = foo{0}Bar();
+        }}
+    }}
+}}";
+
+            return string.Format(template, accessSymbol);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -279,6 +279,7 @@
     <Compile Include="SpacingRules\SA1016UnitTests.cs" />
     <Compile Include="SpacingRules\SA1017UnitTests.cs" />
     <Compile Include="SpacingRules\SA1018UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1019UnitTests.cs" />
     <Compile Include="SpacingRules\SA1020UnitTests.cs" />
     <Compile Include="SpacingRules\SA1021UnitTests.cs" />
     <Compile Include="SpacingRules\SA1022UnitTests.cs" />


### PR DESCRIPTION
Implementing unit tests for #205