### PR TITLE
Fix for SA1111 incorrectly reported for Attributes with no arguments

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1111UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1111UnitTests.cs
@@ -852,7 +852,26 @@ public class FooAttribute : System.Attribute
         public async Task TestAttributeOneParameterOnTheSameLineAsClosingBracketAsync()
         {
             var testCode = @"
-[System.Serializable]
+using System.Diagnostics;
+[Conditional(""DEBUG"")]
+public class FooAttribute: System.Attribute
+{
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Asserts that an attribute with a single parameter does not report if the open and close brackets are on sepsrate lines
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestAttributeOneParameterOnPreviousLineAsClosingBracketAsync()
+        {
+            var testCode = @"
+[
+System.Serializable
+]
 public class Foo
 {
 }";

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1111ClosingParenthesisMustBeOnLineOfLastParameter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1111ClosingParenthesisMustBeOnLineOfLastParameter.cs
@@ -135,7 +135,7 @@
             var lastAttribute = attributeList.Attributes
                                 .Last();
 
-            if (!attributeList.CloseBracketToken.IsMissing)
+            if (!attributeList.CloseBracketToken.IsMissing && lastAttribute.ArgumentList != null)
             {
                 CheckIfLocationOfLastArgumentOrParameterAndCloseTokenAreTheSame(context, lastAttribute,
                     attributeList.CloseBracketToken);


### PR DESCRIPTION
Fix for #808.  SA1111 being incorrectly reported for Attributes with no arguments when the closing bracket is on the next line.