### PR TITLE
Fix for SA1513 reported with yield return and object initializer

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1513UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1513UnitTests.cs
@@ -34,6 +34,7 @@
         {
             var testCode = @"using System;
 using System.Linq;
+using System.Collections.Generic;
 
 public class Foo
 {
@@ -338,6 +339,15 @@ public class Foo
         add
         {
         }
+    }
+
+    // Valid #28 - Test for https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1020
+    private static IEnumerable<object> Method()
+    {
+        yield return new
+        {
+            prop = ""A""
+        };
     }
 
     // This is a regression test for https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/784

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513ClosingCurlyBracketMustBeFollowedByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513ClosingCurlyBracketMustBeFollowedByBlankLine.cs
@@ -159,6 +159,7 @@
 
                     if (nextToken.IsKind(SyntaxKind.SemicolonToken) &&
                         (this.IsPartOf<VariableDeclaratorSyntax>(token) ||
+                         this.IsPartOf<YieldStatementSyntax>(token) ||
                          this.IsPartOf<AssignmentExpressionSyntax>(token) ||
                          this.IsPartOf<ReturnStatementSyntax>(token)))
                     {


### PR DESCRIPTION
Fix for #1020. SA1513 is incorrectly reported when a yield return statement contains an object initializer.

As a side note I'm wondering if it might not be easier to debug the tests for SA1513 in future if they were split out - a separate tests for each individual test case. The test template here is getting rather big.