### PR TITLE
Add code to test fix all providers

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/TestDiagnosticProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/TestDiagnosticProvider.cs
@@ -1,0 +1,40 @@
+﻿namespace StyleCop.Analyzers.Test.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeFixes;
+
+    internal sealed class TestDiagnosticProvider : FixAllContext.DiagnosticProvider
+    {
+        private ImmutableArray<Diagnostic> diagnostics;
+
+        private TestDiagnosticProvider(ImmutableArray<Diagnostic> diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        internal static TestDiagnosticProvider Create(ImmutableArray<Diagnostic> diagnostics)
+        {
+            return new TestDiagnosticProvider(diagnostics);
+        }
+
+        public override Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IEnumerable<Diagnostic>>(this.diagnostics);
+        }
+
+        public override Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IEnumerable<Diagnostic>>(this.diagnostics);
+        }
+
+        public override Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IEnumerable<Diagnostic>>(this.diagnostics);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -146,6 +146,7 @@
     <Compile Include="Helpers\CodeFixVerifier.Helper.cs" />
     <Compile Include="Helpers\DiagnosticResult.cs" />
     <Compile Include="Helpers\DiagnosticVerifier.Helper.cs" />
+    <Compile Include="Helpers\TestDiagnosticProvider.cs" />
     <Compile Include="LayoutRules\SA1500\SA1500UnitTests.Blocks.cs" />
     <Compile Include="LayoutRules\SA1500\SA1500UnitTests.Classes.cs" />
     <Compile Include="LayoutRules\SA1500\SA1500UnitTests.Constructors.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
@@ -1,5 +1,6 @@
 ﻿namespace TestHelper
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
@@ -10,6 +11,7 @@
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using Microsoft.CodeAnalysis.Formatting;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
 
     /// <summary>
@@ -34,40 +36,60 @@
         /// <param name="newSource">A class in the form of a string after the code fix was applied to it.</param>
         /// <param name="codeFixIndex">Index determining which code fix to apply if there are multiple.</param>
         /// <param name="allowNewCompilerDiagnostics">A value indicating whether or not the test will fail if the code fix introduces other warnings after being applied.</param>
+        /// <param name="maxNumberOfIterations">Defines an upper limit for the number of iterations the fixer will be called.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that the task will observe.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected Task VerifyCSharpFixAsync(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, CancellationToken cancellationToken = default(CancellationToken))
+        protected async Task VerifyCSharpFixAsync(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, int maxNumberOfIterations = int.MaxValue, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.VerifyFixAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics, cancellationToken);
+            await this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics, maxNumberOfIterations, GetSingleAnalyzerDocumentAsync, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
-        /// General verifier for code fixes.
-        /// Creates a <see cref="Document"/> from the source string, then gets <see cref="Diagnostic"/>s on it and
-        /// applies the relevant code fixes. Then gets the string after the code fix is applied and compares it with the
-        /// expected result.
-        /// <note type="note">
-        /// <para>If any code fix causes new diagnostics to show up, the test fails unless
-        /// <paramref name="allowNewCompilerDiagnostics"/> is set to <see langword="true"/>.</para>
-        /// </note>
+        /// Called to test a C# fix all provider when applied on the input source as a string.
         /// </summary>
-        /// <param name="language">The language the source classes are in. Values may be taken from the
-        /// <see cref="LanguageNames"/> class.</param>
-        /// <param name="analyzers">The analyzer to be applied to the source code.</param>
-        /// <param name="codeFixProvider">The code fix to be applied to the code wherever the relevant
-        /// <see cref="Diagnostic"/> is found.</param>
         /// <param name="oldSource">A class in the form of a string before the code fix was applied to it.</param>
         /// <param name="newSource">A class in the form of a string after the code fix was applied to it.</param>
         /// <param name="codeFixIndex">Index determining which code fix to apply if there are multiple.</param>
-        /// <param name="allowNewCompilerDiagnostics">A value indicating whether or not the test will fail if the code
-        /// fix introduces other warnings after being applied.</param>
+        /// <param name="allowNewCompilerDiagnostics">A value indicating whether or not the test will fail if the code fix introduces other warnings after being applied.</param>
+        /// <param name="maxNumberOfIterations">Defines an upper limit for the number of iterations the fixer will be called.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that the task will observe.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        private async Task VerifyFixAsync(string language, ImmutableArray<DiagnosticAnalyzer> analyzers, CodeFixProvider codeFixProvider, string oldSource, string newSource, int? codeFixIndex, bool allowNewCompilerDiagnostics, CancellationToken cancellationToken)
+        protected async Task VerifyCSharpFixAllFixAsync(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, int maxNumberOfIterations = int.MaxValue, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            await this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics, maxNumberOfIterations, GetFixAllAnalyzerDocumentAsync, cancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task VerifyFixInternalAsync(string language, ImmutableArray<DiagnosticAnalyzer> analyzers, CodeFixProvider codeFixProvider, string oldSource, string newSource, int? codeFixIndex,
+            bool allowNewCompilerDiagnostics, int maxNumberOfIterations, Func<ImmutableArray<DiagnosticAnalyzer>, CodeFixProvider, int?, CancellationToken, Document, int, Task<Document>> getFixedDocument, CancellationToken cancellationToken)
         {
             var document = this.CreateDocument(oldSource, language);
             var compilerDiagnostics = await GetCompilerDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false);
 
+            document = await getFixedDocument(analyzers, codeFixProvider, codeFixIndex, cancellationToken, document, maxNumberOfIterations).ConfigureAwait(false);
+
+            var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false));
+
+            // check if applying the code fix introduced any new compiler diagnostics
+            if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
+            {
+                // Format and get the compiler diagnostics again so that the locations make sense in the output
+                document = await Formatter.FormatAsync(document, Formatter.Annotation, cancellationToken: cancellationToken).ConfigureAwait(false);
+                newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false));
+
+                string message =
+                    string.Format("Fix introduced new compiler diagnostics:\r\n{0}\r\n\r\nNew document:\r\n{1}\r\n",
+                        string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString())),
+                        (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false)).ToFullString());
+                Assert.True(false, message);
+            }
+
+            // after applying all of the code fixes, compare the resulting string to the inputted one
+            var actual = await GetStringFromDocumentAsync(document, cancellationToken).ConfigureAwait(false);
+            Assert.Equal(newSource, actual);
+        }
+
+        private static async Task<Document> GetSingleAnalyzerDocumentAsync(ImmutableArray<DiagnosticAnalyzer> analyzers, CodeFixProvider codeFixProvider, int? codeFixIndex, CancellationToken cancellationToken, Document document, int maxNumberOfIterations)
+        {
             var previousDiagnostics = ImmutableArray.Create<Diagnostic>();
 
             bool done;
@@ -82,6 +104,11 @@
                 if (!AreDiagnosticsDifferent(analyzerDiagnostics, previousDiagnostics))
                 {
                     break;
+                }
+
+                if (--maxNumberOfIterations < 0)
+                {
+                    Assert.True(false, "The upper limit for the number of code fix iterations was exceeded");
                 }
 
                 previousDiagnostics = analyzerDiagnostics;
@@ -109,26 +136,67 @@
                 }
             }
             while (!done);
+            return document;
+        }
 
-            var newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false));
+        private static async Task<Document> GetFixAllAnalyzerDocumentAsync(ImmutableArray<DiagnosticAnalyzer> analyzers, CodeFixProvider codeFixProvider, int? codeFixIndex, CancellationToken cancellationToken, Document document, int maxNumberOfIterations)
+        {
+            var previousDiagnostics = ImmutableArray.Create<Diagnostic>();
 
-            // check if applying the code fix introduced any new compiler diagnostics
-            if (!allowNewCompilerDiagnostics && newCompilerDiagnostics.Any())
+            var fixAllProvider = codeFixProvider.GetFixAllProvider();
+
+            if (fixAllProvider == null)
             {
-                // Format and get the compiler diagnostics again so that the locations make sense in the output
-                document = await Formatter.FormatAsync(document, Formatter.Annotation, cancellationToken: cancellationToken).ConfigureAwait(false);
-                newCompilerDiagnostics = GetNewDiagnostics(compilerDiagnostics, await GetCompilerDiagnosticsAsync(document, cancellationToken).ConfigureAwait(false));
-
-                string message =
-                    string.Format("Fix introduced new compiler diagnostics:\r\n{0}\r\n\r\nNew document:\r\n{1}\r\n",
-                        string.Join("\r\n", newCompilerDiagnostics.Select(d => d.ToString())),
-                        (await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false)).ToFullString());
-                Assert.True(false, message);
+                return null;
             }
 
-            // after applying all of the code fixes, compare the resulting string to the inputted one
-            var actual = await GetStringFromDocumentAsync(document, cancellationToken).ConfigureAwait(false);
-            Assert.Equal(newSource, actual);
+            bool done;
+            do
+            {
+                var analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzers, new[] { document }, cancellationToken).ConfigureAwait(false);
+                if (analyzerDiagnostics.Length == 0)
+                {
+                    break;
+                }
+
+                if (!AreDiagnosticsDifferent(analyzerDiagnostics, previousDiagnostics))
+                {
+                    break;
+                }
+
+                if (--maxNumberOfIterations < 0)
+                {
+                    Assert.True(false, "The upper limit for the number of fix all iterations was exceeded");
+                }
+
+                previousDiagnostics = analyzerDiagnostics;
+
+                done = true;
+
+                FixAllContext.DiagnosticProvider fixAllDiagnosticProvider = TestDiagnosticProvider.Create(analyzerDiagnostics);
+
+                FixAllContext fixAllContext = new FixAllContext(document, codeFixProvider, FixAllScope.Document, null, codeFixProvider.FixableDiagnosticIds, fixAllDiagnosticProvider, cancellationToken);
+
+                CodeAction action = await fixAllProvider.GetFixAsync(fixAllContext).ConfigureAwait(false);
+
+                if (action == null)
+                {
+                    return document;
+                }
+
+                var fixedDocument = await ApplyFixAsync(document, action, cancellationToken).ConfigureAwait(false);
+
+                if (fixedDocument != document)
+                {
+                    done = false;
+                    var newText = await fixedDocument.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+                    // workaround for issue #936 - force re-parsing to get the same sort of syntax tree as the original document.
+                    document = document.WithText(newText);
+                }
+            }
+            while (!done);
+            return document;
         }
 
         private static bool AreDiagnosticsDifferent(ImmutableArray<Diagnostic> analyzerDiagnostics, ImmutableArray<Diagnostic> previousDiagnostics)


### PR DESCRIPTION
This makes it possible to test fix all providers. I also added a new parameter to limit the number of iterations a fix all provider/code fix provider is allowed to run until all problems are fixed. This is usefull to make sure that a custom fix all provider fixes all problems in one iteration.