### PR TITLE
Code fix for SA1012-SA1015

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1012UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1012UnitTests.cs
@@ -4,6 +4,7 @@
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.SpacingRules;
     using TestHelper;
@@ -12,7 +13,7 @@
     /// <summary>
     /// Unit tests for <see cref="SA1012OpeningCurlyBracketsMustBeSpacedCorrectly"/>
     /// </summary>
-    public class SA1012UnitTests : DiagnosticVerifier
+    public class SA1012UnitTests : CodeFixVerifier
     {
         /// <summary>
         /// Verifies that the analyzer will properly handle an empty source.
@@ -94,6 +95,25 @@
     }
 }
 ";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var test = 2;
+            var x = $""{test}"";
+            x = $"" {test}"";
+            x = $""({test})"";
+            x = $""( {test})"";
+            x = $""{test}"";
+            x = $"" {test}"";
+        }
+    }
+}
+";
+
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(12, 19).WithArguments(" not", "followed"),
@@ -101,6 +121,8 @@
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -122,6 +144,18 @@
 }
 ";
 
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public int TestProperty1 { get; set; }
+        public int TestProperty2 { get; set; }
+        public int TestProperty3 { get; set; }
+        public int TestProperty4 { get; set; }
+    }
+}
+";
+
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(6, 33).WithArguments(string.Empty, "preceded"),
@@ -131,6 +165,8 @@
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -158,6 +194,24 @@
 }
 ";
 
+            var fixedCode = @"namespace TestNamespace
+{
+    using System.Collections.Generic;
+
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            new Dictionary<int, int> { { 1, 1 } };
+            new Dictionary<int, int> { { 1, 1 } };
+            new Dictionary<int, int> { { 1, 1 } };
+            new Dictionary<int, int> { { 1, 1 } };
+            new Dictionary<int, int> { { 1, 1 } };
+        }
+    }
+}
+";
+
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(10, 37).WithArguments(string.Empty, "preceded"),
@@ -171,12 +225,20 @@
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
             yield return new SA1012OpeningCurlyBracketsMustBeSpacedCorrectly();
+        }
+
+        /// <inheritdoc/>
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new OpenCloseSpacingCodeFixProvider();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1013UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1013UnitTests.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.SpacingRules;
     using TestHelper;
@@ -11,7 +12,7 @@
     /// <summary>
     /// Unit tests for <see cref="SA1013ClosingCurlyBracketsMustBeSpacedCorrectly"/>
     /// </summary>
-    public class SA1013UnitTests : DiagnosticVerifier
+    public class SA1013UnitTests : CodeFixVerifier
     {
         /// <summary>
         /// Verifies that the analyzer will properly handle an empty source.
@@ -73,6 +74,24 @@
 }
 ";
 
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var test = 2;
+            var x = $""{test}"";
+            x = $""{test}"";
+            x = $""({test})"";
+            x = $""({test} )"";
+            x = $""{test}"";
+            x = $""{test} "";
+        }
+    }
+}
+";
+
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(12, 25).WithArguments(" not", "preceded"),
@@ -80,6 +99,8 @@
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -99,12 +120,24 @@
 }
 ";
 
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public int TestProperty1 { get; set; }
+        public int TestProperty2 { get; set; }
+    }
+}
+";
+
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(6, 45).WithArguments(string.Empty, "preceded")
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -131,6 +164,23 @@
 }
 ";
 
+            var fixedCode = @"namespace TestNamespace
+{
+    using System.Collections.Generic;
+
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            new Dictionary<int, int> { { 1, 1 } };
+            new Dictionary<int, int> { { 1, 1 } };
+            new Dictionary<int, int> { { 1, 1 } };
+            new Dictionary<int, int> { { 1, 1 } };
+        }
+    }
+}
+";
+
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(10, 46).WithArguments(string.Empty, "preceded"),
@@ -142,6 +192,8 @@
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -217,6 +269,25 @@
 }
 ";
 
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod1(object[] a)
+        {
+        }        
+
+        public void TestMethod2()
+        {
+            TestMethod1(new object[] { });
+            TestMethod1(new object[] { });
+            TestMethod1(new object[] { } );
+            TestMethod1(new object[] { } );
+        }
+    }
+}
+";
+
             // space between closing curly bracket and closing parenthesis should be reported by SA1009
             DiagnosticResult[] expected =
             {
@@ -225,12 +296,20 @@
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
             yield return new SA1013ClosingCurlyBracketsMustBeSpacedCorrectly();
+        }
+
+        /// <inheritdoc/>
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new OpenCloseSpacingCodeFixProvider();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1014UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1014UnitTests.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.SpacingRules;
     using TestHelper;
@@ -11,7 +12,7 @@
     /// <summary>
     /// Unit tests for <see cref="SA1014OpeningGenericBracketsMustBeSpacedCorrectly"/>
     /// </summary>
-    public class SA1014UnitTests : DiagnosticVerifier
+    public class SA1014UnitTests : CodeFixVerifier
     {
         /// <summary>
         /// Verifies that the analyzer will properly handle an empty source.
@@ -70,6 +71,21 @@ public class TestClass3 < T> where T : IEnumerable < object>
 }
 ";
 
+            var fixedCode = @"using System.Collections.Generic;
+
+public class TestClass1<T> where T : IEnumerable<object>
+{
+}
+
+public class TestClass2<T> where T : IEnumerable<object>
+{
+}
+
+public class TestClass3<T> where T : IEnumerable<object>
+{
+}
+";
+
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(3, 25).WithArguments("preceded"),
@@ -83,6 +99,8 @@ public class TestClass3 < T> where T : IEnumerable < object>
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -103,6 +121,17 @@ public class TestClass
 }
 ";
 
+            var fixedCode = @"using System;
+
+public class TestClass
+{
+    public Action<Action<object>> TestProperty1 { get; set; }
+    public Action<Action<object>> TestProperty2 { get; set; }
+    public Action<Action<object>> TestProperty3 { get; set; }
+    public Action<Action<object>> TestProperty4 { get; set; }
+}
+";
+
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(6, 19).WithArguments("preceded"),
@@ -116,6 +145,8 @@ public class TestClass
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -151,6 +182,32 @@ public class TestClass
 }
 ";
 
+            var fixedCode = @"using System;
+
+public class TestClass
+{
+    public Action<Action<object>> TestMethod1<T>()
+    {
+        throw new NotImplementedException();
+    }
+
+    public Action<Action<object>> TestMethod2<T>()
+    {
+        throw new NotImplementedException();
+    }
+
+    public Action<Action<object>> TestMethod3<T>()
+    {
+        throw new NotImplementedException();
+    }
+
+    public Action<Action<object>> TestMethod4<T>()
+    {
+        throw new NotImplementedException();
+    }
+}
+";
+
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(10, 19).WithArguments("preceded"),
@@ -168,6 +225,8 @@ public class TestClass
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -200,6 +259,29 @@ public class TestClass
 }
 ";
 
+            var fixedCode = @"using System;
+
+public class TestClass
+{
+    public void TestMethod1<T>()
+    {
+    }
+
+    public void TestMethod2()
+    {
+        var x = typeof(Action<,>);
+        x = typeof(Action<,>);
+        x = typeof(Action<,>);
+        x = typeof(Action<,>);
+
+        TestMethod1<object>();
+        TestMethod1<object>();
+        TestMethod1<object>();
+        TestMethod1<object>();
+    }
+}
+";
+
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(12, 27).WithArguments("preceded"),
@@ -213,6 +295,8 @@ public class TestClass
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -247,6 +331,12 @@ public class TestClass
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
             yield return new SA1014OpeningGenericBracketsMustBeSpacedCorrectly();
+        }
+
+        /// <inheritdoc/>
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new OpenCloseSpacingCodeFixProvider();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/OpenCloseSpacingCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/OpenCloseSpacingCodeFixProvider.cs
@@ -1,0 +1,128 @@
+﻿namespace StyleCop.Analyzers.SpacingRules
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Composition;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp;
+    using StyleCop.Analyzers.Helpers;
+
+    /// <summary>
+    /// Implements a code fix for the opening and closing spacing diagnostics.
+    /// </summary>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(OpenCloseSpacingCodeFixProvider))]
+    [Shared]
+    public class OpenCloseSpacingCodeFixProvider : CodeFixProvider
+    {
+        internal const string LocationKey = "location";
+        internal const string ActionKey = "action";
+        internal const string LocationPreceding = "preceding";
+        internal const string LocationFollowing = "following";
+        internal const string ActionInsert = "insert";
+        internal const string ActionRemove = "remove";
+
+        private static readonly ImmutableArray<string> FixableDiagnostics =
+            ImmutableArray.Create(
+                SA1012OpeningCurlyBracketsMustBeSpacedCorrectly.DiagnosticId,
+                SA1013ClosingCurlyBracketsMustBeSpacedCorrectly.DiagnosticId,
+                SA1014OpeningGenericBracketsMustBeSpacedCorrectly.DiagnosticId,
+                SA1015ClosingGenericBracketsMustBeSpacedCorrectly.DiagnosticId);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+
+        /// <inheritdoc/>
+        public override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        /// <inheritdoc/>
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            {
+                context.RegisterCodeFix(CodeAction.Create(SpacingResources.OpenCloseSpacingCodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+            }
+
+            return SpecializedTasks.CompletedTask;
+        }
+
+        private static async Task<Document> GetTransformedDocumentAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            var token = syntaxRoot.FindToken(diagnostic.Location.SourceSpan.Start);
+
+            string location;
+            if (!diagnostic.Properties.TryGetValue(LocationKey, out location))
+            {
+                return document;
+            }
+
+            string action;
+            if (!diagnostic.Properties.TryGetValue(ActionKey, out action))
+            {
+                return document;
+            }
+
+            var replaceMap = new Dictionary<SyntaxToken, SyntaxToken>();
+            SyntaxTriviaList triviaList;
+            switch (location)
+            {
+            case LocationPreceding:
+                switch (action)
+                {
+                case ActionInsert:
+                    replaceMap[token] = token.WithLeadingTrivia(token.LeadingTrivia.Add(SyntaxFactory.Space));
+                    break;
+
+                case ActionRemove:
+                    var prevToken = token.GetPreviousToken();
+                    triviaList = prevToken.TrailingTrivia.AddRange(token.LeadingTrivia);
+
+                    replaceMap[prevToken] = prevToken.WithTrailingTrivia();
+                    replaceMap[token] = token.WithLeadingTrivia(triviaList.WithoutTrailingWhitespace());
+                    break;
+
+                default:
+                    return document;
+                }
+
+                break;
+
+            case LocationFollowing:
+                switch (action)
+                {
+                case ActionInsert:
+                    replaceMap[token] = token.WithTrailingTrivia(token.TrailingTrivia.Insert(0, SyntaxFactory.Space));
+                    break;
+
+                case ActionRemove:
+                    var nextToken = token.GetNextToken();
+                    triviaList = token.TrailingTrivia.AddRange(nextToken.LeadingTrivia);
+
+                    replaceMap[token] = token.WithTrailingTrivia();
+                    replaceMap[nextToken] = nextToken.WithLeadingTrivia(triviaList.WithoutLeadingWhitespace());
+                    break;
+
+                default:
+                    return document;
+                }
+
+                break;
+
+            default:
+                return document;
+            }
+
+            var newSyntaxRoot = syntaxRoot.ReplaceTokens(replaceMap.Keys, (t1, t2) => replaceMap[t1]);
+            return document.WithSyntaxRoot(newSyntaxRoot);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1012OpeningCurlyBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1012OpeningCurlyBracketsMustBeSpacedCorrectly.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.SpacingRules
 {
+    using System.Collections.Generic;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
@@ -80,7 +81,12 @@
                 if (followedBySpace)
                 {
                     // Opening curly bracket must{} be {followed} by a space.
-                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), " not", "followed"));
+                    var properties = new Dictionary<string, string>
+                    {
+                        [OpenCloseSpacingCodeFixProvider.LocationKey] = OpenCloseSpacingCodeFixProvider.LocationFollowing,
+                        [OpenCloseSpacingCodeFixProvider.ActionKey] = OpenCloseSpacingCodeFixProvider.ActionRemove
+                    };
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), properties.ToImmutableDictionary(), " not", "followed"));
                 }
 
                 return;
@@ -91,13 +97,23 @@
             if (!precededBySpace)
             {
                 // Opening curly bracket must{} be {preceded} by a space.
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), string.Empty, "preceded"));
+                var properties = new Dictionary<string, string>
+                {
+                    [OpenCloseSpacingCodeFixProvider.LocationKey] = OpenCloseSpacingCodeFixProvider.LocationPreceding,
+                    [OpenCloseSpacingCodeFixProvider.ActionKey] = OpenCloseSpacingCodeFixProvider.ActionInsert
+                };
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), properties.ToImmutableDictionary(), string.Empty, "preceded"));
             }
 
             if (!token.IsLastInLine() && !followedBySpace)
             {
                 // Opening curly bracket must{} be {followed} by a space.
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), string.Empty, "followed"));
+                var properties = new Dictionary<string, string>
+                {
+                    [OpenCloseSpacingCodeFixProvider.LocationKey] = OpenCloseSpacingCodeFixProvider.LocationFollowing,
+                    [OpenCloseSpacingCodeFixProvider.ActionKey] = OpenCloseSpacingCodeFixProvider.ActionInsert
+                };
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), properties.ToImmutableDictionary(), string.Empty, "followed"));
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1013ClosingCurlyBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1013ClosingCurlyBracketsMustBeSpacedCorrectly.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.SpacingRules
 {
+    using System.Collections.Generic;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
@@ -79,7 +80,12 @@
                 if (precededBySpace)
                 {
                     // Closing curly bracket must{ not} be {preceded} by a space.
-                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), " not", "preceded"));
+                    var properties = new Dictionary<string, string>
+                    {
+                        [OpenCloseSpacingCodeFixProvider.LocationKey] = OpenCloseSpacingCodeFixProvider.LocationPreceding,
+                        [OpenCloseSpacingCodeFixProvider.ActionKey] = OpenCloseSpacingCodeFixProvider.ActionRemove
+                    };
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), properties.ToImmutableDictionary(), " not", "preceded"));
                 }
 
                 return;
@@ -105,13 +111,23 @@
             if (!precededBySpace)
             {
                 // Closing curly bracket must{} be {preceded} by a space.
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), string.Empty, "preceded"));
+                var properties = new Dictionary<string, string>
+                {
+                    [OpenCloseSpacingCodeFixProvider.LocationKey] = OpenCloseSpacingCodeFixProvider.LocationPreceding,
+                    [OpenCloseSpacingCodeFixProvider.ActionKey] = OpenCloseSpacingCodeFixProvider.ActionInsert
+                };
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), properties.ToImmutableDictionary(), string.Empty, "preceded"));
             }
 
             if (!lastInLine && !precedesSpecialCharacter && !followedBySpace)
             {
                 // Closing curly bracket must{} be {followed} by a space.
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), string.Empty, "followed"));
+                var properties = new Dictionary<string, string>
+                {
+                    [OpenCloseSpacingCodeFixProvider.LocationKey] = OpenCloseSpacingCodeFixProvider.LocationFollowing,
+                    [OpenCloseSpacingCodeFixProvider.ActionKey] = OpenCloseSpacingCodeFixProvider.ActionInsert
+                };
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), properties.ToImmutableDictionary(), string.Empty, "followed"));
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1014OpeningGenericBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1014OpeningGenericBracketsMustBeSpacedCorrectly.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.SpacingRules
 {
+    using System.Collections.Generic;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
@@ -86,13 +87,23 @@
             if (!firstInLine && precededBySpace)
             {
                 // Opening generic brackets must not be {preceded} by a space.
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), "preceded"));
+                var properties = new Dictionary<string, string>
+                {
+                    [OpenCloseSpacingCodeFixProvider.LocationKey] = OpenCloseSpacingCodeFixProvider.LocationPreceding,
+                    [OpenCloseSpacingCodeFixProvider.ActionKey] = OpenCloseSpacingCodeFixProvider.ActionRemove
+                };
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), properties.ToImmutableDictionary(), "preceded"));
             }
 
             if (followedBySpace)
             {
                 // Opening generic brackets must not be {followed} by a space.
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), "followed"));
+                var properties = new Dictionary<string, string>
+                {
+                    [OpenCloseSpacingCodeFixProvider.LocationKey] = OpenCloseSpacingCodeFixProvider.LocationFollowing,
+                    [OpenCloseSpacingCodeFixProvider.ActionKey] = OpenCloseSpacingCodeFixProvider.ActionRemove
+                };
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), properties.ToImmutableDictionary(), "followed"));
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1015ClosingGenericBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1015ClosingGenericBracketsMustBeSpacedCorrectly.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.SpacingRules
 {
+    using System.Collections.Generic;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
@@ -132,7 +133,12 @@
             if (!firstInLine && precededBySpace)
             {
                 // Closing generic bracket must{ not} be {preceded} by a space.
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), " not", "preceded"));
+                var properties = new Dictionary<string, string>
+                {
+                    [OpenCloseSpacingCodeFixProvider.LocationKey] = OpenCloseSpacingCodeFixProvider.LocationPreceding,
+                    [OpenCloseSpacingCodeFixProvider.ActionKey] = OpenCloseSpacingCodeFixProvider.ActionRemove
+                };
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), properties.ToImmutableDictionary(), " not", "preceded"));
             }
 
             if (!lastInLine)
@@ -140,12 +146,22 @@
                 if (!allowTrailingNoSpace && !followedBySpace)
                 {
                     // Closing generic bracket must{} be {followed} by a space.
-                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), string.Empty, "followed"));
+                    var properties = new Dictionary<string, string>
+                    {
+                        [OpenCloseSpacingCodeFixProvider.LocationKey] = OpenCloseSpacingCodeFixProvider.LocationFollowing,
+                        [OpenCloseSpacingCodeFixProvider.ActionKey] = OpenCloseSpacingCodeFixProvider.ActionInsert
+                    };
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), properties.ToImmutableDictionary(), string.Empty, "followed"));
                 }
                 else if (!allowTrailingSpace && followedBySpace)
                 {
                     // Closing generic bracket must{ not} be {followed} by a space.
-                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), " not", "followed"));
+                    var properties = new Dictionary<string, string>
+                    {
+                        [OpenCloseSpacingCodeFixProvider.LocationKey] = OpenCloseSpacingCodeFixProvider.LocationFollowing,
+                        [OpenCloseSpacingCodeFixProvider.ActionKey] = OpenCloseSpacingCodeFixProvider.ActionRemove
+                    };
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), properties.ToImmutableDictionary(), " not", "followed"));
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SpacingResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SpacingResources.Designer.cs
@@ -64,6 +64,15 @@ namespace StyleCop.Analyzers.SpacingRules {
         /// <summary>
         ///   Looks up a localized string similar to Fix spacing.
         /// </summary>
+        internal static string OpenCloseSpacingCodeFix {
+            get {
+                return ResourceManager.GetString("OpenCloseSpacingCodeFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fix spacing.
+        /// </summary>
         internal static string SA1000CodeFix {
             get {
                 return ResourceManager.GetString("SA1000CodeFix", resourceCulture);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SpacingResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SpacingResources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="OpenCloseSpacingCodeFix" xml:space="preserve">
+    <value>Fix spacing</value>
+  </data>
   <data name="SA1000CodeFix" xml:space="preserve">
     <value>Fix spacing</value>
   </data>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -311,6 +311,7 @@
     <Compile Include="SpacingRules\SA1006PreprocessorKeywordsMustNotBePrecededBySpace.cs" />
     <Compile Include="SpacingRules\SA1007CodeFixProvider.cs" />
     <Compile Include="SpacingRules\SA1007OperatorKeywordMustBeFollowedBySpace.cs" />
+    <Compile Include="SpacingRules\OpenCloseSpacingCodeFixProvider.cs" />
     <Compile Include="SpacingRules\SA1008CodeFixProvider.cs" />
     <Compile Include="SpacingRules\SA1008OpeningParenthesisMustBeSpacedCorrectly.cs" />
     <Compile Include="SpacingRules\SA1009ClosingParenthesisMustBeSpacedCorrectly.cs" />


### PR DESCRIPTION
Single code fix for the recently enabled spacing diagnostics. This should be able to be applied to SA1008-SA1017 in the future. The current code fixes have been left in place.

Fixes #216 
Fixes #217 
Fixes #218 
Fixes #219