### PR TITLE
Fix SA1513 reported in new language constructs

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1513UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1513UnitTests.cs
@@ -354,6 +354,32 @@ public class Foo
                                   Not = ""Food""
                               }).ToList();
     }
+
+    // This is a regression test for https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1049
+    public object[] ExpressionBodiedProperty =>
+        new[]
+        {
+            new object()
+        };
+
+    // This is a regression test for https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1049
+    public object[] ExpressionBodiedMethod() =>
+        new[]
+        {
+            new object()
+        };
+
+    // This is a regression test for https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1049
+    public object[] GetterOnlyAutoProperty1 { get; } =
+        new[]
+        {
+            new object()
+        };
+
+    // This is a regression test for https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1049
+    public object[] GetterOnlyAutoProperty2 { get; } =
+        {
+        };
 }
 ";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513ClosingCurlyBracketMustBeFollowedByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513ClosingCurlyBracketMustBeFollowedByBlankLine.cs
@@ -160,6 +160,8 @@
                     if (nextToken.IsKind(SyntaxKind.SemicolonToken) &&
                         (this.IsPartOf<VariableDeclaratorSyntax>(token) ||
                          this.IsPartOf<YieldStatementSyntax>(token) ||
+                         this.IsPartOf<ArrowExpressionClauseSyntax>(token) ||
+                         this.IsPartOf<EqualsValueClauseSyntax>(token) ||
                          this.IsPartOf<AssignmentExpressionSyntax>(token) ||
                          this.IsPartOf<ReturnStatementSyntax>(token)))
                     {


### PR DESCRIPTION
* [x] Add regression tests for SA1513 in expression-bodied members
* [x] Add regression tests for SA1513 in getter-only auto-properties
* [x] Fix #1049