### PR TITLE
Adding CodeFix for SA1120.

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1120UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1120UnitTests.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.ReadabilityRules;
     using TestHelper;
@@ -24,6 +25,15 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 9);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var expectedFixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+    }
+}";
+            await this.VerifyCSharpFixAsync(testCode, expectedFixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -40,6 +50,16 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 40);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var expectedFixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        System.Console.WriteLine(""A"");
+    }
+}";
+            await this.VerifyCSharpFixAsync(testCode, expectedFixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -56,6 +76,15 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 9);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var expectedFixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+    }
+}";
+            await this.VerifyCSharpFixAsync(testCode, expectedFixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -74,6 +103,15 @@ class Foo
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 9);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var expectedFixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+    }
+}";
+            await this.VerifyCSharpFixAsync(testCode, expectedFixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -106,6 +144,17 @@ class Foo
 }";
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 9);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var expectedFixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        // Foo
+        // Bar
+    }
+}";
+            await this.VerifyCSharpFixAsync(testCode, expectedFixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -118,12 +167,23 @@ class Foo
     {
         // Foo
         // Bar
-        // 
+        //
     }
 }";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 9);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var expectedFixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        // Foo
+        // Bar
+    }
+}";
+            await this.VerifyCSharpFixAsync(testCode, expectedFixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -136,13 +196,24 @@ class Foo
     {
         // 
         // Bar
-        // 
+        //
     }
 }";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 9);
             DiagnosticResult expected2 = this.CSharpDiagnostic().WithLocation(8, 9);
             await this.VerifyCSharpDiagnosticAsync(testCode, new[] { expected, expected2 }, CancellationToken.None).ConfigureAwait(false);
+
+            var expectedFixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        // Bar
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, expectedFixedCode).ConfigureAwait(false);
         }
 
         [Fact]
@@ -166,6 +237,11 @@ class Foo
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
             yield return new SA1120CommentsMustContainText();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new SA1120CodeFixProvider();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1120UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1120UnitTests.cs
@@ -217,6 +217,36 @@ class Foo
         }
 
         [Fact]
+        public async Task TestViolationWithTrailingContentOnLineAsync()
+        {
+            var testCode = @"
+using System;
+class Foo
+{
+    public void Bar()
+    {
+        /* */Console.WriteLine(""baz"");
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 9);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var expectedFixedCode = @"
+using System;
+class Foo
+{
+    public void Bar()
+    {
+        Console.WriteLine(""baz"");
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, expectedFixedCode).ConfigureAwait(false);
+        }
+
+
+        [Fact]
         public async Task TestCodeBlockNoDiagnosticOnInternalBlankLinesAsync()
         {
             var testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.Designer.cs
@@ -638,6 +638,15 @@ namespace StyleCop.Analyzers.ReadabilityRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove empty comment.
+        /// </summary>
+        internal static string SA1120CodeFix {
+            get {
+                return ResourceManager.GetString("SA1120CodeFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The C# comment does not contain any comment text..
         /// </summary>
         internal static string SA1120Description {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.resx
@@ -309,6 +309,9 @@
   <data name="SA1118Title" xml:space="preserve">
     <value>Parameter must not span multiple lines</value>
   </data>
+  <data name="SA1120CodeFix" xml:space="preserve">
+    <value>Remove empty comment</value>
+  </data>
   <data name="SA1120Description" xml:space="preserve">
     <value>The C# comment does not contain any comment text.</value>
   </data>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1120CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1120CodeFixProvider.cs
@@ -1,0 +1,107 @@
+﻿namespace StyleCop.Analyzers.ReadabilityRules
+{
+    using System.Composition;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Collections.Generic;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CSharp;
+    using StyleCop.Analyzers.Helpers;
+
+    /// <summary>
+    /// Implements a code fix for <see cref="SA1120CommentsMustContainText"/>.
+    /// </summary>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SA1120CodeFixProvider))]
+    [Shared]
+    public class SA1120CodeFixProvider : CodeFixProvider
+    {
+        private static readonly ImmutableArray<string> FixableDiagnostics =
+            ImmutableArray.Create(SA1120CommentsMustContainText.DiagnosticId);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+
+        /// <inheritdoc/>
+        public override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
+
+        /// <inheritdoc/>
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            {
+                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1120CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token)), diagnostic);
+            }
+
+            return SpecializedTasks.CompletedTask;
+        }
+
+        private static async Task<Document> GetTransformedDocumentAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var node = root.FindTrivia(diagnostic.Location.SourceSpan.Start, true);
+
+            int diagnosticIndex = 0;
+            var triviaList = TriviaHelper.GetContainingTriviaList(node, out diagnosticIndex);
+
+            var nodesToRemove = new List<SyntaxTrivia>();
+            nodesToRemove.Add(node);
+
+            // If the comment is the first non-whitespace item in the trivia list, we are going to remove all of the leading whitespace.
+            var firstIndex = TriviaHelper.IndexOfFirstNonWhitespaceTrivia(triviaList);
+
+            bool removedLeadingWhitespace = false;
+
+            if (firstIndex == diagnosticIndex)
+            {
+                removedLeadingWhitespace = true;
+                for (int i = diagnosticIndex; i >= 0; i--)
+                {
+                    var start = diagnostic.Location.SourceSpan.Start - (triviaList[diagnosticIndex].SpanStart - triviaList[i].SpanStart);
+                    var prevNode = root.FindTrivia(start, true);
+                    nodesToRemove.Add(prevNode);
+                }
+            }
+
+            var lastIndex = TriviaHelper.IndexOfTrailingWhitespace(triviaList);
+
+            // If the comment is the last non-whitespace item in the trivia list and it also wasn't the first non-whitespace item in the trivia list, then we remove the trailing whitespace.
+            if (diagnosticIndex+node.Span.Length==lastIndex && !removedLeadingWhitespace)
+            {
+                for (int i = diagnosticIndex; i<triviaList.Count; i++)
+                {
+                    var start = diagnostic.Location.SourceSpan.Start + (triviaList[i].SpanStart- triviaList[diagnosticIndex].SpanStart);
+                    var nextNodes = root.FindTrivia(start, true);
+                    nodesToRemove.Add(nextNodes);
+                }
+            }
+
+            var newRoot = root.ReplaceTrivia(nodesToRemove, (a, b) =>
+            {
+                return new SyntaxTrivia();
+            });
+
+            Document updatedDocument = document.WithSyntaxRoot(newRoot);
+            return updatedDocument;
+        }
+
+        private static bool IsSkippableWhitespace(SyntaxTrivia trivia)
+        {
+            switch (trivia.Kind())
+            {
+                case SyntaxKind.EndOfLineTrivia:
+                case SyntaxKind.WhitespaceTrivia:
+                    return true;
+
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -286,6 +286,7 @@
     <Compile Include="ReadabilityRules\SA1116SplitParametersMustStartOnLineAfterDeclaration.cs" />
     <Compile Include="ReadabilityRules\SA1117ParametersMustBeOnSameLineOrSeparateLines.cs" />
     <Compile Include="ReadabilityRules\SA1118ParameterMustNotSpanMultipleLines.cs" />
+    <Compile Include="ReadabilityRules\SA1120CodeFixProvider.cs" />
     <Compile Include="ReadabilityRules\SA1120CommentsMustContainText.cs" />
     <Compile Include="ReadabilityRules\SA1121CodeFixProvider.cs" />
     <Compile Include="ReadabilityRules\SA1121UseBuiltInTypeAlias.cs" />


### PR DESCRIPTION
Fixes #943 
Fails two unit tests with incorrect spacing on the closing brace when
the fix is to the last comment in a trivia list.