### PR TITLE
StyleCopTester improvements

### DIFF
--- a/StyleCop.Analyzers/StyleCopTester/Program.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Program.cs
@@ -20,8 +20,8 @@
     {
         private static void Main(string[] args)
         {
-            // A valid call must have at least two parameters. A solution file and /all or one /id:SAXXXX
-            if (args.Length <= 1)
+            // A valid call must have at least one parameter (a solution file). Optionally it can include /all or /id:SAXXXX.
+            if (args.Length < 1)
             {
                 PrintHelp();
             }
@@ -59,7 +59,20 @@
 
             foreach (var analyzer in analyzers)
             {
-                if (useAll || analyzer.SupportedDiagnostics.Any(y => ids.Contains(y.Id)))
+                if (useAll)
+                {
+                    yield return analyzer;
+                }
+                else if (ids.Count == 0)
+                {
+                    if (analyzer.SupportedDiagnostics.Any(i => i.IsEnabledByDefault))
+                    {
+                        yield return analyzer;
+                    }
+
+                    continue;
+                }
+                else if (analyzer.SupportedDiagnostics.Any(y => ids.Contains(y.Id)))
                 {
                     yield return analyzer;
                 }

--- a/StyleCop.Analyzers/StyleCopTester/Program.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Program.cs
@@ -48,6 +48,11 @@
                 var diagnostics = GetAnalyzerDiagnosticsAsync(solution, args[0], analyzers).Result;
 
                 Console.WriteLine($"Found {diagnostics.Count} diagnostics in {stopwatch.ElapsedMilliseconds}ms");
+
+                foreach (var group in diagnostics.GroupBy(i => i.Id).OrderBy(i => i.Key, StringComparer.OrdinalIgnoreCase))
+                {
+                    Console.WriteLine($"  {group.Key}: {group.Count()} instances");
+                }
             }
         }
 

--- a/StyleCop.Analyzers/StyleCopTester/Program.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Program.cs
@@ -39,13 +39,14 @@
                 }
 
                 MSBuildWorkspace workspace = MSBuildWorkspace.Create();
-                Solution solution = workspace.OpenSolutionAsync(args[0]).Result;
+                string solutionPath = args.SingleOrDefault(i => !i.StartsWith("/"));
+                Solution solution = workspace.OpenSolutionAsync(solutionPath).Result;
 
                 Console.WriteLine($"Loaded solution in {stopwatch.ElapsedMilliseconds}ms");
 
                 stopwatch.Restart();
 
-                var diagnostics = GetAnalyzerDiagnosticsAsync(solution, args[0], analyzers).Result;
+                var diagnostics = GetAnalyzerDiagnosticsAsync(solution, solutionPath, analyzers).Result;
 
                 Console.WriteLine($"Found {diagnostics.Count} diagnostics in {stopwatch.ElapsedMilliseconds}ms");
 

--- a/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
+++ b/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
@@ -44,6 +44,10 @@
     <DocumentationFile>$(OutputPath)$(AssemblyName).xml</DocumentationFile>
     <NoWarn>$(NoWarn),1573,1591</NoWarn>
   </PropertyGroup>
+  <PropertyGroup>
+    <StartArguments>..\..\StyleCopAnalyzers.sln</StartArguments>
+    <StartWorkingDirectory>$(MSBuildProjectDirectory)</StartWorkingDirectory>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>


### PR DESCRIPTION
* Do not require `/all` or `/id:SAXXXX`
* Provide a default debug configuration that works (clone and go)
* Include a summary of located diagnostics by ID