### PR TITLE
Enable tests for code fix behavior with alternate indentation

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
@@ -241,31 +241,33 @@ public class Foo
         /// Verifies that the code fix provider will correctly expand the block to a multiline statement, when it starts on the same line as the parent.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/660")]
+        [Fact]
         public async Task TestCodeFixProviderCorrectlyExpandsBlockInSourceFileWithTabsAsync()
         {
+            this.UseTabs = true;
+
             string testCode =
                 "using System.Diagnostics;\r\n" +
                 "public class Foo\r\n" +
                 "{\r\n" +
-                "\tpublic void Bar(int i)" +
+                "\tpublic void Bar(int i)\r\n" +
                 "\t{\r\n" +
                 "\t\tlock (this) { Debug.Assert(true); }\r\n" +
-                "\t}" +
-                "}";
+                "\t}\r\n" +
+                "}\r\n";
 
             string fixedTestCode =
                 "using System.Diagnostics;\r\n" +
                 "public class Foo\r\n" +
                 "{\r\n" +
-                "\tpublic void Bar(int i)" +
+                "\tpublic void Bar(int i)\r\n" +
                 "\t{\r\n" +
-                "\t\tlock (this)" +
+                "\t\tlock (this)\r\n" +
                 "\t\t{\r\n" +
                 "\t\t\tDebug.Assert(true);\r\n" +
                 "\t\t}\r\n" +
-                "\t}" +
-                "}";
+                "\t}\r\n" +
+                "}\r\n";
 
             await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1503UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1503UnitTests.cs
@@ -259,9 +259,11 @@ public class Foo
         /// Verifies that the codefix provider will properly handle alternate indentations.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/660")]
+        [Fact]
         public async Task TestCodeFixProviderWithAlternateIndentationAsync()
         {
+            this.IndentationSize = 1;
+
             var testCode = @"using System.Diagnostics;
 public class Foo
 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1519UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1519UnitTests.cs
@@ -431,9 +431,11 @@ public class Foo
         /// Verifies that the code fix provider will properly handle alternate indentations.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/660")]
+        [Fact]
         public async Task TestCodeFixProviderWithAlternateIndentationAsync()
         {
+            this.IndentationSize = 1;
+
             var testCode = @"using System.Diagnostics;
 public class Foo
 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1520UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1520UnitTests.cs
@@ -305,9 +305,11 @@ public class Foo
         /// Verifies that the code fix provider will properly handle alternate indentations.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/660")]
+        [Fact]
         public async Task TestCodeFixProviderWithAlternateIndentationAsync()
         {
+            this.IndentationSize = 1;
+
             var testCode = @"using System.Diagnostics;
 public class Foo
 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Properties/AssemblyInfo.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using Xunit;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
@@ -33,3 +34,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: AssemblyInformationalVersion("1.0.0.0-dev")]
+
+[assembly: CollectionBehavior(CollectionBehavior.CollectionPerAssembly, DisableTestParallelization = true)]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
@@ -20,6 +20,40 @@
     /// </summary>
     public abstract partial class CodeFixVerifier : DiagnosticVerifier
     {
+        private const int DefaultIndentationSize = 4;
+        private const bool DefaultUseTabs = false;
+
+        public CodeFixVerifier()
+        {
+            this.IndentationSize = DefaultIndentationSize;
+            this.UseTabs = DefaultUseTabs;
+        }
+
+        /// <summary>
+        /// Gets or sets the value of the <see cref="FormattingOptions.IndentationSize"/> to apply to the test
+        /// workspace.
+        /// </summary>
+        /// <value>
+        /// The value of the <see cref="FormattingOptions.IndentationSize"/> to apply to the test workspace.
+        /// </value>
+        public int IndentationSize
+        {
+            get;
+            protected set;
+        }
+
+        /// <summary>
+        /// Gets or sets the value of the <see cref="FormattingOptions.UseTabs"/> to apply to the test workspace.
+        /// </summary>
+        /// <value>
+        /// The value of the <see cref="FormattingOptions.UseTabs"/> to apply to the test workspace.
+        /// </value>
+        public bool UseTabs
+        {
+            get;
+            protected set;
+        }
+
         /// <summary>
         /// Returns the code fix being tested (C#) - to be implemented in non-abstract class.
         /// </summary>
@@ -57,6 +91,17 @@
         protected async Task VerifyCSharpFixAllFixAsync(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, int maxNumberOfIterations = int.MaxValue, CancellationToken cancellationToken = default(CancellationToken))
         {
             await this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSource, newSource, codeFixIndex, allowNewCompilerDiagnostics, maxNumberOfIterations, GetFixAllAnalyzerDocumentAsync, cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        protected override Solution CreateSolution(ProjectId projectId, string language)
+        {
+            Solution solution = base.CreateSolution(projectId, language);
+            solution.Workspace.Options =
+                solution.Workspace.Options
+                .WithChangedOption(FormattingOptions.IndentationSize, language, this.IndentationSize)
+                .WithChangedOption(FormattingOptions.UseTabs, language, this.UseTabs);
+            return solution;
         }
 
         private async Task VerifyFixInternalAsync(string language, ImmutableArray<DiagnosticAnalyzer> analyzers, CodeFixProvider codeFixProvider, string oldSource, string newSource, int? codeFixIndex,


### PR DESCRIPTION
I was able to address the original reliability problems by disabling test parallelization. It did not appear to have an effect on the overall build and test time.