### PR TITLE
Fix for SA1215 reported for const followed by readonly

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1215UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1215UnitTests.cs
@@ -157,6 +157,23 @@
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verifies that the analyzer will properly handle const before readonly fields.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestConstBeforeReadonlyAsync()
+        {
+            var testCode = @"class TestClass
+{
+    private const int TestField1 = 1;
+    private readonly int TestField2 = 2;
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
         /// <inheritdoc/>
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1215InstanceReadonlyElementsMustAppearBeforeInstanceNonReadonlyElements.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1215InstanceReadonlyElementsMustAppearBeforeInstanceNonReadonlyElements.cs
@@ -54,7 +54,7 @@
 
             var previousFieldReadonly = true;
             var previousAccessLevel = AccessLevel.NotSpecified;
-            var previousMemberStatic = true;
+            var previousMemberStaticOrConst = true;
             foreach (var member in typeDeclaration.Members)
             {
                 var field = member as FieldDeclarationSyntax;
@@ -66,10 +66,10 @@
                 var currentFieldReadonly = field.Modifiers.Any(SyntaxKind.ReadOnlyKeyword);
                 var currentAccessLevel = AccessLevelHelper.GetAccessLevel(field.Modifiers);
                 currentAccessLevel = currentAccessLevel == AccessLevel.NotSpecified ? AccessLevel.Private : currentAccessLevel;
-                var currentMemberStatic = field.Modifiers.Any(SyntaxKind.StaticKeyword);
+                var currentMemberStaticOrConst = field.Modifiers.Any(SyntaxKind.StaticKeyword) || field.Modifiers.Any(SyntaxKind.ConstKeyword);
                 if (currentAccessLevel == previousAccessLevel
-                    && !currentMemberStatic
-                    && !previousMemberStatic
+                    && !currentMemberStaticOrConst
+                    && !previousMemberStaticOrConst
                     && currentFieldReadonly
                     && !previousFieldReadonly)
                 {
@@ -78,7 +78,7 @@
 
                 previousFieldReadonly = currentFieldReadonly;
                 previousAccessLevel = currentAccessLevel;
-                previousMemberStatic = currentMemberStatic;
+                previousMemberStaticOrConst = currentMemberStaticOrConst;
             }
         }
     }


### PR DESCRIPTION
SA1215 was reporting for the following code.

```
const int Field1 = 1;
readonly int Field2;
```