### PR TITLE
StyleCopTester should only analyze C# projects in a solution

### DIFF
--- a/StyleCop.Analyzers/StyleCopTester/Program.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Program.cs
@@ -120,6 +120,11 @@
             // Make sure we analyze the projects in parallel
             foreach (var project in solution.Projects)
             {
+                if (project.Language != LanguageNames.CSharp)
+                {
+                    continue;
+                }
+
                 projectDiagnosticTasks.Add(GetProjectAnalyzerDiagnostics(analyzers, project));
             }
 


### PR DESCRIPTION
Was receiving a large number of AD0001 reports due to attempting to analyze VB projects in **Roslyn.sln**.