### PR TITLE
Reduce the number of memory allocations in SA1404 (CodeAnalysisSuppressionMustHaveJustification)

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1404UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1404UnitTests.cs
@@ -27,6 +27,22 @@
         }
 
         [Fact]
+        public async Task TestSuppressionWithStringLiteralAndUsingAliasDirectiveAsync()
+        {
+            var testCode = @"using SuppressMessageAttribute = System.Diagnostics.CodeAnalysis.SuppressMessageAttribute;
+public class Foo
+{
+    [SuppressMessage(null, null, Justification = ""a justification"")]
+    public void Bar()
+    {
+
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestSuppressionWithNoJustificationAsync()
         {
             var testCode = @"public class Foo
@@ -39,6 +55,42 @@
 }";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 6);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestSuppressionWithUsingAliasDirectiveAndNoJustificationAsync()
+        {
+            var testCode = @"using SuppressMessageAttribute = System.Diagnostics.CodeAnalysis.SuppressMessageAttribute;
+public class Foo
+{
+    [SuppressMessage(null, null)]
+    public void Bar()
+    {
+
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 6);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestSuppressionWithUsingDifferentAliasDirectiveAndNoJustificationAsync()
+        {
+            var testCode = @"using MySuppressionAttribute = System.Diagnostics.CodeAnalysis.SuppressMessageAttribute;
+public class Foo
+{
+    [MySuppression(null, null)]
+    public void Bar()
+    {
+
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 6);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }


### PR DESCRIPTION
* Avoid semantic analysis when simple name analysis will work. This step reuses cached information from SA1121 (UseBuiltInTypeAlias).
* Avoid calling `GetTypeByMetadataName` for every attribute in the compilation. Instead, this method is called once per compilation and cached.

When analyzing StyleCopAnalyzers, SA1404 was the most expensive analyzer in terms of both number of memory allocations and total bytes allocated. The following summary shows the improvement:

| Commit | Inclusive Allocations | Inclusive Bytes |
| --- | --- | --- |
| 6e92da965a17c7885d736bc5f33a56db89041f9b | 545065 | 18977452 |
| 4ae9b5e7f559dd01977d42de8f047bd87368366e | 113 | 10304 |

**Edit:** Analysis now run with the instrumenting profiler to verify accuracy.
