### PR TITLE
SA1028 memory optimizations

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/LinqHelpers/SyntaxTriviaListEnumerable.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LinqHelpers/SyntaxTriviaListEnumerable.cs
@@ -1,0 +1,38 @@
+﻿namespace System.Linq
+{
+    using Collections.Generic;
+    using Microsoft.CodeAnalysis;
+
+    /// <summary>
+    /// This class supports a subset of LINQ operations on <see cref="SyntaxTriviaList"/> without requiring boxing of
+    /// operands as an <see cref="IEnumerable{T}"/>.
+    /// </summary>
+    internal static class SyntaxTriviaListEnumerable
+    {
+        /// <summary>
+        /// Determines if a <see cref="SyntaxTriviaList"/> contains a specific <see cref="SyntaxTrivia"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>This method allows callers to avoid boxing the <see cref="SyntaxTriviaList"/> as an
+        /// <see cref="IEnumerable{T}"/>.</para>
+        /// </remarks>
+        /// <param name="list">The source list.</param>
+        /// <param name="trivia">The element to look for in the list.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="list"/> contains <paramref name="trivia"/>; otherwise,
+        /// <see langword="false"/>.
+        /// </returns>
+        internal static bool Contains(this SyntaxTriviaList list, SyntaxTrivia trivia)
+        {
+            foreach (SyntaxTrivia item in list)
+            {
+                if (item.Equals(trivia))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeMustNotContainTrailingWhitespace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeMustNotContainTrailingWhitespace.cs
@@ -53,7 +53,7 @@
         private static void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
         {
             var root = context.Tree.GetRoot(context.CancellationToken);
-            var text = root.GetText();
+            var text = context.Tree.GetText(context.CancellationToken);
 
             foreach (var trivia in root.DescendantTrivia(descendIntoTrivia: true))
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -187,6 +187,7 @@
     <Compile Include="LayoutRules\SA1518CodeMustNotContainBlankLinesAtEndOfFile.cs" />
     <Compile Include="LayoutRules\SA1519CurlyBracketsMustNotBeOmittedFromMultiLineChildStatement.cs" />
     <Compile Include="LayoutRules\SA1520UseCurlyBracketsConsistently.cs" />
+    <Compile Include="LinqHelpers\SyntaxTriviaListEnumerable.cs" />
     <Compile Include="MaintainabilityRules\MaintainabilityResources.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>


### PR DESCRIPTION
The primary target of this pull request is memory optimizations for SA1028.

* Eliminate boxing of `SyntaxTriviaList` for calls to `Contains` (affects SA1025 and SA1515).
* Use `SyntaxTree.GetText` instead of `SyntaxNode.GetText`, since the latter creates a new copy of the complete content.

### Profiling Results

#### SA1028

Method: Instrumentation of StyleCopTester and StyleCop.Analyzers
Test arguments: `/nostats /id:SA1028 StyleCopAnalyzers.sln`

| Commit | Total Allocations | Total Bytes | Total Allocations (SA1028) | Total Bytes (SA1028) |
| --- | --- | --- | --- | --- |
| b242672f535f7876129f4afd9c16754c922fa0a1 | 555894 | 28184120 | 552256 | 28007808 |
| a084e22410405842591d224fd45c9056e659c59a | 345598 | 11075044 | 341964 | 10898724 |

#### SA1025

Method: Instrumentation of StyleCopTester and StyleCop.Analyzers
Test arguments: `/nostats /id:SA1025 StyleCopAnalyzers.sln`

No measurable gains for this project (affected code is only on code paths which result in a violation).

#### SA1515

Method: Instrumentation of StyleCopTester and StyleCop.Analyzers
Test arguments: `/nostats /id:SA1515 StyleCopAnalyzers.sln`

| Commit | Total Allocations | Total Bytes | Total Allocations (SA1515) | Total Bytes (SA1515) |
| --- | --- | --- | --- | --- |
| b242672f535f7876129f4afd9c16754c922fa0a1 | 304243 | 8602176 | 300616 | 8426052 |
| a084e22410405842591d224fd45c9056e659c59a | 303794 | 8584764 | 300158 | 8408212 |
