### PR TITLE
Fix SA1202 wrongly treats explicit interface implementations as private

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
@@ -542,6 +542,72 @@ class MyClass
         }
 
         /// <summary>
+        /// Verifies that the analyzer will properly handle explicit interface implementations.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestExplicitInterfaceImplementationsAsync()
+        {
+            var testCode = @"using System;
+internal interface IA
+{
+    event EventHandler TestEvent1;
+
+    string T { get; }
+
+    int U { get; }
+
+    string this[string a] { get; }
+
+    void TestMethod1();
+}
+
+class Test : IA
+{
+    private event EventHandler TestEvent2;
+
+    event EventHandler IA.TestEvent1 { add { } remove { } }
+
+    public int Q { get; set; }
+
+    string IA.T
+    {
+        get { return null; }
+    }
+
+    // SA1202 (All public properties must come before all private properties) wrongly reported here.
+    public int W { get; set; }
+
+    protected string S { get; set; }
+
+    // SA1202 should be reported here (according to legacy StyleCop), but is not.
+    int IA.U
+    {
+        get { return 0; }
+    }
+
+    protected int this[int index] { get { return index; } }
+
+    string IA.this[string a] { get { return a; } }
+
+    protected void TestMethod2() { }
+
+    void IA.TestMethod1() { }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                // explicit interface events are considered private by StyleCop
+                this.CSharpDiagnostic().WithLocation(34, 12).WithArguments("public", "properties", "protected"),
+                this.CSharpDiagnostic().WithLocation(41, 15).WithArguments("public", "indexers", "protected"),
+                this.CSharpDiagnostic().WithLocation(45, 13).WithArguments("public", "methods", "protected")
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Verifies that the analyzer will properly handle incomplete members.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1202ElementsMustBeOrderedByAccess.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1202ElementsMustBeOrderedByAccess.cs
@@ -115,7 +115,10 @@
                 currentSyntaxKind = currentSyntaxKind == SyntaxKind.EventFieldDeclaration ? SyntaxKind.EventDeclaration : currentSyntaxKind;
                 AccessLevel currentAccessLevel;
                 var modifiers = member.GetModifiers();
-                if (currentSyntaxKind == SyntaxKind.ConstructorDeclaration && modifiers.Any(SyntaxKind.StaticKeyword))
+                if ((currentSyntaxKind == SyntaxKind.ConstructorDeclaration && modifiers.Any(SyntaxKind.StaticKeyword))
+                    || (currentSyntaxKind == SyntaxKind.MethodDeclaration && (member as MethodDeclarationSyntax)?.ExplicitInterfaceSpecifier != null)
+                    || (currentSyntaxKind == SyntaxKind.PropertyDeclaration && (member as PropertyDeclarationSyntax)?.ExplicitInterfaceSpecifier != null)
+                    || (currentSyntaxKind == SyntaxKind.IndexerDeclaration && (member as IndexerDeclarationSyntax)?.ExplicitInterfaceSpecifier != null))
                 {
                     currentAccessLevel = AccessLevel.Public;
                 }


### PR DESCRIPTION
- [x] Add regression tests for SA1202
- [x] Fixes #1179