### PR TITLE
Fix SA1009 incorrectly reporting trailing comments

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1009UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1009UnitTests.cs
@@ -441,6 +441,114 @@ public class Foo
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verifies the analyzer will properly handle trailing single line comments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestTrailingSingleLineCommentAsync()
+        {
+            var testCode = @"
+public class TestClass
+{
+    public bool TestMethod1() { return true; }
+
+    public void TestMethod2()
+    {
+        TestMethod1()// some comment
+;
+        TestMethod3(
+            TestMethod1()// some comment
+            , TestMethod1());
+    }
+
+    public void TestMethod3(bool a, bool b) { }
+}
+";
+
+            var fixedCode = @"
+public class TestClass
+{
+    public bool TestMethod1() { return true; }
+
+    public void TestMethod2()
+    {
+        TestMethod1() // some comment
+;
+        TestMethod3(
+            TestMethod1() // some comment
+            , TestMethod1());
+    }
+
+    public void TestMethod3(bool a, bool b) { }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(8, 21).WithArguments(string.Empty, "followed"),
+                this.CSharpDiagnostic().WithLocation(11, 25).WithArguments(string.Empty, "followed")
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies the analyzer will properly handle trailing multi-line comments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestTrailingMultiLineCommentAsync()
+        {
+            var testCode = @"
+public class TestClass
+{
+    public bool TestMethod1() { return true; }
+
+    public void TestMethod2()
+    {
+        TestMethod1()/* some comment */
+;
+        TestMethod3(
+            TestMethod1()/* some comment */
+            , TestMethod1());
+    }
+
+    public void TestMethod3(bool a, bool b) { }
+}
+";
+
+            var fixedCode = @"
+public class TestClass
+{
+    public bool TestMethod1() { return true; }
+
+    public void TestMethod2()
+    {
+        TestMethod1() /* some comment */
+;
+        TestMethod3(
+            TestMethod1() /* some comment */
+            , TestMethod1());
+    }
+
+    public void TestMethod3(bool a, bool b) { }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(8, 21).WithArguments(string.Empty, "followed"),
+                this.CSharpDiagnostic().WithLocation(11, 25).WithArguments(string.Empty, "followed")
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
         /// <inheritdoc/>
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
@@ -162,6 +162,18 @@
                 break;
             }
 
+            foreach (var trivia in token.TrailingTrivia)
+            {
+                if ((trivia.IsKind(SyntaxKind.SingleLineCommentTrivia) || trivia.IsKind(SyntaxKind.MultiLineCommentTrivia))
+                    && trivia.GetLineSpan().StartLinePosition.Line == token.GetLine())
+                {
+                    lastInLine = false;
+                    precedesStickyCharacter = false;
+
+                    break;
+                }
+            }
+
             if (precededBySpace)
             {
                 // Closing parenthesis must{ not} be {preceded} by a space.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
@@ -164,12 +164,15 @@
 
             foreach (var trivia in token.TrailingTrivia)
             {
-                if ((trivia.IsKind(SyntaxKind.SingleLineCommentTrivia) || trivia.IsKind(SyntaxKind.MultiLineCommentTrivia))
-                    && trivia.GetLineSpan().StartLinePosition.Line == token.GetLine())
+                if (trivia.IsKind(SyntaxKind.EndOfLineTrivia))
+                {
+                    break;
+                }
+                else if (trivia.IsKind(SyntaxKind.SingleLineCommentTrivia)
+                  || trivia.IsKind(SyntaxKind.MultiLineCommentTrivia))
                 {
                     lastInLine = false;
                     precedesStickyCharacter = false;
-
                     break;
                 }
             }


### PR DESCRIPTION
Diagnostic results were matched against classic StyleCop.

fixes #1187