### PR TITLE
Update behavior of SA1501 when SA1503 is disabled

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
@@ -539,7 +539,7 @@ class TypeName
             this.suppressSA1503 = true;
 
             var testCode = @"using System.Diagnostics;
-public class Foo
+public class TypeName
 {
     public void Bar(int i)
     {
@@ -548,7 +548,7 @@ public class Foo
     }
 }";
             var fixedCode = @"using System.Diagnostics;
-public class Foo
+public class TypeName
 {
     public void Bar(int i)
     {
@@ -589,7 +589,7 @@ public class Foo
             this.suppressSA1503 = true;
 
             var testCode = @"using System.Diagnostics;
-public class Foo
+public class TypeName
 {
     public void Bar(int i)
     {
@@ -616,7 +616,7 @@ public class Foo
             this.suppressSA1503 = true;
 
             var testCode = @"using System.Diagnostics;
-public class Foo
+public class TypeName
 {
     public void Bar(int i)
     {
@@ -643,7 +643,7 @@ public class Foo
             this.suppressSA1503 = true;
 
             var testCode = @"using System.Diagnostics;
-public class Foo
+public class TypeName
 {
     public void Bar(int i)
     {
@@ -652,7 +652,7 @@ public class Foo
 }";
 
             var fixedTestCode = @"using System.Diagnostics;
-public class Foo
+public class TypeName
 {
     public void Bar(int i)
     {
@@ -677,7 +677,7 @@ else
             this.suppressSA1503 = true;
 
             var testCode = @"using System.Diagnostics;
-public class Foo
+public class TypeName
 {
  public void Bar(int i)
  {
@@ -686,7 +686,7 @@ public class Foo
 }";
 
             var fixedTestCode = @"using System.Diagnostics;
-public class Foo
+public class TypeName
 {
  public void Bar(int i)
  {
@@ -708,7 +708,7 @@ public class Foo
             this.suppressSA1503 = true;
 
             var testCode = @"using System.Diagnostics;
-public class Foo
+public class TypeName
 {
     public void Bar(int i)
     {
@@ -719,7 +719,7 @@ public class Foo
 }";
 
             var fixedTestCode = @"using System.Diagnostics;
-public class Foo
+public class TypeName
 {
     public void Bar(int i)
     {
@@ -742,7 +742,7 @@ public class Foo
             this.suppressSA1503 = true;
 
             var testCode = @"using System.Diagnostics;
-public class Foo
+public class TypeName
 {
     public void Bar(int i)
     {
@@ -751,7 +751,7 @@ public class Foo
 }";
 
             var fixedTestCode = @"using System.Diagnostics;
-public class Foo
+public class TypeName
 {
     public void Bar(int i)
     {
@@ -762,7 +762,7 @@ public class Foo
 }";
 
             var batchFixedTestCode = @"using System.Diagnostics;
-public class Foo
+public class TypeName
 {
     public void Bar(int i)
     {
@@ -819,7 +819,7 @@ public class Foo
         private string GenerateTestStatement(string statementText)
         {
             var testCodeFormat = @"using System.Diagnostics;
-public class Foo : System.IDisposable
+public class TypeName : System.IDisposable
 {
     public unsafe void Bar(int i)
     {
@@ -834,7 +834,7 @@ public class Foo : System.IDisposable
         private string GenerateFixedTestStatement(string statementText)
         {
             var fixedTestCodeFormat = @"using System.Diagnostics;
-public class Foo : System.IDisposable
+public class TypeName : System.IDisposable
 {
     public unsafe void Bar(int i)
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
@@ -648,7 +648,7 @@ public class TypeName
     {
         if (i == 0)
             Debug.Assert(true);
-else Debug.Assert(false);
+        else Debug.Assert(false);
     }
 }";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
@@ -565,6 +565,49 @@ public class TypeName
         }
 
         /// <summary>
+        /// Verifies that consecutive single-line statements are properly reported and fixed.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestNoSA1503ConsecutiveStatementsAsync()
+        {
+            this.suppressSA1503 = true;
+
+            var testCode = @"using System;
+using System.Diagnostics;
+public class TypeName
+{
+    public void Bar(string x, string y)
+    {
+        if (x == null) throw new ArgumentNullException(nameof(x));
+        if (y == null) throw new ArgumentNullException(nameof(y));
+    }
+}";
+            var fixedCode = @"using System;
+using System.Diagnostics;
+public class TypeName
+{
+    public void Bar(string x, string y)
+    {
+        if (x == null)
+            throw new ArgumentNullException(nameof(x));
+        if (y == null)
+            throw new ArgumentNullException(nameof(y));
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(7, 24),
+                this.CSharpDiagnostic().WithLocation(8, 24),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Verifies that a statement followed by a block with curly braces will produce no diagnostics results.
         /// </summary>
         /// <param name="statementText">The source code for the first part of a compound statement whose child can be

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
@@ -597,12 +597,7 @@ public class TypeName
     }
 }";
 
-            var expected = new[]
-            {
-                this.CSharpDiagnostic().WithLocation(6, 21),
-                this.CSharpDiagnostic().WithLocation(6, 46)
-            };
-
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 21);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
@@ -624,12 +619,7 @@ public class TypeName
     }
 }";
 
-            var expected = new[]
-            {
-                this.CSharpDiagnostic().WithLocation(6, 21),
-                this.CSharpDiagnostic().WithLocation(6, 33)
-            };
-
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 21);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
@@ -658,8 +648,7 @@ public class TypeName
     {
         if (i == 0)
             Debug.Assert(true);
-else
-            Debug.Assert(false);
+else Debug.Assert(false);
     }
 }";
 
@@ -756,6 +745,49 @@ public class TypeName
     public void Bar(int i)
     {
         if (i == 0)
+            if (i == 0) Debug.Assert(true);
+    }
+}";
+
+            var batchFixedTestCode = @"using System.Diagnostics;
+public class TypeName
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            if (i == 0) Debug.Assert(true);
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode, batchFixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will work properly handle the second pass of multiple cases of missing
+        /// brackets.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestNoSA1503CodeFixProviderWithMultipleNestingsSecondPassAsync()
+        {
+            this.suppressSA1503 = true;
+
+            var testCode = @"using System.Diagnostics;
+public class TypeName
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            if (i == 0) Debug.Assert(true);
+    }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class TypeName
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
             if (i == 0)
                 Debug.Assert(true);
     }
@@ -768,7 +800,7 @@ public class TypeName
     {
         if (i == 0)
             if (i == 0)
-    Debug.Assert(true);
+                Debug.Assert(true);
     }
 }";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
@@ -1,8 +1,10 @@
 ﻿namespace StyleCop.Analyzers.Test.LayoutRules
 {
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.LayoutRules;
@@ -14,7 +16,27 @@
     /// </summary>
     public class SA1501UnitTests : CodeFixVerifier
     {
-        private const string DiagnosticId = SA1501StatementMustNotBeOnASingleLine.DiagnosticId;
+        private bool suppressSA1503 = false;
+
+        /// <summary>
+        /// Gets the statements that will be used in the theory test cases.
+        /// </summary>
+        /// <value>
+        /// The statements that will be used in the theory test cases.
+        /// </value>
+        public static IEnumerable<object[]> TestStatements
+        {
+            get
+            {
+                yield return new[] { "if (i == 0)" };
+                yield return new[] { "while (i == 0)" };
+                yield return new[] { "for (var j = 0; j < i; j++)" };
+                yield return new[] { "foreach (var j in new[] { 1, 2, 3 })" };
+                yield return new[] { "lock (this)" };
+                yield return new[] { "using (this)" };
+                yield return new[] { "fixed (byte* ptr = new byte[10])" };
+            }
+        }
 
         /// <summary>
         /// Verifies that lock statement with single line block statement will trigger a warning.
@@ -490,15 +512,339 @@ class TypeName
             await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verifies that a statement followed by a block without curly braces will produce a warning.
+        /// </summary>
+        /// <param name="statementText">The source code for the first part of a compound statement whose child can be
+        /// either a statement block or a single statement.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(TestStatements))]
+        public async Task TestNoSA1503StatementWithoutCurlyBracketsAsync(string statementText)
+        {
+            this.suppressSA1503 = true;
+
+            var expected = this.CSharpDiagnostic().WithLocation(6, statementText.Length + 10);
+            await this.VerifyCSharpDiagnosticAsync(this.GenerateTestStatement(statementText), expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that a <c>do</c> statement followed by a block without curly braces will produce a warning, and the
+        /// code fix for this warning results in valid code.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestNoSA1503DoStatementAsync()
+        {
+            this.suppressSA1503 = true;
+
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        do Debug.Assert(true);
+        while (false);
+    }
+}";
+            var fixedCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        do
+            Debug.Assert(true);
+        while (false);
+    }
+}";
+
+            var expected = this.CSharpDiagnostic().WithLocation(6, 12);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that a statement followed by a block with curly braces will produce no diagnostics results.
+        /// </summary>
+        /// <param name="statementText">The source code for the first part of a compound statement whose child can be
+        /// either a statement block or a single statement.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(TestStatements))]
+        public async Task TestNoSA1503StatementWithCurlyBracketsAsync(string statementText)
+        {
+            this.suppressSA1503 = true;
+
+            await this.VerifyCSharpDiagnosticAsync(this.GenerateFixedTestStatement(statementText), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that an if / else statement followed by a block without curly braces will produce a warning.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestNoSA1503IfElseStatementWithoutCurlyBracketsAsync()
+        {
+            this.suppressSA1503 = true;
+
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0) Debug.Assert(true); else Debug.Assert(false);
+    }
+}";
+
+            var expected = new[]
+            {
+                this.CSharpDiagnostic().WithLocation(6, 21),
+                this.CSharpDiagnostic().WithLocation(6, 46)
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that nested if statements followed by a block without curly braces will produce warnings.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestNoSA1503MultipleIfStatementsWithoutCurlyBracketsAsync()
+        {
+            this.suppressSA1503 = true;
+
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0) if (i == 0) Debug.Assert(true);
+    }
+}";
+
+            var expected = new[]
+            {
+                this.CSharpDiagnostic().WithLocation(6, 21),
+                this.CSharpDiagnostic().WithLocation(6, 33)
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will work properly for an if .. else statement.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestNoSA1503CodeFixProviderForIfElseStatementAsync()
+        {
+            this.suppressSA1503 = true;
+
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0) Debug.Assert(true); else Debug.Assert(false);
+    }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            Debug.Assert(true);
+else
+            Debug.Assert(false);
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will properly handle alternate indentations.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestNoSA1503CodeFixProviderWithAlternateIndentationAsync()
+        {
+            this.IndentationSize = 1;
+            this.suppressSA1503 = true;
+
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+ public void Bar(int i)
+ {
+  if (i == 0) Debug.Assert(true);
+ }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+ public void Bar(int i)
+ {
+  if (i == 0)
+   Debug.Assert(true);
+ }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will work properly handle non-whitespace trivia.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestNoSA1503CodeFixProviderWithNonWhitespaceTriviaAsync()
+        {
+            this.suppressSA1503 = true;
+
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+#pragma warning restore
+        if (i == 0)
+            Debug.Assert(true);
+    }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+#pragma warning restore
+        if (i == 0)
+            Debug.Assert(true);
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will work properly handle multiple cases of missing brackets.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestNoSA1503CodeFixProviderWithMultipleNestingsAsync()
+        {
+            this.suppressSA1503 = true;
+
+            var testCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0) if (i == 0) Debug.Assert(true);
+    }
+}";
+
+            var fixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            if (i == 0)
+                Debug.Assert(true);
+    }
+}";
+
+            var batchFixedTestCode = @"using System.Diagnostics;
+public class Foo
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            if (i == 0)
+    Debug.Assert(true);
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode, batchFixedTestCode).ConfigureAwait(false);
+        }
+
         /// <inheritdoc/>
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
             yield return new SA1501StatementMustNotBeOnASingleLine();
         }
 
+        /// <inheritdoc/>
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new SA1501CodeFixProvider();
+        }
+
+        protected override Solution CreateSolution(ProjectId projectId, string language)
+        {
+            Solution solution = base.CreateSolution(projectId, language);
+            if (this.suppressSA1503)
+            {
+                Project project = solution.GetProject(projectId);
+                CompilationOptions options = project.CompilationOptions;
+                ImmutableDictionary<string, ReportDiagnostic> specificOptions = options.SpecificDiagnosticOptions;
+                options = options.WithSpecificDiagnosticOptions(specificOptions.Add(SA1503CurlyBracketsMustNotBeOmitted.DiagnosticId, ReportDiagnostic.Suppress));
+                solution = solution.WithProjectCompilationOptions(projectId, options);
+            }
+
+            return solution;
+        }
+
+        /// <summary>
+        /// Verifies that the code fix provider will work properly for a statement.
+        /// </summary>
+        /// <param name="statementText">The source code for the first part of a compound statement whose child can be
+        /// either a statement block or a single statement.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(TestStatements))]
+        private async Task TestNoSA1503CodeFixForStatementAsync(string statementText)
+        {
+            this.suppressSA1503 = true;
+            await this.VerifyCSharpFixAsync(this.GenerateTestStatement(statementText), this.GenerateFixedTestStatement(statementText)).ConfigureAwait(false);
+        }
+
+        private string GenerateTestStatement(string statementText)
+        {
+            var testCodeFormat = @"using System.Diagnostics;
+public class Foo : System.IDisposable
+{
+    public unsafe void Bar(int i)
+    {
+        #STATEMENT# Debug.Assert(true);
+    }
+
+    public void Dispose() {}
+}";
+            return testCodeFormat.Replace("#STATEMENT#", statementText);
+        }
+
+        private string GenerateFixedTestStatement(string statementText)
+        {
+            var fixedTestCodeFormat = @"using System.Diagnostics;
+public class Foo : System.IDisposable
+{
+    public unsafe void Bar(int i)
+    {
+        #STATEMENT#
+            Debug.Assert(true);
+    }
+
+    public void Dispose() {}
+}";
+            return fixedTestCodeFormat.Replace("#STATEMENT#", statementText);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DiagnosticOptionsHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DiagnosticOptionsHelper.cs
@@ -12,12 +12,37 @@
         /// <summary>
         /// Determines if the diagnostic identified by the given identifier is currently suppressed.
         /// </summary>
-        /// <param name="context">The context that will be used to determine if the diagnostic is currenlty suppressed.</param>
+        /// <param name="context">The context that will be used to determine if the diagnostic is currently suppressed.</param>
         /// <param name="diagnosticId">The diagnostic identifier to check.</param>
         /// <returns>True if the diagnostic is currently suppressed.</returns>
         internal static bool IsAnalyzerSuppressed(this SyntaxNodeAnalysisContext context, string diagnosticId)
         {
-            return context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(diagnosticId, ReportDiagnostic.Default) == ReportDiagnostic.Suppress;
+            return context.SemanticModel.Compilation.IsAnalyzerSuppressed(diagnosticId);
+        }
+
+        // There are no start actions in this file. This warning should not be reported.
+#pragma warning disable RS1012 // Start action has no registered actions.
+
+        /// <summary>
+        /// Determines if the diagnostic identified by the given identifier is currently suppressed.
+        /// </summary>
+        /// <param name="context">The context that will be used to determine if the diagnostic is currently suppressed.</param>
+        /// <param name="diagnosticId">The diagnostic identifier to check.</param>
+        /// <returns>True if the diagnostic is currently suppressed.</returns>
+        internal static bool IsAnalyzerSuppressed(this CompilationStartAnalysisContext context, string diagnosticId)
+        {
+            return context.Compilation.IsAnalyzerSuppressed(diagnosticId);
+        }
+
+        /// <summary>
+        /// Determines if the diagnostic identified by the given identifier is currently suppressed.
+        /// </summary>
+        /// <param name="compilation">The compilation that will be used to determine if the diagnostic is currently suppressed.</param>
+        /// <param name="diagnosticId">The diagnostic identifier to check.</param>
+        /// <returns>True if the diagnostic is currently suppressed.</returns>
+        internal static bool IsAnalyzerSuppressed(this Compilation compilation, string diagnosticId)
+        {
+            return compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(diagnosticId, ReportDiagnostic.Default) == ReportDiagnostic.Suppress;
         }
 
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501CodeFixProvider.cs
@@ -288,7 +288,18 @@
 
         private static SyntaxNode GetStatementParent(SyntaxNode node)
         {
-            return node.FirstAncestorOrSelf<StatementSyntax>();
+            StatementSyntax statementSyntax = node.FirstAncestorOrSelf<StatementSyntax>();
+            if (statementSyntax == null)
+            {
+                return null;
+            }
+
+            if (statementSyntax.IsKind(SyntaxKind.IfStatement) && statementSyntax.Parent.IsKind(SyntaxKind.ElseClause))
+            {
+                return statementSyntax.Parent;
+            }
+
+            return statementSyntax;
         }
 
         private class BlockRewriter : CSharpSyntaxRewriter

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501CodeFixProvider.cs
@@ -127,7 +127,10 @@
             var newParentNextToken = parentNextToken;
             if (nextTokenLine == statementCloseLine)
             {
-                newParentNextToken = newParentNextToken.WithLeadingTrivia(parentLastToken.LeadingTrivia);
+                var indentationOptions = IndentationOptions.FromDocument(document);
+                var parentIndentationLevel = IndentationHelper.GetIndentationSteps(indentationOptions, GetStatementParent(statement.Parent));
+                var indentationString = IndentationHelper.GenerateIndentationString(indentationOptions, parentIndentationLevel);
+                newParentNextToken = newParentNextToken.WithLeadingTrivia(SyntaxFactory.Whitespace(indentationString));
             }
 
             var newStatement = ReformatStatement(document, statement);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501StatementMustNotBeOnASingleLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501StatementMustNotBeOnASingleLine.cs
@@ -79,13 +79,13 @@
             if (context.IsAnalyzerSuppressed(SA1503CurlyBracketsMustNotBeOmitted.DiagnosticId))
             {
                 context.RegisterSyntaxNodeActionHonorExclusions(HandleIfStatement, SyntaxKind.IfStatement);
-                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ((DoStatementSyntax)ctx.Node).Statement), SyntaxKind.DoStatement);
-                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ((WhileStatementSyntax)ctx.Node).Statement), SyntaxKind.WhileStatement);
-                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ((ForStatementSyntax)ctx.Node).Statement), SyntaxKind.ForStatement);
-                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ((ForEachStatementSyntax)ctx.Node).Statement), SyntaxKind.ForEachStatement);
-                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ((LockStatementSyntax)ctx.Node).Statement), SyntaxKind.LockStatement);
-                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ((UsingStatementSyntax)ctx.Node).Statement), SyntaxKind.UsingStatement);
-                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ((FixedStatementSyntax)ctx.Node).Statement), SyntaxKind.FixedStatement);
+                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ctx.Node, ((DoStatementSyntax)ctx.Node).Statement), SyntaxKind.DoStatement);
+                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ctx.Node, ((WhileStatementSyntax)ctx.Node).Statement), SyntaxKind.WhileStatement);
+                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ctx.Node, ((ForStatementSyntax)ctx.Node).Statement), SyntaxKind.ForStatement);
+                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ctx.Node, ((ForEachStatementSyntax)ctx.Node).Statement), SyntaxKind.ForEachStatement);
+                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ctx.Node, ((LockStatementSyntax)ctx.Node).Statement), SyntaxKind.LockStatement);
+                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ctx.Node, ((UsingStatementSyntax)ctx.Node).Statement), SyntaxKind.UsingStatement);
+                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ctx.Node, ((FixedStatementSyntax)ctx.Node).Statement), SyntaxKind.FixedStatement);
             }
         }
 
@@ -152,11 +152,11 @@
 
             foreach (StatementSyntax clause in clauses)
             {
-                CheckChildStatement(context, clause);
+                CheckChildStatement(context, clause.Parent, clause);
             }
         }
 
-        private static void CheckChildStatement(SyntaxNodeAnalysisContext context, StatementSyntax childStatement)
+        private static void CheckChildStatement(SyntaxNodeAnalysisContext context, SyntaxNode node, StatementSyntax childStatement)
         {
             if (childStatement == null || childStatement.IsMissing)
             {
@@ -166,6 +166,12 @@
             if (childStatement is BlockSyntax)
             {
                 // BlockSyntax child statements are handled by HandleBlock
+                return;
+            }
+
+            // We are only interested in the first instance of this violation on a line.
+            if (!node.GetFirstToken().IsFirstInLine())
+            {
                 return;
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501StatementMustNotBeOnASingleLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501StatementMustNotBeOnASingleLine.cs
@@ -152,7 +152,13 @@
 
             foreach (StatementSyntax clause in clauses)
             {
-                CheckChildStatement(context, clause.Parent, clause);
+                SyntaxNode node = clause.Parent;
+                if (node.IsKind(SyntaxKind.IfStatement) && node.Parent.IsKind(SyntaxKind.ElseClause))
+                {
+                    node = node.Parent;
+                }
+
+                CheckChildStatement(context, node, clause);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501StatementMustNotBeOnASingleLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501StatementMustNotBeOnASingleLine.cs
@@ -1,10 +1,14 @@
 ﻿namespace StyleCop.Analyzers.LayoutRules
 {
+    using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.Linq;
+    using Helpers;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using SpacingRules;
 
     /// <summary>
     /// A C# statement containing opening and closing curly brackets is written completely on a single line.
@@ -64,7 +68,25 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
+            context.RegisterCompilationStartAction(HandleCompilationStart);
+        }
+
+        private static void HandleCompilationStart(CompilationStartAnalysisContext context)
+        {
             context.RegisterSyntaxNodeActionHonorExclusions(HandleBlock, SyntaxKind.Block);
+
+            // If SA1503 is suppressed, we need to handle compound blocks as well.
+            if (context.IsAnalyzerSuppressed(SA1503CurlyBracketsMustNotBeOmitted.DiagnosticId))
+            {
+                context.RegisterSyntaxNodeActionHonorExclusions(HandleIfStatement, SyntaxKind.IfStatement);
+                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ((DoStatementSyntax)ctx.Node).Statement), SyntaxKind.DoStatement);
+                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ((WhileStatementSyntax)ctx.Node).Statement), SyntaxKind.WhileStatement);
+                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ((ForStatementSyntax)ctx.Node).Statement), SyntaxKind.ForStatement);
+                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ((ForEachStatementSyntax)ctx.Node).Statement), SyntaxKind.ForEachStatement);
+                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ((LockStatementSyntax)ctx.Node).Statement), SyntaxKind.LockStatement);
+                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ((UsingStatementSyntax)ctx.Node).Statement), SyntaxKind.UsingStatement);
+                context.RegisterSyntaxNodeActionHonorExclusions(ctx => CheckChildStatement(ctx, ((FixedStatementSyntax)ctx.Node).Statement), SyntaxKind.FixedStatement);
+            }
         }
 
         private static void HandleBlock(SyntaxNodeAnalysisContext context)
@@ -100,6 +122,74 @@
             }
         }
 
+        private static void HandleIfStatement(SyntaxNodeAnalysisContext context)
+        {
+            var ifStatement = (IfStatementSyntax)context.Node;
+            if (ifStatement.Parent.IsKind(SyntaxKind.ElseClause))
+            {
+                // this will be analyzed as a clause of the outer if statement
+                return;
+            }
+
+            List<StatementSyntax> clauses = new List<StatementSyntax>();
+            for (IfStatementSyntax current = ifStatement; current != null; current = current.Else?.Statement as IfStatementSyntax)
+            {
+                clauses.Add(current.Statement);
+                if (current.Else != null && !(current.Else.Statement is IfStatementSyntax))
+                {
+                    clauses.Add(current.Else.Statement);
+                }
+            }
+
+            if (!context.IsAnalyzerSuppressed(SA1520UseCurlyBracketsConsistently.DiagnosticId))
+            {
+                // inconsistencies will be reported as SA1520, as long as it's not suppressed
+                if (clauses.OfType<BlockSyntax>().Any())
+                {
+                    return;
+                }
+            }
+
+            foreach (StatementSyntax clause in clauses)
+            {
+                CheckChildStatement(context, clause);
+            }
+        }
+
+        private static void CheckChildStatement(SyntaxNodeAnalysisContext context, StatementSyntax childStatement)
+        {
+            if (childStatement == null || childStatement.IsMissing)
+            {
+                return;
+            }
+
+            if (childStatement is BlockSyntax)
+            {
+                // BlockSyntax child statements are handled by HandleBlock
+                return;
+            }
+
+            // We are only interested in the case where statement and childStatement start on the same line. Use
+            // IsFirstInLine to detect this condition easily.
+            SyntaxToken firstChildToken = childStatement.GetFirstToken();
+            if (firstChildToken.IsMissingOrDefault() || firstChildToken.IsFirstInLine())
+            {
+                return;
+            }
+
+            if (!context.IsAnalyzerSuppressed(SA1519CurlyBracketsMustNotBeOmittedFromMultiLineChildStatement.DiagnosticId))
+            {
+                // diagnostics for multi-line statements is handled by SA1519, as long as it's not suppressed
+                FileLinePositionSpan lineSpan = childStatement.GetLineSpan();
+                if (lineSpan.StartLinePosition.Line != lineSpan.EndLinePosition.Line)
+                {
+                    return;
+                }
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, childStatement.GetLocation()));
+        }
+
         private static bool IsSingleLineExpression(ExpressionSyntax containingExpression)
         {
             if (containingExpression == null)
@@ -113,30 +203,12 @@
 
         private static bool IsPartOfStatement(BlockSyntax block)
         {
-            var parent = block.Parent;
-
-            while ((parent != null) && !(parent is StatementSyntax))
-            {
-                parent = parent.Parent;
-            }
-
-            return parent != null;
+            return block.Parent.FirstAncestorOrSelf<StatementSyntax>() != null;
         }
 
         private static ExpressionSyntax GetContainingExpression(SyntaxNode node)
         {
-            while (node != null)
-            {
-                var expressionNode = node as ExpressionSyntax;
-                if (expressionNode != null)
-                {
-                    return expressionNode;
-                }
-
-                node = node.Parent;
-            }
-
-            return null;
+            return node.FirstAncestorOrSelf<ExpressionSyntax>();
         }
     }
 }


### PR DESCRIPTION
This commit updates SA1501 to include special handling for the case where
SA1503 is disabled. In this scenario, statements are analyzed instead of
curly braces.

Fixes #1175