### PR TITLE
Disable XML analysis when documentation diagnostics are disabled

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1601PartialElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1601PartialElementsMustBeDocumented.cs
@@ -100,6 +100,11 @@
 
         private void HandleTypeDeclaration(SyntaxNodeAnalysisContext context)
         {
+            if (context.GetDocumentationMode() != DocumentationMode.Diagnose)
+            {
+                return;
+            }
+
             TypeDeclarationSyntax typeDeclaration = context.Node as TypeDeclarationSyntax;
             if (typeDeclaration != null)
             {
@@ -115,6 +120,11 @@
 
         private void HandleMethodDeclaration(SyntaxNodeAnalysisContext context)
         {
+            if (context.GetDocumentationMode() != DocumentationMode.Diagnose)
+            {
+                return;
+            }
+
             MethodDeclarationSyntax methodDeclaration = context.Node as MethodDeclarationSyntax;
             if (methodDeclaration != null)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1602EnumerationItemsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1602EnumerationItemsMustBeDocumented.cs
@@ -68,6 +68,11 @@
 
         private void HandleEnumMember(SyntaxNodeAnalysisContext context)
         {
+            if (context.GetDocumentationMode() != DocumentationMode.Diagnose)
+            {
+                return;
+            }
+
             EnumMemberDeclarationSyntax enumMemberDeclaration = context.Node as EnumMemberDeclarationSyntax;
             if (enumMemberDeclaration != null)
             {


### PR DESCRIPTION
* Fix #1190
* Fix previously unreported issue where enumeration members would receive warnings when documentation diagnostics were disabled