### PR TITLE
Disable analyzers which we aren't planning to implement

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1645UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1645UnitTests.cs
@@ -1,0 +1,31 @@
+﻿namespace StyleCop.Analyzers.Test.DocumentationRules
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.DocumentationRules;
+    using TestHelper;
+    using Xunit;
+
+    /// <summary>
+    /// This class contains unit tests for <see cref="SA1645IncludedDocumentationFileDoesNotExist"/>.
+    /// </summary>
+    public class SA1645UnitTests : DiagnosticVerifier
+    {
+        [Fact]
+        public void TestDisabledByDefaultAndNotConfigurable()
+        {
+            var analyzer = this.GetCSharpDiagnosticAnalyzers().Single();
+            Assert.Equal(1, analyzer.SupportedDiagnostics.Length);
+            Assert.False(analyzer.SupportedDiagnostics[0].IsEnabledByDefault);
+            Assert.Contains(WellKnownDiagnosticTags.NotConfigurable, analyzer.SupportedDiagnostics[0].CustomTags);
+        }
+
+        /// <inheritdoc/>
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new SA1645IncludedDocumentationFileDoesNotExist();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1646UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1646UnitTests.cs
@@ -1,0 +1,31 @@
+﻿namespace StyleCop.Analyzers.Test.DocumentationRules
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.DocumentationRules;
+    using TestHelper;
+    using Xunit;
+
+    /// <summary>
+    /// This class contains unit tests for <see cref="SA1646IncludedDocumentationXPathDoesNotExist"/>.
+    /// </summary>
+    public class SA1646UnitTests : DiagnosticVerifier
+    {
+        [Fact]
+        public void TestDisabledByDefaultAndNotConfigurable()
+        {
+            var analyzer = this.GetCSharpDiagnosticAnalyzers().Single();
+            Assert.Equal(1, analyzer.SupportedDiagnostics.Length);
+            Assert.False(analyzer.SupportedDiagnostics[0].IsEnabledByDefault);
+            Assert.Contains(WellKnownDiagnosticTags.NotConfigurable, analyzer.SupportedDiagnostics[0].CustomTags);
+        }
+
+        /// <inheritdoc/>
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new SA1646IncludedDocumentationXPathDoesNotExist();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1647UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1647UnitTests.cs
@@ -1,0 +1,31 @@
+﻿namespace StyleCop.Analyzers.Test.DocumentationRules
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.DocumentationRules;
+    using TestHelper;
+    using Xunit;
+
+    /// <summary>
+    /// This class contains unit tests for <see cref="SA1647IncludeNodeDoesNotContainValidFileAndPath"/>.
+    /// </summary>
+    public class SA1647UnitTests : DiagnosticVerifier
+    {
+        [Fact]
+        public void TestDisabledByDefaultAndNotConfigurable()
+        {
+            var analyzer = this.GetCSharpDiagnosticAnalyzers().Single();
+            Assert.Equal(1, analyzer.SupportedDiagnostics.Length);
+            Assert.False(analyzer.SupportedDiagnostics[0].IsEnabledByDefault);
+            Assert.Contains(WellKnownDiagnosticTags.NotConfigurable, analyzer.SupportedDiagnostics[0].CustomTags);
+        }
+
+        /// <inheritdoc/>
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new SA1647IncludeNodeDoesNotContainValidFileAndPath();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1301UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1301UnitTests.cs
@@ -1,8 +1,7 @@
 ﻿namespace StyleCop.Analyzers.Test.NamingRules
 {
     using System.Collections.Generic;
-    using System.Threading;
-    using System.Threading.Tasks;
+    using System.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.NamingRules;
@@ -14,19 +13,16 @@
     /// </summary>
     public class SA1301UnitTests : DiagnosticVerifier
     {
-        /// <summary>
-        /// This is a simple test which simply ensure no error is thrown by the analyzer engine during the instantiation
-        /// of the <see cref="SA1301ElementMustBeginWithLowerCaseLetter"/> analyzer (e.g. from an incorrect argument to
-        /// its <see cref="DiagnosticDescriptor"/>.
-        /// </summary>
-        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task TestSimpleEmptyNamespaceAsync()
+        public void TestDisabledByDefaultAndNotConfigurable()
         {
-            var testCode = @"namespace Test { }";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            var analyzer = this.GetCSharpDiagnosticAnalyzers().Single();
+            Assert.Equal(1, analyzer.SupportedDiagnostics.Length);
+            Assert.False(analyzer.SupportedDiagnostics[0].IsEnabledByDefault);
+            Assert.Contains(WellKnownDiagnosticTags.NotConfigurable, analyzer.SupportedDiagnostics[0].CustomTags);
         }
 
+        /// <inheritdoc/>
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
             yield return new SA1301ElementMustBeginWithLowerCaseLetter();

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -154,6 +154,7 @@
     <Compile Include="DocumentationRules\SA1643UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1645UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1646UnitTests.cs" />
+    <Compile Include="DocumentationRules\SA1647UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1648UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1650UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1651UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -152,6 +152,7 @@
     <Compile Include="DocumentationRules\SA1640UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1642UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1643UnitTests.cs" />
+    <Compile Include="DocumentationRules\SA1645UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1648UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1650UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1651UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -153,6 +153,7 @@
     <Compile Include="DocumentationRules\SA1642UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1643UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1645UnitTests.cs" />
+    <Compile Include="DocumentationRules\SA1646UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1648UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1650UnitTests.cs" />
     <Compile Include="DocumentationRules\SA1651UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1645IncludedDocumentationFileDoesNotExist.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1645IncludedDocumentationFileDoesNotExist.cs
@@ -30,6 +30,7 @@
     /// loaded.</para>
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [NoDiagnostic("This is already handled by the compiler with warning CS1589.")]
     public class SA1645IncludedDocumentationFileDoesNotExist : DiagnosticAnalyzer
     {
         /// <summary>
@@ -42,7 +43,7 @@
         private const string HelpLink = "http://www.stylecop.com/docs/SA1645.html";
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.DocumentationRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledNoTests, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.DocumentationRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledByDefault, Description, HelpLink, WellKnownDiagnosticTags.NotConfigurable);
 
         private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
             ImmutableArray.Create(Descriptor);
@@ -59,7 +60,7 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            // TODO: Implement analysis
+            // This diagnostic is not implemented (by design) in StyleCopAnalyzers.
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1646IncludedDocumentationXPathDoesNotExist.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1646IncludedDocumentationXPathDoesNotExist.cs
@@ -30,6 +30,7 @@
     /// documentation file.</para>
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [NoDiagnostic("This is already handled by the compiler with warning CS1589.")]
     [NoCodeFix("Cannot generate documentation")]
     public class SA1646IncludedDocumentationXPathDoesNotExist : DiagnosticAnalyzer
     {
@@ -43,7 +44,7 @@
         private const string HelpLink = "http://www.stylecop.com/docs/SA1646.html";
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.DocumentationRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledNoTests, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.DocumentationRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledByDefault, Description, HelpLink, WellKnownDiagnosticTags.NotConfigurable);
 
         private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
             ImmutableArray.Create(Descriptor);
@@ -60,7 +61,7 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            // TODO: Implement analysis
+            // This diagnostic is not implemented (by design) in StyleCopAnalyzers.
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1647IncludeNodeDoesNotContainValidFileAndPath.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1647IncludeNodeDoesNotContainValidFileAndPath.cs
@@ -30,6 +30,7 @@
     /// improperly formatted file or path attribute.</para>
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [NoDiagnostic("This is already handled by the compiler with warning CS1590.")]
     [NoCodeFix("Cannot generate documentation")]
     public class SA1647IncludeNodeDoesNotContainValidFileAndPath : DiagnosticAnalyzer
     {
@@ -44,7 +45,7 @@
         private const string HelpLink = "http://www.stylecop.com/docs/SA1647.html";
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.DocumentationRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledNoTests, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.DocumentationRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledByDefault, Description, HelpLink, WellKnownDiagnosticTags.NotConfigurable);
 
         private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
             ImmutableArray.Create(Descriptor);
@@ -61,7 +62,7 @@
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            // TODO: Implement analysis
+            // This diagnostic is not implemented (by design) in StyleCopAnalyzers.
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1301ElementMustBeginWithLowerCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1301ElementMustBeginWithLowerCaseLetter.cs
@@ -8,6 +8,7 @@
     /// There are currently no situations in which this rule will fire.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [NoDiagnostic("This rule has no behavior by design.")]
     [NoCodeFix("Don't fix what isn't broken.")]
     public class SA1301ElementMustBeginWithLowerCaseLetter : DiagnosticAnalyzer
     {
@@ -21,7 +22,7 @@
         private const string HelpLink = "http://www.stylecop.com/docs/SA1301.html";
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.NamingRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.NamingRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledByDefault, Description, HelpLink, WellKnownDiagnosticTags.NotConfigurable);
 
         private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
             ImmutableArray.Create(Descriptor);


### PR DESCRIPTION
* SA1301 (ElementMustBeginWithLowerCaseLetter)
* SA1645 (IncludedDocumentationFileDoesNotExist) (Closes #165)
* SA1646 (IncludedDocumentationXPathDoesNotExist) (Closes #166)
* SA1647 (IncludeNodeDoesNotContainValidFileAndPath) (Closes #167)