### PR TITLE
Implement code fixes for SA1110-SA1113

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1110UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1110UnitTests.cs
@@ -3,6 +3,8 @@
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Analyzers.SpacingRules;
+    using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.ReadabilityRules;
     using TestHelper;
@@ -22,10 +24,20 @@ class Foo
 
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 21);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -39,10 +51,19 @@ public class Foo
     {
     }
 }";
+            var fixedCode = @"
+public class Foo
+{
+    public Foo()
+    {
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 9);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -87,10 +108,20 @@ class Foo
             ();
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        var s = ToString();
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 13);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -105,10 +136,20 @@ class Foo
             ();
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        var s = this.ToString();
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 13);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -123,10 +164,20 @@ class Foo
             ();
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        var s = base.ToString();
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 13);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -142,10 +193,21 @@ class Foo
             ();
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        var name = ""qwe"";
+        var s = name.ToString();
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 13);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -184,10 +246,24 @@ class Foo
             ();
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public static void Baz()
+    {
+    }
+
+    public void Bar()
+    {
+        Foo.Baz();
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(11, 13);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -245,10 +321,20 @@ class Foo
         ();
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        var f = new Foo();
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 9);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -281,10 +367,23 @@ class Foo
         ();
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    class FooInner
+    {
+    }
+    public void Bar()
+    {
+        var f = new Foo.FooInner();
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 9);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -327,10 +426,24 @@ class Foo
         }
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    internal string this[
+    int index]
+    {
+        get
+        {
+            return string.Empty;
+        }
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 5);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -371,10 +484,29 @@ class Foo
 [1];
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public int this[int index]
+    {
+        get
+        {
+            return 1;
+        }
+    }
+
+    public void Bar()
+    {
+        var s = this[
+1];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(15, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -390,10 +522,22 @@ class Foo
 [0];
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        System.Collections.Generic.List<int> list = new System.Collections.Generic.List<int>();
+        var r = list[
+0];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -448,8 +592,21 @@ class Foo
 [1];
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        var arr = new int[10];
+        var s = arr[
+1];
+    }
+}";
+
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -483,6 +640,17 @@ public class Foo
     {
     }
 }";
+            var fixedCode = @"
+using System.Diagnostics;
+public class Foo
+{
+[Conditional(
+""DEBUG""), Conditional(
+""TEST1"")]
+    public void Baz()
+    {
+    }
+}";
 
             DiagnosticResult[] expected =
                 {
@@ -491,6 +659,8 @@ public class Foo
                 };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -519,10 +689,18 @@ public class Foo
     public delegate void MyDel
 (int i);
 }";
+            var fixedCode = @"
+public class Foo
+{
+    public delegate void MyDel(
+int i);
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -553,10 +731,25 @@ public class Foo
         };
     }
 }";
+            var fixedCode = @"
+public class Foo
+{
+    public void Bar()
+    {
+        System.Action<string,string> del = 
+        delegate(
+string s, string s2
+        )
+        {
+        };
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -626,10 +819,22 @@ public class Foo
 ];
     }
 }";
+            var fixedCode = @"
+public class Foo
+{
+    public void Bar()
+    {
+        var arr = new int[
+1,2
+];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -678,10 +883,21 @@ public class Foo
         return null;
     }
 }";
+            var fixedCode = @"
+public class Foo
+{
+    public static Foo operator +(
+Foo a, Foo b)
+    {
+        return null;
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -696,10 +912,21 @@ public class Foo
         return null;
     }
 }";
+            var fixedCode = @"
+public class Foo
+{
+    public static Foo operator +(
+Foo a)
+    {
+        return null;
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -729,10 +956,21 @@ public class Foo
             return null;
         }
 }";
+            var fixedCode = @"
+public class Foo
+{
+        public static explicit operator Foo(
+int i)
+        {
+            return null;
+        }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -772,6 +1010,11 @@ public class Foo
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
             yield return new SA1110OpeningParenthesisMustBeOnDeclarationLine();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new OpenCloseSpacingCodeFixProvider();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1111UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1111UnitTests.cs
@@ -3,6 +3,8 @@
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Analyzers.SpacingRules;
+    using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.ReadabilityRules;
     using TestHelper;
@@ -22,10 +24,20 @@ class Foo
 
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Bar(string s)
+    {
+
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -42,10 +54,22 @@ class Foo
 
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Bar(string s,
+                    int i,
+                    object o)
+    {
+
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -91,10 +115,20 @@ class Foo
 
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public Foo(string s)
+    {
+
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -111,10 +145,22 @@ class Foo
 
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public Foo(string s,
+                    int i,
+                    object o)
+    {
+
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -165,10 +211,25 @@ class Foo
 );
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Bar(string s)
+    {
+
+    }
+
+    public void Baz()
+    {
+        Bar(string.Empty);
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(12, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -210,10 +271,26 @@ class Foo
 );
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Bar(string s, int i)
+    {
+
+    }
+
+    public void Baz()
+    {
+        Bar(string.Empty,
+            5);
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(13, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -275,10 +352,25 @@ class Foo
 );
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public Foo(string s)
+    {
+
+    }
+
+    public void Baz()
+    {
+        var f = new Foo(string.Empty);
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(12, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -299,10 +391,26 @@ class Foo
 );
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public Foo(string s, int i)
+    {
+
+    }
+
+    public void Baz()
+    {
+        var f = new Foo(string.Empty,
+            5);
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(13, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -362,10 +470,23 @@ class Foo
         }
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public int this[int index]
+    {
+        get
+        {
+            return 1;
+        }
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -385,10 +506,25 @@ class Foo
         }
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public int this[int index,
+                    int index2,
+                    int index3]
+    {
+        get
+        {
+            return 1;
+        }
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -429,10 +565,28 @@ class Foo
 ];
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public int this[int index]
+    {
+        get
+        {
+            return 1;
+        }
+    }
+
+    public void Test()
+    {
+        var i = this[1];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(15, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -448,10 +602,21 @@ class Foo
 ];
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Test()
+    {
+        var list = new System.Collections.Generic.List<int>();
+        var i = list[1];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -468,10 +633,22 @@ class Foo
 ];
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    private System.Collections.Generic.List<int> list = new System.Collections.Generic.List<int>();
+
+    public void Test()
+    {
+        var i = list[1];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -488,10 +665,22 @@ class Foo
 ];
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    private System.Collections.Generic.List<int> List2 {get;set;}
+
+    public void Test()
+    {
+        var i = List2[1];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -506,10 +695,20 @@ class Foo
 ];
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Test(System.Collections.Generic.List<int> list)
+    {
+        var i = list[1];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -524,13 +723,26 @@ class Foo
         System.Action a = () => {
         var i = list[1
 ];
-        };      
+        };
+    }
+}";
+            var fixedCode = @"
+class Foo
+{
+    public void Test()
+    {
+        System.Collections.Generic.List<int> list = new System.Collections.Generic.List<int>();
+        System.Action a = () => {
+        var i = list[1];
+        };
     }
 }";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -549,10 +761,24 @@ class Foo
 ];
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public System.Collections.Generic.List<int> Get()
+    {
+        return new System.Collections.Generic.List<int>();
+    }
+    public void Test()
+    {
+        var i = Get()[1];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(11, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -572,10 +798,25 @@ class Foo
 ];
     }
 }";
+            var fixedCode = @"
+class Bar
+{
+    public System.Collections.Generic.List<int> MyList {get;set;}
+}
+class Foo
+{
+    public void Test()
+    {
+        var bar = new Bar();
+        var i = bar.MyList[1];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(12, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -591,10 +832,21 @@ class Foo
 ];
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Test()
+    {
+        var arr = new int[10];
+        var i = arr[1];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -610,10 +862,21 @@ class Foo
 ];
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Test()
+    {
+        var arr = new int[10,15];
+        var i = arr[1,3];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -638,10 +901,30 @@ class Foo
 ];
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public int this[int index, int index2, int index3]
+    {
+        get
+        {
+            return 1;
+        }
+    }
+
+    public void Test()
+    {
+        var i = this[1,    
+                  2,
+                  3];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(17, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -668,10 +951,17 @@ public class Foo
     public delegate void Del(int i, string s
 );
 }";
+            var fixedCode = @"
+public class Foo
+{
+    public delegate void Del(int i, string s);
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -714,10 +1004,24 @@ public class Foo
         };
     }
 }";
+            var fixedCode = @"
+public class Foo
+{
+    public void Bar()
+    {
+        System.Action<string,string> del = 
+        delegate(string s, string s2)
+        {
+
+        };
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 9);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -773,6 +1077,15 @@ public class Foo
     {
     }
 }";
+            var fixedCode = @"
+using System.Diagnostics;
+public class Foo
+{
+[Conditional(""DEBUG""), Conditional(""TEST1"")]
+    public void Baz()
+    {
+    }
+}";
 
             DiagnosticResult[] expected =
                 {
@@ -781,6 +1094,8 @@ public class Foo
                 };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -822,10 +1137,18 @@ using System.Diagnostics;
 public class FooAttribute : System.Attribute
 {
 }";
+            var fixedCode = @"
+using System.Diagnostics;
+[Conditional(""DEBUG""), Conditional(""TEST1"")]
+public class FooAttribute : System.Attribute
+{
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -887,9 +1210,17 @@ Conditional(""DEBUG""
 public class Foo : System.Attribute
 {
 }";
+            var fixedCode = @"using System.Diagnostics;
+[
+Conditional(""DEBUG"")]
+public class Foo : System.Attribute
+{
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 1);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -906,10 +1237,22 @@ public class Foo
 );
     }
 }";
+            var fixedCode = @"
+public class Foo
+{
+    private event System.Action<int, int> MyEvent;
+
+    public void Bar()
+    {
+        MyEvent(1,2);
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -960,10 +1303,23 @@ public class Foo
         };
     }
 }";
+            var fixedCode = @"
+public class Foo
+{
+    public void Bar()
+    {
+        System.Action<string,string> act = (string s, string s2) =>
+        {
+                    
+        };
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -984,10 +1340,26 @@ namespace Test
         }
     }
 }";
+            var fixedCode = @"
+namespace Test
+{
+    using System.Linq;
+
+    public class Foo
+    {
+        public void Bar()
+        {
+            var arr = new int[0];
+            var r = arr.Where((int a) => a > 0);
+        }
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(12, 17);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -1034,10 +1406,20 @@ public class Foo
 ];
     }
 }";
+            var fixedCode = @"
+public class Foo
+{
+    public void Bar()
+    {
+        var arr = new int[1,2];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -1052,10 +1434,20 @@ public class Foo
     ][];
     }
 }";
+            var fixedCode = @"
+public class Foo
+{
+    public void Bar()
+    {
+        var arr = new int[0][];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 5);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -1076,6 +1468,11 @@ public class Foo
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
             yield return new SA1111ClosingParenthesisMustBeOnLineOfLastParameter();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new OpenCloseSpacingCodeFixProvider();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1112UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1112UnitTests.cs
@@ -3,6 +3,8 @@
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Analyzers.SpacingRules;
+    using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.ReadabilityRules;
     using TestHelper;
@@ -22,10 +24,20 @@ class Foo
 
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -71,10 +83,20 @@ class Foo
 
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public Foo()
+    {
+
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -120,10 +142,20 @@ class Foo
 );
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        var s = ToString();
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -169,10 +201,20 @@ class Foo
 );
     }
 }";
+            var fixedCode = @"
+class Foo
+{
+    public void Bar()
+    {
+        var o = new object();
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -249,6 +291,11 @@ public class Foo
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
             yield return new SA1112ClosingParenthesisMustBeOnLineOfOpeningParenthesis();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new OpenCloseSpacingCodeFixProvider();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1113UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1113UnitTests.cs
@@ -3,6 +3,8 @@
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Analyzers.SpacingRules;
+    using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.ReadabilityRules;
     using TestHelper;
@@ -20,10 +22,19 @@
     {
     }
 }";
+            var fixedCode = @"public class Foo
+{
+    public void Bar(string s,
+                    int i)
+    {
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 21);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -37,6 +48,14 @@
     {
     }
 }";
+            var fixedCode = @"public class Foo
+{
+    public void Bar(string s,
+                    int i,
+                    int i2)
+    {
+    }
+}";
 
             DiagnosticResult[] expected =
                 {
@@ -45,6 +64,8 @@
                 };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -72,10 +93,20 @@
                                     , string.Empty);
     }
 }";
+            var fixedCode = @"public class Foo
+{
+    public void Bar()
+    {
+        var result = string.Compare(string.Empty,
+                                    string.Empty);
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 37);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -90,6 +121,15 @@
                                     , System.StringComparison.Ordinal);
     }
 }";
+            var fixedCode = @"public class Foo
+{
+    public void Bar()
+    {
+        var result = string.Compare(string.Empty,
+                                    string.Empty,
+                                    System.StringComparison.Ordinal);
+    }
+}";
 
             DiagnosticResult[] expected =
                 {
@@ -98,6 +138,8 @@
                 };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -129,10 +171,23 @@
                              , string.Empty);
     }
 }";
+            var fixedCode = @"public class Foo
+{
+    public Foo(string s1, string s2)
+    {
+    }  
+    public void Bar()
+    {
+        var result = new Foo(string.Empty,
+                             string.Empty);
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 30);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -150,6 +205,18 @@
                              , string.Empty);
     }
 }";
+            var fixedCode = @"public class Foo
+{
+    public Foo(string s1, string s2, string s3)
+    {
+    }  
+    public void Bar()
+    {
+        var result = new Foo(string.Empty,
+                             string.Empty,
+                             string.Empty);
+    }
+}";
 
             DiagnosticResult[] expected =
                 {
@@ -158,6 +225,8 @@
                 };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -188,10 +257,19 @@
     {
     }
 }";
+            var fixedCode = @"public class Foo
+{
+    public Foo(string s,
+               int i)
+    {
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 16);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -205,6 +283,14 @@
     {
     }
 }";
+            var fixedCode = @"public class Foo
+{
+    public Foo(string s,
+               int i,
+               int i2)
+    {
+    }
+}";
 
             DiagnosticResult[] expected =
                 {
@@ -213,6 +299,8 @@
                 };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -243,10 +331,23 @@
         }
     }
 }";
+            var fixedCode = @"public class Foo
+{
+    public int this[string s,
+                    int i]
+    {
+        get
+        {
+            return 1;
+        }
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 21);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -264,6 +365,18 @@
         }
     }
 }";
+            var fixedCode = @"public class Foo
+{
+    public int this[string s,
+                    int i,
+                    int i2]
+    {
+        get
+        {
+            return 1;
+        }
+    }
+}";
 
             DiagnosticResult[] expected =
                 {
@@ -272,6 +385,8 @@
                 };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -310,10 +425,27 @@
 , 5];
     }
 }";
+            var fixedCode = @"public class Foo
+{
+    public int this[string s, int i]
+    {
+        get
+        {
+            return 1;
+        }
+    }
+    public void Bar()
+    {
+        var i = this[string.Empty,
+5];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(13, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -335,6 +467,22 @@
     ,4];
     }
 }";
+            var fixedCode = @"public class Foo
+{
+    public int this[string s, int i, int i2]
+    {
+        get
+        {
+            return 1;
+        }
+    }
+    public void Bar()
+    {
+        var i = this[string.Empty,
+5,
+    4];
+    }
+}";
 
             DiagnosticResult[] expected =
                 {
@@ -343,6 +491,8 @@
                 };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -382,10 +532,24 @@
             };
     }
 }";
+            var fixedCode = @"public class Foo
+{
+    public void Bar()
+    {
+         System.Action<string,int> i = 
+            delegate(string s,
+            int j)
+            {
+
+            };
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 13);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -414,10 +578,17 @@
     delegate void Del(string str
 , int i);
 }";
+            var fixedCode = @"public class Foo
+{
+    delegate void Del(string str,
+int i);
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -429,6 +600,12 @@
 , int i
 , long l);
 }";
+            var fixedCode = @"public class Foo
+{
+    delegate void Del(string str,
+int i,
+long l);
+}";
 
             DiagnosticResult[] expected =
                 {
@@ -437,6 +614,8 @@
                 };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -462,6 +641,15 @@
                 , l) => { };
         }
 }";
+            var fixedCode = @"public class Foo
+{
+        public void Bar()
+        {
+            System.Action<string, int, long> a = (s,
+                i,
+                l) => { };
+        }
+}";
 
             DiagnosticResult[] expected =
                 {
@@ -470,6 +658,8 @@
                 };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -511,10 +701,20 @@ public class SimpleApiOriginal
 , CharSet=CharSet.Auto)]
     public static extern int MessageBox(IntPtr hWnd, String text, String caption, uint type);
  }";
+            var fixedCode = @"using System;
+using System.Runtime.InteropServices;
+public class SimpleApiOriginal
+{
+    [DllImport(""user32.dll"",
+CharSet=CharSet.Auto)]
+    public static extern int MessageBox(IntPtr hWnd, String text, String caption, uint type);
+ }";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -544,6 +744,16 @@ public class Foo
         {
         }
     }";
+            var fixedCode = @"using System.Diagnostics;
+public class Foo
+{
+    [Conditional(""A""),
+Conditional(""B""),
+Conditional(""C"")]
+        public void Bar()
+        {
+        }
+    }";
 
             DiagnosticResult[] expected =
                 {
@@ -552,6 +762,8 @@ public class Foo
                 };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -581,10 +793,21 @@ public class Foo
         return null;
     }
 }";
+            var fixedCode = @"
+public class Foo
+{
+    public static Foo operator +(Foo a,
+Foo b)
+    {
+        return null;
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -630,10 +853,21 @@ public class Foo
 , 2];
     }
 }";
+            var fixedCode = @"
+public class Foo
+{
+    public void Bar()
+    {
+        var a = new int[1,
+2];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -699,10 +933,22 @@ public class Foo
 , 0];
     }
 }";
+            var fixedCode = @"
+public class Foo
+{
+    public void Bar()
+    {
+        var a = new int[1,2];
+        int i = a[0,
+0];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -755,10 +1001,27 @@ public class Foo4
 , 0];
     }
 }";
+            var fixedCode = @"
+public class Foo3
+{
+    public int this[int index1, int index2] => 0;
+}
+
+public class Foo4
+{
+    public void Bar()
+    {
+        var f = new Foo3();
+        var i = f[0,
+0];
+    }
+}";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(13, 1);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -806,6 +1069,11 @@ public class Foo4
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
             yield return new SA1113CommaMustBeOnSameLineAsPreviousParameter();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new OpenCloseSpacingCodeFixProvider();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TriviaHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TriviaHelper.cs
@@ -16,8 +16,10 @@
         /// Returns the index of the first non-whitespace trivia in the given trivia list.
         /// </summary>
         /// <param name="triviaList">The trivia list to process.</param>
+        /// <param name="endOfLineIsWhitespace"><see langword="true"/> to treat <see cref="SyntaxKind.EndOfLineTrivia"/>
+        /// as whitespace; otherwise, <see langword="false"/>.</param>
         /// <returns>The index where the non-whitespace starts, or -1 if there is no non-whitespace trivia.</returns>
-        internal static int IndexOfFirstNonWhitespaceTrivia(IReadOnlyList<SyntaxTrivia> triviaList)
+        internal static int IndexOfFirstNonWhitespaceTrivia(IReadOnlyList<SyntaxTrivia> triviaList, bool endOfLineIsWhitespace = true)
         {
             for (var index = 0; index < triviaList.Count; index++)
             {
@@ -25,6 +27,13 @@
                 switch (currentTrivia.Kind())
                 {
                 case SyntaxKind.EndOfLineTrivia:
+                    if (!endOfLineIsWhitespace)
+                    {
+                        return index;
+                    }
+
+                    break;
+
                 case SyntaxKind.WhitespaceTrivia:
                     break;
 
@@ -138,10 +147,12 @@
         /// Strips all leading whitespace trivia from the trivia list until a non-whitespace trivia is encountered.
         /// </summary>
         /// <param name="triviaList">The trivia list to strip of its leading whitespace.</param>
+        /// <param name="endOfLineIsWhitespace"><see langword="true"/> to treat <see cref="SyntaxKind.EndOfLineTrivia"/>
+        /// as whitespace; otherwise, <see langword="false"/>.</param>
         /// <returns>The modified triviaList.</returns>
-        internal static SyntaxTriviaList WithoutLeadingWhitespace(this SyntaxTriviaList triviaList)
+        internal static SyntaxTriviaList WithoutLeadingWhitespace(this SyntaxTriviaList triviaList, bool endOfLineIsWhitespace = true)
         {
-            var nonWhitespaceIndex = IndexOfFirstNonWhitespaceTrivia(triviaList);
+            var nonWhitespaceIndex = IndexOfFirstNonWhitespaceTrivia(triviaList, endOfLineIsWhitespace);
             return (nonWhitespaceIndex >= 0) ? SyntaxFactory.TriviaList(triviaList.Take(nonWhitespaceIndex)) : SyntaxFactory.TriviaList();
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1110OpeningParenthesisMustBeOnDeclarationLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1110OpeningParenthesisMustBeOnDeclarationLine.cs
@@ -1,11 +1,13 @@
 ﻿namespace StyleCop.Analyzers.ReadabilityRules
 {
+    using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using SpacingRules;
     using StyleCop.Analyzers.Helpers;
 
     /// <summary>
@@ -90,7 +92,8 @@
 
             if (parameterListSyntax != null && !parameterListSyntax.OpenParenToken.IsMissing)
             {
-                CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, parameterListSyntax.OpenParenToken);
+                bool preserveLayout = parameterListSyntax.Parameters.Any();
+                CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, parameterListSyntax.OpenParenToken, preserveLayout);
             }
         }
 
@@ -107,7 +110,8 @@
 
             if (parameterListSyntax != null && !parameterListSyntax.OpenParenToken.IsMissing)
             {
-                CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, parameterListSyntax.OpenParenToken);
+                bool preserveLayout = parameterListSyntax.Parameters.Any();
+                CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, parameterListSyntax.OpenParenToken, preserveLayout);
             }
         }
 
@@ -126,7 +130,8 @@
 
             if (!firstSize.OpenBracketToken.IsMissing)
             {
-                CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, firstSize.OpenBracketToken);
+                bool preserveLayout = firstSize.Sizes.Any();
+                CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, firstSize.OpenBracketToken, preserveLayout);
             }
         }
 
@@ -142,7 +147,8 @@
                 return;
             }
 
-            CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, anonymousMethod.ParameterList.OpenParenToken);
+            bool preserveLayout = anonymousMethod.ParameterList.Parameters.Any();
+            CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, anonymousMethod.ParameterList.OpenParenToken, preserveLayout);
         }
 
         private static void HandleDelegateDeclaration(SyntaxNodeAnalysisContext context)
@@ -153,7 +159,8 @@
                 delegateDeclaration.ParameterList != null &&
                 !delegateDeclaration.ParameterList.OpenParenToken.IsMissing)
             {
-                CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, delegateDeclaration.ParameterList.OpenParenToken);
+                bool preserveLayout = delegateDeclaration.ParameterList.Parameters.Any();
+                CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, delegateDeclaration.ParameterList.OpenParenToken, preserveLayout);
             }
         }
 
@@ -178,7 +185,8 @@
                     !attribute.ArgumentList.OpenParenToken.IsMissing &&
                     !identifierNameSyntax.Identifier.IsMissing)
                 {
-                    CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, attribute.ArgumentList.OpenParenToken);
+                    bool preserveLayout = attribute.ArgumentList.Arguments.Any();
+                    CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, attribute.ArgumentList.OpenParenToken, preserveLayout);
                 }
             }
         }
@@ -194,7 +202,8 @@
                 return;
             }
 
-            CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, elementAccess.ArgumentList.OpenBracketToken);
+            bool preserveLayout = elementAccess.ArgumentList.Arguments.Any();
+            CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, elementAccess.ArgumentList.OpenBracketToken, preserveLayout);
         }
 
         private static void HandleIndexerDeclaration(SyntaxNodeAnalysisContext obj)
@@ -206,7 +215,8 @@
                 !indexerDeclaration.ParameterList.IsMissing &&
                 !indexerDeclaration.ParameterList.OpenBracketToken.IsMissing)
             {
-                CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(obj, indexerDeclaration.ParameterList.OpenBracketToken);
+                bool preserveLayout = indexerDeclaration.ParameterList.Parameters.Any();
+                CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(obj, indexerDeclaration.ParameterList.OpenBracketToken, preserveLayout);
             }
         }
 
@@ -224,7 +234,8 @@
             if (objectCreation.ArgumentList != null
                 && !objectCreation.ArgumentList.OpenParenToken.IsMissing)
             {
-                CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, objectCreation.ArgumentList.OpenParenToken);
+                bool preserveLayout = objectCreation.ArgumentList.Arguments.Any();
+                CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, objectCreation.ArgumentList.OpenParenToken, preserveLayout);
             }
         }
 
@@ -261,7 +272,8 @@
                     !invocationExpression.ArgumentList.OpenParenToken.IsMissing &&
                     !identifierNameSyntax.Identifier.IsMissing)
                 {
-                    CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, invocationExpression.ArgumentList.OpenParenToken);
+                    bool preserveLayout = invocationExpression.ArgumentList.Arguments.Any();
+                    CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, invocationExpression.ArgumentList.OpenParenToken, preserveLayout);
                 }
             }
         }
@@ -273,7 +285,8 @@
                 && !constructotDeclarationSyntax.ParameterList.OpenParenToken.IsMissing
                 && !constructotDeclarationSyntax.Identifier.IsMissing)
             {
-                CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, constructotDeclarationSyntax.ParameterList.OpenParenToken);
+                bool preserveLayout = constructotDeclarationSyntax.ParameterList.Parameters.Any();
+                CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, constructotDeclarationSyntax.ParameterList.OpenParenToken, preserveLayout);
             }
         }
 
@@ -284,11 +297,12 @@
                 && !methodDeclaration.ParameterList.OpenParenToken.IsMissing
                 && !methodDeclaration.Identifier.IsMissing)
             {
-                CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, methodDeclaration.ParameterList.OpenParenToken);
+                bool preserveLayout = methodDeclaration.ParameterList.Parameters.Any();
+                CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(context, methodDeclaration.ParameterList.OpenParenToken, preserveLayout);
             }
         }
 
-        private static void CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(SyntaxNodeAnalysisContext context, SyntaxToken openToken)
+        private static void CheckIfLocationOfPreviousTokenAndOpenTokenAreTheSame(SyntaxNodeAnalysisContext context, SyntaxToken openToken, bool preserveLayout)
         {
             var previousToken = openToken.GetPreviousToken();
             if (previousToken.IsMissing)
@@ -302,7 +316,13 @@
                 openParenLine.IsValid &&
                 openParenLine.StartLinePosition.Line != prevTokenLine.StartLinePosition.Line)
             {
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, openToken.GetLocation()));
+                var properties = new Dictionary<string, string>
+                {
+                    [OpenCloseSpacingCodeFixProvider.LocationKey] = OpenCloseSpacingCodeFixProvider.LocationPreceding,
+                    [OpenCloseSpacingCodeFixProvider.ActionKey] = OpenCloseSpacingCodeFixProvider.ActionRemove,
+                    [OpenCloseSpacingCodeFixProvider.LayoutKey] = preserveLayout ? OpenCloseSpacingCodeFixProvider.LayoutPreserve : OpenCloseSpacingCodeFixProvider.LayoutPack
+                };
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, openToken.GetLocation(), properties.ToImmutableDictionary()));
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1111ClosingParenthesisMustBeOnLineOfLastParameter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1111ClosingParenthesisMustBeOnLineOfLastParameter.cs
@@ -1,10 +1,12 @@
 ﻿namespace StyleCop.Analyzers.ReadabilityRules
 {
+    using System.Collections.Generic;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using SpacingRules;
     using StyleCop.Analyzers.Helpers;
 
     /// <summary>
@@ -338,7 +340,13 @@
                 closeParenLine.IsValid &&
                 closeParenLine.StartLinePosition.Line != lastParameterLine.EndLinePosition.Line)
             {
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, closeToken.GetLocation()));
+                var properties = new Dictionary<string, string>
+                {
+                    [OpenCloseSpacingCodeFixProvider.LocationKey] = OpenCloseSpacingCodeFixProvider.LocationPreceding,
+                    [OpenCloseSpacingCodeFixProvider.ActionKey] = OpenCloseSpacingCodeFixProvider.ActionRemove,
+                    [OpenCloseSpacingCodeFixProvider.LayoutKey] = OpenCloseSpacingCodeFixProvider.LayoutPack
+                };
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, closeToken.GetLocation(), properties.ToImmutableDictionary()));
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1112ClosingParenthesisMustBeOnLineOfOpeningParenthesis.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1112ClosingParenthesisMustBeOnLineOfOpeningParenthesis.cs
@@ -1,11 +1,12 @@
 ﻿namespace StyleCop.Analyzers.ReadabilityRules
 {
+    using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using SpacingRules;
     using StyleCop.Analyzers.Helpers;
 
     /// <summary>
@@ -133,7 +134,13 @@
                 openParenLine.IsValid &&
                 openParenLine.StartLinePosition.Line != closeParenLine.StartLinePosition.Line)
             {
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, closeToken.GetLocation()));
+                var properties = new Dictionary<string, string>
+                {
+                    [OpenCloseSpacingCodeFixProvider.LocationKey] = OpenCloseSpacingCodeFixProvider.LocationPreceding,
+                    [OpenCloseSpacingCodeFixProvider.ActionKey] = OpenCloseSpacingCodeFixProvider.ActionRemove,
+                    [OpenCloseSpacingCodeFixProvider.LayoutKey] = OpenCloseSpacingCodeFixProvider.LayoutPack
+                };
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, closeToken.GetLocation(), properties.ToImmutableDictionary()));
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1113CommaMustBeOnSameLineAsPreviousParameter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1113CommaMustBeOnSameLineAsPreviousParameter.cs
@@ -1,10 +1,12 @@
 ﻿namespace StyleCop.Analyzers.ReadabilityRules
 {
+    using System.Collections.Generic;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using SpacingRules;
     using StyleCop.Analyzers.Helpers;
 
     /// <summary>
@@ -240,7 +242,13 @@
 
                     if (previousNode.GetEndLine() < nodeOrToken.GetLineSpan().StartLinePosition.Line)
                     {
-                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, nodeOrToken.GetLocation()));
+                        var properties = new Dictionary<string, string>
+                        {
+                            [OpenCloseSpacingCodeFixProvider.LocationKey] = OpenCloseSpacingCodeFixProvider.LocationPreceding,
+                            [OpenCloseSpacingCodeFixProvider.ActionKey] = OpenCloseSpacingCodeFixProvider.ActionRemove,
+                            [OpenCloseSpacingCodeFixProvider.LayoutKey] = OpenCloseSpacingCodeFixProvider.LayoutPreserve
+                        };
+                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, nodeOrToken.GetLocation(), properties.ToImmutableDictionary()));
                     }
                 }
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/OpenCloseSpacingCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/OpenCloseSpacingCodeFixProvider.cs
@@ -41,6 +41,7 @@
                 SA1019MemberAccessSymbolsMustBeSpacedCorrectly.DiagnosticId,
                 SA1020IncrementDecrementSymbolsMustBeSpacedCorrectly.DiagnosticId,
                 SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly.DiagnosticId,
+                SA1110OpeningParenthesisMustBeOnDeclarationLine.DiagnosticId,
                 SA1113CommaMustBeOnSameLineAsPreviousParameter.DiagnosticId);
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/OpenCloseSpacingCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/OpenCloseSpacingCodeFixProvider.cs
@@ -42,6 +42,7 @@
                 SA1020IncrementDecrementSymbolsMustBeSpacedCorrectly.DiagnosticId,
                 SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly.DiagnosticId,
                 SA1110OpeningParenthesisMustBeOnDeclarationLine.DiagnosticId,
+                SA1111ClosingParenthesisMustBeOnLineOfLastParameter.DiagnosticId,
                 SA1113CommaMustBeOnSameLineAsPreviousParameter.DiagnosticId);
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/OpenCloseSpacingCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/OpenCloseSpacingCodeFixProvider.cs
@@ -43,6 +43,7 @@
                 SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly.DiagnosticId,
                 SA1110OpeningParenthesisMustBeOnDeclarationLine.DiagnosticId,
                 SA1111ClosingParenthesisMustBeOnLineOfLastParameter.DiagnosticId,
+                SA1112ClosingParenthesisMustBeOnLineOfOpeningParenthesis.DiagnosticId,
                 SA1113CommaMustBeOnSameLineAsPreviousParameter.DiagnosticId);
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/OpenCloseSpacingCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/OpenCloseSpacingCodeFixProvider.cs
@@ -10,6 +10,7 @@
     using Microsoft.CodeAnalysis.CodeActions;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.CSharp;
+    using ReadabilityRules;
     using StyleCop.Analyzers.Helpers;
 
     /// <summary>
@@ -21,10 +22,13 @@
     {
         internal const string LocationKey = "location";
         internal const string ActionKey = "action";
+        internal const string LayoutKey = "layout";
         internal const string LocationPreceding = "preceding";
         internal const string LocationFollowing = "following";
         internal const string ActionInsert = "insert";
         internal const string ActionRemove = "remove";
+        internal const string LayoutPack = "pack";
+        internal const string LayoutPreserve = "preserve";
 
         private static readonly ImmutableArray<string> FixableDiagnostics =
             ImmutableArray.Create(
@@ -36,7 +40,8 @@
                 SA1015ClosingGenericBracketsMustBeSpacedCorrectly.DiagnosticId,
                 SA1019MemberAccessSymbolsMustBeSpacedCorrectly.DiagnosticId,
                 SA1020IncrementDecrementSymbolsMustBeSpacedCorrectly.DiagnosticId,
-                SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly.DiagnosticId);
+                SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly.DiagnosticId,
+                SA1113CommaMustBeOnSameLineAsPreviousParameter.DiagnosticId);
 
         /// <inheritdoc/>
         public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
@@ -76,6 +81,12 @@
                 return document;
             }
 
+            string layout;
+            if (!diagnostic.Properties.TryGetValue(LayoutKey, out layout))
+            {
+                layout = LayoutPack;
+            }
+
             var replaceMap = new Dictionary<SyntaxToken, SyntaxToken>();
             SyntaxTriviaList triviaList;
             switch (location)
@@ -89,14 +100,17 @@
 
                 case ActionRemove:
                     var prevToken = token.GetPreviousToken();
+                    bool tokenIsFirstInLine = token.IsFirstInLine();
+                    bool preserveLayout = layout == LayoutPreserve;
                     triviaList = prevToken.TrailingTrivia.AddRange(token.LeadingTrivia);
 
                     replaceMap[prevToken] = prevToken.WithTrailingTrivia();
-                    if (triviaList.All(i => i.IsKind(SyntaxKind.WhitespaceTrivia) || i.IsKind(SyntaxKind.EndOfLineTrivia)))
+                    if ((!preserveLayout || !tokenIsFirstInLine)
+                        && triviaList.All(i => i.IsKind(SyntaxKind.WhitespaceTrivia) || i.IsKind(SyntaxKind.EndOfLineTrivia)))
                     {
                         replaceMap[token] = token.WithLeadingTrivia();
                     }
-                    else if (token.IsFirstInLine() && token.IsLastInLine())
+                    else if (tokenIsFirstInLine && token.IsLastInLine())
                     {
                         /* This block covers the case where `token` is the only non-trivia token on its line. However,
                          * the line may still contain non-whitespace trivia which we want the removal process to
@@ -141,7 +155,7 @@
                     }
                     else
                     {
-                        SyntaxTriviaList trailingTrivia = triviaList.AddRange(token.TrailingTrivia);
+                        SyntaxTriviaList trailingTrivia = triviaList.AddRange(token.TrailingTrivia.WithoutLeadingWhitespace(endOfLineIsWhitespace: false));
                         replaceMap[token] = token.WithLeadingTrivia().WithTrailingTrivia(trailingTrivia);
                     }
 


### PR DESCRIPTION
This pull request implements code fixes for the following diagnostics:

* SA1110 (OpeningParenthesisMustBeOnDeclarationLine) (fixes #504)
* SA1111 (ClosingParenthesisMustBeOnLineOfLastParameter) (fixes #402)
* SA1112 (ClosingParenthesisMustBeOnLineOfOpeningParenthesis) (fixes #1102)
* SA1113 (CommaMustBeOnSameLineAsPreviousParameter) (fixes #503)