### PR TITLE
Fixed issue with SA1514

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1514UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1514UnitTests.cs
@@ -715,6 +715,51 @@ namespace TestNamespace
         }
 
         /// <summary>
+        /// Verifies that comments before documentation are properly handled, when the comment is preceded by empty lines.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestDocumenationPrecededByCommentNotReportedForLooseCommentAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    using System;
+
+    // some comment
+    /// <summary>
+    /// some documentation.
+    /// </summary>
+    public class TestClass
+    {
+    }
+}
+";
+            var fixedCode = @"namespace TestNamespace
+{
+    using System;
+
+    // some comment
+
+    /// <summary>
+    /// some documentation.
+    /// </summary>
+    public class TestClass
+    {
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(6, 5)
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Verifies that trailing comments before documentation are properly handled.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1514ElementDocumentationHeaderMustBePrecededByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1514ElementDocumentationHeaderMustBePrecededByBlankLine.cs
@@ -111,7 +111,6 @@
             var triviaList = TriviaHelper.GetContainingTriviaList(documentationHeader, out documentationHeaderIndex);
             var eolCount = 0;
             var done = false;
-            var hasComment = false;
             for (var i = documentationHeaderIndex - 1; !done && (i >= 0); i--)
             {
                 switch (triviaList[i].Kind())
@@ -131,17 +130,9 @@
                     eolCount++;
                     done = true;
                     break;
-                case SyntaxKind.SingleLineCommentTrivia:
-                    if (triviaList[i].GetLine() != triviaList[i].Token.GetLine())
-                    {
-                        eolCount--;
-                    }
-
-                    hasComment = true;
-                    break;
                 default:
                     done = true;
-                    return;
+                    break;
                 }
             }
 
@@ -151,7 +142,7 @@
                 return;
             }
 
-            if (!done && !hasComment)
+            if (!done)
             {
                 var prevToken = documentationHeader.Token.GetPreviousToken();
                 if (prevToken.IsKind(SyntaxKind.OpenBraceToken))


### PR DESCRIPTION
This fixes an issue where a documentation header that is directly preceded by a single comment line that in its turn is preceded by one or more empty lines will not produce the expected diagnostic.

This fixes an issue that was introduced in #1150 and #1216.
It also fixes the root cause for #1131