### PR TITLE
Use StringComparison.Ordinal in calls to string.StartsWith

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/DiagnosticVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/DiagnosticVerifier.cs
@@ -1,5 +1,6 @@
 ﻿namespace TestHelper
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
@@ -294,12 +295,12 @@
             if (filenames == null)
             {
                 // Also check if the analyzer honors exclusions
-                if (expected.Any(x => x.Id.StartsWith("SA") || x.Id.StartsWith("SX")))
+                if (expected.Any(x => x.Id.StartsWith("SA", StringComparison.Ordinal) || x.Id.StartsWith("SX", StringComparison.Ordinal)))
                 {
                     // We want to look at non-stylecop diagnostics only. We also insert a new line at the beginning
                     // so we have to move all diagnostic location down by one line
                     var expectedResults = expected
-                        .Where(x => !x.Id.StartsWith("SA") && !x.Id.StartsWith("SX"))
+                        .Where(x => !x.Id.StartsWith("SA", StringComparison.Ordinal) && !x.Id.StartsWith("SX", StringComparison.Ordinal))
                         .Select(x => x.WithLineOffset(1))
                         .ToArray();
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1608ElementDocumentationMustNotHaveDefaultSummary.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1608ElementDocumentationMustNotHaveDefaultSummary.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.DocumentationRules
 {
+    using System;
     using System.Collections.Immutable;
     using Helpers;
     using Microsoft.CodeAnalysis;
@@ -79,7 +80,7 @@
 
                         if (!string.IsNullOrEmpty(text))
                         {
-                            if (text.TrimStart().StartsWith(DefaultText))
+                            if (text.TrimStart().StartsWith(DefaultText, StringComparison.Ordinal))
                             {
                                 context.ReportDiagnostic(Diagnostic.Create(Descriptor, summaryElement.GetLocation()));
                             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/StandardTextDiagnosticBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/StandardTextDiagnosticBase.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.DocumentationRules
 {
+    using System;
     using System.Linq;
     using Helpers;
     using Microsoft.CodeAnalysis;
@@ -131,7 +132,7 @@
             }
 
             string secondTextPartText = XmlCommentHelper.GetText(secondTextPart, normalizeWhitespace: true);
-            if (!secondTextPartText.StartsWith(secondText))
+            if (!secondTextPartText.StartsWith(secondText, StringComparison.Ordinal))
             {
                 return false;
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1512SingleLineCommentsMustNotBeFollowedByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1512SingleLineCommentsMustNotBeFollowedByBlankLine.cs
@@ -107,7 +107,7 @@
 
             foreach (var trivia in syntaxRoot.DescendantTrivia().Where(trivia => trivia.IsKind(SyntaxKind.SingleLineCommentTrivia)))
             {
-                if (trivia.ToString().StartsWith("////"))
+                if (trivia.ToString().StartsWith("////", StringComparison.Ordinal))
                 {
                     // ignore commented out code
                     continue;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515SingleLineCommentMustBePrecededByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515SingleLineCommentMustBePrecededByBlankLine.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.LayoutRules
 {
+    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
@@ -113,7 +114,7 @@
                     continue;
                 }
 
-                if (trivia.ToString().StartsWith("////"))
+                if (trivia.ToString().StartsWith("////", StringComparison.Ordinal))
                 {
                     // ignore commented out code
                     continue;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1308VariableNamesMustNotBePrefixed.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1308VariableNamesMustNotBePrefixed.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.NamingRules
 {
+    using System;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
@@ -86,9 +87,9 @@
                     continue;
                 }
 
-                if (!identifier.ValueText.StartsWith("m_")
-                    && !identifier.ValueText.StartsWith("s_")
-                    && !identifier.ValueText.StartsWith("t_"))
+                if (!identifier.ValueText.StartsWith("m_", StringComparison.Ordinal)
+                    && !identifier.ValueText.StartsWith("s_", StringComparison.Ordinal)
+                    && !identifier.ValueText.StartsWith("t_", StringComparison.Ordinal))
                 {
                     continue;
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1309FieldNamesMustNotBeginWithUnderscore.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1309FieldNamesMustNotBeginWithUnderscore.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.NamingRules
 {
+    using System;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
@@ -86,7 +87,7 @@
                     continue;
                 }
 
-                if (!identifier.ValueText.StartsWith("_"))
+                if (!identifier.ValueText.StartsWith("_", StringComparison.Ordinal))
                 {
                     continue;
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SX1309FieldNamesMustBeginWithUnderscore.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SX1309FieldNamesMustBeginWithUnderscore.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.NamingRules
 {
+    using System;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
@@ -102,7 +103,7 @@
                     continue;
                 }
 
-                if (identifier.ValueText.StartsWith("_"))
+                if (identifier.ValueText.StartsWith("_", StringComparison.Ordinal))
                 {
                     continue;
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SX1309SStaticFieldNamesMustBeginWithUnderscore.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SX1309SStaticFieldNamesMustBeginWithUnderscore.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.NamingRules
 {
+    using System;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
@@ -113,7 +114,7 @@
                     continue;
                 }
 
-                if (identifier.ValueText.StartsWith("_"))
+                if (identifier.ValueText.StartsWith("_", StringComparison.Ordinal))
                 {
                     continue;
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1108BlockStatementsMustNotContainEmbeddedComments.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1108BlockStatementsMustNotContainEmbeddedComments.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.ReadabilityRules
 {
+    using System;
     using System.Collections.Immutable;
     using System.Linq;
     using Microsoft.CodeAnalysis;
@@ -137,7 +138,7 @@
         private bool IsComment(SyntaxTrivia syntaxTrivia)
         {
             var isSingleLineComment = syntaxTrivia.IsKind(SyntaxKind.SingleLineCommentTrivia)
-                && !syntaxTrivia.ToFullString().StartsWith(@"////");
+                && !syntaxTrivia.ToFullString().StartsWith(@"////", StringComparison.Ordinal);
             return isSingleLineComment
                 || syntaxTrivia.IsKind(SyntaxKind.MultiLineCommentTrivia);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1004DocumentationLinesMustBeginWithSingleSpace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1004DocumentationLinesMustBeginWithSingleSpace.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.SpacingRules
 {
+    using System;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
@@ -118,7 +119,7 @@
                 switch (lastLeadingTrivia.Kind())
                 {
                 case SyntaxKind.WhitespaceTrivia:
-                    if (lastLeadingTrivia.ToFullString().StartsWith(" "))
+                    if (lastLeadingTrivia.ToFullString().StartsWith(" ", StringComparison.Ordinal))
                     {
                         return;
                     }
@@ -144,7 +145,7 @@
                 return;
 
             case SyntaxKind.XmlTextLiteralToken:
-                if (token.Text.StartsWith(" "))
+                if (token.Text.StartsWith(" ", StringComparison.Ordinal))
                 {
                     return;
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
@@ -1,5 +1,6 @@
 ﻿namespace StyleCop.Analyzers.SpacingRules
 {
+    using System;
     using System.Collections.Immutable;
     using System.Composition;
     using System.Threading.Tasks;
@@ -58,7 +59,7 @@
         private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxTrivia trivia)
         {
             string text = trivia.ToFullString();
-            if (!text.StartsWith("//"))
+            if (!text.StartsWith("//", StringComparison.Ordinal))
             {
                 return Task.FromResult(document);
             }

--- a/StyleCop.Analyzers/StyleCopTester/Program.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Program.cs
@@ -41,7 +41,7 @@
                 }
 
                 MSBuildWorkspace workspace = MSBuildWorkspace.Create();
-                string solutionPath = args.SingleOrDefault(i => !i.StartsWith("/"));
+                string solutionPath = args.SingleOrDefault(i => !i.StartsWith("/", StringComparison.Ordinal));
                 Solution solution = workspace.OpenSolutionAsync(solutionPath).Result;
 
                 Console.WriteLine($"Loaded solution in {stopwatch.ElapsedMilliseconds}ms");
@@ -71,7 +71,7 @@
                     Console.WriteLine($"  {group.Key}: {group.Count()} instances");
 
                     // Print out analyzer diagnostics like AD0001 for analyzer exceptions
-                    if (group.Key.StartsWith("AD"))
+                    if (group.Key.StartsWith("AD", StringComparison.Ordinal))
                     {
                         foreach (var item in group)
                         {
@@ -115,7 +115,7 @@
         {
             bool useAll = args.Contains("/all");
 
-            HashSet<string> ids = new HashSet<string>(args.Where(y => y.StartsWith("/id:")).Select(y => y.Substring(4)));
+            HashSet<string> ids = new HashSet<string>(args.Where(y => y.StartsWith("/id:", StringComparison.Ordinal)).Select(y => y.Substring(4)));
 
             foreach (var analyzer in analyzers)
             {


### PR DESCRIPTION
This change resulted in a 9.9% performance improvement for the analysis of Roslyn.sln due to reduced lock contention and a more efficient string comparison operation.