### PR TITLE
Avoid boxing SyntaxTriviaList in calls to Any and All with a predicate

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/LinqHelpers/SyntaxTriviaListEnumerable.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LinqHelpers/SyntaxTriviaListEnumerable.cs
@@ -26,5 +26,69 @@
         {
             return list.IndexOf(trivia) != -1;
         }
+
+        /// <summary>
+        /// Determines if a <see cref="SyntaxTriviaList"/> contains any trivia matching the conditions specified by a
+        /// predicate.
+        /// </summary>
+        /// <remarks>
+        /// <para>This method allows callers to avoid boxing the <see cref="SyntaxTriviaList"/> as an
+        /// <see cref="IEnumerable{T}"/>.</para>
+        /// </remarks>
+        /// <param name="list">The <see cref="SyntaxTriviaList"/> to search.</param>
+        /// <param name="predicate">The predicate determining the matching conditions for trivia.</param>
+        /// <returns>
+        /// <see langword="true"/> if the specified list contains any trivia matching the specified predicate;
+        /// otherwise, <see langword="false"/>.
+        /// </returns>
+        internal static bool Any(this SyntaxTriviaList list, Func<SyntaxTrivia, bool> predicate)
+        {
+            if (predicate == null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            foreach (SyntaxTrivia trivia in list)
+            {
+                if (predicate(trivia))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Determines if all of the trivia in a <see cref="SyntaxTriviaList"/> match the conditions specified by a
+        /// predicate.
+        /// </summary>
+        /// <remarks>
+        /// <para>This method allows callers to avoid boxing the <see cref="SyntaxTriviaList"/> as an
+        /// <see cref="IEnumerable{T}"/>.</para>
+        /// </remarks>
+        /// <param name="list">The <see cref="SyntaxTriviaList"/> to search.</param>
+        /// <param name="predicate">The predicate determining the matching conditions for trivia.</param>
+        /// <returns>
+        /// <see langword="true"/> if all trivia in the specified list match the specified predicate; otherwise,
+        /// <see langword="false"/>. If the list is empty, this method returns <see langword="true"/>.
+        /// </returns>
+        internal static bool All(this SyntaxTriviaList list, Func<SyntaxTrivia, bool> predicate)
+        {
+            if (predicate == null)
+            {
+                throw new ArgumentNullException(nameof(predicate));
+            }
+
+            foreach (SyntaxTrivia trivia in list)
+            {
+                if (!predicate(trivia))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
     }
 }


### PR DESCRIPTION
This improves the performance of `OpenCloseSpacingCodeFixProvider` and a few other smaller cases.