### PR TITLE
Improved handling of `?` in the presence of syntax errors

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1018UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1018UnitTests.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.SpacingRules;
@@ -105,6 +106,41 @@
             await this.VerifyCSharpDiagnosticAsync(testCode, expectedResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedTestCode, fixedExpectedResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// This is a regression test for DotNetAnalyzers/StyleCopAnalyzers#1256.
+        /// https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1256
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestSyntaxErrorAtEndOfFileAsync()
+        {
+            string testCode = @"namespace StyleCopAnalyzers_Test
+{
+    public class Class1
+    {
+        private void Test()
+        {
+            var hello = ""world"";
+        }
+    }
+}
+?
+";
+
+            DiagnosticResult[] expected =
+            {
+                new DiagnosticResult
+                {
+                    Id = "CS1031",
+                    Message = "Type expected",
+                    Severity = DiagnosticSeverity.Error,
+                    Locations = new[] { new DiagnosticResultLocation("Test0.cs", 10, 2) }
+                }
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
@@ -48,7 +48,12 @@
                     continue;
                 }
 
-                var nullableType = (NullableTypeSyntax)syntaxRoot.FindNode(diagnostic.Location.SourceSpan);
+                var nullableType = syntaxRoot.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true) as NullableTypeSyntax;
+                if (nullableType == null)
+                {
+                    continue;
+                }
+
                 var questionToken = nullableType.QuestionToken;
                 var precedingToken = questionToken.GetPreviousToken();
                 var triviaList = precedingToken.TrailingTrivia.AddRange(questionToken.LeadingTrivia);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018NullableTypeSymbolsMustNotBePrecededBySpace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018NullableTypeSymbolsMustNotBePrecededBySpace.cs
@@ -60,6 +60,12 @@
                 return;
             }
 
+            NullableTypeSyntax parentNullableTypeSyntax = questionToken.Parent as NullableTypeSyntax;
+            if (parentNullableTypeSyntax != null && parentNullableTypeSyntax.ElementType.IsMissing)
+            {
+                return;
+            }
+
             /* Do not test for the first character on the line!
              * The StyleCop documentation is wrong there, the actual StyleCop code does not accept it.
              */


### PR DESCRIPTION
I updated the code fix to handle this syntax, but I also updated the analyzer to not report any warnings for the syntax you showed.

Fixes #1256