### PR TITLE
Add additional test for SA1100 with indexers

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1100UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1100UnitTests.cs
@@ -1023,6 +1023,19 @@ public class Foo
         }
 
         [Fact]
+        public async Task TestIndexerWithLocalDefinitionAsync()
+        {
+            var testCode = @"
+class ClassName : System.Collections.Generic.List<int>
+{
+  public new int this[int index] { get { return base[index]; } }
+  public int Property { get { return base[0]; } }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestIndexerAsync()
         {
             var testCode = @"


### PR DESCRIPTION
This test makes sure the new code in #1260 doesn't report false positives.