### PR TITLE
Add a JSON schema for stylecop.json

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/SettingsFileCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/SettingsFileCodeFixProvider.cs
@@ -21,6 +21,7 @@
     {
         private const string StyleCopSettingsFileName = "stylecop.json";
         private const string DefaultSettingsFileContent = @"{
+  ""$schema"": ""https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json"",
   ""settings"": {
     ""documentationRules"": {
       ""companyName"": ""PlaceholderCompany""

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json
@@ -1,0 +1,26 @@
+﻿{
+  "$schema": "http://json-schema.org/draft-04/schema",
+  "id": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "title": "StyleCop Analyzers Configuration",
+  "description": "Configuration file for StyleCop Analyzers",
+  "type": "object",
+  "properties": {
+    "settings": {
+      "type": "object",
+      "description": "The top-level object containing configuration properties for built-in rules.",
+      "properties": {
+        "documentationRules": {
+          "type": "object",
+          "description": "Configuration for documentation rules (SA1600-)",
+          "properties": {
+            "companyName": {
+              "type": "string",
+              "description": "The name of the company which appears in file headers.",
+              "default": "PlaceholderCompany"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -394,6 +394,7 @@
       <Symbols>True</Symbols>
       <PackageAnalysis>False</PackageAnalysis>
     </NuGetManifest>
+    <None Include="Settings\stylecop.schema.json" />
     <None Include="tools\install.ps1" />
     <None Include="tools\uninstall.ps1" />
     <None Include="ReadMe.txt" />


### PR DESCRIPTION
This updates the default settings file (added in #1250) to include a JSON schema reference which allows us to document and reliably maintain the recognized structure of the settings file over time.