### PR TITLE
Make all diagnostic ids constants

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
@@ -24,56 +24,57 @@
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class FileHeaderAnalyzers : DiagnosticAnalyzer
     {
-        private static readonly string SA1633Identifier = "SA1633";
+        private const string SA1633Identifier = "SA1633";
+        private const string SA1634Identifier = "SA1634";
+        private const string SA1635Identifier = "SA1635";
+        private const string SA1636Identifier = "SA1636";
+        private const string SA1637Identifier = "SA1637";
+        private const string SA1638Identifier = "SA1638";
+        private const string SA1639Identifier = "SA1639";
+        private const string SA1640Identifier = "SA1640";
+        private const string SA1641Identifier = "SA1641";
+
         private static readonly LocalizableString SA1633Title = new LocalizableResourceString(nameof(DocumentationResources.SA1633Title), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1633MessageFormatMissing = new LocalizableResourceString(nameof(DocumentationResources.SA1633MessageFormatMissing), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1633MessageFormatMalformed = new LocalizableResourceString(nameof(DocumentationResources.SA1633MessageFormatMalformed), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1633Description = new LocalizableResourceString(nameof(DocumentationResources.SA1633Description), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly string SA1633HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md";
 
-        private static readonly string SA1634Identifier = "SA1634";
         private static readonly LocalizableString SA1634Title = new LocalizableResourceString(nameof(DocumentationResources.SA1634Title), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1634MessageFormat = new LocalizableResourceString(nameof(DocumentationResources.SA1634MessageFormat), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1634Description = new LocalizableResourceString(nameof(DocumentationResources.SA1634Description), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly string SA1634HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1634.md";
 
-        private static readonly string SA1635Identifier = "SA1635";
         private static readonly LocalizableString SA1635Title = new LocalizableResourceString(nameof(DocumentationResources.SA1635Title), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1635MessageFormat = new LocalizableResourceString(nameof(DocumentationResources.SA1635MessageFormat), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1635Description = new LocalizableResourceString(nameof(DocumentationResources.SA1635Description), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly string SA1635HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1635.md";
 
-        private static readonly string SA1636Identifier = "SA1636";
         private static readonly LocalizableString SA1636Title = new LocalizableResourceString(nameof(DocumentationResources.SA1636Title), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1636MessageFormat = new LocalizableResourceString(nameof(DocumentationResources.SA1636MessageFormat), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1636Description = new LocalizableResourceString(nameof(DocumentationResources.SA1636Description), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly string SA1636HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1636.md";
 
-        private static readonly string SA1637Identifier = "SA1637";
         private static readonly LocalizableString SA1637Title = new LocalizableResourceString(nameof(DocumentationResources.SA1637Title), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1637MessageFormat = new LocalizableResourceString(nameof(DocumentationResources.SA1637MessageFormat), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1637Description = new LocalizableResourceString(nameof(DocumentationResources.SA1637Description), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly string SA1637HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1637.md";
 
-        private static readonly string SA1638Identifier = "SA1638";
         private static readonly LocalizableString SA1638Title = new LocalizableResourceString(nameof(DocumentationResources.SA1638Title), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1638MessageFormat = new LocalizableResourceString(nameof(DocumentationResources.SA1638MessageFormat), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1638Description = new LocalizableResourceString(nameof(DocumentationResources.SA1638Description), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly string SA1638HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1638.md";
 
-        private static readonly string SA1639Identifier = "SA1639";
         private static readonly LocalizableString SA1639Title = new LocalizableResourceString(nameof(DocumentationResources.SA1639Title), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1639MessageFormat = new LocalizableResourceString(nameof(DocumentationResources.SA1639MessageFormat), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1639Description = new LocalizableResourceString(nameof(DocumentationResources.SA1639Description), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly string SA1639HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1639.md";
 
-        private static readonly string SA1640Identifier = "SA1640";
         private static readonly LocalizableString SA1640Title = new LocalizableResourceString(nameof(DocumentationResources.SA1640Title), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1640MessageFormat = new LocalizableResourceString(nameof(DocumentationResources.SA1640MessageFormat), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1640Description = new LocalizableResourceString(nameof(DocumentationResources.SA1640Description), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly string SA1640HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1640.md";
 
-        private static readonly string SA1641Identifier = "SA1641";
         private static readonly LocalizableString SA1641Title = new LocalizableResourceString(nameof(DocumentationResources.SA1641Title), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1641MessageFormat = new LocalizableResourceString(nameof(DocumentationResources.SA1641MessageFormat), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1641Description = new LocalizableResourceString(nameof(DocumentationResources.SA1641Description), DocumentationResources.ResourceManager, typeof(DocumentationResources));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA110xQueryClauses.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA110xQueryClauses.cs
@@ -19,25 +19,26 @@
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class SA110xQueryClauses : DiagnosticAnalyzer
     {
-        private static readonly string SA1102Identifier = "SA1102";
+        private const string SA1102Identifier = "SA1102";
+        private const string SA1103Identifier = "SA1103";
+        private const string SA1104Identifier = "SA1104";
+        private const string SA1105Identifier = "SA1105";
+
         private static readonly LocalizableString SA1102Title = new LocalizableResourceString(nameof(ReadabilityResources.SA1102Title), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
         private static readonly LocalizableString SA1102MessageFormat = new LocalizableResourceString(nameof(ReadabilityResources.SA1102MessageFormat), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
         private static readonly LocalizableString SA1102Description = new LocalizableResourceString(nameof(ReadabilityResources.SA1102Description), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
         private static readonly string SA1102HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1102.md";
 
-        private static readonly string SA1103Identifier = "SA1103";
         private static readonly LocalizableString SA1103Title = new LocalizableResourceString(nameof(ReadabilityResources.SA1103Title), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
         private static readonly LocalizableString SA1103MessageFormat = new LocalizableResourceString(nameof(ReadabilityResources.SA1103MessageFormat), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
         private static readonly LocalizableString SA1103Description = new LocalizableResourceString(nameof(ReadabilityResources.SA1103Description), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
         private static readonly string SA1103HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1103.md";
 
-        private static readonly string SA1104Identifier = "SA1104";
         private static readonly LocalizableString SA1104Title = new LocalizableResourceString(nameof(ReadabilityResources.SA1104Title), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
         private static readonly LocalizableString SA1104MessageFormat = new LocalizableResourceString(nameof(ReadabilityResources.SA1104MessageFormat), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
         private static readonly LocalizableString SA1104Description = new LocalizableResourceString(nameof(ReadabilityResources.SA1104Description), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
         private static readonly string SA1104HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1104.md";
 
-        private static readonly string SA1105Identifier = "SA1105";
         private static readonly LocalizableString SA1105Title = new LocalizableResourceString(nameof(ReadabilityResources.SA1105Title), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
         private static readonly LocalizableString SA1105MessageFormat = new LocalizableResourceString(nameof(ReadabilityResources.SA1105MessageFormat), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
         private static readonly LocalizableString SA1105Description = new LocalizableResourceString(nameof(ReadabilityResources.SA1105Description), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));


### PR DESCRIPTION
The status page has to figure out what descriptor syntax node matches which Descriptor object it has in memory. It tries to get the value of the id by using SemanticModels GetConstantValue method.
To make this work the variables used have to be constant. Without this change the status page shows "Unknown" for the status of the diagnostic