### PR TITLE
Propagate encodings in SA1412

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/TestDiagnosticProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/TestDiagnosticProvider.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -23,12 +24,12 @@
 
         public override Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
         {
-            return Task.FromResult<IEnumerable<Diagnostic>>(this.diagnostics);
+            return Task.FromResult(this.diagnostics.Where(i => i.Location.GetLineSpan().Path == document.Name));
         }
 
         public override Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken cancellationToken)
         {
-            return Task.FromResult<IEnumerable<Diagnostic>>(this.diagnostics);
+            return Task.FromResult(this.diagnostics.Where(i => !i.Location.IsInSource));
         }
 
         internal static TestDiagnosticProvider Create(ImmutableArray<Diagnostic> diagnostics)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1412UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1412UnitTests.cs
@@ -77,9 +77,11 @@
             var document = project.Documents.First();
 
             // Create a diagnostic for the document to fix
+            var properties = ImmutableDictionary<string, string>.Empty.SetItem(SA1412StoreFilesAsUtf8.EncodingProperty, this.fileEncoding.WebName);
             var diagnostic = Diagnostic.Create(
                 this.GetCSharpDiagnosticAnalyzers().First().SupportedDiagnostics.First(),
-                Location.Create(await document.GetSyntaxTreeAsync().ConfigureAwait(false), TextSpan.FromBounds(0, 0)));
+                Location.Create(await document.GetSyntaxTreeAsync().ConfigureAwait(false), TextSpan.FromBounds(0, 0)),
+                properties);
 
             await codeFixer.RegisterCodeFixesAsync(new CodeFixContext(document, diagnostic, (ca, d) =>
             {
@@ -161,9 +163,11 @@
             foreach (var document in project.Documents)
             {
                 // Create a diagnostic for the document to fix
+                var properties = ImmutableDictionary<string, string>.Empty.SetItem(SA1412StoreFilesAsUtf8.EncodingProperty, (await document.GetTextAsync().ConfigureAwait(false)).Encoding.WebName);
                 var diagnostic = Diagnostic.Create(
                     descriptor,
-                    Location.Create(await document.GetSyntaxTreeAsync().ConfigureAwait(false), TextSpan.FromBounds(0, 0)));
+                    Location.Create(await document.GetSyntaxTreeAsync().ConfigureAwait(false), TextSpan.FromBounds(0, 0)),
+                    properties);
                 diagnostics.Add(diagnostic);
             }
 
@@ -225,9 +229,11 @@
             foreach (var document in project.Documents)
             {
                 // Create a diagnostic for the document to fix
+                var properties = ImmutableDictionary<string, string>.Empty.SetItem(SA1412StoreFilesAsUtf8.EncodingProperty, (await document.GetTextAsync().ConfigureAwait(false)).Encoding.WebName);
                 var diagnostic = Diagnostic.Create(
                     descriptor,
-                    Location.Create(await document.GetSyntaxTreeAsync().ConfigureAwait(false), TextSpan.FromBounds(0, 0)));
+                    Location.Create(await document.GetSyntaxTreeAsync().ConfigureAwait(false), TextSpan.FromBounds(0, 0)),
+                    properties);
                 diagnostics.Add(diagnostic);
             }
 
@@ -246,7 +252,7 @@
             operation.Apply(workspace, CancellationToken.None);
 
             // project should now have the "fixed document" in it.
-            // Because of limitations in roslyn the fixed document should
+            // Because of limitations in Roslyn the fixed document should
             // have a different DocumentId then the broken document
             project = workspace.CurrentSolution.Projects.First();
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1412StoreFilesAsUtf8.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1412StoreFilesAsUtf8.cs
@@ -37,6 +37,14 @@
 
         private static byte[] utf8Preamble = Encoding.UTF8.GetPreamble();
 
+        /// <summary>
+        /// Gets the key for the detected encoding name in the <see cref="Diagnostic.Properties"/> collection.
+        /// </summary>
+        /// <value>
+        /// The key for the detected encoding name in the <see cref="Diagnostic.Properties"/> collection.
+        /// </value>
+        public static string EncodingProperty { get; } = "Encoding";
+
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
         {
@@ -58,7 +66,8 @@
 
             if (!IsUtf8Preamble(preamble))
             {
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.Create(context.Tree, TextSpan.FromBounds(0, 0))));
+                ImmutableDictionary<string, string> properties = ImmutableDictionary<string, string>.Empty.SetItem(EncodingProperty, context.Tree.Encoding?.WebName ?? "<null>");
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.Create(context.Tree, TextSpan.FromBounds(0, 0)), properties));
             }
         }
 


### PR DESCRIPTION
In SA1412 (StoreFilesAsUtf8), file encodings are detected as part of the diagnostic. This change updates the reported diagnostics to propagate the name of the detected encoding so it doesn't have to be reevaluated as part of the code fix.

This change is not a perfect fix for #1169, but it improves upon the situation slightly. In order to fix all closed files, you can open a closed file which reported SA1412 and use the Fix All action before the IDE has the chance to recalculate diagnostics for the file. The encoding used for the code fix will be the one used by the analyzer while the file was closed, which will result in fixing all *other* closed files.