### PR TITLE
Fix SA1121 SyntaxToken.Text usage should have been SyntaxToken.ValueText

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1121UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1121UnitTests.cs
@@ -140,6 +140,31 @@ public class Foo
 
         [Theory]
         [MemberData(nameof(AllTypes))]
+        public async Task TestEscapedVariableDeclarationAsync(string predefined, string fullName)
+        {
+            if (fullName.IndexOf('.') >= 0)
+            {
+                return;
+            }
+
+            string testSource = @"namespace NotSystem {{
+public class ClassName
+{{
+    public void Bar()
+    {{
+        @{0} test;
+    }}
+
+    public struct @{0} {{ }}
+}}
+}}";
+
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testSource, predefined), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testSource, fullName), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(AllTypes))]
         public async Task TestVariableDeclarationCodeFixAsync(string predefined, string fullName)
         {
             string testSource = @"namespace System {{

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121UseBuiltInTypeAlias.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121UseBuiltInTypeAlias.cs
@@ -160,7 +160,7 @@
                 return;
             }
 
-            switch (identifierNameSyntax.Identifier.Text)
+            switch (identifierNameSyntax.Identifier.ValueText)
             {
             case "bool":
             case "byte":
@@ -193,7 +193,7 @@
             // if the identifier name doesn't match the name of a special type
             if (!identifierNameSyntax.SyntaxTree.ContainsUsingAlias())
             {
-                switch (identifierNameSyntax.Identifier.Text)
+                switch (identifierNameSyntax.Identifier.ValueText)
                 {
                 case nameof(Boolean):
                 case nameof(Byte):


### PR DESCRIPTION
I found this :bug: in code coverage reports, not in a user feedback (thankfully; no one should have code like this).