### PR TITLE
Variable and parameter naming analyzers and fixes

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1306UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1306UnitTests.cs
@@ -44,6 +44,31 @@ string Bar = """", car = """", Dar = """";
             await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, modifiers), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// This test ensures the implementation of <see cref="SA1306FieldNamesMustBeginWithLowerCaseLetter"/> is
+        /// correct with respect to the documented behavior for parameters and local variables (including local
+        /// constants).
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestThatDiagnosticIsNotReportedForParametersAndLocalsAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName(string Parameter1, string parameter2)
+    {
+        const int Constant = 1;
+        const int constant = 1;
+        int Variable;
+        int variable;
+        int Variable1, Variable2;
+        int variable1, variable2;
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
         [Theory]
         [InlineData("")]
         [InlineData("readonly")]
@@ -82,6 +107,7 @@ string car;
 string dar;
 }}";
 
+            await this.VerifyCSharpDiagnosticAsync(string.Format(fixedCode, modifiers), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(string.Format(testCode, modifiers), string.Format(fixedCode, modifiers)).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1306UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1306UnitTests.cs
@@ -159,7 +159,7 @@ string bar, car, dar;
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
-            return new SA1306CodeFixProvider();
+            return new RenameToLowerCaseCodeFixProvider();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1312UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1312UnitTests.cs
@@ -1,0 +1,235 @@
+﻿namespace StyleCop.Analyzers.Test.NamingRules
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.NamingRules;
+    using TestHelper;
+    using Xunit;
+
+    public class SA1312UnitTests : CodeFixVerifier
+    {
+        [Fact]
+        public async Task TestThatDiagnosticIsNotReportedForConstVariableAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        const string Bar = """", car = """", Dar = """";
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestThatDiagnosticIsReported_SingleVariableAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        string Bar;
+        string car;
+        string Par;
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithArguments("Bar").WithLocation(5, 16),
+                this.CSharpDiagnostic().WithArguments("Par").WithLocation(7, 16)
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        string bar;
+        string car;
+        string par;
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestThatDiagnosticIsReported_MultipleVariablesAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        string Bar, car, Par;
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithArguments("Bar").WithLocation(5, 16),
+                this.CSharpDiagnostic().WithArguments("Par").WithLocation(5, 26)
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        string bar, car, par;
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestVariableStartingWithAnUnderscoreAsync()
+        {
+            // Makes sure SA1312 is reported for variables starting with an underscore
+            var testCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        string _bar = ""baz"";
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("_bar").WithLocation(5, 16);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            // Verify the code fix doesn't do anything in this case
+            await this.VerifyCSharpFixAsync(testCode, testCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestVariableStartingWithLetterAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        string bar = ""baz"";
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestVariablePlacedInsideNativeMethodsClassAsync()
+        {
+            var testCode = @"public class FooNativeMethods
+{
+    public void MethodName()
+    {
+        string Bar = ""baz"";
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1315")]
+        public async Task TestRenameConflictsWithVariableAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        string variable = ""Text"";
+        string Variable = variable.ToString();
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("Variable").WithLocation(5, 16);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        string variable = ""Text"";
+        string variableValue = variable.ToString();
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestRenameConflictsWithKeywordAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        string Int;
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("Int").WithLocation(5, 16);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        string @int;
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1315")]
+        public async Task TestRenameConflictsWithParameterAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName(int parameter)
+    {
+        string Parameter = parameter.ToString();
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("Parameter").WithLocation(5, 16);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"public class TypeName
+{
+    public void MethodName(int parameter)
+    {
+        string parameterValue = parameter.ToString();
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new SA1312VariableNamesMustBeginWithLowerCaseLetter();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new RenameToLowerCaseCodeFixProvider();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
@@ -1,0 +1,225 @@
+﻿namespace StyleCop.Analyzers.Test.NamingRules
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.NamingRules;
+    using TestHelper;
+    using Xunit;
+
+    public class SA1313UnitTests : CodeFixVerifier
+    {
+        [Fact]
+        public async Task TestThatDiagnosticIsReported_SingleParameterAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName(string Bar)
+    {
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("Bar").WithLocation(3, 35);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"public class TypeName
+{
+    public void MethodName(string bar)
+    {
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestThatDiagnosticIsReported_MultipleParametersAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName(string Bar, string car, string Par)
+    {
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithArguments("Bar").WithLocation(3, 35),
+                this.CSharpDiagnostic().WithArguments("Par").WithLocation(3, 59)
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"public class TypeName
+{
+    public void MethodName(string bar, string car, string par)
+    {
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestParameterStartingWithAnUnderscoreAsync()
+        {
+            // Makes sure SA1313 is reported for parameters starting with an underscore
+            var testCode = @"public class TypeName
+{
+    public void MethodName(string _bar)
+    {
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("_bar").WithLocation(3, 35);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            // Verify the code fix doesn't do anything in this case
+            await this.VerifyCSharpFixAsync(testCode, testCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestParameterStartingWithLetterAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName(string bar)
+    {
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestParameterPlacedInsideNativeMethodsClassAsync()
+        {
+            var testCode = @"public class FooNativeMethods
+{
+    public void MethodName(string Bar)
+    {
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1315")]
+        public async Task TestRenameConflictsWithVariableAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName(string Parameter)
+    {
+        string parameter = ""Text"";
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("Parameter").WithLocation(3, 35);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"public class TypeName
+{
+    public void MethodName(string parameterValue)
+    {
+        string parameter = ""Text"";
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestRenameConflictsWithKeywordAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName(string Int)
+    {
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("Int").WithLocation(3, 35);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"public class TypeName
+{
+    public void MethodName(string @int)
+    {
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1315")]
+        public async Task TestRenameConflictsWithLaterParameterAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName(string Parameter, int parameter)
+    {
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("Parameter").WithLocation(3, 35);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"public class TypeName
+{
+    public void MethodName(string parameterValue, int parameter)
+    {
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact(Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1315")]
+        public async Task TestRenameConflictsWithEarlierParameterAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName(string parameter, int Parameter)
+    {
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("Parameter").WithLocation(3, 50);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"public class TypeName
+{
+    public void MethodName(string parameter, int parameterValue)
+    {
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
+        {
+            yield return new SA1313ParameterNamesMustBeginWithLowerCaseLetter();
+        }
+
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new RenameToLowerCaseCodeFixProvider();
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -258,6 +258,7 @@
     <Compile Include="NamingRules\SA1310UnitTests.cs" />
     <Compile Include="NamingRules\SA1311UnitTests.cs" />
     <Compile Include="NamingRules\SA1312UnitTests.cs" />
+    <Compile Include="NamingRules\SA1313UnitTests.cs" />
     <Compile Include="NamingRules\SX1309SUnitTests.cs" />
     <Compile Include="NamingRules\SX1309UnitTests.cs" />
     <Compile Include="OrderingRules\SA1200UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -257,6 +257,7 @@
     <Compile Include="NamingRules\SA1309UnitTests.cs" />
     <Compile Include="NamingRules\SA1310UnitTests.cs" />
     <Compile Include="NamingRules\SA1311UnitTests.cs" />
+    <Compile Include="NamingRules\SA1312UnitTests.cs" />
     <Compile Include="NamingRules\SX1309SUnitTests.cs" />
     <Compile Include="NamingRules\SX1309UnitTests.cs" />
     <Compile Include="OrderingRules\SA1200UnitTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/NamingResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/NamingResources.Designer.cs
@@ -69,5 +69,32 @@ namespace StyleCop.Analyzers.NamingRules {
                 return ResourceManager.GetString("RenameToCodeFix", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The name of a variable in C# does not begin with a lower-case letter..
+        /// </summary>
+        internal static string SA1312Description {
+            get {
+                return ResourceManager.GetString("SA1312Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Variable &apos;{0}&apos; must begin with lower-case letter.
+        /// </summary>
+        internal static string SA1312MessageFormat {
+            get {
+                return ResourceManager.GetString("SA1312MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Variable names must begin with lower-case letter.
+        /// </summary>
+        internal static string SA1312Title {
+            get {
+                return ResourceManager.GetString("SA1312Title", resourceCulture);
+            }
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/NamingResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/NamingResources.Designer.cs
@@ -96,5 +96,32 @@ namespace StyleCop.Analyzers.NamingRules {
                 return ResourceManager.GetString("SA1312Title", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The name of a parameter in C# does not begin with a lower-case letter..
+        /// </summary>
+        internal static string SA1313Description {
+            get {
+                return ResourceManager.GetString("SA1313Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameter &apos;{0}&apos; must begin with lower-case letter.
+        /// </summary>
+        internal static string SA1313MessageFormat {
+            get {
+                return ResourceManager.GetString("SA1313MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Parameter names must begin with lower-case letter.
+        /// </summary>
+        internal static string SA1313Title {
+            get {
+                return ResourceManager.GetString("SA1313Title", resourceCulture);
+            }
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/NamingResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/NamingResources.resx
@@ -120,4 +120,13 @@
   <data name="RenameToCodeFix" xml:space="preserve">
     <value>Rename To '{0}'</value>
   </data>
+  <data name="SA1312Description" xml:space="preserve">
+    <value>The name of a variable in C# does not begin with a lower-case letter.</value>
+  </data>
+  <data name="SA1312MessageFormat" xml:space="preserve">
+    <value>Variable '{0}' must begin with lower-case letter</value>
+  </data>
+  <data name="SA1312Title" xml:space="preserve">
+    <value>Variable names must begin with lower-case letter</value>
+  </data>
 </root>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/NamingResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/NamingResources.resx
@@ -129,4 +129,13 @@
   <data name="SA1312Title" xml:space="preserve">
     <value>Variable names must begin with lower-case letter</value>
   </data>
+  <data name="SA1313Description" xml:space="preserve">
+    <value>The name of a parameter in C# does not begin with a lower-case letter.</value>
+  </data>
+  <data name="SA1313MessageFormat" xml:space="preserve">
+    <value>Parameter '{0}' must begin with lower-case letter</value>
+  </data>
+  <data name="SA1313Title" xml:space="preserve">
+    <value>Parameter names must begin with lower-case letter</value>
+  </data>
 </root>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToLowerCaseCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToLowerCaseCodeFixProvider.cs
@@ -9,18 +9,20 @@
     using Microsoft.CodeAnalysis.CodeFixes;
 
     /// <summary>
-    /// Implements a code fix for <see cref="SA1306FieldNamesMustBeginWithLowerCaseLetter"/>.
+    /// Implements a code fix for diagnostics which are fixed by renaming a symbol to start with a lower case letter.
     /// </summary>
     /// <remarks>
     /// <para>To fix a violation of this rule, change the name of the field or variable so that it begins with a
     /// lower-case letter, or place the item within a <c>NativeMethods</c> class if appropriate.</para>
     /// </remarks>
-    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SA1306CodeFixProvider))]
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RenameToLowerCaseCodeFixProvider))]
     [Shared]
-    public class SA1306CodeFixProvider : CodeFixProvider
+    public class RenameToLowerCaseCodeFixProvider : CodeFixProvider
     {
         private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1306FieldNamesMustBeginWithLowerCaseLetter.DiagnosticId);
+            ImmutableArray.Create(
+                SA1306FieldNamesMustBeginWithLowerCaseLetter.DiagnosticId,
+                SA1312VariableNamesMustBeginWithLowerCaseLetter.DiagnosticId);
 
         /// <inheritdoc/>
         public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
@@ -39,7 +41,7 @@
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1306FieldNamesMustBeginWithLowerCaseLetter.DiagnosticId))
+                if (!this.FixableDiagnosticIds.Contains(diagnostic.Id))
                 {
                     continue;
                 }
@@ -53,7 +55,7 @@
                 if (!string.IsNullOrEmpty(token.ValueText))
                 {
                     var newName = char.ToLower(token.ValueText[0]) + token.ValueText.Substring(1);
-                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.RenameToCodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken), equivalenceKey: nameof(SA1306CodeFixProvider)), diagnostic);
+                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.RenameToCodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken), equivalenceKey: nameof(RenameToLowerCaseCodeFixProvider)), diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToLowerCaseCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToLowerCaseCodeFixProvider.cs
@@ -22,7 +22,8 @@
         private static readonly ImmutableArray<string> FixableDiagnostics =
             ImmutableArray.Create(
                 SA1306FieldNamesMustBeginWithLowerCaseLetter.DiagnosticId,
-                SA1312VariableNamesMustBeginWithLowerCaseLetter.DiagnosticId);
+                SA1312VariableNamesMustBeginWithLowerCaseLetter.DiagnosticId,
+                SA1313ParameterNamesMustBeginWithLowerCaseLetter.DiagnosticId);
 
         /// <inheritdoc/>
         public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1306FieldNamesMustBeginWithLowerCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1306FieldNamesMustBeginWithLowerCaseLetter.cs
@@ -8,19 +8,19 @@
     using Microsoft.CodeAnalysis.Diagnostics;
 
     /// <summary>
-    /// The name of a field or variable in C# does not begin with a lower-case letter.
+    /// The name of a field in C# does not begin with a lower-case letter.
     /// </summary>
     /// <remarks>
-    /// <para>A violation of this rule occurs when the name of a field or variable begins with an upper-case letter.
-    /// Constants, non-private readonly fields and static readonly must always start with an uppercase letter, whilst
+    /// <para>A violation of this rule occurs when the name of a field begins with an upper-case letter. Constants,
+    /// non-private readonly fields and static readonly fields must always start with an uppercase letter, whilst
     /// private readonly fields must start with a lowercase letter. Also, public or internal fields must always start
     /// with an uppercase letter.</para>
     ///
-    /// <para>If the field or variable name is intended to match the name of an item associated with Win32 or COM, and
-    /// thus needs to begin with an upper-case letter, place the field or variable within a special <c>NativeMethods</c>
-    /// class. A <c>NativeMethods</c> class is any class which contains a name ending in <c>NativeMethods</c>, and is
-    /// intended as a placeholder for Win32 or COM wrappers. StyleCop will ignore this violation if the item is placed
-    /// within a <c>NativeMethods</c> class.</para>
+    /// <para>If the field name is intended to match the name of an item associated with Win32 or COM, and thus needs to
+    /// begin with an upper-case letter, place the field within a special <c>NativeMethods</c> class. A
+    /// <c>NativeMethods</c> class is any class which contains a name ending in <c>NativeMethods</c>, and is intended as
+    /// a placeholder for Win32 or COM wrappers. StyleCop will ignore this violation if the item is placed within a
+    /// <c>NativeMethods</c> class.</para>
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class SA1306FieldNamesMustBeginWithLowerCaseLetter : DiagnosticAnalyzer
@@ -31,7 +31,7 @@
         public const string DiagnosticId = "SA1306";
         private const string Title = "Field names must begin with lower-case letter";
         private const string MessageFormat = "Field '{0}' must begin with lower-case letter";
-        private const string Description = "The name of a field or variable in C# does not begin with a lower-case letter.";
+        private const string Description = "The name of a field in C# does not begin with a lower-case letter.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1306.md";
 
         private static readonly DiagnosticDescriptor Descriptor =

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1312VariableNamesMustBeginWithLowerCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1312VariableNamesMustBeginWithLowerCaseLetter.cs
@@ -1,0 +1,94 @@
+﻿namespace StyleCop.Analyzers.NamingRules
+{
+    using System.Collections.Immutable;
+    using Helpers;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    /// <summary>
+    /// The name of a variable in C# does not begin with a lower-case letter.
+    /// </summary>
+    /// <remarks>
+    /// <para>A violation of this rule occurs when the name of a variable does not begin with a lower-case letter.</para>
+    ///
+    /// <para>If the variable name is intended to match the name of an item associated with Win32 or COM, and thus needs
+    /// to begin with an upper-case letter, place the variable within a special <c>NativeMethods</c> class. A
+    /// <c>NativeMethods</c> class is any class which contains a name ending in <c>NativeMethods</c>, and is intended as
+    /// a placeholder for Win32 or COM wrappers. StyleCop will ignore this violation if the item is placed within a
+    /// <c>NativeMethods</c> class.</para>
+    /// </remarks>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class SA1312VariableNamesMustBeginWithLowerCaseLetter : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// The ID for diagnostics produced by the <see cref="SA1312VariableNamesMustBeginWithLowerCaseLetter"/> analyzer.
+        /// </summary>
+        public const string DiagnosticId = "SA1312";
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(NamingResources.SA1312Title), NamingResources.ResourceManager, typeof(NamingResources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(NamingResources.SA1312MessageFormat), NamingResources.ResourceManager, typeof(NamingResources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(NamingResources.SA1312Description), NamingResources.ResourceManager, typeof(NamingResources));
+        private static readonly string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1312.md";
+
+        private static readonly DiagnosticDescriptor Descriptor =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.NamingRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+
+        private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
+            ImmutableArray.Create(Descriptor);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        {
+            get
+            {
+                return SupportedDiagnosticsValue;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeActionHonorExclusions(HandleVariableDeclarationSyntax, SyntaxKind.VariableDeclaration);
+        }
+
+        private static void HandleVariableDeclarationSyntax(SyntaxNodeAnalysisContext context)
+        {
+            VariableDeclarationSyntax syntax = (VariableDeclarationSyntax)context.Node;
+            if (NamedTypeHelpers.IsContainedInNativeMethodsClass(syntax))
+            {
+                return;
+            }
+
+            LocalDeclarationStatementSyntax parentDeclaration = syntax.Parent as LocalDeclarationStatementSyntax;
+            if (parentDeclaration?.IsConst ?? false)
+            {
+                // this diagnostic does not apply to locals constants
+                return;
+            }
+
+            foreach (VariableDeclaratorSyntax variableDeclarator in syntax.Variables)
+            {
+                if (variableDeclarator == null)
+                {
+                    continue;
+                }
+
+                var identifier = variableDeclarator.Identifier;
+                if (identifier.IsMissing)
+                {
+                    continue;
+                }
+
+                string name = identifier.ValueText;
+                if (string.IsNullOrEmpty(name) || char.IsLower(name[0]))
+                {
+                    continue;
+                }
+
+                // Variable names must begin with lower-case letter
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, identifier.GetLocation(), name));
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1313ParameterNamesMustBeginWithLowerCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1313ParameterNamesMustBeginWithLowerCaseLetter.cs
@@ -1,0 +1,79 @@
+﻿namespace StyleCop.Analyzers.NamingRules
+{
+    using System.Collections.Immutable;
+    using Helpers;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+
+    /// <summary>
+    /// The name of a parameter in C# does not begin with a lower-case letter.
+    /// </summary>
+    /// <remarks>
+    /// <para>A violation of this rule occurs when the name of a parameter does not begin with a lower-case letter.</para>
+    ///
+    /// <para>If the parameter name is intended to match the name of an item associated with Win32 or COM, and thus
+    /// needs to begin with an upper-case letter, place the parameter within a special <c>NativeMethods</c> class. A
+    /// <c>NativeMethods</c> class is any class which contains a name ending in <c>NativeMethods</c>, and is intended as
+    /// a placeholder for Win32 or COM wrappers. StyleCop will ignore this violation if the item is placed within a
+    /// <c>NativeMethods</c> class.</para>
+    /// </remarks>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class SA1313ParameterNamesMustBeginWithLowerCaseLetter : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// The ID for diagnostics produced by the <see cref="SA1313ParameterNamesMustBeginWithLowerCaseLetter"/> analyzer.
+        /// </summary>
+        public const string DiagnosticId = "SA1313";
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(NamingResources.SA1313Title), NamingResources.ResourceManager, typeof(NamingResources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(NamingResources.SA1313MessageFormat), NamingResources.ResourceManager, typeof(NamingResources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(NamingResources.SA1313Description), NamingResources.ResourceManager, typeof(NamingResources));
+        private static readonly string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1313.md";
+
+        private static readonly DiagnosticDescriptor Descriptor =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.NamingRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+
+        private static readonly ImmutableArray<DiagnosticDescriptor> SupportedDiagnosticsValue =
+            ImmutableArray.Create(Descriptor);
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+        {
+            get
+            {
+                return SupportedDiagnosticsValue;
+            }
+        }
+
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+        {
+            context.RegisterSyntaxNodeActionHonorExclusions(HandleParameterSyntax, SyntaxKind.Parameter);
+        }
+
+        private static void HandleParameterSyntax(SyntaxNodeAnalysisContext context)
+        {
+            ParameterSyntax syntax = (ParameterSyntax)context.Node;
+            if (NamedTypeHelpers.IsContainedInNativeMethodsClass(syntax))
+            {
+                return;
+            }
+
+            var identifier = syntax.Identifier;
+            if (identifier.IsMissing)
+            {
+                return;
+            }
+
+            string name = identifier.ValueText;
+            if (string.IsNullOrEmpty(name) || char.IsLower(name[0]))
+            {
+                return;
+            }
+
+            // Parameter names must begin with lower-case letter
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, identifier.GetLocation(), name));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -216,6 +216,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>NamingResources.resx</DependentUpon>
     </Compile>
+    <Compile Include="NamingRules\RenameToLowerCaseCodeFixProvider.cs" />
     <Compile Include="NamingRules\RenameToUpperCaseCodeFixProvider.cs" />
     <Compile Include="NamingRules\SA1300ElementMustBeginWithUpperCaseLetter.cs" />
     <Compile Include="NamingRules\SA1301ElementMustBeginWithLowerCaseLetter.cs" />
@@ -224,7 +225,6 @@
     <Compile Include="NamingRules\SA1303ConstFieldNamesMustBeginWithUpperCaseLetter.cs" />
     <Compile Include="NamingRules\SA1304NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter.cs" />
     <Compile Include="NamingRules\SA1305FieldNamesMustNotUseHungarianNotation.cs" />
-    <Compile Include="NamingRules\SA1306CodeFixProvider.cs" />
     <Compile Include="NamingRules\SA1306FieldNamesMustBeginWithLowerCaseLetter.cs" />
     <Compile Include="NamingRules\SA1307AccessibleFieldsMustBeginWithUpperCaseLetter.cs" />
     <Compile Include="NamingRules\SA1308CodeFixProvider.cs" />
@@ -234,6 +234,7 @@
     <Compile Include="NamingRules\SA1310CodeFixProvider.cs" />
     <Compile Include="NamingRules\SA1310FieldNamesMustNotContainUnderscore.cs" />
     <Compile Include="NamingRules\SA1311StaticReadonlyFieldsMustBeginWithUpperCaseLetter.cs" />
+    <Compile Include="NamingRules\SA1312VariableNamesMustBeginWithLowerCaseLetter.cs" />
     <Compile Include="NamingRules\SX1309CodeFixProvider.cs" />
     <Compile Include="NamingRules\SX1309FieldNamesMustBeginWithUnderscore.cs" />
     <Compile Include="NamingRules\SX1309SStaticFieldNamesMustBeginWithUnderscore.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -235,6 +235,7 @@
     <Compile Include="NamingRules\SA1310FieldNamesMustNotContainUnderscore.cs" />
     <Compile Include="NamingRules\SA1311StaticReadonlyFieldsMustBeginWithUpperCaseLetter.cs" />
     <Compile Include="NamingRules\SA1312VariableNamesMustBeginWithLowerCaseLetter.cs" />
+    <Compile Include="NamingRules\SA1313ParameterNamesMustBeginWithLowerCaseLetter.cs" />
     <Compile Include="NamingRules\SX1309CodeFixProvider.cs" />
     <Compile Include="NamingRules\SX1309FieldNamesMustBeginWithUnderscore.cs" />
     <Compile Include="NamingRules\SX1309SStaticFieldNamesMustBeginWithUnderscore.cs" />

--- a/StyleCopAnalyzers.sln
+++ b/StyleCopAnalyzers.sln
@@ -119,6 +119,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentat
 		documentation\SA1309.md = documentation\SA1309.md
 		documentation\SA1310.md = documentation\SA1310.md
 		documentation\SA1311.md = documentation\SA1311.md
+		documentation\SA1312.md = documentation\SA1312.md
 		documentation\SA1400.md = documentation\SA1400.md
 		documentation\SA1401.md = documentation\SA1401.md
 		documentation\SA1402.md = documentation\SA1402.md

--- a/StyleCopAnalyzers.sln
+++ b/StyleCopAnalyzers.sln
@@ -120,6 +120,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentat
 		documentation\SA1310.md = documentation\SA1310.md
 		documentation\SA1311.md = documentation\SA1311.md
 		documentation\SA1312.md = documentation\SA1312.md
+		documentation\SA1313.md = documentation\SA1313.md
 		documentation\SA1400.md = documentation\SA1400.md
 		documentation\SA1401.md = documentation\SA1401.md
 		documentation\SA1402.md = documentation\SA1402.md

--- a/documentation/SA1306.md
+++ b/documentation/SA1306.md
@@ -17,19 +17,28 @@
 
 ## Cause
 
-The name of a field or variable in C# does not begin with a lower-case letter.
+The name of a field in C# does not begin with a lower-case letter.
 
 ## Rule description
 
-A violation of this rule occurs when the name of a field or variable begins with 
-                    an upper-case letter. Constants, non-private readonly fields and static readonly must always start with an uppercase letter, whilst 
-                    private readonly fields must start with a lowercase letter. Also, public or internal fields must always start with an uppercase letter.
+A violation of this rule occurs when the name of a field begins with an upper-case letter. Constants, non-private
+readonly fields and static readonly fields must always start with an uppercase letter, whilst private readonly fields
+must start with a lowercase letter. Also, public or internal fields must always start with an uppercase letter.
 
-If the field or variable name is intended to match the name of an item associated with Win32 or COM, and thus needs to begin with an upper-case letter, place the field or variable within a special *NativeMethods* class. A NativeMethods class is any class which contains a name ending in NativeMethods, and is intended as a placeholder for Win32 or COM wrappers. StyleCop will ignore this violation if the item is placed within a NativeMethods class.
+If the field name is intended to match the name of an item associated with Win32 or COM, and thus needs to begin with an
+upper-case letter, place the field within a special `NativeMethods` class. A `NativeMethods` class is any class which
+contains a name ending in `NativeMethods`, and is intended as a placeholder for Win32 or COM wrappers. StyleCop will
+ignore this violation if the item is placed within a `NativeMethods` class.
+
+> :warning: This rule deviates from the corresponding rule in StyleCop "classic" in the following way:
+>
+> This rule only checks the names of fields. SA1306 in StyleCop "classic" checks fields, parameters, and local
+> variables.
 
 ## How to fix violations
 
-To fix a violation of this rule, change the name of the field or variable so that it begins with a lower-case letter, or place the item within a NativeMethods class if appropriate.
+To fix a violation of this rule, change the name of the field so that it begins with a lower-case letter, or place the
+item within a `NativeMethods` class if appropriate.
 
 ## How to suppress violations
 
@@ -39,5 +48,6 @@ To fix a violation of this rule, change the name of the field or variable so tha
 
 ```csharp
 #pragma warning disable SA1306 // FieldNamesMustBeginWithLowerCaseLetter
+private int Field = 3;
 #pragma warning restore SA1306 // FieldNamesMustBeginWithLowerCaseLetter
 ```

--- a/documentation/SA1312.md
+++ b/documentation/SA1312.md
@@ -1,0 +1,42 @@
+﻿## SA1312
+
+<table>
+<tr>
+  <td>TypeName</td>
+  <td>SA1312VariableNamesMustBeginWithLowerCaseLetter</td>
+</tr>
+<tr>
+  <td>CheckId</td>
+  <td>SA1312</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Naming Rules</td>
+</tr>
+</table>
+
+## Cause
+
+The name of a variable in C# does not begin with a lower-case letter.
+
+## Rule description
+
+A violation of this rule occurs when the name of a variable does not begin with a lower-case letter.
+
+If the variable name is intended to match the name of an item associated with Win32 or COM, and thus needs to begin with
+an upper-case letter, place the variable within a special `NativeMethods` class. A `NativeMethods` class is any class
+which contains a name ending in `NativeMethods`, and is intended as a placeholder for Win32 or COM wrappers. StyleCop
+will ignore this violation if the item is placed within a `NativeMethods` class.
+
+## How to fix violations
+
+To fix a violation of this rule, change the name of the variable so that it begins with a lower-case letter, or place
+the item within a `NativeMethods` class if appropriate.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable SA1312 // VariableNamesMustBeginWithLowerCaseLetter
+int Variable = 3;
+#pragma warning restore SA1312 // VariableNamesMustBeginWithLowerCaseLetter
+```

--- a/documentation/SA1313.md
+++ b/documentation/SA1313.md
@@ -1,0 +1,44 @@
+## SA1313
+
+<table>
+<tr>
+  <td>TypeName</td>
+  <td>SA1313ParameterNamesMustBeginWithLowerCaseLetter</td>
+</tr>
+<tr>
+  <td>CheckId</td>
+  <td>SA1313</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Naming Rules</td>
+</tr>
+</table>
+
+## Cause
+
+The name of a parameter in C# does not begin with a lower-case letter.
+
+## Rule description
+
+A violation of this rule occurs when the name of a parameter does not begin with a lower-case letter.
+
+If the parameter name is intended to match the name of an item associated with Win32 or COM, and thus needs to begin
+with an upper-case letter, place the parameter within a special `NativeMethods` class. A `NativeMethods` class is any
+class which contains a name ending in `NativeMethods`, and is intended as a placeholder for Win32 or COM wrappers.
+StyleCop will ignore this violation if the item is placed within a `NativeMethods` class.
+
+## How to fix violations
+
+To fix a violation of this rule, change the name of the parameter so that it begins with a lower-case letter, or place
+the item within a `NativeMethods` class if appropriate.
+
+## How to suppress violations
+
+```csharp
+#pragma warning disable SA1312 // ParameterNamesMustBeginWithLowerCaseLetter
+void Method(int Parameter)
+#pragma warning restore SA1312 // ParameterNamesMustBeginWithLowerCaseLetter
+{
+}
+```


### PR DESCRIPTION
This pull request adds two new rules:

* SA1312 (VariableNamesMustBeginWithLowerCaseLetter) (fixes #1310)
* SA1313 (ParameterNamesMustBeginWithLowerCaseLetter) (fixes #1311)

It also updates the documentation for SA1306 (FieldNamesMustBeginWithLowerCaseLetter) to explicitly state the deviation from StyleCop "classic".