### PR TITLE
Implement code fix testing in StyleCopTester

### DIFF
--- a/StyleCop.Analyzers/StyleCopTester/CodeFixEquivalenceGroup.cs
+++ b/StyleCop.Analyzers/StyleCopTester/CodeFixEquivalenceGroup.cs
@@ -1,0 +1,89 @@
+﻿namespace StyleCopTester
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+
+    internal class CodeFixEquivalenceGroup
+    {
+        private CodeFixEquivalenceGroup(
+            string equivalenceKey,
+            Solution solution,
+            FixAllProvider fixAllProvider,
+            CodeFixProvider codeFixProvider,
+            ImmutableArray<Diagnostic> diagnosticsToFix)
+        {
+            this.CodeFixEquivalenceKey = equivalenceKey;
+            this.Solution = solution;
+            this.FixAllProvider = fixAllProvider;
+            this.CodeFixProvider = codeFixProvider;
+            this.DiagnosticsToFix = diagnosticsToFix;
+        }
+
+        internal string CodeFixEquivalenceKey { get; }
+
+        internal Solution Solution { get; }
+
+        internal FixAllProvider FixAllProvider { get; }
+
+        internal CodeFixProvider CodeFixProvider { get; }
+
+        internal ImmutableArray<Diagnostic> DiagnosticsToFix { get; }
+
+        internal async Task<ImmutableArray<CodeActionOperation>> GetOperationsAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Diagnostic diagnostic = this.DiagnosticsToFix.First();
+            Document document = this.Solution.GetDocument(diagnostic.Location.SourceTree);
+
+            var diagnosticsProvider = TesterDiagnosticProvider.Create(this.DiagnosticsToFix);
+
+            var context = new FixAllContext(document, this.CodeFixProvider, FixAllScope.Solution, this.CodeFixEquivalenceKey, this.DiagnosticsToFix.Select(x => x.Id), diagnosticsProvider, cancellationToken);
+
+            CodeAction action = await this.FixAllProvider.GetFixAsync(context).ConfigureAwait(false);
+
+            return await action.GetOperationsAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        internal static async Task<ImmutableList<CodeFixEquivalenceGroup>> CreateAsync(CodeFixProvider codeFixProvider, IEnumerable<Diagnostic> allDiagnostics, Solution solution)
+        {
+            var fixAllProvider = codeFixProvider.GetFixAllProvider();
+
+            var relevantDiagnostics = allDiagnostics.Where(diagnostic => codeFixProvider.FixableDiagnosticIds.Contains(diagnostic.Id)).ToImmutableArray();
+
+            if (fixAllProvider == null)
+            {
+                return ImmutableList.Create<CodeFixEquivalenceGroup>();
+            }
+
+            List<CodeAction> actions = new List<CodeAction>();
+
+            foreach (var diagnostic in relevantDiagnostics)
+            {
+                actions.AddRange(await GetFixesAsync(solution, codeFixProvider, diagnostic).ConfigureAwait(false));
+            }
+
+            List<CodeFixEquivalenceGroup> groups = new List<CodeFixEquivalenceGroup>();
+
+            foreach (var item in actions.GroupBy(x => x.EquivalenceKey))
+            {
+                groups.Add(new CodeFixEquivalenceGroup(item.Key, solution, fixAllProvider, codeFixProvider, relevantDiagnostics));
+            }
+
+            return groups.ToImmutableList();
+        }
+
+        private static async Task<IEnumerable<CodeAction>> GetFixesAsync(Solution solution, CodeFixProvider codeFixProvider, Diagnostic diagnostic)
+        {
+            List<CodeAction> codeActions = new List<CodeAction>();
+
+            await codeFixProvider.RegisterCodeFixesAsync(new CodeFixContext(solution.GetDocument(diagnostic.Location.SourceTree), diagnostic, (a, d) => codeActions.Add(a), CancellationToken.None));
+
+            return codeActions;
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCopTester/CodeFixEquivalenceGroup.cs
+++ b/StyleCop.Analyzers/StyleCopTester/CodeFixEquivalenceGroup.cs
@@ -35,20 +35,6 @@
 
         internal ImmutableArray<Diagnostic> DiagnosticsToFix { get; }
 
-        internal async Task<ImmutableArray<CodeActionOperation>> GetOperationsAsync(CancellationToken cancellationToken = default(CancellationToken))
-        {
-            Diagnostic diagnostic = this.DiagnosticsToFix.First();
-            Document document = this.Solution.GetDocument(diagnostic.Location.SourceTree);
-
-            var diagnosticsProvider = TesterDiagnosticProvider.Create(this.DiagnosticsToFix);
-
-            var context = new FixAllContext(document, this.CodeFixProvider, FixAllScope.Solution, this.CodeFixEquivalenceKey, this.DiagnosticsToFix.Select(x => x.Id), diagnosticsProvider, cancellationToken);
-
-            CodeAction action = await this.FixAllProvider.GetFixAsync(context).ConfigureAwait(false);
-
-            return await action.GetOperationsAsync(cancellationToken).ConfigureAwait(false);
-        }
-
         internal static async Task<ImmutableList<CodeFixEquivalenceGroup>> CreateAsync(CodeFixProvider codeFixProvider, IEnumerable<Diagnostic> allDiagnostics, Solution solution)
         {
             var fixAllProvider = codeFixProvider.GetFixAllProvider();
@@ -75,6 +61,20 @@
             }
 
             return groups.ToImmutableList();
+        }
+
+        internal async Task<ImmutableArray<CodeActionOperation>> GetOperationsAsync(CancellationToken cancellationToken = default(CancellationToken))
+        {
+            Diagnostic diagnostic = this.DiagnosticsToFix.First();
+            Document document = this.Solution.GetDocument(diagnostic.Location.SourceTree);
+
+            var diagnosticsProvider = TesterDiagnosticProvider.Create(this.DiagnosticsToFix);
+
+            var context = new FixAllContext(document, this.CodeFixProvider, FixAllScope.Solution, this.CodeFixEquivalenceKey, this.DiagnosticsToFix.Select(x => x.Id), diagnosticsProvider, cancellationToken);
+
+            CodeAction action = await this.FixAllProvider.GetFixAsync(context).ConfigureAwait(false);
+
+            return await action.GetOperationsAsync(cancellationToken).ConfigureAwait(false);
         }
 
         private static async Task<IEnumerable<CodeAction>> GetFixesAsync(Solution solution, CodeFixProvider codeFixProvider, Diagnostic diagnostic)

--- a/StyleCop.Analyzers/StyleCopTester/Extensions.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Extensions.cs
@@ -19,7 +19,7 @@
             }
         }
 
-        internal static void AddToInnerList<TKey, TValue>(this IDictionary<TKey, ImmutableHashSet<TValue>> dictionary, TKey key, TValue item)
+        internal static void AddToInnerSet<TKey, TValue>(this IDictionary<TKey, ImmutableHashSet<TValue>> dictionary, TKey key, TValue item)
         {
             ImmutableHashSet<TValue> items;
 

--- a/StyleCop.Analyzers/StyleCopTester/Extensions.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Extensions.cs
@@ -1,0 +1,22 @@
+﻿namespace StyleCopTester
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+
+    internal static class Extensions
+    {
+        internal static void AddToInnerList<TKey, TValue>(this IDictionary<TKey, ImmutableList<TValue>> dictionary, TKey key, TValue item)
+        {
+            ImmutableList<TValue> items;
+
+            if (dictionary.TryGetValue(key, out items))
+            {
+                dictionary[key] = items.Add(item);
+            }
+            else
+            {
+                dictionary.Add(key, ImmutableList.Create(item));
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCopTester/Extensions.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Extensions.cs
@@ -18,5 +18,19 @@
                 dictionary.Add(key, ImmutableList.Create(item));
             }
         }
+
+        internal static void AddToInnerList<TKey, TValue>(this IDictionary<TKey, ImmutableHashSet<TValue>> dictionary, TKey key, TValue item)
+        {
+            ImmutableHashSet<TValue> items;
+
+            if (dictionary.TryGetValue(key, out items))
+            {
+                dictionary[key] = items.Add(item);
+            }
+            else
+            {
+                dictionary.Add(key, ImmutableHashSet.Create(item));
+            }
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCopTester/Program.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Program.cs
@@ -82,6 +82,11 @@
                     }
                 }
 
+                if (args.Contains("/nocf"))
+                {
+                    return;
+                }
+
                 Console.WriteLine("Calculating fixes");
 
                 List<CodeAction> fixes = new List<CodeAction>();
@@ -284,6 +289,7 @@
             Console.WriteLine("Options:");
             Console.WriteLine("/all     Run all StyleCopAnalyzers analyzers, including ones that are disabled by default");
             Console.WriteLine("/nostats Disable the display of statistics");
+            Console.WriteLine("/nostats Disable the calculation of code fixes");
             Console.WriteLine("/id:<id> Enable analyzer with diagnostic ID < id > (when this is specified, only this analyzer is enabled)");
         }
     }

--- a/StyleCop.Analyzers/StyleCopTester/Program.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Program.cs
@@ -127,7 +127,6 @@
                     WriteLine(ex.ToString(), ConsoleColor.Yellow);
                 }
             }
-
         }
 
         private static void WriteLine(string text, ConsoleColor color)

--- a/StyleCop.Analyzers/StyleCopTester/Program.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Program.cs
@@ -123,7 +123,7 @@
                 catch (Exception ex)
                 {
                     // Report thrown exceptions
-                    WriteLine($"The fix {fix.CodeFixEquivalenceKey} threw an exception:", ConsoleColor.Yellow);
+                    WriteLine($"The fix '{fix.CodeFixEquivalenceKey}' threw an exception:", ConsoleColor.Yellow);
                     WriteLine(ex.ToString(), ConsoleColor.Yellow);
                 }
             }
@@ -171,11 +171,8 @@
                     // Report thrown exceptions
                     lock (lockObject)
                     {
-                        Console.ForegroundColor = ConsoleColor.Yellow;
-                        Console.WriteLine($"The fix '{fix.Title} 'threw an exception:");
-                        Console.ForegroundColor = ConsoleColor.Red;
-                        Console.WriteLine(ex);
-                        Console.ResetColor();
+                        WriteLine($"The fix '{fix.Title}' threw an exception:", ConsoleColor.Yellow);
+                        WriteLine(ex.ToString(), ConsoleColor.Red);
                     }
                 }
             });
@@ -302,7 +299,7 @@
                 var supportedDiagnosticIds = fixAllProvider.GetSupportedFixAllDiagnosticIds(provider);
                 foreach (var id in supportedDiagnosticIds)
                 {
-                    fixAllProviders.AddToInnerList(fixAllProvider, id);
+                    fixAllProviders.AddToInnerSet(fixAllProvider, id);
                 }
             }
 
@@ -354,11 +351,11 @@
         {
             Console.WriteLine("Usage: StyleCopTester [options] <Solution>");
             Console.WriteLine("Options:");
-            Console.WriteLine("/all     Run all StyleCopAnalyzers analyzers, including ones that are disabled by default");
-            Console.WriteLine("/nostats Disable the display of statistics");
+            Console.WriteLine("/all       Run all StyleCopAnalyzers analyzers, including ones that are disabled by default");
+            Console.WriteLine("/nostats   Disable the display of statistics");
             Console.WriteLine("/codefixes Test single code fixes");
-            Console.WriteLine("/fixall Test fix all providers");
-            Console.WriteLine("/id:<id> Enable analyzer with diagnostic ID < id > (when this is specified, only this analyzer is enabled)");
+            Console.WriteLine("/fixall    Test fix all providers");
+            Console.WriteLine("/id:<id>   Enable analyzer with diagnostic ID < id > (when this is specified, only this analyzer is enabled)");
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCopTester/Program.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Program.cs
@@ -102,9 +102,26 @@
 
                 stopwatch.Restart();
 
+                object lockObject = new object();
+
                 Parallel.ForEach(fixes, fix =>
                 {
-                    fix.GetOperationsAsync(CancellationToken.None).GetAwaiter().GetResult();
+                    try
+                    {
+                        fix.GetOperationsAsync(CancellationToken.None).GetAwaiter().GetResult();
+                    }
+                    catch (Exception ex)
+                    {
+                        // Report thrown exceptions
+                        lock (lockObject)
+                        {
+                            Console.ForegroundColor = ConsoleColor.Yellow;
+                            Console.WriteLine($"The fix '{fix.Title} 'threw an exception:");
+                            Console.ForegroundColor = ConsoleColor.Red;
+                            Console.WriteLine(ex);
+                            Console.ResetColor();
+                        }
+                    }
                 });
 
                 Console.WriteLine($"Calculating changes completed in {stopwatch.ElapsedMilliseconds}ms");

--- a/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
+++ b/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
@@ -22,6 +22,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>..\StyleCop.Analyzers.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -119,10 +120,12 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CodeFixEquivalenceGroup.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Statistic.cs" />
+    <Compile Include="TesterDiagnosticProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\StyleCop.Analyzers.ruleset">

--- a/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
+++ b/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
@@ -119,6 +119,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Extensions.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Statistic.cs" />

--- a/StyleCop.Analyzers/StyleCopTester/TesterDiagnosticProvider.cs
+++ b/StyleCop.Analyzers/StyleCopTester/TesterDiagnosticProvider.cs
@@ -1,0 +1,40 @@
+﻿namespace StyleCopTester
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeFixes;
+
+    internal sealed class TesterDiagnosticProvider : FixAllContext.DiagnosticProvider
+    {
+        private ImmutableArray<Diagnostic> diagnostics;
+
+        private TesterDiagnosticProvider(ImmutableArray<Diagnostic> diagnostics)
+        {
+            this.diagnostics = diagnostics;
+        }
+
+        public override Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+        {
+            return Task.FromResult<IEnumerable<Diagnostic>>(this.diagnostics);
+        }
+
+        public override Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(this.diagnostics.Where(i => i.Location.GetLineSpan().Path == document.Name));
+        }
+
+        public override Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(this.diagnostics.Where(i => !i.Location.IsInSource));
+        }
+
+        internal static TesterDiagnosticProvider Create(ImmutableArray<Diagnostic> diagnostics)
+        {
+            return new TesterDiagnosticProvider(diagnostics);
+        }
+    }
+}


### PR DESCRIPTION
When trying it with roslyn it reports a bunch of [exceptions](https://gist.github.com/pdelvo/d5e7792797b66b5ff8ee) for renames. We should look at. I dont know if its our fault.