### PR TITLE
Fix that SA1028 CF throws ArgumentOutOfRangeException

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
@@ -275,10 +275,7 @@
                 .AppendLine("/// </summary>")
                 .ToString();
 
-            DiagnosticResult[] expected =
-            {
-                this.CSharpDiagnostic().WithLocation(2, 10),
-            };
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(2, 10);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
@@ -260,6 +260,31 @@
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        [Fact]
+        public async Task TrailingWhitespaceAfterTextTokenAsync()
+        {
+            string testCode = new StringBuilder()
+                .AppendLine("/// <summary>")
+                .AppendLine("/// &amp; ")
+                .AppendLine("/// </summary>")
+                .ToString();
+
+            string fixedCode = new StringBuilder()
+                .AppendLine("/// <summary>")
+                .AppendLine("/// &amp;")
+                .AppendLine("/// </summary>")
+                .ToString();
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(2, 10),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
             yield return new SA1028CodeMustNotContainTrailingWhitespace();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
@@ -116,7 +116,7 @@
                     var newTextTokens = xmlNode.TextTokens;
                     foreach (var textToken in newTextTokens)
                     {
-                        if (textToken.Span.IntersectsWith(diagnosticSpan))
+                        if (textToken.Span.Contains(diagnosticSpan))
                         {
                             diagnosticSpanWithinTrivia = TextSpan.FromBounds(diagnosticSpan.Start - textToken.Span.Start, diagnosticSpan.End - textToken.Span.Start);
                             oldTriviaContent = textToken.ValueText;


### PR DESCRIPTION
if the trailing whitespace is in a seperate text token in XmlText.

Fixes #1313