### PR TITLE
Rewrite StyleCopTester as an asynchronous console application

### DIFF
--- a/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
+++ b/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
@@ -118,6 +118,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CodeFixEquivalenceGroup.cs" />
@@ -135,6 +136,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <Analyzer Include="..\..\packages\AsyncUsageAnalyzers.1.0.0-alpha003\analyzers\dotnet\AsyncUsageAnalyzers.dll" />
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-beta009\analyzers\dotnet\cs\Newtonsoft.Json.dll" />

--- a/StyleCop.Analyzers/StyleCopTester/packages.config
+++ b/StyleCop.Analyzers/StyleCopTester/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="AsyncUsageAnalyzers" version="1.0.0-alpha003" targetFramework="net452" developmentDependency="true" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net45" />


### PR DESCRIPTION
This change makes it easier to integrate the console application with asynchronous operations in Roslyn.