### PR TITLE
Correct issues with trivia in code fix for SA1212 and SA1213

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/HelperTests/TriviaHelperTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/HelperTests/TriviaHelperTests.cs
@@ -66,7 +66,7 @@ public class Foo
 }");
 
             var accessor = tree.GetRoot().DescendantNodes().OfType<AccessorDeclarationSyntax>().Single();
-            Assert.True(accessor.GetFirstToken().HasLeadingBlankLines());
+            Assert.False(accessor.GetFirstToken().HasLeadingBlankLines());
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1212UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1212UnitTests.cs
@@ -57,7 +57,6 @@ public class Foo
         {
             return i;
         }
-
         /// <summary>
         /// The setter documentation
         /// </summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1212UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1212UnitTests.cs
@@ -72,6 +72,118 @@ public class Foo
         }
 
         [Fact]
+        public async Task TestPropertyWithLineCommentAsync()
+        {
+            var testCode = @"
+public class Foo
+{
+    private int i = 0;
+
+    public int Prop
+    {
+        // The setter documentation
+        set
+        {
+            i = value;
+        }
+
+        // The getter documentation
+        get
+        {
+            return i;
+        }
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(9, 9);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"
+public class Foo
+{
+    private int i = 0;
+
+    public int Prop
+    {
+        // The getter documentation
+        get
+        {
+            return i;
+        }
+        // The setter documentation
+        set
+        {
+            i = value;
+        }
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestPropertyWithBlockCommentAsync()
+        {
+            var testCode = @"
+public class Foo
+{
+    private int i = 0;
+
+    public int Prop
+    {
+        /*
+         * The setter documentation
+         */
+        set
+        {
+            i = value;
+        }
+
+        /*
+         * The getter documentation
+         */
+        get
+        {
+            return i;
+        }
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(11, 9);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"
+public class Foo
+{
+    private int i = 0;
+
+    public int Prop
+    {
+        /*
+         * The getter documentation
+         */
+        get
+        {
+            return i;
+        }
+        /*
+         * The setter documentation
+         */
+        set
+        {
+            i = value;
+        }
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestPropertyWithBackingFieldDeclarationSetterBeforeGetterAsync()
         {
             var testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1213UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1213UnitTests.cs
@@ -61,6 +61,122 @@ public class Foo
         }
 
         [Fact]
+        public async Task TestAddAccessorAfterRemoveAccessorWithLineCommentAsync()
+        {
+            var testCode = @"
+using System;
+public class Foo
+{
+    private EventHandler nameChanged;
+
+    public event EventHandler NameChanged
+    {
+        // This is the remove accessor.
+        remove
+        {
+            this.nameChanged -= value;
+        }
+
+        // This is the add accessor.
+        add
+        {
+            this.nameChanged += value;
+        }
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 9);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"
+using System;
+public class Foo
+{
+    private EventHandler nameChanged;
+
+    public event EventHandler NameChanged
+    {
+        // This is the add accessor.
+        add
+        {
+            this.nameChanged += value;
+        }
+        // This is the remove accessor.
+        remove
+        {
+            this.nameChanged -= value;
+        }
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestAddAccessorAfterRemoveAccessorWithBlockCommentAsync()
+        {
+            var testCode = @"
+using System;
+public class Foo
+{
+    private EventHandler nameChanged;
+
+    public event EventHandler NameChanged
+    {
+        /*
+         * This is the remove accessor.
+         */
+        remove
+        {
+            this.nameChanged -= value;
+        }
+
+        /*
+         * This is the add accessor.
+         */
+        add
+        {
+            this.nameChanged += value;
+        }
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(12, 9);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"
+using System;
+public class Foo
+{
+    private EventHandler nameChanged;
+
+    public event EventHandler NameChanged
+    {
+        /*
+         * This is the add accessor.
+         */
+        add
+        {
+            this.nameChanged += value;
+        }
+        /*
+         * This is the remove accessor.
+         */
+        remove
+        {
+            this.nameChanged -= value;
+        }
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestAddAccessorAfterRemoveAccessorSameLineAsync()
         {
             var testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TriviaHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TriviaHelper.cs
@@ -233,22 +233,22 @@
             var blankLineCount = -1;
             while (index >= 0)
             {
+                if (triviaList[index].HasBuiltinEndLine() && !triviaList[index].IsKind(SyntaxKind.EndOfLineTrivia))
+                {
+                    blankLineCount++;
+                    return blankLineCount > 0;
+                }
+
                 switch (triviaList[index].Kind())
                 {
                 case SyntaxKind.WhitespaceTrivia:
-                case SyntaxKind.SingleLineDocumentationCommentTrivia:
                     // ignore;
                     break;
+
                 case SyntaxKind.EndOfLineTrivia:
                     blankLineCount++;
                     break;
-                case SyntaxKind.IfDirectiveTrivia:
-                case SyntaxKind.ElifDirectiveTrivia:
-                case SyntaxKind.ElseDirectiveTrivia:
-                case SyntaxKind.EndIfDirectiveTrivia:
-                    // directive trivia have an embedded end of line
-                    blankLineCount++;
-                    return blankLineCount > 0;
+
                 default:
                     return blankLineCount > 0;
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1212SA1213CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1212SA1213CodeFixProvider.cs
@@ -82,8 +82,7 @@
 
         private static bool AccessorsAreOnTheSameLine(AccessorDeclarationSyntax firstAccesor, AccessorDeclarationSyntax secondAccessor)
         {
-            return firstAccesor.GetLocation().GetLineSpan().EndLinePosition.Line ==
-                   secondAccessor.GetLocation().GetLineSpan().EndLinePosition.Line;
+            return firstAccesor.GetEndLine() == secondAccessor.GetEndLine();
         }
 
         private static AccessorDeclarationSyntax GetNewAccessor(AccessorListSyntax accessorList, AccessorDeclarationSyntax firstAccessor, AccessorDeclarationSyntax secondAccessor)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1212SA1213CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1212SA1213CodeFixProvider.cs
@@ -62,14 +62,6 @@
 
             syntaxRoot = trackedRoot.InsertNodesBefore(trackedFirstAccessor, new[] { newAccessor });
 
-            trackedFirstAccessor = syntaxRoot.GetCurrentNode(firstAccesor);
-            if (secondAccessor.GetFirstToken().HasLeadingBlankLines())
-            {
-                var newFirstAccessor = trackedFirstAccessor.WithLeadingTrivia(
-                    TriviaHelper.MergeTriviaLists(new[] { SyntaxFactory.CarriageReturnLineFeed }, trackedFirstAccessor.GetLeadingTrivia()));
-                syntaxRoot = syntaxRoot.ReplaceNode(trackedFirstAccessor, newFirstAccessor);
-            }
-
             var trackedLastAccessor = syntaxRoot.GetCurrentNode(secondAccessor);
             var keepTriviaOptions = AccessorsAreOnTheSameLine(firstAccesor, secondAccessor)
                 ? SyntaxRemoveOptions.KeepEndOfLine
@@ -100,7 +92,7 @@
 
             if (secondAccessor.GetFirstToken().HasLeadingBlankLines())
             {
-                newAccessor.WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed, SyntaxFactory.CarriageReturnLineFeed);
+                newAccessor = newAccessor.WithTrailingTrivia(SyntaxFactory.CarriageReturnLineFeed, SyntaxFactory.CarriageReturnLineFeed);
             }
 
             return newAccessor;


### PR DESCRIPTION
This pull request addresses a number of issues in #1252:

* The change to `TriviaHelper.HasLeadingBlankLines` was not valid. The behavior of this method is corrected and a unit test in SA1212 is updated to reflect that a blank line is no longer inserted in the code fix result.
* Failure to assign the result of a call to `WithTrailingTrivia` was resulting in code duplication in the code fix provider.
* New unit tests are added to cover behavior with line comments and block comments. The expected output of these is currently set to match the *actual* behavior. A separate issue will be opened regarding the *desired* behavior.