### PR TITLE
changed newtonsoft reference to 6.0.8

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -74,8 +74,8 @@
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/packages.config
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net452" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.0-beta009" targetFramework="net452" developmentDependency="true" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" />
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net452" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -416,8 +416,8 @@
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\portable-net45+win8\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/StyleCop.Analyzers/StyleCop.Analyzers/packages.config
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable-net45+win8" />
-  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="portable45-net45+win8" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="portable45-net45+win8" />
   <package id="NuGet.CommandLine" version="2.8.3" targetFramework="portable45-net45+win8" />
   <package id="StyleCop.Analyzers" version="1.0.0-beta009" targetFramework="portable45-net45+win8" developmentDependency="true" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="portable45-net45+win8" />

--- a/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
+++ b/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
@@ -78,8 +78,8 @@
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/StyleCop.Analyzers/StyleCopTester/packages.config
+++ b/StyleCop.Analyzers/StyleCopTester/packages.config
@@ -8,6 +8,7 @@
   <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net45" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.0-beta009" targetFramework="net452" developmentDependency="true" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net45" />
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net45" />


### PR DESCRIPTION
based on the [post below](http://stackoverflow.com/questions/30042728/attempting-to-deserialize-an-object-using-json-net-in-windows-10-universal-app-f), I downgraded newtonsoft to version 6.0.8, which solves the reference problem for [https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1345].
it's a temporary solution perhaps, but it does solve the problem until the warnings can be more permanently sorted out.

http://stackoverflow.com/questions/30042728/attempting-to-deserialize-an-object-using-json-net-in-windows-10-universal-app-f
