### PR TITLE
Tester fixes

### DIFF
--- a/StyleCop.Analyzers/StyleCopTester/TesterDiagnosticProvider.cs
+++ b/StyleCop.Analyzers/StyleCopTester/TesterDiagnosticProvider.cs
@@ -24,7 +24,7 @@
 
         public override Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
         {
-            return Task.FromResult(this.diagnostics.Where(i => i.Location.GetLineSpan().Path == document.Name));
+            return Task.FromResult(this.diagnostics.Where(i => i.Location.GetLineSpan().Path == document.FilePath));
         }
 
         public override Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken cancellationToken)

--- a/StyleCop.Analyzers/StyleCopTester/TesterDiagnosticProvider.cs
+++ b/StyleCop.Analyzers/StyleCopTester/TesterDiagnosticProvider.cs
@@ -10,31 +10,40 @@
 
     internal sealed class TesterDiagnosticProvider : FixAllContext.DiagnosticProvider
     {
-        private ImmutableArray<Diagnostic> diagnostics;
+        private readonly ImmutableDictionary<string, ImmutableArray<Diagnostic>> documentDiagnostics;
+        private readonly ImmutableDictionary<ProjectId, ImmutableArray<Diagnostic>> projectDiagnostics;
 
-        private TesterDiagnosticProvider(ImmutableArray<Diagnostic> diagnostics)
+        public TesterDiagnosticProvider(ImmutableDictionary<string, ImmutableArray<Diagnostic>> documentDiagnostics, ImmutableDictionary<ProjectId, ImmutableArray<Diagnostic>> projectDiagnostics)
         {
-            this.diagnostics = diagnostics;
+            this.documentDiagnostics = documentDiagnostics;
+            this.projectDiagnostics = projectDiagnostics;
         }
 
         public override Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(Project project, CancellationToken cancellationToken)
         {
-            return Task.FromResult<IEnumerable<Diagnostic>>(this.diagnostics);
+            return Task.FromResult(this.projectDiagnostics.Values.SelectMany(i => i).Concat(this.documentDiagnostics.Values.SelectMany(i => i)));
         }
 
         public override Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)
         {
-            return Task.FromResult(this.diagnostics.Where(i => i.Location.GetLineSpan().Path == document.FilePath));
+            ImmutableArray<Diagnostic> diagnostics;
+            if (!this.documentDiagnostics.TryGetValue(document.FilePath, out diagnostics))
+            {
+                return Task.FromResult(Enumerable.Empty<Diagnostic>());
+            }
+
+            return Task.FromResult(diagnostics.AsEnumerable());
         }
 
         public override Task<IEnumerable<Diagnostic>> GetProjectDiagnosticsAsync(Project project, CancellationToken cancellationToken)
         {
-            return Task.FromResult(this.diagnostics.Where(i => !i.Location.IsInSource));
-        }
+            ImmutableArray<Diagnostic> diagnostics;
+            if (!this.projectDiagnostics.TryGetValue(project.Id, out diagnostics))
+            {
+                return Task.FromResult(Enumerable.Empty<Diagnostic>());
+            }
 
-        internal static TesterDiagnosticProvider Create(ImmutableArray<Diagnostic> diagnostics)
-        {
-            return new TesterDiagnosticProvider(diagnostics);
+            return Task.FromResult(diagnostics.AsEnumerable());
         }
     }
 }


### PR DESCRIPTION
* Fix TesterDiagnosticProvider not actually providing any document diagnostics (no code fixes were being applied with `/fixall`)
* Fix severe performance problems calculating document diagnostics