### PR TITLE
Implement a fix all provider for SA1122

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
@@ -1,7 +1,9 @@
 ﻿namespace StyleCop.Analyzers.ReadabilityRules
 {
+    using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Composition;
+    using System.Threading;
     using System.Threading.Tasks;
     using Helpers;
     using Microsoft.CodeAnalysis;
@@ -40,7 +42,7 @@
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
         {
-            return CustomFixAllProviders.BatchFixer;
+            return FixAll.Instance;
         }
 
         /// <inheritdoc/>
@@ -54,18 +56,48 @@
                     continue;
                 }
 
-                var node = root?.FindNode(diagnostic.Location.SourceSpan, findInsideTrivia: true, getInnermostNodeForTie: true);
-                if (node != null && node.IsKind(SyntaxKind.StringLiteralExpression))
-                {
-                    context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1122CodeFix, token => GetTransformedDocumentAsync(context.Document, root, node), equivalenceKey: nameof(SA1122CodeFixProvider)), diagnostic);
-                }
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        ReadabilityResources.SA1122CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        equivalenceKey: nameof(SA1122CodeFixProvider)),
+                    diagnostic);
             }
         }
 
-        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, SyntaxNode node)
+        private static async Task<Document> GetTransformedDocumentAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
         {
-            var newSyntaxRoot = root.ReplaceNode(node, StringEmptyExpression.WithTriviaFrom(node));
-            return Task.FromResult(document.WithSyntaxRoot(newSyntaxRoot));
+            var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+
+            var node = syntaxRoot.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+            var newSyntaxRoot = syntaxRoot.ReplaceNode(node, StringEmptyExpression.WithTriviaFrom(node));
+            return document.WithSyntaxRoot(newSyntaxRoot);
+        }
+
+        private class FixAll : DocumentBasedFixAllProvider
+        {
+            public static FixAllProvider Instance { get; } =
+                new FixAll();
+
+            protected override string CodeActionTitle
+                => ReadabilityResources.SA1122CodeFix;
+
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            {
+                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                var syntaxRoot = await document.GetSyntaxRootAsync(fixAllContext.CancellationToken).ConfigureAwait(false);
+
+                List<SyntaxNode> expressions = new List<SyntaxNode>();
+                foreach (var diagnostic in diagnostics)
+                {
+                    var node = syntaxRoot.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
+                    expressions.Add(node);
+                }
+
+                return syntaxRoot.ReplaceNodes(
+                    expressions,
+                    (originalNode, rewrittenNode) => StringEmptyExpression.WithTriviaFrom(rewrittenNode));
+            }
         }
     }
 }


### PR DESCRIPTION
This code fix is now able to fix 1617 violations of this rule in Roslyn.sln in 8154ms on my machine (previously ran out of memory before completing when run as a 32-bit process).