### PR TITLE
Implement a FixAllProvider for SA1026CodeFixProvider

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1026CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1026CodeFixProvider.cs
@@ -75,7 +75,7 @@
         {
             public static FixAllProvider Instance { get; } = new FixAll();
 
-            protected override string CodeActionTitle => SpacingResources.OpenCloseSpacingCodeFix;
+            protected override string CodeActionTitle => SpacingResources.SA1026CodeFix;
 
             protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
             {


### PR DESCRIPTION
87 violations in Roslyn.sln fix all time reduced from 8539ms to 4736ms.