### PR TITLE
Print instances/sec in StyleCopTester

### DIFF
--- a/StyleCop.Analyzers/StyleCopTester/CodeFixEquivalenceGroup.cs
+++ b/StyleCop.Analyzers/StyleCopTester/CodeFixEquivalenceGroup.cs
@@ -26,6 +26,8 @@
             this.CodeFixProvider = codeFixProvider;
             this.DocumentDiagnosticsToFix = documentDiagnosticsToFix;
             this.ProjectDiagnosticsToFix = projectDiagnosticsToFix;
+            this.NumberOfDiagnostics = documentDiagnosticsToFix.SelectMany(x => x.Value.Select(y => y.Value).SelectMany(y => y)).Count()
+                + projectDiagnosticsToFix.SelectMany(x => x.Value).Count();
         }
 
         internal string CodeFixEquivalenceKey { get; }
@@ -39,6 +41,8 @@
         internal ImmutableDictionary<ProjectId, ImmutableDictionary<string, ImmutableArray<Diagnostic>>> DocumentDiagnosticsToFix { get; }
 
         internal ImmutableDictionary<ProjectId, ImmutableArray<Diagnostic>> ProjectDiagnosticsToFix { get; }
+
+        internal int NumberOfDiagnostics { get; }
 
         internal static async Task<ImmutableArray<CodeFixEquivalenceGroup>> CreateAsync(CodeFixProvider codeFixProvider, ImmutableDictionary<ProjectId, ImmutableArray<Diagnostic>> allDiagnostics, Solution solution, CancellationToken cancellationToken)
         {

--- a/StyleCop.Analyzers/StyleCopTester/Program.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Program.cs
@@ -147,14 +147,14 @@
                 try
                 {
                     stopwatch.Restart();
-                    Console.WriteLine($"Calculating fix for {fix.CodeFixEquivalenceKey}.");
+                    Console.WriteLine($"Calculating fix for {fix.CodeFixEquivalenceKey} using {fix.FixAllProvider.ToString()} for {fix.NumberOfDiagnostics} instances.");
                     await fix.GetOperationsAsync(cancellationToken).ConfigureAwait(true);
-                    WriteLine($"Calculating changes completed in {stopwatch.ElapsedMilliseconds}ms", ConsoleColor.Yellow);
+                    WriteLine($"Calculating changes completed in {stopwatch.ElapsedMilliseconds}ms. This is {fix.NumberOfDiagnostics / stopwatch.Elapsed.TotalSeconds:0.000} instances/second.", ConsoleColor.Yellow);
                 }
                 catch (Exception ex)
                 {
                     // Report thrown exceptions
-                    WriteLine($"The fix '{fix.CodeFixEquivalenceKey}' threw an exception:", ConsoleColor.Yellow);
+                    WriteLine($"The fix '{fix.CodeFixEquivalenceKey}' threw an exception after {stopwatch.ElapsedMilliseconds}ms:", ConsoleColor.Yellow);
                     WriteLine(ex.ToString(), ConsoleColor.Yellow);
                 }
             }


### PR DESCRIPTION
Generates an output similar to:
```
Calculating changes
Calculating fix for SA1509CodeFixProvider using StyleCop.Analyzers.Helpers.CustomBatchFixAllProvider for 43 instances.
Calculating changes completed in 5570ms. This is 7,720 instances/second.
Calculating fix for SA1503CodeFixProvider using StyleCop.Analyzers.LayoutRules.SA1503CodeFixProvider+FixAll for 984 instances.
Calculating changes completed in 3386ms. This is 290,528 instances/second.
Calculating fix for SA1508CodeFixProvider using StyleCop.Analyzers.Helpers.CustomBatchFixAllProvider for 12 instances.
Calculating changes completed in 958ms. This is 12,517 instances/second.
Calculating fix for SA1518CodeFixProvider using StyleCop.Analyzers.Helpers.CustomBatchFixAllProvider for 31 instances.
Calculating changes completed in 3795ms. This is 8,167 instances/second.
Calculating fix for SA1505CodeFixProvider using StyleCop.Analyzers.Helpers.CustomBatchFixAllProvider for 15 instances.
Calculating changes completed in 1008ms. This is 14,868 instances/second.
Calculating fix for SA1515CodeFixProvider using StyleCop.Analyzers.LayoutRules.SA1515CodeFixProvider+FixAll for 14567 instances.
Calculating changes completed in 1249ms. This is 11659,924 instances/second.
Calculating fix for SA1504CodeFixProviderMultipleLines using StyleCop.Analyzers.Helpers.CustomBatchFixAllProvider for 5 instances.
Calculating changes completed in 22066ms. This is 0,227 instances/second.
Calculating fix for SA1514CodeFixProvider using StyleCop.Analyzers.Helpers.CustomBatchFixAllProvider for 84 instances.
Calculating changes completed in 15396ms. This is 5,456 instances/second.
Calculating fix for SA1507CodeFixProvider using StyleCop.Analyzers.LayoutRules.SA1507CodeFixProvider+FixAll for 482 instances.
Calculating changes completed in 2098ms. This is 229,671 instances/second.
Calculating fix for SA1517CodeFixProvider using StyleCop.Analyzers.Helpers.CustomBatchFixAllProvider for 3 instances.
Calculating changes completed in 122ms. This is 24,403 instances/second.
Calculating fix for SA1506CodeFixProvider using StyleCop.Analyzers.Helpers.CustomBatchFixAllProvider for 2 instances.
Calculating changes completed in 269ms. This is 7,409 instances/second.
Calculating fix for SA1516CodeFixProvider using StyleCop.Analyzers.LayoutRules.SA1516CodeFixProvider+FixAll for 3530 instances.
Calculating changes completed in 518ms. This is 6807,851 instances/second.
Calculating fix for SA1501CodeFixProvider using StyleCop.Analyzers.Helpers.CustomBatchFixAllProvider for 63 instances.
```