### PR TITLE
Optimizations for DocumentBasedFixAllProvider

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DocumentBasedFixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DocumentBasedFixAllProvider.cs
@@ -50,11 +50,26 @@
             return Task.FromResult(fixAction);
         }
 
+        /// <summary>
+        /// Fixes all occurrences of a diagnostic in a specific document.
+        /// </summary>
+        /// <param name="fixAllContext">The context for the Fix All operation.</param>
+        /// <param name="document">The document to fix.</param>
+        /// <returns>
+        /// <para>The new <see cref="SyntaxNode"/> representing the root of the fixed document.</para>
+        /// <para>-or-</para>
+        /// <para><see langword="null"/>, if no changes were made to the document.</para>
+        /// </returns>
         protected abstract Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document);
 
         private async Task<Document> GetDocumentFixesAsync(FixAllContext fixAllContext)
         {
             var newRoot = await this.FixAllInDocumentAsync(fixAllContext, fixAllContext.Document).ConfigureAwait(false);
+            if (newRoot == null)
+            {
+                return fixAllContext.Document;
+            }
+
             return fixAllContext.Document.WithSyntaxRoot(newRoot);
         }
 
@@ -70,6 +85,11 @@
             for (int i = 0; i < documents.Length; i++)
             {
                 var newDocumentRoot = await newDocuments[i].ConfigureAwait(false);
+                if (newDocumentRoot == null)
+                {
+                    continue;
+                }
+
                 solution = solution.WithDocumentSyntaxRoot(documents[i].Id, newDocumentRoot);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DocumentBasedFixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DocumentBasedFixAllProvider.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeActions;
@@ -14,53 +15,76 @@
     {
         protected abstract string CodeActionTitle { get; }
 
-        public override async Task<CodeAction> GetFixAsync(FixAllContext fixAllContext)
+        public override Task<CodeAction> GetFixAsync(FixAllContext fixAllContext)
         {
+            CodeAction fixAction;
             switch (fixAllContext.Scope)
             {
             case FixAllScope.Document:
-                var newRoot = await this.FixAllInDocumentAsync(fixAllContext, fixAllContext.Document).ConfigureAwait(false);
-                return CodeAction.Create(this.CodeActionTitle, token => Task.FromResult(fixAllContext.Document.WithSyntaxRoot(newRoot)));
+                fixAction = CodeAction.Create(
+                    this.CodeActionTitle,
+                    cancellationToken => this.GetDocumentFixesAsync(fixAllContext.WithCancellationToken(cancellationToken)),
+                    nameof(DocumentBasedFixAllProvider));
+                break;
 
             case FixAllScope.Project:
-                Solution solution = await this.GetProjectFixesAsync(fixAllContext, fixAllContext.Project).ConfigureAwait(false);
-                return CodeAction.Create(this.CodeActionTitle, token => Task.FromResult(solution));
+                fixAction = CodeAction.Create(
+                    this.CodeActionTitle,
+                    cancellationToken => this.GetProjectFixesAsync(fixAllContext.WithCancellationToken(cancellationToken), fixAllContext.Project),
+                    nameof(DocumentBasedFixAllProvider));
+                break;
 
             case FixAllScope.Solution:
-                var newSolution = fixAllContext.Solution;
-                var projectIds = newSolution.ProjectIds;
-                for (int i = 0; i < projectIds.Count; i++)
-                {
-                    newSolution = await this.GetProjectFixesAsync(fixAllContext, newSolution.GetProject(projectIds[i])).ConfigureAwait(false);
-                }
-
-                return CodeAction.Create(this.CodeActionTitle, token => Task.FromResult(newSolution));
+                fixAction = CodeAction.Create(
+                    this.CodeActionTitle,
+                    cancellationToken => this.GetSolutionFixesAsync(fixAllContext.WithCancellationToken(cancellationToken)),
+                    nameof(DocumentBasedFixAllProvider));
+                break;
 
             case FixAllScope.Custom:
             default:
-                return null;
+                fixAction = null;
+                break;
             }
+
+            return Task.FromResult(fixAction);
         }
 
         protected abstract Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document);
 
-        private async Task<Solution> GetProjectFixesAsync(FixAllContext fixAllContext, Project project)
+        private async Task<Document> GetDocumentFixesAsync(FixAllContext fixAllContext)
         {
-            Solution solution = project.Solution;
-            var oldDocuments = project.Documents.ToImmutableArray();
-            List<Task<SyntaxNode>> newDocuments = new List<Task<SyntaxNode>>(oldDocuments.Length);
-            foreach (var document in oldDocuments)
+            var newRoot = await this.FixAllInDocumentAsync(fixAllContext, fixAllContext.Document).ConfigureAwait(false);
+            return fixAllContext.Document.WithSyntaxRoot(newRoot);
+        }
+
+        private async Task<Solution> GetSolutionFixesAsync(FixAllContext fixAllContext, ImmutableArray<Document> documents)
+        {
+            Solution solution = fixAllContext.Solution;
+            List<Task<SyntaxNode>> newDocuments = new List<Task<SyntaxNode>>(documents.Length);
+            foreach (var document in documents)
             {
                 newDocuments.Add(this.FixAllInDocumentAsync(fixAllContext, document));
             }
 
-            for (int i = 0; i < oldDocuments.Length; i++)
+            for (int i = 0; i < documents.Length; i++)
             {
                 var newDocumentRoot = await newDocuments[i].ConfigureAwait(false);
-                solution = solution.WithDocumentSyntaxRoot(oldDocuments[i].Id, newDocumentRoot);
+                solution = solution.WithDocumentSyntaxRoot(documents[i].Id, newDocumentRoot);
             }
 
             return solution;
+        }
+
+        private Task<Solution> GetProjectFixesAsync(FixAllContext fixAllContext, Project project)
+        {
+            return this.GetSolutionFixesAsync(fixAllContext, project.Documents.ToImmutableArray());
+        }
+
+        private Task<Solution> GetSolutionFixesAsync(FixAllContext fixAllContext)
+        {
+            ImmutableArray<Document> documents = fixAllContext.Solution.Projects.SelectMany(i => i.Documents).ToImmutableArray();
+            return this.GetSolutionFixesAsync(fixAllContext, documents);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CodeFixProvider.cs
@@ -98,6 +98,11 @@
             protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
             {
                 var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                if (diagnostics.IsEmpty)
+                {
+                    return null;
+                }
+
                 SyntaxNode syntaxRoot = await document.GetSyntaxRootAsync().ConfigureAwait(false);
                 List<SyntaxNode> nodesNeedingBlocks = new List<SyntaxNode>(diagnostics.Length);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1507CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1507CodeFixProvider.cs
@@ -63,12 +63,18 @@
 
             protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
             {
+                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                if (diagnostics.IsEmpty)
+                {
+                    return null;
+                }
+
                 var newLine = fixAllContext.Document.Project.Solution.Workspace.Options.GetOption(FormattingOptions.NewLine, LanguageNames.CSharp);
                 var text = await document.GetTextAsync().ConfigureAwait(false);
 
                 List<TextChange> changes = new List<TextChange>();
 
-                foreach (var diagnostic in await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false))
+                foreach (var diagnostic in diagnostics)
                 {
                     changes.Add(new TextChange(diagnostic.Location.SourceSpan, newLine));
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1512CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1512CodeFixProvider.cs
@@ -123,6 +123,11 @@
             protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
             {
                 var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                if (diagnostics.IsEmpty)
+                {
+                    return null;
+                }
+
                 var syntaxRoot = await document.GetSyntaxRootAsync().ConfigureAwait(false);
 
                 List<SyntaxTrivia> trivias = new List<SyntaxTrivia>();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515CodeFixProvider.cs
@@ -109,6 +109,11 @@
             protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
             {
                 var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                if (diagnostics.IsEmpty)
+                {
+                    return null;
+                }
+
                 var syntaxRoot = await document.GetSyntaxRootAsync().ConfigureAwait(false);
 
                 List<SyntaxTrivia> trivias = new List<SyntaxTrivia>();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1516CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1516CodeFixProvider.cs
@@ -112,6 +112,11 @@
             protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
             {
                 var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                if (diagnostics.IsEmpty)
+                {
+                    return null;
+                }
+
                 var syntaxRoot = await document.GetSyntaxRootAsync().ConfigureAwait(false);
 
                 List<SyntaxNode> nodes = new List<SyntaxNode>();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408FixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408FixAllProvider.cs
@@ -17,6 +17,10 @@
         protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
         {
             var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+            if (diagnostics.IsEmpty)
+            {
+                return null;
+            }
 
             var newDocument = document;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionFixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionFixAllProvider.cs
@@ -14,6 +14,11 @@
         protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
         {
             var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+            if (diagnostics.IsEmpty)
+            {
+                return null;
+            }
+
             SyntaxNode root = await document.GetSyntaxRootAsync().ConfigureAwait(false);
 
             var nodesToRemove = diagnostics.Select(d => root.FindNode(d.Location.SourceSpan, findInsideTrivia: true))

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
@@ -89,6 +89,11 @@
             protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
             {
                 var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                if (diagnostics.IsEmpty)
+                {
+                    return null;
+                }
+
                 var syntaxRoot = await document.GetSyntaxRootAsync().ConfigureAwait(false);
 
                 List<SyntaxToken> tokensToReplace = new List<SyntaxToken>(diagnostics.Length);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
@@ -82,6 +82,10 @@
             protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
             {
                 var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                if (diagnostics.IsEmpty)
+                {
+                    return null;
+                }
 
                 SyntaxNode syntaxRoot = await document.GetSyntaxRootAsync().ConfigureAwait(false);
                 List<SyntaxNode> nodesNeedingQualification = new List<SyntaxNode>(diagnostics.Length);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1107FixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1107FixAllProvider.cs
@@ -14,6 +14,12 @@
 
         protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
         {
+            var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+            if (diagnostics.IsEmpty)
+            {
+                return null;
+            }
+
             DocumentEditor editor = await DocumentEditor.CreateAsync(document, fixAllContext.CancellationToken).ConfigureAwait(false);
 
             SyntaxNode root = editor.GetChangedRoot();
@@ -21,7 +27,7 @@
             ImmutableList<SyntaxNode> nodesToChange = ImmutableList.Create<SyntaxNode>();
 
             // Make sure all nodes we care about are tracked
-            foreach (var diagnostic in await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false))
+            foreach (var diagnostic in diagnostics)
             {
                 var location = diagnostic.Location;
                 var syntaxNode = root.FindNode(location.SourceSpan);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
@@ -85,6 +85,11 @@
             protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
             {
                 var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                if (diagnostics.IsEmpty)
+                {
+                    return null;
+                }
+
                 var syntaxRoot = await document.GetSyntaxRootAsync(fixAllContext.CancellationToken).ConfigureAwait(false);
 
                 List<SyntaxNode> expressions = new List<SyntaxNode>();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/OpenCloseSpacingCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/OpenCloseSpacingCodeFixProvider.cs
@@ -259,6 +259,11 @@
             protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
             {
                 var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                if (diagnostics.IsEmpty)
+                {
+                    return null;
+                }
+
                 var syntaxRoot = await document.GetSyntaxRootAsync().ConfigureAwait(false);
 
                 var replaceMap = new Dictionary<SyntaxToken, SyntaxToken>();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
@@ -86,6 +86,11 @@
             protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
             {
                 var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                if (diagnostics.IsEmpty)
+                {
+                    return null;
+                }
+
                 var text = await document.GetTextAsync().ConfigureAwait(false);
 
                 List<TextChange> changes = new List<TextChange>();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1025CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1025CodeFixProvider.cs
@@ -75,6 +75,11 @@
             protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
             {
                 var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                if (diagnostics.IsEmpty)
+                {
+                    return null;
+                }
+
                 var syntaxRoot = await document.GetSyntaxRootAsync().ConfigureAwait(false);
 
                 List<SyntaxTrivia> tokensToFix = new List<SyntaxTrivia>();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
@@ -71,11 +71,17 @@
 
             protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
             {
+                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                if (diagnostics.IsEmpty)
+                {
+                    return null;
+                }
+
                 var text = await document.GetTextAsync().ConfigureAwait(false);
 
                 List<TextChange> changes = new List<TextChange>();
 
-                foreach (var diagnostic in await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false))
+                foreach (var diagnostic in diagnostics)
                 {
                     changes.Add(new TextChange(diagnostic.Location.SourceSpan, string.Empty));
                 }


### PR DESCRIPTION
* Move work out of `GetFixAsync` (Fixes #1411)
* Optimize handling of documents with no diagnostics