### PR TITLE
Disable SA1633 by default and update configuration documentation

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
@@ -312,6 +312,12 @@
                 return;
             }
 
+            if (string.Equals(settings.DocumentationRules.CopyrightText, DocumentationSettings.DefaultCopyrightText, StringComparison.OrdinalIgnoreCase))
+            {
+                // The copyright text is meaningless until the company name is configured by the user.
+                return;
+            }
+
             if (string.CompareOrdinal(copyrightText.Trim(' ', '\r', '\n'), settings.DocumentationRules.CopyrightText) != 0)
             {
                 var location = fileHeader.GetElementLocation(context.Tree, copyrightElement);
@@ -331,6 +337,12 @@
 
             if (compilation.IsAnalyzerSuppressed(SA1641Identifier))
             {
+                return;
+            }
+
+            if (string.Equals(settings.DocumentationRules.CompanyName, DocumentationSettings.DefaultCompanyName, StringComparison.OrdinalIgnoreCase))
+            {
+                // The company name is meaningless until configured by the user.
                 return;
             }
 

--- a/documentation/Configuration.md
+++ b/documentation/Configuration.md
@@ -37,6 +37,18 @@ The easiest way to add a **stylecop.json** configuration file to a new project i
 > 5. Save and close the project file.
 > 6. Right click the unloaded project in **Solution Explorer** and select **Reload Project**.
 
+### JSON Schema for IntelliSense
+
+A JSON schema is available for **stylecop.json**. By including a reference in **stylecop.json** to this schema, Visual Studio will offer IntelliSense functionality (code completion, quick info, etc.) while editing this file. The schema may be configured by adding the following top-level property in **stylecop.json**:
+
+```json
+{
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json"
+}
+```
+
+> :bulb: The code fix described previously automatically configures **stylecop.json** to reference the schema.
+
 ### Source Control
 
 For best results, **stylecop.json** should be included in source control. This will automatically propagate the expected settings to all team members working on the project.

--- a/documentation/Configuration.md
+++ b/documentation/Configuration.md
@@ -14,7 +14,7 @@ StyleCop Analyzers is configured using two separate mechanisms: code analysis ru
 
 Code analysis rule sets are the standard way to configure most diagnostic analyzers within Visual Studio 2015. Information about creating and customizing these files can be found in the [Using Rule Sets to Group Code Analysis Rules](https://msdn.microsoft.com/en-us/library/dd264996.aspx) documentation on MSDN.
 
-## Getting started with **stylecop.json**
+## Getting Started with **stylecop.json**
 
 The easiest way to add a **stylecop.json** configuration file to a new project is using a code fix provided by the project. To invoke the code fix, open any file where SA1633 is reported¹ and press Ctrl+. to bring up the Quick Fix menu. From the menu, select **Add StyleCop settings file to the project**.
 
@@ -36,6 +36,16 @@ The easiest way to add a **stylecop.json** configuration file to a new project i
 
 > 5. Save and close the project file.
 > 6. Right click the unloaded project in **Solution Explorer** and select **Reload Project**.
+
+### Source Control
+
+For best results, **stylecop.json** should be included in source control. This will automatically propagate the expected settings to all team members working on the project.
+
+> :warning: If you are working in Git, make sure your **.gitignore** file *does not* contain the following line. This line should be removed if present.
+>
+> ```
+> [Ss]tyle[Cc]op.*
+> ```
 
 ## Documentation Rules
 


### PR DESCRIPTION
* ~~Disable SA1633 by default~~ Suppress SA1636 and SA1641 when expected text has not been configured (fixes #1366)
* Document source control requirements for **stylecop.json**
* Document JSON schema functionality for **stylecop.json** (supersedes #1405)
