### PR TITLE
Implement a code fix provider for SA1626 (SingleLineCommentsMustNotUseDocumentationStyleSlashes)

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1626UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1626UnitTests.cs
@@ -19,9 +19,9 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         public async Task TestClassWithXmlCommentAsync()
         {
             var testCode = @"/// <summary>
-/// Xml Documentation
+/// XML Documentation
 /// </summary>
-public class Foo
+public class TypeName
 {
     public void Bar()
     {
@@ -34,7 +34,7 @@ public class Foo
         [Fact]
         public async Task TestMethodWithCommentAsync()
         {
-            var testCode = @"public class Foo
+            var testCode = @"public class TypeName
 {
     public void Bar()
     {
@@ -48,7 +48,7 @@ public class Foo
         [Fact]
         public async Task TestMethodWithOneLineThreeSlashCommentAsync()
         {
-            var testCode = @"public class Foo
+            var testCode = @"public class TypeName
 {
     public void Bar()
     {
@@ -67,7 +67,7 @@ public class Foo
         [Fact]
         public async Task TestMethodWithMultiLineThreeSlashCommentAsync()
         {
-            var testCode = @"public class Foo
+            var testCode = @"public class TypeName
 {
     public void Bar()
     {
@@ -87,7 +87,7 @@ public class Foo
         [Fact]
         public async Task TestMethodWithCodeCommentsAsync()
         {
-            var testCode = @"public class Foo
+            var testCode = @"public class TypeName
 {
     public void Bar()
     {
@@ -101,7 +101,7 @@ public class Foo
         [Fact]
         public async Task TestMethodWithSingeLineDocumentationAsync()
         {
-            var testCode = @"public class Foo
+            var testCode = @"public class TypeName
 {
     /// <summary>Summary text</summary>
     public void Bar()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1626UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1626UnitTests.cs
@@ -6,12 +6,13 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.DocumentationRules;
     using TestHelper;
     using Xunit;
 
-    public class SA1626UnitTests : DiagnosticVerifier
+    public class SA1626UnitTests : CodeFixVerifier
     {
         private const string DiagnosticId = SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes.DiagnosticId;
 
@@ -56,12 +57,20 @@ public class TypeName
     }
 }
 ";
-            var expected = new[]
-            {
-                this.CSharpDiagnostic().WithLocation(5, 9)
-            };
+            var fixedCode = @"public class TypeName
+{
+    public void Bar()
+    {
+        // This is a comment
+    }
+}
+";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 9);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -76,12 +85,25 @@ public class TypeName
     }
 }
 ";
-            var expected = new[]
+            var fixedCode = @"public class TypeName
+{
+    public void Bar()
+    {
+        // This is
+        // a comment
+    }
+}
+";
+
+            DiagnosticResult[] expected =
             {
-                this.CSharpDiagnostic().WithLocation(5, 9)
+                this.CSharpDiagnostic().WithLocation(5, 9),
+                this.CSharpDiagnostic().WithLocation(6, 9),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -112,9 +134,16 @@ public class TypeName
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        /// <inheritdoc/>
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
             yield return new SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes();
+        }
+
+        /// <inheritdoc/>
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new SA1626CodeFixProvider();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
@@ -89,6 +89,15 @@ namespace StyleCop.Analyzers.DocumentationRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Convert to line comment.
+        /// </summary>
+        internal static string SA1626CodeFix {
+            get {
+                return ResourceManager.GetString("SA1626CodeFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add file header.
         /// </summary>
         internal static string SA1633CodeFix {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
@@ -126,6 +126,9 @@
   <data name="SA1617CodeFix" xml:space="preserve">
     <value>Remove &lt;returns&gt; XML comment</value>
   </data>
+  <data name="SA1626CodeFix" xml:space="preserve">
+    <value>Convert to line comment</value>
+  </data>
   <data name="SA1633CodeFix" xml:space="preserve">
     <value>Add file header</value>
   </data>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1626CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1626CodeFixProvider.cs
@@ -1,0 +1,100 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.DocumentationRules
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Composition;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Text;
+    using StyleCop.Analyzers.Helpers;
+
+    /// <summary>
+    /// Implements a code fix for <see cref="SA1626CodeFixProvider"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>To fix a violation of this rule, remove a slash from the beginning of the comment so that it begins with
+    /// only two slashes.</para>
+    /// </remarks>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SA1626CodeFixProvider))]
+    [Shared]
+    public class SA1626CodeFixProvider : CodeFixProvider
+    {
+        /// <inheritdoc/>
+        public override ImmutableArray<string> FixableDiagnosticIds { get; }
+            = ImmutableArray.Create(SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes.DiagnosticId);
+
+        /// <inheritdoc/>
+        public override FixAllProvider GetFixAllProvider()
+        {
+            return FixAll.Instance;
+        }
+
+        /// <inheritdoc/>
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            foreach (Diagnostic diagnostic in context.Diagnostics)
+            {
+                if (diagnostic.Id != SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes.DiagnosticId)
+                {
+                    continue;
+                }
+
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        DocumentationResources.SA1626CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        equivalenceKey: nameof(SA1626CodeFixProvider)),
+                    diagnostic);
+            }
+
+            return SpecializedTasks.CompletedTask;
+        }
+
+        private static async Task<Document> GetTransformedDocumentAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+            TextChange textChange = new TextChange(new TextSpan(diagnostic.Location.SourceSpan.Start, 1), string.Empty);
+            return document.WithText(text.WithChanges(textChange));
+        }
+
+        private class FixAll : DocumentBasedFixAllProvider
+        {
+            public static FixAllProvider Instance { get; } =
+                new FixAll();
+
+            protected override string CodeActionTitle =>
+                DocumentationResources.SA1626CodeFix;
+
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            {
+                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                if (diagnostics.IsEmpty)
+                {
+                    return null;
+                }
+
+                var text = await document.GetTextAsync().ConfigureAwait(false);
+
+                List<TextChange> changes = new List<TextChange>();
+                foreach (var diagnostic in diagnostics)
+                {
+                    var sourceSpan = diagnostic.Location.SourceSpan;
+                    changes.Add(new TextChange(new TextSpan(sourceSpan.Start, 1), string.Empty));
+                }
+
+                changes.Sort((left, right) => left.Span.Start.CompareTo(right.Span.Start));
+
+                var tree = await document.GetSyntaxTreeAsync().ConfigureAwait(false);
+                return await tree.WithChangedText(text.WithChanges(changes)).GetRootAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -88,6 +88,7 @@
     <Compile Include="DocumentationRules\SA1623PropertySummaryDocumentationMustMatchAccessors.cs" />
     <Compile Include="DocumentationRules\SA1624PropertySummaryDocumentationMustOmitSetAccessorWithRestrictedAccess.cs" />
     <Compile Include="DocumentationRules\SA1625ElementDocumentationMustNotBeCopiedAndPasted.cs" />
+    <Compile Include="DocumentationRules\SA1626CodeFixProvider.cs" />
     <Compile Include="DocumentationRules\SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes.cs" />
     <Compile Include="DocumentationRules\SA1627DocumentationTextMustNotBeEmpty.cs" />
     <Compile Include="DocumentationRules\SA1628DocumentationTextMustBeginWithACapitalLetter.cs" />


### PR DESCRIPTION
Fixes #655