### PR TITLE
Fix encoded HTML tags in description messages

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1620GenericTypeParameterDocumentationMustMatchTypeParameters.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1620GenericTypeParameterDocumentationMustMatchTypeParameters.cs
@@ -36,7 +36,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// </summary>
         public const string DiagnosticId = "SA1620";
         private const string Title = "Generic type parameter documentation must match type parameters";
-        private const string Description = "The &lt;typeparam&gt; tags within the Xml header documentation for a generic C# element do not match the generic type parameters on the element.";
+        private const string Description = "The <typeparam> tags within the Xml header documentation for a generic C# element do not match the generic type parameters on the element.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1620.md";
 
         private const string MissingTypeParamForDocumentationMessageFormat = "The type parameter '{0}' does not exist.";

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1622GenericTypeParameterDocumentationMustHaveText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1622GenericTypeParameterDocumentationMustHaveText.cs
@@ -33,7 +33,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         public const string DiagnosticId = "SA1622";
         private const string Title = "Generic type parameter documentation must have text";
         private const string MessageFormat = "Generic type parameter documentation must have text";
-        private const string Description = "A &lt;typeparam&gt; tag within the Xml header documentation for a generic C# element is empty.";
+        private const string Description = "A <typeparam> tag within the Xml header documentation for a generic C# element is empty.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1622.md";
 
         private static readonly DiagnosticDescriptor Descriptor =

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1623PropertySummaryDocumentationMustMatchAccessors.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1623PropertySummaryDocumentationMustMatchAccessors.cs
@@ -198,7 +198,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         public const string DiagnosticId = "SA1623";
         private const string Title = "Property summary documentation must match accessors";
         private const string MessageFormat = "TODO: Message format";
-        private const string Description = "The documentation text within a C# property’s &lt;summary&gt; tag does not match the accessors within the property.";
+        private const string Description = "The documentation text within a C# property’s <summary> tag does not match the accessors within the property.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md";
 
         private static readonly DiagnosticDescriptor Descriptor =


### PR DESCRIPTION
This fixes all encoded HTML tags in description messages for rule classes (See #1355).