### PR TITLE
Remove unnecessary missing token checks

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToLowerCaseCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToLowerCaseCodeFixProvider.cs
@@ -51,11 +51,6 @@ namespace StyleCop.Analyzers.NamingRules
                 }
 
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
-                if (token.IsMissing)
-                {
-                    continue;
-                }
-
                 if (!string.IsNullOrEmpty(token.ValueText))
                 {
                     var newName = char.ToLower(token.ValueText[0]) + token.ValueText.Substring(1);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToUpperCaseCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToUpperCaseCodeFixProvider.cs
@@ -59,11 +59,6 @@ namespace StyleCop.Analyzers.NamingRules
                 }
 
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
-                if (token.IsMissing)
-                {
-                    continue;
-                }
-
                 var newName = char.ToUpper(token.ValueText[0]) + token.ValueText.Substring(1);
                 var memberSyntax = this.GetParentTypeDeclaration(token);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1302CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1302CodeFixProvider.cs
@@ -42,11 +42,6 @@ namespace StyleCop.Analyzers.NamingRules
                 }
 
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
-                if (token.IsMissing)
-                {
-                    continue;
-                }
-
                 var newName = "I" + token.ValueText;
                 context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.RenameToCodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1308CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1308CodeFixProvider.cs
@@ -49,11 +49,6 @@ namespace StyleCop.Analyzers.NamingRules
 
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
 
-                if (token.IsMissing)
-                {
-                    continue;
-                }
-
                 // The variable name is the full suffix. In this case we cannot generate a valid variable name and thus will not offer a code fix.
                 if (token.ValueText.Length <= 2)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1309CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1309CodeFixProvider.cs
@@ -48,11 +48,6 @@ namespace StyleCop.Analyzers.NamingRules
                 }
 
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
-                if (token.IsMissing)
-                {
-                    continue;
-                }
-
                 if (!string.IsNullOrEmpty(token.ValueText))
                 {
                     var newName = token.ValueText.TrimStart(new[] { '_' });

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1310CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1310CodeFixProvider.cs
@@ -49,11 +49,6 @@ namespace StyleCop.Analyzers.NamingRules
                 }
 
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
-                if (token.IsMissing)
-                {
-                    continue;
-                }
-
                 string currentName = token.ValueText;
                 string proposedName = BuildProposedName(currentName);
                 if (proposedName != currentName)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SX1309CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SX1309CodeFixProvider.cs
@@ -50,11 +50,6 @@ namespace StyleCop.Analyzers.NamingRules
                 }
 
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
-                if (token.IsMissing)
-                {
-                    continue;
-                }
-
                 if (!string.IsNullOrEmpty(token.ValueText))
                 {
                     string newName = '_' + token.ValueText;


### PR DESCRIPTION
In each of these cases, the diagnostic analyzers already ensure that the token at the reported location is not missing.

Closes #539