### PR TITLE
Improve IsFirstInLine and IsLastInLine performance

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/HelperTests/TokenHelperTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/HelperTests/TokenHelperTests.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.HelperTests
+{
+    using System.Linq;
+    using Analyzers.Helpers;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Xunit;
+
+    public class TokenHelperTests
+    {
+        [Fact]
+        public void TestIsFirstInLineSpecialCase()
+        {
+            string testCode = @"class MyClass {
+} /// <summary>
+/// Text
+/// </summary>
+struct MyStruct { }";
+            var syntaxTree = CSharpSyntaxTree.ParseText(testCode);
+            var root = syntaxTree.GetRoot();
+
+            Assert.True(root.FindToken(64).IsFirstInLine());
+        }
+
+        [Fact]
+        public void TestIsLastInLineSpecialCase()
+        {
+            string testCode = @"class MyClass {
+} /// <summary>
+/// Text
+/// </summary>
+struct /**
+Foo
+**/ MyStruct { }";
+            var syntaxTree = CSharpSyntaxTree.ParseText(testCode);
+            var root = syntaxTree.GetRoot();
+
+            Assert.True(root.FindToken(64).IsLastInLine());
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Helpers\DiagnosticVerifier.Helper.cs" />
     <Compile Include="Helpers\ExclusionTestAnalyzer.cs" />
     <Compile Include="Helpers\TestDiagnosticProvider.cs" />
+    <Compile Include="HelperTests\TokenHelperTests.cs" />
     <Compile Include="HelperTests\TriviaHelperTests.cs" />
     <Compile Include="LayoutRules\SA1500\SA1500UnitTests.Blocks.cs" />
     <Compile Include="LayoutRules\SA1500\SA1500UnitTests.Classes.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TokenHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TokenHelpers.cs
@@ -5,6 +5,7 @@ namespace StyleCop.Analyzers.Helpers
 {
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Text;
 
     /// <summary>
     /// Provides helper methods to work with token.
@@ -18,8 +19,8 @@ namespace StyleCop.Analyzers.Helpers
         /// <returns>true if token is first in line, otherwise false.</returns>
         internal static bool IsFirstInLine(this SyntaxToken token)
         {
-            SyntaxToken previousToken = token.GetPreviousToken();
-            return previousToken.IsKind(SyntaxKind.None) || previousToken.GetEndLine() < token.GetLine();
+            return token.SyntaxTree == null
+                || token.SyntaxTree.GetLineSpan(token.FullSpan).StartLinePosition.Character == 0;
         }
 
         /// <summary>
@@ -29,8 +30,9 @@ namespace StyleCop.Analyzers.Helpers
         /// <returns>true if token is last in line, otherwise false.</returns>
         internal static bool IsLastInLine(this SyntaxToken token)
         {
-            SyntaxToken nextToken = token.GetNextToken();
-            return nextToken.IsKind(SyntaxKind.None) || token.GetEndLine() < nextToken.GetLine();
+            return token.SyntaxTree == null
+                || token.SyntaxTree.GetLineSpan(token.FullSpan).EndLinePosition.Character == 0
+                || token.SyntaxTree.Length == token.FullSpan.End;
         }
 
         /// <summary>


### PR DESCRIPTION
IsFirstInLine was showing up as a hot path when measuring performance. 2.3% of the time spent analyzing roslyn was spent in this method. With this change the time goes down to 0.3%.

GetNextToken and GetPreviousToken are very expensive and we should try to avoid using them if possible.