### PR TITLE
Reduce trivia list allocations

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TriviaHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TriviaHelper.cs
@@ -217,7 +217,7 @@ namespace StyleCop.Analyzers.Helpers
         /// <param name="trivia">The trivia to create the list from.</param>
         /// <param name="triviaIndex">The index of the trivia in the created trivia list.</param>
         /// <returns>The created trivia list.</returns>
-        internal static IReadOnlyList<SyntaxTrivia> GetContainingTriviaList(SyntaxTrivia trivia, out int triviaIndex)
+        internal static DualTriviaListHelper GetContainingTriviaList(SyntaxTrivia trivia, out int triviaIndex)
         {
             var token = trivia.Token;
             SyntaxTriviaList part1;
@@ -249,7 +249,7 @@ namespace StyleCop.Analyzers.Helpers
         /// <param name="list1">The first part of the new list.</param>
         /// <param name="list2">The second part of the new list.</param>
         /// <returns>The merged trivia list.</returns>
-        internal static IReadOnlyList<SyntaxTrivia> MergeTriviaLists(IReadOnlyList<SyntaxTrivia> list1, IReadOnlyList<SyntaxTrivia> list2)
+        internal static DualTriviaListHelper MergeTriviaLists(SyntaxTriviaList list1, SyntaxTriviaList list2)
         {
             return new DualTriviaListHelper(list1, list2);
         }
@@ -403,13 +403,13 @@ namespace StyleCop.Analyzers.Helpers
         /// <summary>
         /// Helper class that merges two SyntaxTriviaLists with (hopefully) the lowest possible performance penalty.
         /// </summary>
-        private class DualTriviaListHelper : IReadOnlyList<SyntaxTrivia>
+        internal struct DualTriviaListHelper : IReadOnlyList<SyntaxTrivia>
         {
-            private readonly IReadOnlyList<SyntaxTrivia> part1;
+            private readonly SyntaxTriviaList part1;
             private readonly int part1Count;
-            private readonly IReadOnlyList<SyntaxTrivia> part2;
+            private readonly SyntaxTriviaList part2;
 
-            public DualTriviaListHelper(IReadOnlyList<SyntaxTrivia> part1, IReadOnlyList<SyntaxTrivia> part2)
+            public DualTriviaListHelper(SyntaxTriviaList part1, SyntaxTriviaList part2)
             {
                 this.part1 = part1;
                 this.part2 = part2;
@@ -454,6 +454,16 @@ namespace StyleCop.Analyzers.Helpers
             IEnumerator IEnumerable.GetEnumerator()
             {
                 return this.GetEnumerator();
+            }
+
+            public SyntaxTrivia First()
+            {
+                return this[0];
+            }
+
+            public SyntaxTrivia Last()
+            {
+                return this[this.Count - 1];
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1509OpeningCurlyBracketsMustNotBePrecededByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1509OpeningCurlyBracketsMustNotBePrecededByBlankLine.cs
@@ -91,7 +91,7 @@ namespace StyleCop.Analyzers.LayoutRules
         private static void AnalyzeOpenBrace(SyntaxTreeAnalysisContext context, SyntaxToken openBrace)
         {
             var prevToken = openBrace.GetPreviousToken();
-            var triviaList = prevToken.IsKind(SyntaxKind.None) ? openBrace.LeadingTrivia : TriviaHelper.MergeTriviaLists(prevToken.TrailingTrivia, openBrace.LeadingTrivia);
+            var triviaList = TriviaHelper.MergeTriviaLists(prevToken.TrailingTrivia, openBrace.LeadingTrivia);
 
             var done = false;
             var eolCount = 0;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1212SA1213CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1212SA1213CodeFixProvider.cs
@@ -98,8 +98,8 @@ namespace StyleCop.Analyzers.OrderingRules
             var newLeadingTrivia = GetLeadingTriviaWithoutLeadingBlankLines(secondAccessor);
             if (AccessorsAreOnTheSameLine(firstAccessor, secondAccessor))
             {
-                var leadingWhitespace = firstAccessor.GetLeadingTrivia().Where(x => x.IsKind(SyntaxKind.WhitespaceTrivia)).ToList();
-                newLeadingTrivia = SyntaxFactory.TriviaList(TriviaHelper.MergeTriviaLists(newLeadingTrivia, leadingWhitespace));
+                var leadingWhitespace = firstAccessor.GetLeadingTrivia().Where(x => x.IsKind(SyntaxKind.WhitespaceTrivia));
+                newLeadingTrivia = SyntaxFactory.TriviaList(TriviaHelper.MergeTriviaLists(newLeadingTrivia, SyntaxTriviaList.Empty.AddRange(leadingWhitespace)));
             }
 
             var newAccessor = accessorList.Accessors[1]

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1108BlockStatementsMustNotContainEmbeddedComments.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1108BlockStatementsMustNotContainEmbeddedComments.cs
@@ -135,11 +135,20 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
         private static void FindAllComments(SyntaxNodeAnalysisContext context, SyntaxToken previousToken, SyntaxToken openBraceToken)
         {
-            var comments = previousToken.TrailingTrivia.Where(IsComment)
-                .Concat(openBraceToken.LeadingTrivia.Where(IsComment));
-            foreach (var comment in comments)
+            foreach (var comment in previousToken.TrailingTrivia)
             {
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, comment.GetLocation()));
+                if (IsComment(comment))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, comment.GetLocation()));
+                }
+            }
+
+            foreach (var comment in openBraceToken.LeadingTrivia)
+            {
+                if (IsComment(comment))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, comment.GetLocation()));
+                }
             }
         }
 


### PR DESCRIPTION
After running a memory profiling session I saw that we are allocating a lot of SyntaxTriviaList structs on the heap because of casting them to IReadOnlyList. 
![snip_20150918031719](https://cloud.githubusercontent.com/assets/1710209/9950159/d6e8efcc-5db7-11e5-8cb3-69f9fce9fb17.png)

In this PR I reduce the number of allocations by not casting to an Interface and using the struct directly. I also made DualTriviaListHelper a struct and I made sure we dont cast it to IReadOnlyList. There is still a lot of room for improvement.

I also changed a few spots where we used Linq on structs.