### PR TITLE
File header code fix should only replace the copyright element

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1634UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1634UnitTests.cs
@@ -14,6 +14,8 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     /// </summary>
     public class SA1634UnitTests : FileHeaderTestBase
     {
+        private string multiLineSettings;
+
         /// <summary>
         /// Verifies that a file header without a copyright element will produce the expected diagnostic (none for the default case)
         /// </summary>
@@ -94,10 +96,46 @@ namespace Bar
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1634Descriptor).WithLocation(1, 1);
             await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
         }
+        /// <summary>
+        /// Verifies that a file header with a copyright element will not produce a diagnostic message.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestValidMultiLineFileHeaderWithCopyrightLastAsync()
+        {
+            var testCode = @"// <author>
+//   John Doe
+// </author>
+// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright (c) FooCorp. All rights reserved.
+// Licence is FooBar MIT.
+// </copyright>
+
+namespace Bar
+{
+}
+";
+            this.multiLineSettings = @"
+{
+  ""settings"": {
+    ""documentationRules"": {
+      ""companyName"": ""FooCorp"",
+      ""copyrightText"": ""Copyright (c) FooCorp. All rights reserved.\nLicence is FooBar MIT.""
+    }
+  }
+}
+";
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
 
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             throw new System.NotImplementedException();
+        }
+
+        protected override string GetSettings()
+        {
+            return this.multiLineSettings ?? base.GetSettings();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1634UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1634UnitTests.cs
@@ -131,6 +131,41 @@ namespace Bar
         }
 
         /// <summary>
+        /// Verifies that we keep leading spaces in a file header when adding copyright text.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestFileHeaderKeepsLeadingWhiteSpaceWhenAddingCopyrightMessageAsync()
+        {
+            var testCode = @"    // <author>FooCorp</author>
+    // <summary>
+    //   FooCorp Bar class
+    // </summary>
+
+namespace Bar
+{
+}
+";
+            var fixedCode = @"    // <copyright file=""Test0.cs"" company=""FooCorp"">
+    // Copyright (c) FooCorp. All rights reserved.
+    // </copyright>
+    // <author>FooCorp</author>
+    // <summary>
+    //   FooCorp Bar class
+    // </summary>
+
+namespace Bar
+{
+}
+";
+
+            var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1634Descriptor).WithLocation(1, 5);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Verifies that a file header with missing copyright text the fix leaves behind other comments.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
@@ -153,6 +188,80 @@ namespace Bar
 //   John Doe
 // </author>
 // <summary>This is a test file.</summary>
+
+namespace Bar
+{
+}
+";
+
+            var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1634Descriptor).WithLocation(1, 1);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that a file header with missing copyright text and a multiline comment without leading stars the fix leaves behind other comments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestFileHeaderForMultilineCommentWithoutLeadingStarsFixWithReplaceCopyrightTagTextAsync()
+        {
+            var testCode = @"/* <author>
+     John Doe
+   </author>
+   <summary>This is a test file.</summary>
+ */
+
+namespace Bar
+{
+}
+";
+            var fixedCode = @"/* <copyright file=""Test0.cs"" company=""FooCorp"">
+   Copyright (c) FooCorp. All rights reserved.
+   </copyright>
+   <author>
+     John Doe
+   </author>
+   <summary>This is a test file.</summary>
+ */
+
+namespace Bar
+{
+}
+";
+
+            var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1634Descriptor).WithLocation(1, 1);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that a file header with missing copyright text and a multiline comment with leading stars the fix leaves behind other comments.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestFileHeaderForMultilineCommentWithLeadingStarsFixWithReplaceCopyrightTagTextAsync()
+        {
+            var testCode = @"/* <author>
+ *   John Doe
+ * </author>
+ * <summary>This is a test file.</summary>
+ */
+
+namespace Bar
+{
+}
+";
+            var fixedCode = @"/* <copyright file=""Test0.cs"" company=""FooCorp"">
+ * Copyright (c) FooCorp. All rights reserved.
+ * </copyright>
+ * <author>
+ *   John Doe
+ * </author>
+ * <summary>This is a test file.</summary>
+ */
 
 namespace Bar
 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1636UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1636UnitTests.cs
@@ -230,6 +230,228 @@ namespace Bar
             await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verifies that we keep leading spaces in a file header when fixing text.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestFileHeaderKeepsLeadingWhiteSpaceWhenFixingCopyrightMessageAsync()
+        {
+            this.useMultiLineHeaderTestSettings = true;
+
+            var testCode = @"    // <author>FooCorp</author>
+    // <copyright file=""Test0.cs"" company=""FooCorp"">
+    //  Not copyright (c) FooCorp. All rights reserved.
+    //
+    //  Line #3
+    // </copyright>
+    // <summary>
+    //   FooCorp Bar class
+    // </summary>
+
+namespace Bar
+{
+}
+";
+            var fixedCode = @"    // <author>FooCorp</author>
+    // <copyright file=""Test0.cs"" company=""FooCorp"">
+    // copyright (c) FooCorp. All rights reserved.
+    //
+    // Line #3
+    // </copyright>
+    // <summary>
+    //   FooCorp Bar class
+    // </summary>
+
+namespace Bar
+{
+}
+";
+
+            var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1636Descriptor).WithLocation(2, 8);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that a multi line file header will be fixed correctly (for multiple line comments) without a leading star
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestFileHeaderWithMultiLineCommentAndNoLeadingStarsFixingCopyrightMessageStaysMultiLineAsync()
+        {
+            this.useMultiLineHeaderTestSettings = true;
+
+            var testCode = @"/*
+   <author>FooCorp</author>
+   <copyright file=""Test0.cs"" company=""FooCorp"">
+     NOT copyright (c) FooCorp. All rights reserved.
+
+     Line #3
+   </copyright>
+   <summary>FooCorp Bar Class</summary>
+ */
+
+namespace Bar
+{
+}
+";
+
+            var fixedCode = @"/*
+   <author>FooCorp</author>
+   <copyright file=""Test0.cs"" company=""FooCorp"">
+   copyright (c) FooCorp. All rights reserved.
+
+   Line #3
+   </copyright>
+   <summary>FooCorp Bar Class</summary>
+ */
+
+namespace Bar
+{
+}
+";
+
+            var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1636Descriptor).WithLocation(3, 4);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that a multi line file header will be fixed correctly (for multiple line comments) with a leading star
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestFileHeaderWithMultiLineCommentAndLeadingStarsFixingCopyrightMessageStaysMultiLineAsync()
+        {
+            this.useMultiLineHeaderTestSettings = true;
+
+            var testCode = @"/*
+ * <author>FooCorp</author>
+ * <copyright file=""Test0.cs"" company=""FooCorp"">
+ *   NOT copyright (c) FooCorp. All rights reserved.
+ *
+ *   Line #3
+ * </copyright>
+ * <summary>FooCorp Bar Class</summary>
+ */
+
+namespace Bar
+{
+}
+";
+
+            var fixedCode = @"/*
+ * <author>FooCorp</author>
+ * <copyright file=""Test0.cs"" company=""FooCorp"">
+ * copyright (c) FooCorp. All rights reserved.
+ *
+ * Line #3
+ * </copyright>
+ * <summary>FooCorp Bar Class</summary>
+ */
+
+namespace Bar
+{
+}
+";
+
+            var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1636Descriptor).WithLocation(3, 4);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that a multi line file header will be fixed correctly (for multiple line comments) with a leading star
+        /// and the initial line at the top of the file.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestFileHeaderWithMultiLineCommentAndAuthorAtTopAndLeadingStarsFixingCopyrightMessageStaysMultiLineAsync()
+        {
+            this.useMultiLineHeaderTestSettings = true;
+
+            var testCode = @"/* <author>FooCorp</author>
+ * <copyright file=""Test0.cs"" company=""FooCorp"">
+ *   NOT copyright (c) FooCorp. All rights reserved.
+ *
+ *   Line #3
+ * </copyright>
+ * <summary>FooCorp Bar Class</summary>
+ */
+
+namespace Bar
+{
+}
+";
+
+            var fixedCode = @"/* <author>FooCorp</author>
+ * <copyright file=""Test0.cs"" company=""FooCorp"">
+ * copyright (c) FooCorp. All rights reserved.
+ *
+ * Line #3
+ * </copyright>
+ * <summary>FooCorp Bar Class</summary>
+ */
+
+namespace Bar
+{
+}
+";
+
+            var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1636Descriptor).WithLocation(2, 4);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that a multi line file header will be fixed correctly (for multiple line comments) with a leading star
+        /// and the initial line at the top of the file.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestFileHeaderWithMultiLineCommentAndCopyrightAtTopAndLeadingStarsFixingCopyrightMessageStaysMultiLineAsync()
+        {
+            this.useMultiLineHeaderTestSettings = true;
+
+            var testCode = @"/* <copyright file=""Test0.cs"" company=""FooCorp"">
+ *   NOT copyright (c) FooCorp. All rights reserved.
+ *
+ *   Line #3
+ * </copyright>
+ * <author>FooCorp</author>
+ * <summary>FooCorp Bar Class</summary>
+ */
+
+namespace Bar
+{
+}
+";
+
+            var fixedCode = @"/* <copyright file=""Test0.cs"" company=""FooCorp"">
+ * copyright (c) FooCorp. All rights reserved.
+ *
+ * Line #3
+ * </copyright>
+ * <author>FooCorp</author>
+ * <summary>FooCorp Bar Class</summary>
+ */
+
+namespace Bar
+{
+}
+";
+
+            var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1636Descriptor).WithLocation(1, 4);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new FileHeaderCodeFixProvider();

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1636UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1636UnitTests.cs
@@ -74,6 +74,44 @@ namespace Bar
             await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verifies that a file header with an incorrect copyright text the fix only replaces the text.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestFileHeaderFixWithReplaceCopyrightTagTextAsync()
+        {
+            var testCode = @"// <author>
+//   John Doe
+// </author>
+// <copyright file=""Test0.cs"" company=""FooCorp"">
+//   Copyright (c) Not FooCorp. All rights reserved.
+// </copyright>
+// <summary>This is a test file.</summary>
+
+namespace Bar
+{
+}
+";
+            var fixedCode = @"// <author>
+//   John Doe
+// </author>
+// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright (c) FooCorp. All rights reserved.
+// </copyright>
+// <summary>This is a test file.</summary>
+
+namespace Bar
+{
+}
+";
+
+            var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1636Descriptor).WithLocation(4, 4);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new FileHeaderCodeFixProvider();

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1636UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1636UnitTests.cs
@@ -192,7 +192,6 @@ namespace Bar
             await this.VerifyCSharpDiagnosticAsync(new[] { testCode1, testCode2, testCode3 }, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        /// <inheritdoc/>
         /// <summary>
         /// Verifies that a file header with an incorrect copyright text the fix only replaces the text.
         /// </summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
@@ -315,13 +315,15 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
-            if (string.Equals(settings.DocumentationRules.CopyrightText, DocumentationSettings.DefaultCopyrightText, StringComparison.OrdinalIgnoreCase))
+            var settingsCopyrightText = settings.DocumentationRules.CopyrightText;
+            if (string.Equals(settingsCopyrightText, DocumentationSettings.DefaultCopyrightText, StringComparison.OrdinalIgnoreCase))
             {
                 // The copyright text is meaningless until the company name is configured by the user.
                 return;
             }
 
-            if (string.CompareOrdinal(copyrightText.Trim(' ', '\r', '\n'), settings.DocumentationRules.CopyrightText) != 0)
+            // Remove any leading or trailing spaces and remove the extra space put in as a seperator.
+            if (string.CompareOrdinal(copyrightText.Trim(' ', '\r', '\n').Replace("\n ","\n"), settingsCopyrightText.Trim(' ', '\r', '\n')) != 0)
             {
                 var location = fileHeader.GetElementLocation(context.Tree, copyrightElement);
                 context.ReportDiagnostic(Diagnostic.Create(SA1636Descriptor, location));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
@@ -323,7 +323,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             }
 
             // Remove any leading or trailing spaces and remove the extra space put in as a seperator.
-            if (string.CompareOrdinal(copyrightText.Trim(' ', '\r', '\n').Replace("\n ","\n"), settingsCopyrightText.Trim(' ', '\r', '\n')) != 0)
+            if (string.CompareOrdinal(copyrightText.Trim(' ', '\r', '\n').Replace("\n ", "\n"), settingsCopyrightText.Trim(' ', '\r', '\n')) != 0)
             {
                 var location = fileHeader.GetElementLocation(context.Tree, copyrightElement);
                 context.ReportDiagnostic(Diagnostic.Create(SA1636Descriptor, location));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderCodeFixProvider.cs
@@ -140,11 +140,6 @@ namespace StyleCop.Analyzers.DocumentationRules
                 }
             }
 
-            if (isMalformedHeader)
-            {
-                copyrightTriviaIndex = null;
-            }
-
             // Remove copyright lines in reverse order
             removalList.Reverse();
             foreach (var triviaLine in removalList)
@@ -155,23 +150,20 @@ namespace StyleCop.Analyzers.DocumentationRules
             string newLineText = document.Project.Solution.Workspace.Options.GetOption(FormattingOptions.NewLine, LanguageNames.CSharp);
 
             var newHeaderTrivia = CreateNewHeader(document.Name, settings, newLineText);
-            if (copyrightTriviaIndex.HasValue)
+            if (!isMalformedHeader && copyrightTriviaIndex.HasValue)
             {
-                if (inCopyright)
-                {
-                    newHeaderTrivia = newHeaderTrivia.Add(SyntaxFactory.CarriageReturnLineFeed);
-                }
-
-                trivia = trivia.ReplaceRange(trivia[copyrightTriviaIndex.Value], newHeaderTrivia);
-                return root.WithLeadingTrivia(trivia);
+                // Replace copyright element in place.
+                return root.WithLeadingTrivia(trivia.ReplaceRange(trivia[copyrightTriviaIndex.Value], newHeaderTrivia));
             }
             else
             {
+                // Add blank line if we don't already have comments at top of file.
                 if ((trivia.Count == 0) || (trivia[0].Kind() != SyntaxKind.SingleLineCommentTrivia))
                 {
                     newHeaderTrivia = newHeaderTrivia.Add(SyntaxFactory.CarriageReturnLineFeed);
                 }
 
+                // Insert header at top of the file.
                 return root.WithLeadingTrivia(newHeaderTrivia.Add(SyntaxFactory.CarriageReturnLineFeed).AddRange(trivia));
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderCodeFixProvider.cs
@@ -30,6 +30,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         public override ImmutableArray<string> FixableDiagnosticIds { get; }
             = ImmutableArray.Create(
                 FileHeaderAnalyzers.SA1633DescriptorMissing.Id,
+                FileHeaderAnalyzers.SA1634Descriptor.Id,
                 FileHeaderAnalyzers.SA1635Descriptor.Id,
                 FileHeaderAnalyzers.SA1636Descriptor.Id);
 
@@ -56,48 +57,81 @@ namespace StyleCop.Analyzers.DocumentationRules
             var settings = document.Project.AnalyzerOptions.GetStyleCopSettings();
 
             var fileHeader = FileHeaderHelpers.ParseFileHeader(root);
-            var newSyntaxRoot = fileHeader.IsMissing ? AddHeader(document, root, document.Name, settings) : ReplaceHeader(document, root, settings);
+            var xmlFileHeader = FileHeaderHelpers.ParseXmlFileHeader(root);
+            var newSyntaxRoot = fileHeader.IsMissing ? AddHeader(document, root, document.Name, settings) : ReplaceHeader(document, root, settings, xmlFileHeader.IsMalformed);
 
             return document.WithSyntaxRoot(newSyntaxRoot);
         }
 
-        private static SyntaxNode ReplaceHeader(Document document, SyntaxNode root, StyleCopSettings settings)
+        private static SyntaxNode ReplaceHeader(Document document, SyntaxNode root, StyleCopSettings settings, bool isMalformedHeader)
         {
+            // If the header is well formed Xml then we parse out the copyright otherwise
             // Skip single line comments, whitespace, and end of line trivia until a blank line is encountered.
             SyntaxTriviaList trivia = root.GetLeadingTrivia();
-
             bool onBlankLine = false;
-            while (trivia.Any())
+            bool inCopyright = isMalformedHeader;
+            int? copyrightTriviaIndex = null;
+            var removalList = new System.Collections.Generic.List<int>();
+
+            // Need to do this with index so we get the line endings correct.
+            for (int i = 0; i < trivia.Count; i++)
             {
+                var triviaLine = trivia[i];
                 bool done = false;
-                switch (trivia[0].Kind())
+                switch (triviaLine.Kind())
                 {
-                case SyntaxKind.SingleLineCommentTrivia:
-                    trivia = trivia.RemoveAt(0);
-                    onBlankLine = false;
-                    break;
+                    case SyntaxKind.SingleLineCommentTrivia:
+                        if (!isMalformedHeader)
+                        {
+                            var openingTag = triviaLine.ToFullString().Contains("<copyright ");
+                            var closingTag = triviaLine.ToFullString().Contains("</copyright>") ||
+                                (openingTag && triviaLine.ToFullString().Trim().EndsWith("/>"));
+                            if (openingTag)
+                            {
+                                inCopyright = !closingTag;
+                                copyrightTriviaIndex = i;
+                            }
+                            else
+                            {
+                                if (inCopyright)
+                                {
+                                    removalList.Add(i);
+                                    inCopyright = !closingTag;
+                                }
+                            }
+                        }
+                        else
+                        {
+                            removalList.Add(i);
+                        }
 
-                case SyntaxKind.WhitespaceTrivia:
-                    trivia = trivia.RemoveAt(0);
-                    break;
+                        onBlankLine = false;
+                        break;
 
-                case SyntaxKind.EndOfLineTrivia:
-                    trivia = trivia.RemoveAt(0);
+                    case SyntaxKind.WhitespaceTrivia:
+                        removalList.Add(i);
+                        break;
 
-                    if (onBlankLine)
-                    {
+                    case SyntaxKind.EndOfLineTrivia:
+                        if (inCopyright)
+                        {
+                            removalList.Add(i);
+                        }
+
+                        if (onBlankLine)
+                        {
+                            done = true;
+                        }
+                        else
+                        {
+                            onBlankLine = true;
+                        }
+
+                        break;
+
+                    default:
                         done = true;
-                    }
-                    else
-                    {
-                        onBlankLine = true;
-                    }
-
-                    break;
-
-                default:
-                    done = true;
-                    break;
+                        break;
                 }
 
                 if (done)
@@ -106,8 +140,40 @@ namespace StyleCop.Analyzers.DocumentationRules
                 }
             }
 
+            if (isMalformedHeader)
+            {
+                copyrightTriviaIndex = null;
+            }
+
+            // Remove copyright lines in reverse order
+            removalList.Reverse();
+            foreach (var triviaLine in removalList)
+            {
+                trivia = trivia.RemoveAt(triviaLine);
+            }
+
             string newLineText = document.Project.Solution.Workspace.Options.GetOption(FormattingOptions.NewLine, LanguageNames.CSharp);
-            return root.WithLeadingTrivia(CreateNewHeader(document.Name, settings, newLineText).Add(SyntaxFactory.CarriageReturnLineFeed).Add(SyntaxFactory.CarriageReturnLineFeed).AddRange(trivia));
+
+            var newHeaderTrivia = CreateNewHeader(document.Name, settings, newLineText);
+            if (copyrightTriviaIndex.HasValue)
+            {
+                if (inCopyright)
+                {
+                    newHeaderTrivia = newHeaderTrivia.Add(SyntaxFactory.CarriageReturnLineFeed);
+                }
+
+                trivia = trivia.ReplaceRange(trivia[copyrightTriviaIndex.Value], newHeaderTrivia);
+                return root.WithLeadingTrivia(trivia);
+            }
+            else
+            {
+                if ((trivia.Count == 0) || (trivia[0].Kind() != SyntaxKind.SingleLineCommentTrivia))
+                {
+                    newHeaderTrivia = newHeaderTrivia.Add(SyntaxFactory.CarriageReturnLineFeed);
+                }
+
+                return root.WithLeadingTrivia(newHeaderTrivia.Add(SyntaxFactory.CarriageReturnLineFeed).AddRange(trivia));
+            }
         }
 
         private static SyntaxNode AddHeader(Document document, SyntaxNode root, string name, StyleCopSettings settings)
@@ -139,7 +205,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         private static string GetCopyrightText(string copyrightText, string newLineText)
         {
             copyrightText = copyrightText.Replace("\r\n", "\n");
-            return string.Join(newLineText + "// ", copyrightText.Split('\n'));
+            return string.Join(newLineText + "// ", copyrightText.Split('\n')).Replace("// " + newLineText, "//" + newLineText);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -450,8 +450,8 @@
     <Analyzer Include="..\..\packages\AsyncUsageAnalyzers.1.0.0-alpha003\analyzers\dotnet\AsyncUsageAnalyzers.dll" />
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-beta011\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
-    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-beta011\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-beta012\analyzers\dotnet\cs\Newtonsoft.Json.dll" />
+    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0-beta012\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="DocumentationRules\DocumentationResources.resx">


### PR DESCRIPTION
Fixes for SA1634 & SA1636 to deal with other copyright header elements. If the header is already valid then this only replaces the <copyright> tag contents. Otherwise it does the previous behaviour of replacing the whole header.

Also removed trailing spaces on blank lines in copyright text.

Fixes #1434