### PR TITLE
Use a builder instead of ImmutableDictionary in JSON models

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/DocumentationSettings.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/DocumentationSettings.cs
@@ -36,7 +36,7 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
         /// This is the backing field for the <see cref="Variables"/> property.
         /// </summary>
         [JsonProperty("variables", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        private ImmutableDictionary<string, string> variables;
+        private ImmutableDictionary<string, string>.Builder variables;
 
         /// <summary>
         /// This is the backing field for the <see cref="XmlHeader"/> property.
@@ -82,7 +82,7 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
         {
             this.companyName = DefaultCompanyName;
             this.copyrightText = DefaultCopyrightText;
-            this.variables = ImmutableDictionary<string, string>.Empty;
+            this.variables = ImmutableDictionary<string, string>.Empty.ToBuilder();
             this.xmlHeader = true;
 
             this.documentExposedElements = true;
@@ -138,7 +138,7 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
         {
             get
             {
-                return this.variables;
+                return this.variables.ToImmutable();
             }
         }
 


### PR DESCRIPTION
This works around JamesNK/Newtonsoft.Json#652 by avoiding the direct use of immutable types in the serialization process. The result remains efficient because the builder class caches the last returned immutable instance, and will continue returning the same instance as long as no changes are made to the builder.

Fixes #1359