### PR TITLE
Improve SA1642 and SA1643 code fix

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
@@ -219,6 +219,102 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorMissingDocumentationAsync(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", true).ConfigureAwait(false);
         }
 
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestNonPrivateConstructorSimpleDocumentationAsync(string typeKind)
+        {
+            await this.TestConstructorSimpleDocumentationAsync(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestNonPrivateConstructorSimpleDocumentationGenericAsync(string typeKind)
+        {
+            await this.TestConstructorSimpleDocumentationAsync(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestPrivateConstructorSimpleDocumentationAsync(string typeKind)
+        {
+            await this.TestConstructorSimpleDocumentationAsync(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestPrivateConstructorSimpleDocumentationGenericAsync(string typeKind)
+        {
+            await this.TestConstructorSimpleDocumentationAsync(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestStaticConstructorSimpleDocumentationAsync(string typeKind)
+        {
+            await this.TestConstructorSimpleDocumentationAsync(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", false).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestStaticConstructorSimpleDocumentationGenericAsync(string typeKind)
+        {
+            await this.TestConstructorSimpleDocumentationAsync(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", true).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestNonPrivateConstructorSimpleDocumentationWrongTypeNameAsync(string typeKind)
+        {
+            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestNonPrivateConstructorSimpleDocumentationGenericWrongTypeNameAsync(string typeKind)
+        {
+            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestPrivateConstructorSimpleDocumentationWrongTypeNameAsync(string typeKind)
+        {
+            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestPrivateConstructorSimpleDocumentationGenericWrongTypeNameAsync(string typeKind)
+        {
+            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestStaticConstructorSimpleDocumentationWrongTypeNameAsync(string typeKind)
+        {
+            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", false).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        public async Task TestStaticConstructorSimpleDocumentationGenericWrongTypeNameAsync(string typeKind)
+        {
+            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", true).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// This is a regression test for DotNetAnalyzers/StyleCopAnalyzers#676 "SA1642 misfires on nested structs,
         /// requiring text describing the outer type"
@@ -467,6 +563,96 @@ internal abstract class CustomizableBlockSubscriberBase<TSource, TTarget, TSubsc
 }}";
 
             string part3 = part2.EndsWith(".") ? string.Empty : ".";
+            fixedCode = string.Format(fixedCode, typeKind, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers, arguments);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        private async Task TestConstructorSimpleDocumentationAsync(string typeKind, string modifiers, string part1, string part2, bool generic)
+        {
+            string part3 = part2.EndsWith(".") ? string.Empty : ".";
+
+            var testCode = @"namespace FooNamespace
+{{
+    public {0} Foo{1}
+    {{
+        /// <summary>
+        /// {3}Foo{4}{5}
+        /// </summary>
+        {6}
+        Foo({7})
+        {{
+
+        }}
+    }}
+}}";
+            string arguments = typeKind == "struct" && modifiers != "static" ? "int argument" : null;
+            testCode = string.Format(testCode, typeKind, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers, arguments);
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 13);
+
+            await this.VerifyCSharpDiagnosticAsync(
+                testCode,
+                expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"namespace FooNamespace
+{{
+    public {0} Foo{1}
+    {{
+        /// <summary>
+        /// {3}<see cref=""Foo{2}""/>{4}{5}
+        /// </summary>
+        {6}
+        Foo({7})
+        {{
+
+        }}
+    }}
+}}";
+            fixedCode = string.Format(fixedCode, typeKind, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers, arguments);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        private async Task TestConstructorSimpleDocumentationWrongTypeNameAsync(string typeKind, string modifiers, string part1, string part2, bool generic)
+        {
+            string part3 = part2.EndsWith(".") ? string.Empty : ".";
+
+            var testCode = @"namespace FooNamespace
+{{
+    public {0} Foo{1}
+    {{
+        /// <summary>
+        /// {3}Bar{4}{5}
+        /// </summary>
+        {6}
+        Foo({7})
+        {{
+
+        }}
+    }}
+}}";
+            string arguments = typeKind == "struct" && modifiers != "static" ? "int argument" : null;
+            testCode = string.Format(testCode, typeKind, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers, arguments);
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 13);
+
+            await this.VerifyCSharpDiagnosticAsync(
+                testCode,
+                expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"namespace FooNamespace
+{{
+    public {0} Foo{1}
+    {{
+        /// <summary>
+        /// {3}<see cref=""Foo{2}""/>{4}{5}
+        /// </summary>
+        {6}
+        Foo({7})
+        {{
+
+        }}
+    }}
+}}";
             fixedCode = string.Format(fixedCode, typeKind, generic ? "<T1, T2>" : string.Empty, generic ? "{T1, T2}" : string.Empty, part1, part2, part3, modifiers, arguments);
             await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
@@ -411,7 +411,6 @@ internal abstract class CustomizableBlockSubscriberBase<TSource, TTarget, TSubsc
 {
     /// <summary>
     /// Initializes a new instance of the <see cref=""CustomizableBlockSubscriberBase{TSource, TTarget, TSubscribedElement}""/> class.
-    /// Initializes a new instance of the <see cref=""ProjectBuildSnapshotService""/> class.
     /// </summary>
     protected CustomizableBlockSubscriberBase()
     {
@@ -419,7 +418,7 @@ internal abstract class CustomizableBlockSubscriberBase<TSource, TTarget, TSubsc
 }
 ";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 9);
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 43);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
@@ -592,7 +591,8 @@ internal abstract class CustomizableBlockSubscriberBase<TSource, TTarget, TSubsc
 
             await this.VerifyCSharpDiagnosticAsync(
                 testCode,
-                expected, CancellationToken.None).ConfigureAwait(false);
+                expected,
+                CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"namespace FooNamespace
 {{
@@ -637,7 +637,8 @@ internal abstract class CustomizableBlockSubscriberBase<TSource, TTarget, TSubsc
 
             await this.VerifyCSharpDiagnosticAsync(
                 testCode,
-                expected, CancellationToken.None).ConfigureAwait(false);
+                expected,
+                CancellationToken.None).ConfigureAwait(false);
 
             var fixedCode = @"namespace FooNamespace
 {{

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -54,7 +54,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                     continue;
                 }
 
-                var node = root.FindNode(diagnostic.Location.SourceSpan, findInsideTrivia: true) as XmlNodeSyntax;
+                var node = root.FindNode(diagnostic.Location.SourceSpan, findInsideTrivia: true, getInnermostNodeForTie: true);
 
                 var xmlElementSyntax = node as XmlElementSyntax;
 
@@ -64,7 +64,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                 }
                 else
                 {
-                    var xmlEmptyElementSyntax = node as XmlEmptyElementSyntax;
+                    var xmlEmptyElementSyntax = (XmlEmptyElementSyntax)node;
                     context.RegisterCodeFix(CodeAction.Create(DocumentationResources.SA1642SA1643CodeFix, token => GetTransformedDocumentAsync(context.Document, root, xmlEmptyElementSyntax), equivalenceKey: nameof(SA1642SA1643CodeFixProvider)), diagnostic);
                 }
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/StandardTextDiagnosticBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/StandardTextDiagnosticBase.cs
@@ -32,6 +32,11 @@ namespace StyleCop.Analyzers.DocumentationRules
             None,
 
             /// <summary>
+            /// A standard text was found but the see element was incorrect.
+            /// </summary>
+            InvalidSeeTag,
+
+            /// <summary>
             /// A match to the expected text was found.
             /// </summary>
             FoundMatch,
@@ -75,11 +80,22 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                 if (firstTextPartSyntax != null && classReferencePart != null && secondTextParSyntaxt != null)
                 {
-                    if (TextPartsMatch(firstTextPart, secondTextPart, firstTextPartSyntax, secondTextParSyntaxt)
-                        && SeeTagIsCorrect(context, classReferencePart, declarationSyntax))
+                    if (TextPartsMatch(firstTextPart, secondTextPart, firstTextPartSyntax, secondTextParSyntaxt))
                     {
-                        // We found a correct standard text
-                        return MatchResult.FoundMatch;
+                        if (SeeTagIsCorrect(context, classReferencePart, declarationSyntax))
+                        {
+                            // We found a correct standard text
+                            return MatchResult.FoundMatch;
+                        }
+                        else
+                        {
+                            if (diagnosticDescriptor != null)
+                            {
+                                context.ReportDiagnostic(Diagnostic.Create(diagnosticDescriptor, classReferencePart.GetLocation()));
+                            }
+
+                            return MatchResult.None;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Fixes #415.

With these changes the code fix does a better job detecting mistakes in the standard text. If the standard text has the wrong class name in its text it will fix that instead of inserting a new standard text at the beginning of the summary. Examples:

It replaces a text form of the class name with a see tag:
```csharp
/// <summary>
/// Initializes a new instance of the Foo class.
/// </summary>
```
->
```csharp
/// <summary>
/// Initializes a new instance of the <see cref="Foo"/> class.
/// </summary>
```
It fixes a wrong see tag:
```csharp
/// <summary>
/// Initializes a new instance of the <see cref="Bar"/> class.
/// </summary>
```
->
```csharp
/// <summary>
/// Initializes a new instance of the <see cref="Foo"/> class.
/// </summary>
```
And it fixes a wrong class text with the correct class name:
```csharp
/// <summary>
/// Initializes a new instance of the Bar class.
/// </summary>
```
->
```csharp
/// <summary>
/// Initializes a new instance of the <see cref="Foo"/> class.
/// </summary>
```