### PR TITLE
Added logic to escape characters in XmlComments in the fixer.

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1634UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1634UnitTests.cs
@@ -274,6 +274,51 @@ namespace Bar
             await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verifies that a multi line file header containing characters that need xml escaping gets fixed correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestFileHeaderWithMultiLineCommentAndFieldsNeedingXmlEscapingAsync()
+        {
+            this.multiLineSettings = @"
+{
+  ""settings"": {
+    ""documentationRules"": {
+      ""companyName"": ""Foo & Bar Corp"",
+      ""copyrightText"": ""copyright (c) {companyName}. All rights reserved.\n\nLine #3""
+    }
+  }
+}
+";
+
+            var testCode = @"// <author>FooCorp</author>
+// <summary>Foo &amp; Bar Corp Bar Class</summary>
+ 
+namespace Bar
+{
+}
+";
+
+            var fixedCode = @"// <copyright file=""Test0.cs"" company=""Foo &amp; Bar Corp"">
+// copyright (c) Foo &amp; Bar Corp. All rights reserved.
+//
+// Line #3
+// </copyright>
+// <author>FooCorp</author>
+// <summary>Foo &amp; Bar Corp Bar Class</summary>
+ 
+namespace Bar
+{
+}
+";
+
+            var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1634Descriptor).WithLocation(1, 1);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new FileHeaderCodeFixProvider();

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1634UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1634UnitTests.cs
@@ -285,7 +285,7 @@ namespace Bar
 {
   ""settings"": {
     ""documentationRules"": {
-      ""companyName"": ""Foo & Bar Corp"",
+      ""companyName"": ""Foo & Bar \""quote\"" Corp"",
       ""copyrightText"": ""copyright (c) {companyName}. All rights reserved.\n\nLine #3""
     }
   }
@@ -300,8 +300,8 @@ namespace Bar
 }
 ";
 
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""Foo &amp; Bar Corp"">
-// copyright (c) Foo &amp; Bar Corp. All rights reserved.
+            var fixedCode = @"// <copyright file=""Test0.cs"" company=""Foo &amp; Bar &quot;quote&quot; Corp"">
+// copyright (c) Foo &amp; Bar ""quote"" Corp. All rights reserved.
 //
 // Line #3
 // </copyright>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderCodeFixProvider.cs
@@ -353,8 +353,8 @@ namespace StyleCop.Analyzers.DocumentationRules
 
         private static string WrapInXmlComment(string prefixWithLeadingSpaces, string copyrightText, string filename, StyleCopSettings settings, string newLineText)
         {
-            string encodedFilename = new XText(filename).ToString();
-            string encodedCompanyName = new XText(settings.DocumentationRules.CompanyName).ToString();
+            string encodedFilename = new XAttribute("t", filename).ToString().Substring(2).Trim('"');
+            string encodedCompanyName = new XAttribute("t", settings.DocumentationRules.CompanyName).ToString().Substring(2).Trim('"');
             string encodedCopyrightText = new XText(copyrightText).ToString();
 
             return

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderCodeFixProvider.cs
@@ -10,6 +10,7 @@ namespace StyleCop.Analyzers.DocumentationRules
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
+    using System.Xml.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeActions;
     using Microsoft.CodeAnalysis.CodeFixes;
@@ -352,9 +353,13 @@ namespace StyleCop.Analyzers.DocumentationRules
 
         private static string WrapInXmlComment(string prefixWithLeadingSpaces, string copyrightText, string filename, StyleCopSettings settings, string newLineText)
         {
+            string encodedFilename = new XText(filename).ToString();
+            string encodedCompanyName = new XText(settings.DocumentationRules.CompanyName).ToString();
+            string encodedCopyrightText = new XText(copyrightText).ToString();
+
             return
-                $"{prefixWithLeadingSpaces} <copyright file=\"{filename}\" company=\"{settings.DocumentationRules.CompanyName}\">" + newLineText
-                + copyrightText + newLineText
+                $"{prefixWithLeadingSpaces} <copyright file=\"{encodedFilename}\" company=\"{encodedCompanyName}\">" + newLineText
+                + encodedCopyrightText + newLineText
                 + prefixWithLeadingSpaces + " </copyright>";
         }
 


### PR DESCRIPTION
I realised we don't cope with &, <, > and friends in the wrap xml header logic.
Fix & test code attached.