### PR TITLE
SA1107: Dont report if the previous statement is missing its last token

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1107UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1107UnitTests.cs
@@ -6,6 +6,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.ReadabilityRules;
@@ -120,6 +121,35 @@ class ClassName
 }
 ";
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestThatAnalyzerIgnoresStatementsWithMissingTokenAsync()
+        {
+            string testCode = @"
+using System;
+class ClassName
+{
+    public static void Foo(string a, string b)
+    {
+        int i
+        if (true)
+        {
+            Console.WriteLine(""Bar"");
+        }
+    }
+}
+";
+            DiagnosticResult expected = new DiagnosticResult
+            {
+                Id = "CS1002",
+                Message = "; expected",
+                Severity = DiagnosticSeverity.Error,
+            };
+
+            expected = expected.WithLocation(7, 14);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1107CodeMustNotContainMultipleStatementsOnOneLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1107CodeMustNotContainMultipleStatementsOnOneLine.cs
@@ -62,22 +62,31 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
             if (block != null && block.Statements.Any())
             {
-                FileLinePositionSpan previousStatementLocation = block.Statements[0].GetLineSpan();
+                var previousStatement = block.Statements[0];
+                FileLinePositionSpan previousStatementLocation = previousStatement.GetLineSpan();
                 FileLinePositionSpan currentStatementLocation;
 
                 for (int i = 1; i < block.Statements.Count; i++)
                 {
-                    currentStatementLocation = block.Statements[i].GetLineSpan();
+                    var currentStatement = block.Statements[i];
+                    currentStatementLocation = currentStatement.GetLineSpan();
 
                     if (previousStatementLocation.EndLinePosition.Line
-                        == currentStatementLocation.StartLinePosition.Line)
+                        == currentStatementLocation.StartLinePosition.Line
+                        && !IsLastTokenMissing(previousStatement))
                     {
                         context.ReportDiagnostic(Diagnostic.Create(Descriptor, block.Statements[i].GetLocation()));
                     }
 
                     previousStatementLocation = currentStatementLocation;
+                    previousStatement = currentStatement;
                 }
             }
+        }
+
+        private static bool IsLastTokenMissing(StatementSyntax previousStatement)
+        {
+            return previousStatement.GetLastToken(includeZeroWidth: true, includeSkipped: true).IsMissing;
         }
     }
 }


### PR DESCRIPTION
I know this is pedantic, but it was a little bit annoying. When writing a statement that has its last token missing (e.g. a missing semicolon) SA1107 is reported in the following statement. The reason is that roslyn puts the missing semicolon at the start of the next line. So SA1107 is reported because the next statement is on the same line as the missing semicolon. In this code the whole if statement has squiggles. With this change SA1107 is not reported if the last token of the previous statement is missing.