### PR TITLE
Combine test and code coverage passes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,8 @@ before_build:
 build:
   project: StyleCopAnalyzers.sln
   verbosity: minimal
-after_test:
-- .\packages\OpenCover.4.6.166\tools\OpenCover.Console.exe -register:user -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"C:\projects\stylecopanalyzers\StyleCop.Analyzers\StyleCop.Analyzers.Test\bin\Debug\StyleCop.Analyzers.Test.dll -noshadow -appveyor" -filter:"+[StyleCop*]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -output:.\StyleCopAnalyzers_coverage.xml
+test_script:
+- .\packages\OpenCover.4.6.166\tools\OpenCover.Console.exe -register:user -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"C:\projects\stylecopanalyzers\StyleCop.Analyzers\StyleCop.Analyzers.Test\bin\Debug\StyleCop.Analyzers.Test.dll -noshadow -appveyor" -returntargetcode -filter:"+[StyleCop*]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -hideskipped:All -output:.\StyleCopAnalyzers_coverage.xml
 - "SET PATH=C:\\Python34;C:\\Python34\\Scripts;%PATH%"
 - pip install codecov
 - codecov -f "StyleCopAnalyzers_coverage.xml"


### PR DESCRIPTION
This pull request improves build performance by combining the test and code coverage phases. By returning the XUnit status code from OpenCover (see OpenCover/opencover#333), we avoid the silent failures problem described in #1560. See AppVeyor build [1.0.1909](https://ci.appveyor.com/project/sharwell/stylecopanalyzers/build/1.0.1909) for proof that test failures cause a build failure.