### PR TITLE
Added custom build targets to nuget package to simplify setting item group for settings file

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.nuspec
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.nuspec
@@ -27,7 +27,6 @@
     <file src="tools\uninstall.ps1" target="tools\" />
     
     <!-- MSBuild imports -->
-    <file src="build\StyleCop.Analyzers.props" target="build\" />
     <file src="build\StyleCop.Analyzers.targets" target="build\" />
 
     <!-- Source code -->

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.nuspec
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.nuspec
@@ -25,6 +25,10 @@
     <!-- Scripts -->
     <file src="tools\install.ps1" target="tools\" />
     <file src="tools\uninstall.ps1" target="tools\" />
+    
+    <!-- MSBuild imports -->
+    <file src="build\StyleCop.Analyzers.props" target="build\" />
+    <file src="build\StyleCop.Analyzers.targets" target="build\" />
 
     <!-- Source code -->
     <file src="**\*.cs" exclude="obj\**\*.cs" target="src"/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/build/StyleCop.Analyzers.props
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/build/StyleCop.Analyzers.props
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <AdditionalFileItemNames>$(AdditionalFileItemNames);StyleCopSettings</AdditionalFileItemNames>
+  </PropertyGroup>
+
+</Project>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/build/StyleCop.Analyzers.props
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/build/StyleCop.Analyzers.props
@@ -1,8 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-  <PropertyGroup>
-    <AdditionalFileItemNames>$(AdditionalFileItemNames);StyleCopSettings</AdditionalFileItemNames>
-  </PropertyGroup>
-
-</Project>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/build/StyleCop.Analyzers.targets
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/build/StyleCop.Analyzers.targets
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+    <!-- Add items to the Item Type menu in VS. -->
+    <AvailableItemName Include="StyleCopSettings" />
+  </ItemGroup>
+
+</Project>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/build/StyleCop.Analyzers.targets
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/build/StyleCop.Analyzers.targets
@@ -1,9 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <ItemGroup Condition="'$(BuildingInsideVisualStudio)' == 'true'">
-    <!-- Add items to the Item Type menu in VS. -->
-    <AvailableItemName Include="StyleCopSettings" />
-  </ItemGroup>
+  <Target Name="InjectStyleCopSettings"
+          BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <StyleCopSettings Include="@(None)"
+                        Condition="'%(Filename)%(Extension)' == 'stylecop.json'"/>
+      <AdditionalFiles Include="%(StyleCopSettings.Identity)" />
+    </ItemGroup>
+  </Target>
 
 </Project>


### PR DESCRIPTION
Added custom .targets and .props file with code to make it easy to set the item group for stylecop.json to StyleCopSettings. Include StyleCopSettings in AdditionalFileItemNames group.

I wouldn't be surprised if you've though of this already... and have a good reason why we shouldn't include it. But maybe it's just that nobody got around to it ;-)