### PR TITLE
Initial work on a fix all provider for renames

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/RenameHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/RenameHelper.cs
@@ -3,11 +3,17 @@
 
 namespace StyleCop.Analyzers.Helpers
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.FindSymbols;
     using Microsoft.CodeAnalysis.Rename;
+    using Microsoft.CodeAnalysis.Text;
 
     internal static class RenameHelper
     {
@@ -21,12 +27,183 @@ namespace StyleCop.Analyzers.Helpers
             var annotatedToken = annotatedRoot.FindToken(declarationToken.SpanStart);
 
             var semanticModel = await annotatedDocument.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
-            var symbol = semanticModel.GetDeclaredSymbol(annotatedToken.Parent, cancellationToken);
+            var symbol = semanticModel.GetDeclaredSymbol(annotatedToken.Parent, cancellationToken)
+                ?? semanticModel.GetSymbolInfo(annotatedToken.Parent, cancellationToken).Symbol;
 
             var newSolution = await Renamer.RenameSymbolAsync(annotatedSolution, symbol, newName, null, cancellationToken).ConfigureAwait(false);
 
             // TODO: return annotatedSolution instead of newSolution if newSolution contains any new errors (for any project)
             return newSolution;
+        }
+
+        /// <summary>
+        /// Tries to rename multiple symbols in a solution.
+        /// </summary>
+        /// <remarks>
+        /// Algorithm:
+        /// 1. Calculate a map that maps a symbol to the set of documents where it was referenced in.
+        /// 2. Calculate a map that maps a new name to all the symbols which should be renamed to it.
+        /// 3. With this information get a set of symbols that can be safely renamed.
+        /// 4. Get all text changes that correspond to the safe renames.
+        /// 5. Apply all renames.
+        /// </remarks>
+        /// <param name="symbols">The set of symbols that should be renamed.</param>
+        /// <param name="getNewName">A callback that should return the new name of a given symbol.</param>
+        /// <param name="solution">The solution where the rename should be made in.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/> to cancel the asynchronous process.</param>
+        /// <returns>A <see cref="Solution"/> where as much occurences of symbols in <paramref name="symbols"/> are renamed.</returns>
+        internal static async Task<Solution> RenameAllSymbolsAsync(
+            ImmutableHashSet<ISymbol> symbols,
+            Func<ISymbol, string> getNewName,
+            Solution solution,
+            CancellationToken cancellationToken)
+        {
+            Dictionary<ISymbol, ImmutableHashSet<Document>> symbolDocuments = await GetSymbolReferencesAsync(symbols, solution, cancellationToken).ConfigureAwait(false);
+
+            ImmutableDictionary<string, ImmutableHashSet<ISymbol>> newNamesToSymbols = GetNewNameReferences(symbols, getNewName);
+
+            ImmutableHashSet<ISymbol> symbolsThatCanBeRenamed = GetSymbolsThatCanBeSafelyRenamed(symbolDocuments, newNamesToSymbols);
+
+            Dictionary<Document, SortedSet<TextChange>> textChanges = await GetTextChangesAsync(getNewName, solution, symbolDocuments, symbolsThatCanBeRenamed).ConfigureAwait(false);
+
+            return await GetChangedSolutionAsync(solution, textChanges).ConfigureAwait(false);
+        }
+
+        private static async Task<Solution> GetChangedSolutionAsync(Solution solution, Dictionary<Document, SortedSet<TextChange>> textChanges)
+        {
+            // Apply text changes
+            foreach (var change in textChanges)
+            {
+                // TODO: parallelize
+                var text = await change.Key.GetTextAsync().ConfigureAwait(false);
+                solution = solution.WithDocumentText(change.Key.Id, text.WithChanges(change.Value));
+            }
+
+            return solution;
+        }
+
+        private static async Task<Dictionary<Document, SortedSet<TextChange>>> GetTextChangesAsync(Func<ISymbol, string> getNewName, Solution solution, Dictionary<ISymbol, ImmutableHashSet<Document>> symbolDocuments, ImmutableHashSet<ISymbol> symbolsThatCanBeRenamed)
+        {
+            Dictionary<Document, SortedSet<TextChange>> textChanges = new Dictionary<Document, SortedSet<TextChange>>();
+
+            foreach (var item in symbolDocuments.SelectMany(x => x.Value))
+            {
+                if (!textChanges.ContainsKey(item))
+                {
+                    textChanges.Add(item, new SortedSet<TextChange>(Comparer<TextChange>.Create((a, b) => a.Span.Start.CompareTo(b.Span.Start))));
+                }
+            }
+
+            foreach (var symbol in symbolsThatCanBeRenamed)
+            {
+                Solution newSolution = await Renamer.RenameSymbolAsync(solution, symbol, getNewName(symbol), null).ConfigureAwait(false);
+
+                SolutionChanges changes = newSolution.GetChanges(solution);
+                var changesDocumentIds = changes.GetProjectChanges().SelectMany(x => x.GetChangedDocuments()).ToArray();
+
+                foreach (var id in changesDocumentIds)
+                {
+                    var oldDocument = solution.GetDocument(id);
+                    var newDocument = newSolution.GetDocument(id);
+
+                    // TODO: parallelize
+                    var newTextChanges = await newDocument.GetTextChangesAsync(oldDocument).ConfigureAwait(false);
+
+                    foreach (var textChange in newTextChanges)
+                    {
+                        textChanges[oldDocument].Add(textChange);
+                    }
+                }
+            }
+
+            return textChanges;
+        }
+
+        private static ImmutableHashSet<ISymbol> GetSymbolsThatCanBeSafelyRenamed(Dictionary<ISymbol, ImmutableHashSet<Document>> symbolDocuments, ImmutableDictionary<string, ImmutableHashSet<ISymbol>> newNamesToSymbols)
+        {
+            var symbolsThatCanBeRenamed = ImmutableHashSet.CreateBuilder<ISymbol>();
+
+            foreach (var item in newNamesToSymbols)
+            {
+                foreach (var symbol in GetSafeRenames(item.Value, symbolDocuments))
+                {
+                    symbolsThatCanBeRenamed.Add(symbol);
+                }
+            }
+
+            return symbolsThatCanBeRenamed.ToImmutable();
+        }
+
+        private static ImmutableDictionary<string, ImmutableHashSet<ISymbol>> GetNewNameReferences(ImmutableHashSet<ISymbol> symbols, Func<ISymbol, string> getNewName)
+        {
+            return symbols
+                .GroupBy(x => getNewName(x))
+                .ToImmutableDictionary(x => x.Key, x => x.ToImmutableHashSet());
+        }
+
+        private static async Task<Dictionary<ISymbol, ImmutableHashSet<Document>>> GetSymbolReferencesAsync(ImmutableHashSet<ISymbol> symbols, Solution solution, CancellationToken cancellationToken)
+        {
+            Dictionary<ISymbol, ImmutableHashSet<Document>> symbolDocuments = new Dictionary<ISymbol, ImmutableHashSet<Document>>();
+
+            foreach (var symbol in symbols)
+            {
+                // TODO: This should be parallelized
+                symbolDocuments.Add(symbol, await GetDocumentsWithSymbolInItAsync(symbol, solution, cancellationToken).ConfigureAwait(false));
+            }
+
+            return symbolDocuments;
+        }
+
+        private static IEnumerable<ISymbol> GetSafeRenames(ImmutableHashSet<ISymbol> symbols, Dictionary<ISymbol, ImmutableHashSet<Document>> symbolDocuments)
+        {
+            // We prefer renames that effect a small number of documents to maximize the number of renames we do.
+            // We sort the symbols by the number of effected documents and greedily choose symbols in that order.
+            // Note: This is not optimal. If we have documents { a, b, c, d, e, f} and renames that effect these documents:
+            //       {a, b, c}, {d, e, f}, {c, d}
+            //       we choose poorly.
+            // This is essentially the set packing problem which can't be approximated very well.
+            HashSet<Document> documents = new HashSet<Document>();
+
+            KeyValuePair<ISymbol, ImmutableHashSet<Document>>[] items = symbolDocuments.Where(x => symbols.Contains(x.Key)).ToArray();
+
+            Array.Sort(items, (a, b) => a.Value.Count.CompareTo(b.Value.Count));
+
+            foreach (var documentsLinkedToSymbol in items)
+            {
+                if (!documentsLinkedToSymbol.Value.Any(documents.Contains))
+                {
+                    foreach (var item in documentsLinkedToSymbol.Value)
+                    {
+                        documents.Add(item);
+                        yield return documentsLinkedToSymbol.Key;
+                    }
+                }
+            }
+        }
+
+        private static async Task<ImmutableHashSet<Document>> GetDocumentsWithSymbolInItAsync(ISymbol symbol, Solution solution, CancellationToken cancellationToken)
+        {
+            var references = await SymbolFinder.FindReferencesAsync(symbol, solution, cancellationToken).ConfigureAwait(false);
+            var referencedInDocuments = references.SelectMany(x => x.Locations)
+                .Select(x => x.Document);
+
+            var resultBuilder = ImmutableHashSet.CreateBuilder<Document>();
+
+            var declarations = symbol.Locations
+                .Where(y => y.IsInSource)
+                .Select(y => solution.GetDocument(y.SourceTree));
+
+            foreach (var declarationDocuments in declarations)
+            {
+                resultBuilder.Add(declarationDocuments);
+            }
+
+            foreach (var document in referencedInDocuments)
+            {
+                resultBuilder.Add(document);
+            }
+
+            return resultBuilder.ToImmutable();
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameFixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameFixAllProvider.cs
@@ -1,0 +1,77 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.NamingRules
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Helpers;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+
+    internal class RenameFixAllProvider : FixAllProvider
+    {
+        private readonly string title;
+        private readonly Func<ISymbol, string> getNewName;
+
+        public RenameFixAllProvider(string title, Func<ISymbol, string> getNewName)
+        {
+            this.title = title;
+            this.getNewName = getNewName;
+        }
+
+        public async override Task<CodeAction> GetFixAsync(FixAllContext fixAllContext)
+        {
+            switch (fixAllContext.Scope)
+            {
+            case FixAllScope.Document:
+                return CodeAction.Create(this.title, async t => await GetActionAsync(fixAllContext.Solution, await fixAllContext.GetDocumentDiagnosticsAsync(fixAllContext.Document).ConfigureAwait(false), this.getNewName, t).ConfigureAwait(false));
+            case FixAllScope.Project:
+                return CodeAction.Create(this.title, async t => await GetActionAsync(fixAllContext.Solution, await fixAllContext.GetAllDiagnosticsAsync(fixAllContext.Project).ConfigureAwait(false), this.getNewName, t).ConfigureAwait(false));
+            case FixAllScope.Solution:
+                var diagnostics = new List<Diagnostic>();
+                foreach (var item in fixAllContext.Solution.Projects)
+                {
+                    diagnostics.AddRange(await fixAllContext.GetAllDiagnosticsAsync(item).ConfigureAwait(false));
+                }
+
+                return CodeAction.Create(this.title, async t => await GetActionAsync(fixAllContext.Solution, diagnostics, this.getNewName, t).ConfigureAwait(false));
+            case FixAllScope.Custom:
+                break;
+            default:
+                break;
+            }
+
+            return null;
+        }
+
+        private static async Task<Solution> GetActionAsync(Solution solution, IEnumerable<Diagnostic> diagnostics, Func<ISymbol, string> getNewName, CancellationToken cancellationToken)
+        {
+            List<ISymbol> symbolsToRename = new List<ISymbol>();
+
+            foreach (var grouping in diagnostics.Select(x => x.Location).GroupBy(y => y.SourceTree))
+            {
+                var document = solution.GetDocument(grouping.Key);
+                var root = await document.GetSyntaxRootAsync().ConfigureAwait(false);
+                var semanticModel = await document.GetSemanticModelAsync().ConfigureAwait(false);
+
+                foreach (var location in grouping)
+                {
+                    var node = root.FindNode(location.SourceSpan, getInnermostNodeForTie: true);
+                    var symbol = semanticModel.GetDeclaredSymbol(node) ?? semanticModel.GetSymbolInfo(node).Symbol;
+                    if (symbol != null)
+                    {
+                        symbolsToRename.Add(symbol);
+                    }
+                }
+            }
+
+            return await RenameHelper.RenameAllSymbolsAsync(symbolsToRename.ToImmutableHashSet(), getNewName, solution, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToLowerCaseCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToLowerCaseCodeFixProvider.cs
@@ -34,7 +34,7 @@ namespace StyleCop.Analyzers.NamingRules
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
         {
-            return CustomFixAllProviders.BatchFixer;
+            return new RenameFixAllProvider(NamingResources.RenameToCodeFix, symbol => GetNewName(symbol));
         }
 
         /// <inheritdoc/>
@@ -57,6 +57,12 @@ namespace StyleCop.Analyzers.NamingRules
                     context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.RenameToCodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken), equivalenceKey: nameof(RenameToLowerCaseCodeFixProvider)), diagnostic);
                 }
             }
+        }
+
+        private static string GetNewName(ISymbol symbol)
+        {
+            string oldName = symbol.Name;
+            return char.ToLower(oldName[0]) + oldName.Substring(1);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1300ElementMustBeginWithUpperCaseLetter.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.NamingRules
 {
+    using System;
     using System.Collections.Immutable;
     using System.Linq;
     using Microsoft.CodeAnalysis;
@@ -212,7 +213,7 @@ namespace StyleCop.Analyzers.NamingRules
                 return;
             }
 
-            var symbolInfo = context.SemanticModel.GetDeclaredSymbol(identifier.Parent);
+            var symbolInfo = context.SemanticModel.GetDeclaredSymbol(identifier.Parent) ?? context.SemanticModel.GetSymbolInfo(identifier.Parent).Symbol;
             if (symbolInfo != null && NamedTypeHelpers.IsImplementingAnInterfaceMember(symbolInfo))
             {
                 return;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -220,6 +220,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>NamingResources.resx</DependentUpon>
     </Compile>
+    <Compile Include="NamingRules\RenameFixAllProvider.cs" />
     <Compile Include="NamingRules\RenameToLowerCaseCodeFixProvider.cs" />
     <Compile Include="NamingRules\RenameToUpperCaseCodeFixProvider.cs" />
     <Compile Include="NamingRules\SA1300ElementMustBeginWithUpperCaseLetter.cs" />


### PR DESCRIPTION
With this PR I implement a RenameFixAllProvider that can batch fix rename changes. It is more robust compared to the batch fixer because it only applies changes that can be applied at the same time without effecting each other. because of limitations in roslyns renamer it cant detect conflicts in renames itself but it can prevent conflicts between all rename tasks.

I need to write some unit tests that test the new batch renaming. Also I have to write some more code to prevent some more renames in partial types or derived types. Also the renamer can be used in more places (probably all SA13XX rules). Currently this is used for SA1300, SA1303, SA1304, SA1307, SA1311, SA1306, SA1312 and SA1313. This is currently approx. 10x faster than the batch fixer.

This also fixed that namespace renames were not applied globally. A test for this is also missing right now.

 This is still a work in progress but I want to get some early feedback on this.