### PR TITLE
Removed unnecessary diagnostic id checks

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1513UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1513UnitTests.cs
@@ -548,6 +548,7 @@ public class Foo
         public async Task TestCodeFixAsync()
         {
             var testCode = @"using System;
+using System.Collections.Generic;
 
 public class Foo
 {
@@ -623,6 +624,7 @@ public class Foo
 ";
 
             var fixedTestCode = @"using System;
+using System.Collections.Generic;
 
 public class Foo
 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
@@ -163,6 +163,12 @@ namespace TestHelper
                 done = true;
                 for (var i = 0; i < analyzerDiagnostics.Length; i++)
                 {
+                    if (!codeFixProvider.FixableDiagnosticIds.Contains(analyzerDiagnostics[i].Id))
+                    {
+                        // do not pass unsupported diagnostics to a code fix provider
+                        continue;
+                    }
+
                     var actions = new List<CodeAction>();
                     var context = new CodeFixContext(document, analyzerDiagnostics[i], (a, d) => actions.Add(a), cancellationToken);
                     await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
@@ -235,6 +241,12 @@ namespace TestHelper
                 string equivalenceKey = null;
                 foreach (var diagnostic in analyzerDiagnostics)
                 {
+                    if (!codeFixProvider.FixableDiagnosticIds.Contains(diagnostic.Id))
+                    {
+                        // do not pass unsupported diagnostics to a code fix provider
+                        continue;
+                    }
+
                     var actions = new List<CodeAction>();
                     var context = new CodeFixContext(document, diagnostic, (a, d) => actions.Add(a), cancellationToken);
                     await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
@@ -342,8 +354,13 @@ namespace TestHelper
             Assert.True(index < analyzerDiagnostics.Count());
 
             var actions = new List<CodeAction>();
-            var context = new CodeFixContext(document, analyzerDiagnostics[index], (a, d) => actions.Add(a), cancellationToken);
-            await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
+
+            // do not pass unsupported diagnostics to a code fix provider
+            if (codeFixProvider.FixableDiagnosticIds.Contains(analyzerDiagnostics[index].Id))
+            {
+                var context = new CodeFixContext(document, analyzerDiagnostics[index], (a, d) => actions.Add(a), cancellationToken);
+                await codeFixProvider.RegisterCodeFixesAsync(context).ConfigureAwait(false);
+            }
 
             return actions.ToImmutableArray();
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderCodeFixProvider.cs
@@ -50,7 +50,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => this.FixableDiagnosticIds.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(DocumentationResources.SA1633CodeFix, token => GetTransformedDocumentAsync(context.Document, token), equivalenceKey: nameof(FileHeaderCodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/InheritdocCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/InheritdocCodeFixProvider.cs
@@ -42,11 +42,6 @@ namespace StyleCop.Analyzers.DocumentationRules
             SyntaxNode root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!this.FixableDiagnosticIds.Contains(diagnostic.Id))
-                {
-                    continue;
-                }
-
                 SyntaxToken identifierToken = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (identifierToken.IsMissingOrDefault())
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1609SA1610CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1609SA1610CodeFixProvider.cs
@@ -47,11 +47,6 @@ namespace StyleCop.Analyzers.DocumentationRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!FixableDiagnostics.Contains(diagnostic.Id, StringComparer.Ordinal))
-                {
-                    continue;
-                }
-
                 string description = DocumentationResources.SA1609SA1610CodeFix;
                 context.RegisterCodeFix(CodeAction.Create(description, cancellationToken => this.GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken), equivalenceKey: nameof(SA1609SA1610CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1615SA1616CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1615SA1616CodeFixProvider.cs
@@ -47,11 +47,6 @@ namespace StyleCop.Analyzers.DocumentationRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!FixableDiagnostics.Contains(diagnostic.Id, StringComparer.Ordinal))
-                {
-                    continue;
-                }
-
                 string description = "Document return value";
                 context.RegisterCodeFix(CodeAction.Create(description, cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken), equivalenceKey: nameof(SA1615SA1616CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1617CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1617CodeFixProvider.cs
@@ -40,7 +40,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(DocumentationResources.SA1617CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1617CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1626CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1626CodeFixProvider.cs
@@ -40,11 +40,6 @@ namespace StyleCop.Analyzers.DocumentationRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                if (diagnostic.Id != SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes.DiagnosticId)
-                {
-                    continue;
-                }
-
                 context.RegisterCodeFix(
                     CodeAction.Create(
                         DocumentationResources.SA1626CodeFix,

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -49,11 +49,6 @@ namespace StyleCop.Analyzers.DocumentationRules
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!FixableDiagnostics.Contains(diagnostic.Id))
-                {
-                    continue;
-                }
-
                 var node = root.FindNode(diagnostic.Location.SourceSpan, findInsideTrivia: true, getInnermostNodeForTie: true);
 
                 var xmlElementSyntax = node as XmlElementSyntax;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1651CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1651CodeFixProvider.cs
@@ -43,11 +43,6 @@ namespace StyleCop.Analyzers.DocumentationRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!FixableDiagnostics.Contains(diagnostic.Id, StringComparer.Ordinal))
-                {
-                    continue;
-                }
-
                 var documentRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
                 SyntaxNode syntax = documentRoot.FindNode(diagnostic.Location.SourceSpan, findInsideTrivia: true, getInnermostNodeForTie: true);
                 if (syntax == null)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501CodeFixProvider.cs
@@ -38,7 +38,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1501CodeFix, cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken), equivalenceKey: nameof(SA1501CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1502CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1502CodeFixProvider.cs
@@ -38,7 +38,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1502CodeFix, token => this.GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1502CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CodeFixProvider.cs
@@ -49,7 +49,7 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             var syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 var node = syntaxRoot.FindNode(diagnostic.Location.SourceSpan, false, true) as StatementSyntax;
                 if (node == null || node.IsMissing)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1504CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1504CodeFixProvider.cs
@@ -41,7 +41,7 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             var syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-            foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (var diagnostic in context.Diagnostics)
             {
                 var node = syntaxRoot.FindNode(diagnostic.Location.SourceSpan);
                 var accessorList = GetAccessorList(node);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1505CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1505CodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (var diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1505CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1505CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1506CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1506CodeFixProvider.cs
@@ -36,7 +36,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (var diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1506CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1506CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1507CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1507CodeFixProvider.cs
@@ -38,7 +38,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1507CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1507CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1508CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1508CodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (var diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1508CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1508CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1509CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1509CodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)).ToList())
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(
                     CodeAction.Create(

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1510CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1510CodeFixProvider.cs
@@ -35,7 +35,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1510CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1510CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1511CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1511CodeFixProvider.cs
@@ -35,7 +35,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1511CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1511CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1512CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1512CodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1512CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1512CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513CodeFixProvider.cs
@@ -39,7 +39,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1513CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1513CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1514CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1514CodeFixProvider.cs
@@ -36,7 +36,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1514CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1514CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515CodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1515CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1515CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1516CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1516CodeFixProvider.cs
@@ -40,7 +40,7 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             var syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1516CodeFix, token => GetTransformedDocumentAsync(context.Document, syntaxRoot, diagnostic, context.CancellationToken), equivalenceKey: nameof(SA1516CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1517CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1517CodeFixProvider.cs
@@ -36,7 +36,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1517CodeFix, token => GetTransformedDocumentAsync(context.Document, token), equivalenceKey: nameof(SA1517CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1518CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1518CodeFixProvider.cs
@@ -36,7 +36,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1518CodeFix, token => GetTransformedDocumentAsync(context.Document, token), equivalenceKey: nameof(SA1518CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
@@ -44,11 +44,6 @@ namespace StyleCop.Analyzers.MaintainabilityRules
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1119StatementMustNotUseUnnecessaryParenthesis.DiagnosticId))
-                {
-                    continue;
-                }
-
                 SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true, findInsideTrivia: true);
                 if (node.IsMissing)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
@@ -43,11 +43,6 @@ namespace StyleCop.Analyzers.MaintainabilityRules
             var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1400AccessModifierMustBeDeclared.DiagnosticId))
-                {
-                    continue;
-                }
-
                 SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
                 if (node == null || node.IsMissing)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1402CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1402CodeFixProvider.cs
@@ -43,11 +43,6 @@ namespace StyleCop.Analyzers.MaintainabilityRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1402FileMayOnlyContainASingleClass.DiagnosticId))
-                {
-                    continue;
-                }
-
                 context.RegisterCodeFix(CodeAction.Create(MaintainabilityResources.SA1402CodeFix, cancellationToken => GetTransformedSolutionAsync(context.Document, diagnostic, cancellationToken), equivalenceKey: nameof(SA1402CodeFixProvider)), diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1404CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1404CodeFixProvider.cs
@@ -43,11 +43,6 @@ namespace StyleCop.Analyzers.MaintainabilityRules
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!this.FixableDiagnosticIds.Contains(diagnostic.Id))
-                {
-                    continue;
-                }
-
                 var node = root.FindNode(diagnostic.Location.SourceSpan);
 
                 var attribute = node as AttributeSyntax;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
@@ -42,11 +42,6 @@ namespace StyleCop.Analyzers.MaintainabilityRules
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!this.FixableDiagnosticIds.Contains(diagnostic.Id))
-                {
-                    continue;
-                }
-
                 SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan);
                 if (node.IsMissing)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1410SA1411CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1410SA1411CodeFixProvider.cs
@@ -43,11 +43,6 @@ namespace StyleCop.Analyzers.MaintainabilityRules
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!this.FixableDiagnosticIds.Contains(diagnostic.Id))
-                {
-                    continue;
-                }
-
                 SyntaxNode node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true);
                 if (node.IsMissing)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1412CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1412CodeFixProvider.cs
@@ -41,11 +41,6 @@ namespace StyleCop.Analyzers.MaintainabilityRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!this.FixableDiagnosticIds.Contains(diagnostic.Id))
-                {
-                    continue;
-                }
-
                 string usedEncoding = diagnostic.Properties[SA1412StoreFilesAsUtf8.EncodingProperty];
 
                 context.RegisterCodeFix(

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToLowerCaseCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToLowerCaseCodeFixProvider.cs
@@ -45,11 +45,6 @@ namespace StyleCop.Analyzers.NamingRules
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!this.FixableDiagnosticIds.Contains(diagnostic.Id))
-                {
-                    continue;
-                }
-
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (!string.IsNullOrEmpty(token.ValueText))
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToUpperCaseCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToUpperCaseCodeFixProvider.cs
@@ -53,11 +53,6 @@ namespace StyleCop.Analyzers.NamingRules
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!FixableDiagnostics.Contains(diagnostic.Id))
-                {
-                    continue;
-                }
-
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 var newName = char.ToUpper(token.ValueText[0]) + token.ValueText.Substring(1);
                 var memberSyntax = this.GetParentTypeDeclaration(token);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1302CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1302CodeFixProvider.cs
@@ -36,11 +36,6 @@ namespace StyleCop.Analyzers.NamingRules
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1302InterfaceNamesMustBeginWithI.DiagnosticId))
-                {
-                    continue;
-                }
-
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 var newName = "I" + token.ValueText;
                 context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.RenameToCodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken)), diagnostic);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1308CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1308CodeFixProvider.cs
@@ -42,11 +42,6 @@ namespace StyleCop.Analyzers.NamingRules
             var root = await document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1308VariableNamesMustNotBePrefixed.DiagnosticId))
-                {
-                    continue;
-                }
-
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
 
                 // The variable name is the full suffix. In this case we cannot generate a valid variable name and thus will not offer a code fix.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1309CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1309CodeFixProvider.cs
@@ -42,11 +42,6 @@ namespace StyleCop.Analyzers.NamingRules
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1309FieldNamesMustNotBeginWithUnderscore.DiagnosticId))
-                {
-                    continue;
-                }
-
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (!string.IsNullOrEmpty(token.ValueText))
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1310CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1310CodeFixProvider.cs
@@ -43,11 +43,6 @@ namespace StyleCop.Analyzers.NamingRules
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1310FieldNamesMustNotContainUnderscore.DiagnosticId))
-                {
-                    continue;
-                }
-
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 string currentName = token.ValueText;
                 string proposedName = BuildProposedName(currentName);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SX1309CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SX1309CodeFixProvider.cs
@@ -43,12 +43,6 @@ namespace StyleCop.Analyzers.NamingRules
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SX1309FieldNamesMustBeginWithUnderscore.DiagnosticId)
-                    && !diagnostic.Id.Equals(SX1309SStaticFieldNamesMustBeginWithUnderscore.DiagnosticId))
-                {
-                    continue;
-                }
-
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 if (!string.IsNullOrEmpty(token.ValueText))
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/ElementOrderCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/ElementOrderCodeFixProvider.cs
@@ -44,7 +44,7 @@ namespace StyleCop.Analyzers.OrderingRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(OrderingResources.ElementOrderCodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(ElementOrderCodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1205CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1205CodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace StyleCop.Analyzers.OrderingRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(OrderingResources.SA1205CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1205CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1207CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1207CodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace StyleCop.Analyzers.OrderingRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(OrderingResources.SA1207CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1207CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1212SA1213CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1212SA1213CodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace StyleCop.Analyzers.OrderingRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(
                     CodeAction.Create(

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionCodeFixProvider.cs
@@ -41,11 +41,6 @@ namespace StyleCop.Analyzers.ReadabilityRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!this.FixableDiagnosticIds.Contains(diagnostic.Id))
-                {
-                    continue;
-                }
-
                 context.RegisterCodeFix(CodeAction.Create("Remove region", token => GetTransformedDocumentAsync(context.Document, diagnostic), equivalenceKey: nameof(RemoveRegionCodeFixProvider)), diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
@@ -42,11 +42,6 @@ namespace StyleCop.Analyzers.ReadabilityRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists.DiagnosticId))
-                {
-                    continue;
-                }
-
                 context.RegisterCodeFix(
                     CodeAction.Create(
                         ReadabilityResources.SA1100CodeFix,

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
@@ -47,11 +47,6 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1101PrefixLocalCallsWithThis.DiagnosticId))
-                {
-                    continue;
-                }
-
                 var node = root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true) as SimpleNameSyntax;
                 if (node == null)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1102CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1102CodeFixProvider.cs
@@ -38,7 +38,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (var diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1102CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1102CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1103CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1103CodeFixProvider.cs
@@ -41,7 +41,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
         {
             var syntaxRoot = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
-            foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (var diagnostic in context.Diagnostics)
             {
                 var queryExpression = (QueryExpressionSyntax)syntaxRoot.FindNode(diagnostic.Location.SourceSpan).Parent;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1104SA1105CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1104SA1105CodeFixProvider.cs
@@ -38,7 +38,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (var diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1104SA1105CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1104SA1105CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1107CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1107CodeFixProvider.cs
@@ -44,11 +44,6 @@ namespace StyleCop.Analyzers.ReadabilityRules
             var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1107CodeMustNotContainMultipleStatementsOnOneLine.DiagnosticId))
-                {
-                    continue;
-                }
-
                 var node = root?.FindNode(diagnostic.Location.SourceSpan, findInsideTrivia: true, getInnermostNodeForTie: true);
 
                 if (node?.Parent as BlockSyntax != null)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1116CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1116CodeFixProvider.cs
@@ -40,11 +40,6 @@ namespace StyleCop.Analyzers.ReadabilityRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1116SplitParametersMustStartOnLineAfterDeclaration.DiagnosticId))
-                {
-                    continue;
-                }
-
                 context.RegisterCodeFix(
                     CodeAction.Create(
                         ReadabilityResources.SA1116CodeFix,

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1120CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1120CodeFixProvider.cs
@@ -37,7 +37,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (var diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1120CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), nameof(SA1120CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
@@ -63,11 +63,6 @@ namespace StyleCop.Analyzers.ReadabilityRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1121UseBuiltInTypeAlias.DiagnosticId))
-                {
-                    continue;
-                }
-
                 context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1121CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1121CodeFixProvider)), diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
@@ -54,11 +54,6 @@ namespace StyleCop.Analyzers.ReadabilityRules
             var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1122UseStringEmptyForEmptyStrings.DiagnosticId))
-                {
-                    continue;
-                }
-
                 context.RegisterCodeFix(
                     CodeAction.Create(
                         ReadabilityResources.SA1122CodeFix,

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1127CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1127CodeFixProvider.cs
@@ -39,7 +39,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (var diagnostic in context.Diagnostics.Where(d => this.FixableDiagnosticIds.Contains(d.Id)))
+            foreach (var diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(
                     CodeAction.Create(

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/SettingsFileCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/SettingsFileCodeFixProvider.cs
@@ -69,7 +69,7 @@ namespace StyleCop.Analyzers.Settings
                 return SpecializedTasks.CompletedTask;
             }
 
-            foreach (var diagnostic in context.Diagnostics.Where(d => this.FixableDiagnosticIds.Contains(d.Id)))
+            foreach (var diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(SettingsResources.SettingsFileCodeFix, token => GetTransformedSolutionAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SettingsFileCodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
@@ -41,7 +41,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (var diagnostic in context.Diagnostics)
             {
                 if (diagnostic.Properties.ContainsKey(SA1003SymbolsMustBeSpacedCorrectly.CodeFixAction))
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1004CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1004CodeFixProvider.cs
@@ -41,11 +41,6 @@ namespace StyleCop.Analyzers.SpacingRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1004DocumentationLinesMustBeginWithSingleSpace.DiagnosticId))
-                {
-                    continue;
-                }
-
                 context.RegisterCodeFix(
                     CodeAction.Create(
                         SpacingResources.SA1004CodeFix,

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
@@ -45,11 +45,6 @@ namespace StyleCop.Analyzers.SpacingRules
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1005SingleLineCommentsMustBeginWithSingleSpace.DiagnosticId))
-                {
-                    continue;
-                }
-
                 context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1005CodeFix, t => GetTransformedDocumentAsync(context.Document, diagnostic.Location, t), equivalenceKey: nameof(SA1005CodeFixProvider)), diagnostic);
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
@@ -46,11 +46,6 @@ namespace StyleCop.Analyzers.SpacingRules
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                if (!diagnostic.Id.Equals(SA1018NullableTypeSymbolsMustNotBePrecededBySpace.DiagnosticId))
-                {
-                    continue;
-                }
-
                 var nullableType = syntaxRoot.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true) as NullableTypeSyntax;
                 if (nullableType == null)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1025CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1025CodeFixProvider.cs
@@ -41,7 +41,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (var diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(
                     CodeAction.Create(

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1027CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1027CodeFixProvider.cs
@@ -38,7 +38,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (Diagnostic diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (Diagnostic diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1027CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1027CodeFixProvider)), diagnostic);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/TokenSpacingCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/TokenSpacingCodeFixProvider.cs
@@ -118,7 +118,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// <inheritdoc/>
         public override Task RegisterCodeFixesAsync(CodeFixContext context)
         {
-            foreach (var diagnostic in context.Diagnostics.Where(d => FixableDiagnostics.Contains(d.Id)))
+            foreach (var diagnostic in context.Diagnostics)
             {
                 context.RegisterCodeFix(CodeAction.Create(SpacingResources.TokenSpacingCodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(TokenSpacingCodeFixProvider)), diagnostic);
             }


### PR DESCRIPTION
- Removed the `.Where` and `if (...)` conditions that check to see if a diagnostic ID is fixable. See discussion in #1441 
- Fixed failing SA1513 unit test 
- Modified `CodeFixVerifier` to only present supported diagnostics to a code fix provider

This is part 1 of the breakup of #1452