### PR TITLE
Removed FixableDiagnostics fields

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1609SA1610CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1609SA1610CodeFixProvider.cs
@@ -30,11 +30,9 @@ namespace StyleCop.Analyzers.DocumentationRules
     [Shared]
     internal class SA1609SA1610CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1609PropertyDocumentationMustHaveValue.DiagnosticId, SA1610PropertyDocumentationMustHaveValueText.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1609PropertyDocumentationMustHaveValue.DiagnosticId, SA1610PropertyDocumentationMustHaveValueText.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1615SA1616CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1615SA1616CodeFixProvider.cs
@@ -30,11 +30,9 @@ namespace StyleCop.Analyzers.DocumentationRules
     [Shared]
     internal class SA1615SA1616CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1615ElementReturnValueMustBeDocumented.DiagnosticId, SA1616ElementReturnValueDocumentationMustHaveText.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1615ElementReturnValueMustBeDocumented.DiagnosticId, SA1616ElementReturnValueDocumentationMustHaveText.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1617CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1617CodeFixProvider.cs
@@ -25,11 +25,9 @@ namespace StyleCop.Analyzers.DocumentationRules
     [Shared]
     internal class SA1617CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1617VoidReturnValueMustNotBeDocumented.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1617VoidReturnValueMustNotBeDocumented.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -30,11 +30,11 @@ namespace StyleCop.Analyzers.DocumentationRules
     [Shared]
     internal class SA1642SA1643CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.DiagnosticId, SA1643DestructorSummaryDocumentationMustBeginWithStandardText.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(
+                SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.DiagnosticId,
+                SA1643DestructorSummaryDocumentationMustBeginWithStandardText.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1651CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1651CodeFixProvider.cs
@@ -26,11 +26,9 @@ namespace StyleCop.Analyzers.DocumentationRules
     [Shared]
     internal class SA1651CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1651DoNotUsePlaceholderElements.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1651DoNotUsePlaceholderElements.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501CodeFixProvider.cs
@@ -23,11 +23,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1501CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1501StatementMustNotBeOnASingleLine.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1501StatementMustNotBeOnASingleLine.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1502CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1502CodeFixProvider.cs
@@ -23,11 +23,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1502CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1502ElementMustNotBeOnASingleLine.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1502ElementMustNotBeOnASingleLine.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CodeFixProvider.cs
@@ -26,17 +26,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1503CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1503CurlyBracketsMustNotBeOmitted.DiagnosticId, SA1519CurlyBracketsMustNotBeOmittedFromMultiLineChildStatement.DiagnosticId, SA1520UseCurlyBracketsConsistently.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds
-        {
-            get
-            {
-                return FixableDiagnostics;
-            }
-        }
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1503CurlyBracketsMustNotBeOmitted.DiagnosticId, SA1519CurlyBracketsMustNotBeOmittedFromMultiLineChildStatement.DiagnosticId, SA1520UseCurlyBracketsConsistently.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1504CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1504CodeFixProvider.cs
@@ -24,11 +24,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1504CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1504AllAccessorsMustBeSingleLineOrMultiLine.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1504AllAccessorsMustBeSingleLineOrMultiLine.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1505CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1505CodeFixProvider.cs
@@ -22,11 +22,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1505CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1505OpeningCurlyBracketsMustNotBeFollowedByBlankLine.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1505OpeningCurlyBracketsMustNotBeFollowedByBlankLine.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1506CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1506CodeFixProvider.cs
@@ -21,11 +21,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1506CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1506ElementDocumentationHeadersMustNotBeFollowedByBlankLine.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1506ElementDocumentationHeadersMustNotBeFollowedByBlankLine.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1507CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1507CodeFixProvider.cs
@@ -23,11 +23,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1507CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1507CodeMustNotContainMultipleBlankLinesInARow.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1507CodeMustNotContainMultipleBlankLinesInARow.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1508CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1508CodeFixProvider.cs
@@ -22,11 +22,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1508CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1508ClosingCurlyBracketsMustNotBePrecededByBlankLine.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1508ClosingCurlyBracketsMustNotBePrecededByBlankLine.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1509CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1509CodeFixProvider.cs
@@ -22,11 +22,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1509CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1509OpeningCurlyBracketsMustNotBePrecededByBlankLine.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1509OpeningCurlyBracketsMustNotBePrecededByBlankLine.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1510CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1510CodeFixProvider.cs
@@ -20,11 +20,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1510CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1510ChainedStatementBlocksMustNotBePrecededByBlankLine.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1510ChainedStatementBlocksMustNotBePrecededByBlankLine.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1511CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1511CodeFixProvider.cs
@@ -20,11 +20,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1511CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1511WhileDoFooterMustNotBePrecededByBlankLine.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1511WhileDoFooterMustNotBePrecededByBlankLine.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1512CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1512CodeFixProvider.cs
@@ -22,11 +22,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1512CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1512SingleLineCommentsMustNotBeFollowedByBlankLine.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1512SingleLineCommentsMustNotBeFollowedByBlankLine.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513CodeFixProvider.cs
@@ -24,11 +24,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1513CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1513ClosingCurlyBracketMustBeFollowedByBlankLine.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1513ClosingCurlyBracketMustBeFollowedByBlankLine.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1514CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1514CodeFixProvider.cs
@@ -21,11 +21,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1514CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1514ElementDocumentationHeaderMustBePrecededByBlankLine.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1514ElementDocumentationHeaderMustBePrecededByBlankLine.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515CodeFixProvider.cs
@@ -22,11 +22,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1515CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1515SingleLineCommentMustBePrecededByBlankLine.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1515SingleLineCommentMustBePrecededByBlankLine.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1516CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1516CodeFixProvider.cs
@@ -23,11 +23,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1516CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1516ElementsMustBeSeparatedByBlankLine.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1516ElementsMustBeSeparatedByBlankLine.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1517CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1517CodeFixProvider.cs
@@ -21,11 +21,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1517CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1517CodeMustNotContainBlankLinesAtStartOfFile.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1517CodeMustNotContainBlankLinesAtStartOfFile.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1518CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1518CodeFixProvider.cs
@@ -21,11 +21,9 @@ namespace StyleCop.Analyzers.LayoutRules
     [Shared]
     internal class SA1518CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1518CodeMustNotContainBlankLinesAtEndOfFile.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1518CodeMustNotContainBlankLinesAtEndOfFile.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
@@ -25,11 +25,9 @@ namespace StyleCop.Analyzers.MaintainabilityRules
     [Shared]
     internal class SA1119CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1119StatementMustNotUseUnnecessaryParenthesis.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1119StatementMustNotUseUnnecessaryParenthesis.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
@@ -25,11 +25,9 @@ namespace StyleCop.Analyzers.MaintainabilityRules
     [Shared]
     internal class SA1400CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1400AccessModifierMustBeDeclared.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1400AccessModifierMustBeDeclared.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1402CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1402CodeFixProvider.cs
@@ -25,11 +25,9 @@ namespace StyleCop.Analyzers.MaintainabilityRules
     [Shared]
     internal class SA1402CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1402FileMayOnlyContainASingleClass.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1402FileMayOnlyContainASingleClass.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1404CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1404CodeFixProvider.cs
@@ -24,11 +24,9 @@ namespace StyleCop.Analyzers.MaintainabilityRules
     [Shared]
     internal class SA1404CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1404CodeAnalysisSuppressionMustHaveJustification.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1404CodeAnalysisSuppressionMustHaveJustification.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
@@ -23,11 +23,11 @@ namespace StyleCop.Analyzers.MaintainabilityRules
     [Shared]
     internal class SA1407SA1408CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1407ArithmeticExpressionsMustDeclarePrecedence.DiagnosticId, SA1408ConditionalExpressionsMustDeclarePrecedence.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(
+                SA1407ArithmeticExpressionsMustDeclarePrecedence.DiagnosticId,
+                SA1408ConditionalExpressionsMustDeclarePrecedence.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1410SA1411CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1410SA1411CodeFixProvider.cs
@@ -22,13 +22,11 @@ namespace StyleCop.Analyzers.MaintainabilityRules
     [Shared]
     internal class SA1410SA1411CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
+        /// <inheritdoc/>
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
             ImmutableArray.Create(
                 SA1410RemoveDelegateParenthesisWhenPossible.DiagnosticId,
                 SA1411AttributeConstructorMustNotUseUnnecessaryParenthesis.DiagnosticId);
-
-        /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1412CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1412CodeFixProvider.cs
@@ -24,11 +24,9 @@ namespace StyleCop.Analyzers.MaintainabilityRules
     [Shared]
     internal class SA1412CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1412StoreFilesAsUtf8.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1412StoreFilesAsUtf8.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToLowerCaseCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToLowerCaseCodeFixProvider.cs
@@ -22,14 +22,12 @@ namespace StyleCop.Analyzers.NamingRules
     [Shared]
     internal class RenameToLowerCaseCodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
+        /// <inheritdoc/>
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
             ImmutableArray.Create(
                 SA1306FieldNamesMustBeginWithLowerCaseLetter.DiagnosticId,
                 SA1312VariableNamesMustBeginWithLowerCaseLetter.DiagnosticId,
                 SA1313ParameterNamesMustBeginWithLowerCaseLetter.DiagnosticId);
-
-        /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToUpperCaseCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToUpperCaseCodeFixProvider.cs
@@ -28,16 +28,14 @@ namespace StyleCop.Analyzers.NamingRules
     {
         private const string Suffix = "Value";
 
-        private static readonly ImmutableArray<string> FixableDiagnostics =
+        /// <inheritdoc/>
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
             ImmutableArray.Create(
                 SA1300ElementMustBeginWithUpperCaseLetter.DiagnosticId,
                 SA1303ConstFieldNamesMustBeginWithUpperCaseLetter.DiagnosticId,
                 SA1304NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter.DiagnosticId,
                 SA1307AccessibleFieldsMustBeginWithUpperCaseLetter.DiagnosticId,
                 SA1311StaticReadonlyFieldsMustBeginWithUpperCaseLetter.DiagnosticId);
-
-        /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1302CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1302CodeFixProvider.cs
@@ -22,11 +22,9 @@ namespace StyleCop.Analyzers.NamingRules
     [Shared]
     internal class SA1302CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1302InterfaceNamesMustBeginWithI.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1302InterfaceNamesMustBeginWithI.DiagnosticId);
 
         /// <inheritdoc/>
         public override async Task RegisterCodeFixesAsync(CodeFixContext context)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1308CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1308CodeFixProvider.cs
@@ -23,11 +23,9 @@ namespace StyleCop.Analyzers.NamingRules
     [Shared]
     internal class SA1308CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1308VariableNamesMustNotBePrefixed.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1308VariableNamesMustNotBePrefixed.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1309CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1309CodeFixProvider.cs
@@ -22,11 +22,9 @@ namespace StyleCop.Analyzers.NamingRules
     [Shared]
     internal class SA1309CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-          ImmutableArray.Create(SA1309FieldNamesMustNotBeginWithUnderscore.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+          ImmutableArray.Create(SA1309FieldNamesMustNotBeginWithUnderscore.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1310CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1310CodeFixProvider.cs
@@ -23,11 +23,9 @@ namespace StyleCop.Analyzers.NamingRules
     [Shared]
     internal class SA1310CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-          ImmutableArray.Create(SA1310FieldNamesMustNotContainUnderscore.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+          ImmutableArray.Create(SA1310FieldNamesMustNotContainUnderscore.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SX1309CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SX1309CodeFixProvider.cs
@@ -23,11 +23,11 @@ namespace StyleCop.Analyzers.NamingRules
     [Shared]
     internal class SX1309CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SX1309FieldNamesMustBeginWithUnderscore.DiagnosticId, SX1309SStaticFieldNamesMustBeginWithUnderscore.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(
+                SX1309FieldNamesMustBeginWithUnderscore.DiagnosticId,
+                SX1309SStaticFieldNamesMustBeginWithUnderscore.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/ElementOrderCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/ElementOrderCodeFixProvider.cs
@@ -23,7 +23,8 @@ namespace StyleCop.Analyzers.OrderingRules
     [Shared]
     internal class ElementOrderCodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
+        /// <inheritdoc/>
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
             ImmutableArray.Create(
                 SA1201ElementsMustAppearInTheCorrectOrder.DiagnosticId,
                 SA1202ElementsMustBeOrderedByAccess.DiagnosticId,
@@ -31,9 +32,6 @@ namespace StyleCop.Analyzers.OrderingRules
                 SA1204StaticElementsMustAppearBeforeInstanceElements.DiagnosticId,
                 SA1214StaticReadonlyElementsMustAppearBeforeStaticNonReadonlyElements.DiagnosticId,
                 SA1215InstanceReadonlyElementsMustAppearBeforeInstanceNonReadonlyElements.DiagnosticId);
-
-        /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1205CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1205CodeFixProvider.cs
@@ -22,11 +22,9 @@ namespace StyleCop.Analyzers.OrderingRules
     [Shared]
     internal class SA1205CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1205PartialElementsMustDeclareAccess.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1205PartialElementsMustDeclareAccess.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1207CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1207CodeFixProvider.cs
@@ -22,11 +22,9 @@ namespace StyleCop.Analyzers.OrderingRules
     [Shared]
     internal class SA1207CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1207ProtectedMustComeBeforeInternal.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1207ProtectedMustComeBeforeInternal.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1212SA1213CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1212SA1213CodeFixProvider.cs
@@ -22,11 +22,9 @@ namespace StyleCop.Analyzers.OrderingRules
     [Shared]
     internal class SA1212SA1213CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1212PropertyAccessorsMustFollowOrder.DiagnosticId, SA1213EventAccessorsMustFollowOrder.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1212PropertyAccessorsMustFollowOrder.DiagnosticId, SA1213EventAccessorsMustFollowOrder.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/UsingCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/UsingCodeFixProvider.cs
@@ -28,7 +28,8 @@ namespace StyleCop.Analyzers.OrderingRules
     {
         private static readonly List<UsingDirectiveSyntax> EmptyUsingsList = new List<UsingDirectiveSyntax>();
 
-        private static readonly ImmutableArray<string> FixableDiagnostics =
+        /// <inheritdoc/>
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
             ImmutableArray.Create(
                 SA1200UsingDirectivesMustBePlacedWithinNamespace.DiagnosticId,
                 SA1208SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectives.DiagnosticId,
@@ -37,9 +38,6 @@ namespace StyleCop.Analyzers.OrderingRules
                 SA1211UsingAliasDirectivesMustBeOrderedAlphabeticallyByAliasName.DiagnosticId,
                 SA1216UsingStaticDirectivesMustBePlacedAtTheCorrectLocation.DiagnosticId,
                 SA1217UsingStaticDirectivesMustBeOrderedAlphabetically.DiagnosticId);
-
-        /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionCodeFixProvider.cs
@@ -23,11 +23,9 @@ namespace StyleCop.Analyzers.ReadabilityRules
     [Shared]
     internal class RemoveRegionCodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1123DoNotPlaceRegionsWithinElements.DiagnosticId, SA1124DoNotUseRegions.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1123DoNotPlaceRegionsWithinElements.DiagnosticId, SA1124DoNotUseRegions.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
@@ -25,11 +25,9 @@ namespace StyleCop.Analyzers.ReadabilityRules
     [Shared]
     internal class SA1100CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
@@ -28,11 +28,10 @@ namespace StyleCop.Analyzers.ReadabilityRules
     internal class SA1101CodeFixProvider : CodeFixProvider
     {
         private static readonly ThisExpressionSyntax ThisExpressionSyntax = SyntaxFactory.ThisExpression();
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1101PrefixLocalCallsWithThis.DiagnosticId);
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1101PrefixLocalCallsWithThis.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1102CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1102CodeFixProvider.cs
@@ -23,11 +23,9 @@ namespace StyleCop.Analyzers.ReadabilityRules
     [Shared]
     internal class SA1102CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA110xQueryClauses.SA1102Descriptor.Id);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA110xQueryClauses.SA1102Descriptor.Id);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1103CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1103CodeFixProvider.cs
@@ -24,11 +24,9 @@ namespace StyleCop.Analyzers.ReadabilityRules
     [Shared]
     internal class SA1103CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA110xQueryClauses.SA1103Descriptor.Id);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA110xQueryClauses.SA1103Descriptor.Id);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1104SA1105CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1104SA1105CodeFixProvider.cs
@@ -23,11 +23,11 @@ namespace StyleCop.Analyzers.ReadabilityRules
     [Shared]
     internal class SA1104SA1105CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA110xQueryClauses.SA1104Descriptor.Id, SA110xQueryClauses.SA1105Descriptor.Id);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(
+                SA110xQueryClauses.SA1104Descriptor.Id,
+                SA110xQueryClauses.SA1105Descriptor.Id);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1107CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1107CodeFixProvider.cs
@@ -26,11 +26,9 @@ namespace StyleCop.Analyzers.ReadabilityRules
     {
         private static readonly SA1107FixAllProvider FixAllProvider = new SA1107FixAllProvider();
 
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1107CodeMustNotContainMultipleStatementsOnOneLine.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1107CodeMustNotContainMultipleStatementsOnOneLine.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1120CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1120CodeFixProvider.cs
@@ -22,11 +22,9 @@ namespace StyleCop.Analyzers.ReadabilityRules
     [Shared]
     internal class SA1120CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1120CommentsMustContainText.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1120CommentsMustContainText.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
@@ -46,11 +46,9 @@ namespace StyleCop.Analyzers.ReadabilityRules
             [SpecialType.System_UInt64] = SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ULongKeyword))
         };
 
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1121UseBuiltInTypeAlias.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1121UseBuiltInTypeAlias.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
@@ -28,9 +28,6 @@ namespace StyleCop.Analyzers.ReadabilityRules
     {
         private static readonly SyntaxNode StringEmptyExpression;
 
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1122UseStringEmptyForEmptyStrings.DiagnosticId);
-
         static SA1122CodeFixProvider()
         {
             var identifierNameSyntax = SyntaxFactory.IdentifierName(nameof(string.Empty));
@@ -40,7 +37,8 @@ namespace StyleCop.Analyzers.ReadabilityRules
         }
 
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1122UseStringEmptyForEmptyStrings.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
@@ -26,11 +26,9 @@ namespace StyleCop.Analyzers.SpacingRules
     [Shared]
     internal class SA1003CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1003SymbolsMustBeSpacedCorrectly.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1003SymbolsMustBeSpacedCorrectly.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
@@ -26,11 +26,9 @@ namespace StyleCop.Analyzers.SpacingRules
     [Shared]
     internal class SA1005CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1005SingleLineCommentsMustBeginWithSingleSpace.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1005SingleLineCommentsMustBeginWithSingleSpace.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
@@ -27,11 +27,9 @@ namespace StyleCop.Analyzers.SpacingRules
     [Shared]
     internal class SA1018CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1018NullableTypeSymbolsMustNotBePrecededBySpace.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1018NullableTypeSymbolsMustNotBePrecededBySpace.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1025CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1025CodeFixProvider.cs
@@ -26,11 +26,9 @@ namespace StyleCop.Analyzers.SpacingRules
     [Shared]
     internal class SA1025CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1025CodeMustNotContainMultipleWhitespaceInARow.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1025CodeMustNotContainMultipleWhitespaceInARow.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1027CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1027CodeFixProvider.cs
@@ -23,11 +23,9 @@ namespace StyleCop.Analyzers.SpacingRules
     [Shared]
     internal class SA1027CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1027TabsMustNotBeUsed.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1027TabsMustNotBeUsed.DiagnosticId);
 
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
@@ -24,11 +24,9 @@ namespace StyleCop.Analyzers.SpacingRules
     [Shared]
     internal class SA1028CodeFixProvider : CodeFixProvider
     {
-        private static readonly ImmutableArray<string> FixableDiagnostics =
-            ImmutableArray.Create(SA1028CodeMustNotContainTrailingWhitespace.DiagnosticId);
-
         /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SA1028CodeMustNotContainTrailingWhitespace.DiagnosticId);
 
         /// <inheritdoc/>
         public sealed override FixAllProvider GetFixAllProvider()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/TokenSpacingCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/TokenSpacingCodeFixProvider.cs
@@ -34,7 +34,8 @@ namespace StyleCop.Analyzers.SpacingRules
         private const string LayoutPack = "pack";
         private const string LayoutPreserve = "preserve";
 
-        private static readonly ImmutableArray<string> FixableDiagnostics =
+        /// <inheritdoc/>
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
             ImmutableArray.Create(
                 SA1000KeywordsMustBeSpacedCorrectly.DiagnosticId,
                 SA1001CommasMustBeSpacedCorrectly.DiagnosticId,
@@ -62,9 +63,6 @@ namespace StyleCop.Analyzers.SpacingRules
                 SA1111ClosingParenthesisMustBeOnLineOfLastParameter.DiagnosticId,
                 SA1112ClosingParenthesisMustBeOnLineOfOpeningParenthesis.DiagnosticId,
                 SA1113CommaMustBeOnSameLineAsPreviousParameter.DiagnosticId);
-
-        /// <inheritdoc/>
-        public override ImmutableArray<string> FixableDiagnosticIds => FixableDiagnostics;
 
         internal static ImmutableDictionary<string, string> InsertPreceding { get; } =
             ImmutableDictionary<string, string>.Empty


### PR DESCRIPTION
- Removed all `FixableDiagnostics` fields and assigned the immutable array directly to the `FixableDiagnosticsId` override

This is part 2 of the breakup of #1452