### PR TITLE
Reformatted all RegisterCodeFix calls

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
@@ -80,6 +80,15 @@ namespace StyleCop.Analyzers.DocumentationRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Document return value.
+        /// </summary>
+        internal static string SA1615SA1616CodeFix {
+            get {
+                return ResourceManager.GetString("SA1615SA1616CodeFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Remove &lt;returns&gt; XML comment.
         /// </summary>
         internal static string SA1617CodeFix {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
@@ -123,6 +123,9 @@
   <data name="SA1609SA1610CodeFix" xml:space="preserve">
     <value>Document value from summary</value>
   </data>
+  <data name="SA1615SA1616CodeFix" xml:space="preserve">
+    <value>Document return value</value>
+  </data>
   <data name="SA1617CodeFix" xml:space="preserve">
     <value>Remove &lt;returns&gt; XML comment</value>
   </data>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderCodeFixProvider.cs
@@ -52,7 +52,12 @@ namespace StyleCop.Analyzers.DocumentationRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(DocumentationResources.SA1633CodeFix, token => GetTransformedDocumentAsync(context.Document, token), equivalenceKey: nameof(FileHeaderCodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        DocumentationResources.SA1633CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, cancellationToken),
+                        nameof(FileHeaderCodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1609SA1610CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1609SA1610CodeFixProvider.cs
@@ -45,8 +45,12 @@ namespace StyleCop.Analyzers.DocumentationRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                string description = DocumentationResources.SA1609SA1610CodeFix;
-                context.RegisterCodeFix(CodeAction.Create(description, cancellationToken => this.GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken), equivalenceKey: nameof(SA1609SA1610CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        DocumentationResources.SA1609SA1610CodeFix,
+                        cancellationToken => this.GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1609SA1610CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1615SA1616CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1615SA1616CodeFixProvider.cs
@@ -45,8 +45,12 @@ namespace StyleCop.Analyzers.DocumentationRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                string description = "Document return value";
-                context.RegisterCodeFix(CodeAction.Create(description, cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken), equivalenceKey: nameof(SA1615SA1616CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        DocumentationResources.SA1615SA1616CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1615SA1616CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1617CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1617CodeFixProvider.cs
@@ -40,7 +40,12 @@ namespace StyleCop.Analyzers.DocumentationRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(DocumentationResources.SA1617CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1617CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        DocumentationResources.SA1617CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1617CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1626CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1626CodeFixProvider.cs
@@ -44,7 +44,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                     CodeAction.Create(
                         DocumentationResources.SA1626CodeFix,
                         cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
-                        equivalenceKey: nameof(SA1626CodeFixProvider)),
+                        nameof(SA1626CodeFixProvider)),
                     diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -55,12 +55,22 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                 if (xmlElementSyntax != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create(DocumentationResources.SA1642SA1643CodeFix, token => GetTransformedDocumentAsync(context.Document, root, xmlElementSyntax), equivalenceKey: nameof(SA1642SA1643CodeFixProvider)), diagnostic);
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            DocumentationResources.SA1642SA1643CodeFix,
+                            cancellationToken => GetTransformedDocumentAsync(context.Document, root, xmlElementSyntax),
+                            nameof(SA1642SA1643CodeFixProvider)),
+                        diagnostic);
                 }
                 else
                 {
                     var xmlEmptyElementSyntax = (XmlEmptyElementSyntax)node;
-                    context.RegisterCodeFix(CodeAction.Create(DocumentationResources.SA1642SA1643CodeFix, token => GetTransformedDocumentAsync(context.Document, root, xmlEmptyElementSyntax), equivalenceKey: nameof(SA1642SA1643CodeFixProvider)), diagnostic);
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            DocumentationResources.SA1642SA1643CodeFix,
+                            cancellationToken => GetTransformedDocumentAsync(context.Document, root, xmlEmptyElementSyntax),
+                            nameof(SA1642SA1643CodeFixProvider)),
+                        diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1651CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1651CodeFixProvider.cs
@@ -61,8 +61,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                     continue;
                 }
 
-                string description = DocumentationResources.SA1651CodeFix;
-                context.RegisterCodeFix(CodeAction.Create(description, cancellationToken => this.GetTransformedDocumentAsync(context.Document, xmlElementSyntax, cancellationToken), equivalenceKey: nameof(SA1651CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        DocumentationResources.SA1651CodeFix,
+                        cancellationToken => this.GetTransformedDocumentAsync(context.Document, xmlElementSyntax, cancellationToken),
+                        nameof(SA1651CodeFixProvider)),
+                    diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1500CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1500CodeFixProvider.cs
@@ -40,7 +40,12 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1500CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1500CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1500CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1500CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501CodeFixProvider.cs
@@ -38,7 +38,12 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1501CodeFix, cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken), equivalenceKey: nameof(SA1501CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1501CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1501CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1502CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1502CodeFixProvider.cs
@@ -38,7 +38,12 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1502CodeFix, token => this.GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1502CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1502CodeFix,
+                        cancellationToken => this.GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1502CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503CodeFixProvider.cs
@@ -55,7 +55,12 @@ namespace StyleCop.Analyzers.LayoutRules
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1503CodeFix, token => GetTransformedDocumentAsync(context.Document, syntaxRoot, node, token), equivalenceKey: nameof(SA1503CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1503CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, syntaxRoot, node, cancellationToken),
+                        nameof(SA1503CodeFixProvider)),
+                    diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1504CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1504CodeFixProvider.cs
@@ -82,10 +82,20 @@ namespace StyleCop.Analyzers.LayoutRules
 
                 if (canOfferSingleLineFix)
                 {
-                    context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1504CodeFixSingleLine, token => GetTransformedDocumentForSingleLineAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1504CodeFixProvider) + "SingleLine"), diagnostic);
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            LayoutResources.SA1504CodeFixSingleLine,
+                            cancellationToken => GetTransformedDocumentForSingleLineAsync(context.Document, diagnostic, cancellationToken),
+                            nameof(SA1504CodeFixProvider) + "SingleLine"),
+                        diagnostic);
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1504CodeFixMultipleLines, token => GetTransformedDocumentForMutipleLinesAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1504CodeFixProvider) + "MultipleLines"), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1504CodeFixMultipleLines,
+                        cancellationToken => GetTransformedDocumentForMutipleLinesAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1504CodeFixProvider) + "MultipleLines"),
+                    diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1505CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1505CodeFixProvider.cs
@@ -37,7 +37,12 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1505CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1505CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1505CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1505CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1506CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1506CodeFixProvider.cs
@@ -36,7 +36,12 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1506CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1506CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1506CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1506CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1507CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1507CodeFixProvider.cs
@@ -38,7 +38,12 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1507CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1507CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1507CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1507CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1508CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1508CodeFixProvider.cs
@@ -37,7 +37,12 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1508CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1508CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1508CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1508CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1509CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1509CodeFixProvider.cs
@@ -41,7 +41,7 @@ namespace StyleCop.Analyzers.LayoutRules
                     CodeAction.Create(
                         LayoutResources.SA1509CodeFix,
                         token => this.GetTransformedDocumentAsync(context.Document, diagnostic, token),
-                        equivalenceKey: nameof(SA1509CodeFixProvider)),
+                        nameof(SA1509CodeFixProvider)),
                     diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1510CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1510CodeFixProvider.cs
@@ -35,7 +35,12 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1510CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1510CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1510CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1510CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1511CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1511CodeFixProvider.cs
@@ -35,7 +35,12 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1511CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1511CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1511CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1511CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1512CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1512CodeFixProvider.cs
@@ -37,7 +37,12 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1512CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1512CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1512CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1512CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513CodeFixProvider.cs
@@ -39,7 +39,12 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1513CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1513CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1513CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1513CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1514CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1514CodeFixProvider.cs
@@ -36,7 +36,12 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1514CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1514CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1514CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1514CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515CodeFixProvider.cs
@@ -37,7 +37,12 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1515CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1515CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1515CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1515CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1516CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1516CodeFixProvider.cs
@@ -40,7 +40,12 @@ namespace StyleCop.Analyzers.LayoutRules
 
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1516CodeFix, token => GetTransformedDocumentAsync(context.Document, syntaxRoot, diagnostic, context.CancellationToken), equivalenceKey: nameof(SA1516CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1516CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, syntaxRoot, diagnostic, context.CancellationToken),
+                        nameof(SA1516CodeFixProvider)),
+                    diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1517CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1517CodeFixProvider.cs
@@ -36,7 +36,12 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1517CodeFix, token => GetTransformedDocumentAsync(context.Document, token), equivalenceKey: nameof(SA1517CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1517CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, cancellationToken),
+                        nameof(SA1517CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1518CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1518CodeFixProvider.cs
@@ -36,7 +36,12 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(LayoutResources.SA1518CodeFix, token => GetTransformedDocumentAsync(context.Document, token), equivalenceKey: nameof(SA1518CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        LayoutResources.SA1518CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, cancellationToken),
+                        nameof(SA1518CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119CodeFixProvider.cs
@@ -52,7 +52,12 @@ namespace StyleCop.Analyzers.MaintainabilityRules
 
                 if (syntax != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create(MaintainabilityResources.SA1119CodeFix, token => GetTransformedDocumentAsync(context.Document, root, syntax), equivalenceKey: nameof(SA1119CodeFixProvider)), diagnostic);
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            MaintainabilityResources.SA1119CodeFix,
+                            cancellationToken => GetTransformedDocumentAsync(context.Document, root, syntax),
+                            nameof(SA1119CodeFixProvider)),
+                        diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1400CodeFixProvider.cs
@@ -53,7 +53,12 @@ namespace StyleCop.Analyzers.MaintainabilityRules
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(MaintainabilityResources.SA1400CodeFix, token => GetTransformedDocumentAsync(context.Document, root, declarationNode), equivalenceKey: nameof(SA1400CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        MaintainabilityResources.SA1400CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, root, declarationNode),
+                        nameof(SA1400CodeFixProvider)),
+                    diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1402CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1402CodeFixProvider.cs
@@ -41,7 +41,12 @@ namespace StyleCop.Analyzers.MaintainabilityRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(MaintainabilityResources.SA1402CodeFix, cancellationToken => GetTransformedSolutionAsync(context.Document, diagnostic, cancellationToken), equivalenceKey: nameof(SA1402CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        MaintainabilityResources.SA1402CodeFix,
+                        cancellationToken => GetTransformedSolutionAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1402CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1407SA1408CodeFixProvider.cs
@@ -51,7 +51,12 @@ namespace StyleCop.Analyzers.MaintainabilityRules
                 BinaryExpressionSyntax syntax = node as BinaryExpressionSyntax;
                 if (syntax != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create(MaintainabilityResources.SA1407SA1408CodeFix, token => GetTransformedDocumentAsync(context.Document, root, syntax), equivalenceKey: nameof(SA1407SA1408CodeFixProvider)), diagnostic);
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            MaintainabilityResources.SA1407SA1408CodeFix,
+                            cancellationToken => GetTransformedDocumentAsync(context.Document, root, syntax),
+                            nameof(SA1407SA1408CodeFixProvider)),
+                        diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1410SA1411CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1410SA1411CodeFixProvider.cs
@@ -52,7 +52,12 @@ namespace StyleCop.Analyzers.MaintainabilityRules
 
                 if (node != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create(MaintainabilityResources.SA1410SA1411CodeFix, token => GetTransformedDocumentAsync(context.Document, root, node), equivalenceKey: nameof(SA1410SA1411CodeFixProvider)), diagnostic);
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            MaintainabilityResources.SA1410SA1411CodeFix,
+                            cancellationToken => GetTransformedDocumentAsync(context.Document, root, node),
+                            nameof(SA1410SA1411CodeFixProvider)),
+                        diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1412CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1412CodeFixProvider.cs
@@ -45,7 +45,7 @@ namespace StyleCop.Analyzers.MaintainabilityRules
                     CodeAction.Create(
                         string.Format(MaintainabilityResources.SA1412CodeFix, usedEncoding),
                         cancellationToken => GetTransformedSolutionAsync(context.Document, cancellationToken),
-                        equivalenceKey: nameof(SA1412CodeFixProvider) + "." + usedEncoding),
+                        nameof(SA1412CodeFixProvider) + "." + usedEncoding),
                     diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToLowerCaseCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToLowerCaseCodeFixProvider.cs
@@ -47,7 +47,12 @@ namespace StyleCop.Analyzers.NamingRules
                 if (!string.IsNullOrEmpty(token.ValueText))
                 {
                     var newName = char.ToLower(token.ValueText[0]) + token.ValueText.Substring(1);
-                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.RenameToCodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken), equivalenceKey: nameof(RenameToLowerCaseCodeFixProvider)), diagnostic);
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            string.Format(NamingResources.RenameToCodeFix, newName),
+                            cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken),
+                            nameof(RenameToLowerCaseCodeFixProvider)),
+                        diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToUpperCaseCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/RenameToUpperCaseCodeFixProvider.cs
@@ -58,7 +58,7 @@ namespace StyleCop.Analyzers.NamingRules
                 if (memberSyntax is NamespaceDeclarationSyntax)
                 {
                     // namespaces are not symbols. So we are just renaming the namespace
-                    Func<CancellationToken, Task<Document>> renameNamespace = t =>
+                    Func<CancellationToken, Task<Document>> renameNamespace = cancellationToken =>
                     {
                         IdentifierNameSyntax identifierSyntax = (IdentifierNameSyntax)token.Parent;
 
@@ -68,7 +68,12 @@ namespace StyleCop.Analyzers.NamingRules
                         return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));
                     };
 
-                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.RenameToCodeFix, newName), renameNamespace, equivalenceKey: nameof(RenameToUpperCaseCodeFixProvider) + "_" + diagnostic.Id), diagnostic);
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            string.Format(NamingResources.RenameToCodeFix, newName),
+                            renameNamespace,
+                            nameof(RenameToUpperCaseCodeFixProvider) + "_" + diagnostic.Id),
+                        diagnostic);
                 }
                 else if (memberSyntax != null)
                 {
@@ -85,7 +90,12 @@ namespace StyleCop.Analyzers.NamingRules
                         newName = newName + Suffix;
                     }
 
-                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.RenameToCodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken), equivalenceKey: nameof(RenameToUpperCaseCodeFixProvider) + "_" + diagnostic.Id), diagnostic);
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            string.Format(NamingResources.RenameToCodeFix, newName),
+                            cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken),
+                            nameof(RenameToUpperCaseCodeFixProvider) + "_" + diagnostic.Id),
+                        diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1302CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1302CodeFixProvider.cs
@@ -36,7 +36,12 @@ namespace StyleCop.Analyzers.NamingRules
             {
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 var newName = "I" + token.ValueText;
-                context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.RenameToCodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        string.Format(NamingResources.RenameToCodeFix, newName),
+                        cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken),
+                        nameof(SA1302CodeFixProvider)),
+                    diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1308CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1308CodeFixProvider.cs
@@ -69,7 +69,12 @@ namespace StyleCop.Analyzers.NamingRules
                 if (!string.IsNullOrEmpty(token.ValueText))
                 {
                     var newName = token.ValueText.Substring(numberOfCharsToRemove);
-                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.RenameToCodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken), equivalenceKey: nameof(SA1308CodeFixProvider)), diagnostic);
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            string.Format(NamingResources.RenameToCodeFix, newName),
+                            cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken),
+                            nameof(SA1308CodeFixProvider)),
+                        diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1309CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1309CodeFixProvider.cs
@@ -52,7 +52,12 @@ namespace StyleCop.Analyzers.NamingRules
                         continue;
                     }
 
-                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.RenameToCodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken), equivalenceKey: nameof(SA1309CodeFixProvider)), diagnostic);
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            string.Format(NamingResources.RenameToCodeFix, newName),
+                            cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken),
+                            nameof(SA1309CodeFixProvider)),
+                        diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1310CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1310CodeFixProvider.cs
@@ -46,7 +46,12 @@ namespace StyleCop.Analyzers.NamingRules
                 string proposedName = BuildProposedName(currentName);
                 if (proposedName != currentName)
                 {
-                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.RenameToCodeFix, proposedName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, proposedName, cancellationToken), equivalenceKey: nameof(SA1310CodeFixProvider)), diagnostic);
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            string.Format(NamingResources.RenameToCodeFix, proposedName),
+                            cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, proposedName, cancellationToken),
+                            nameof(SA1310CodeFixProvider)),
+                        diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SX1309CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SX1309CodeFixProvider.cs
@@ -47,7 +47,12 @@ namespace StyleCop.Analyzers.NamingRules
                 if (!string.IsNullOrEmpty(token.ValueText))
                 {
                     string newName = '_' + token.ValueText;
-                    context.RegisterCodeFix(CodeAction.Create(string.Format(NamingResources.RenameToCodeFix, newName), cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken), equivalenceKey: nameof(SX1309CodeFixProvider)), diagnostic);
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            string.Format(NamingResources.RenameToCodeFix, newName),
+                            cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken),
+                            nameof(SX1309CodeFixProvider)),
+                        diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/ElementOrderCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/ElementOrderCodeFixProvider.cs
@@ -44,7 +44,12 @@ namespace StyleCop.Analyzers.OrderingRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(OrderingResources.ElementOrderCodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(ElementOrderCodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        OrderingResources.ElementOrderCodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(ElementOrderCodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1205CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1205CodeFixProvider.cs
@@ -37,7 +37,12 @@ namespace StyleCop.Analyzers.OrderingRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(OrderingResources.SA1205CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1205CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        OrderingResources.SA1205CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1205CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1207CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1207CodeFixProvider.cs
@@ -37,7 +37,12 @@ namespace StyleCop.Analyzers.OrderingRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(OrderingResources.SA1207CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1207CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        OrderingResources.SA1207CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1207CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/UsingCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/UsingCodeFixProvider.cs
@@ -64,7 +64,7 @@ namespace StyleCop.Analyzers.OrderingRules
                     CodeAction.Create(
                         OrderingResources.UsingCodeFix,
                         cancellationToken => GetTransformedDocumentAsync(context.Document, syntaxRoot, cancellationToken),
-                        equivalenceKey: nameof(UsingCodeFixProvider)),
+                        nameof(UsingCodeFixProvider)),
                     diagnostic);
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.Designer.cs
@@ -62,6 +62,15 @@ namespace StyleCop.Analyzers.ReadabilityRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove region.
+        /// </summary>
+        internal static string RemoveRegionCodeFix {
+            get {
+                return ResourceManager.GetString("RemoveRegionCodeFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Replace &apos;base.&apos; with &apos;this.&apos;.
         /// </summary>
         internal static string SA1100CodeFix {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="RemoveRegionCodeFix" xml:space="preserve">
+    <value>Remove region</value>
+  </data>
   <data name="SA1100CodeFix" xml:space="preserve">
     <value>Replace 'base.' with 'this.'</value>
   </data>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/RemoveRegionCodeFixProvider.cs
@@ -39,7 +39,12 @@ namespace StyleCop.Analyzers.ReadabilityRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create("Remove region", token => GetTransformedDocumentAsync(context.Document, diagnostic), equivalenceKey: nameof(RemoveRegionCodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        ReadabilityResources.RemoveRegionCodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic),
+                        nameof(RemoveRegionCodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100CodeFixProvider.cs
@@ -44,7 +44,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
                     CodeAction.Create(
                         ReadabilityResources.SA1100CodeFix,
                         cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
-                        equivalenceKey: nameof(SA1100CodeFixProvider)),
+                        nameof(SA1100CodeFixProvider)),
                     diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1101CodeFixProvider.cs
@@ -52,7 +52,12 @@ namespace StyleCop.Analyzers.ReadabilityRules
                     return;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1101CodeFix, token => GetTransformedDocumentAsync(context.Document, root, node), equivalenceKey: nameof(SA1101CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        ReadabilityResources.SA1101CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, root, node),
+                        nameof(SA1101CodeFixProvider)),
+                    diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1102CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1102CodeFixProvider.cs
@@ -38,7 +38,12 @@ namespace StyleCop.Analyzers.ReadabilityRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1102CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1102CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        ReadabilityResources.SA1102CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1102CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1103CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1103CodeFixProvider.cs
@@ -45,10 +45,20 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
                 if (queryExpression.DescendantTrivia().All(AcceptableSingleLineTrivia))
                 {
-                    context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1103CodeFixSingleLine, token => GetTransformedDocumentFromSingleLineAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1103CodeFixProvider) + "Single"), diagnostic);
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            ReadabilityResources.SA1103CodeFixSingleLine,
+                            cancellationToken => GetTransformedDocumentFromSingleLineAsync(context.Document, diagnostic, cancellationToken),
+                            nameof(SA1103CodeFixProvider) + "Single"),
+                        diagnostic);
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1103CodeFixMultipleLines, token => GetTransformedDocumentForMultipleLinesAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1103CodeFixProvider) + "Multiple"), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        ReadabilityResources.SA1103CodeFixMultipleLines,
+                        cancellationToken => GetTransformedDocumentForMultipleLinesAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1103CodeFixProvider) + "Multiple"),
+                    diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1104SA1105CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1104SA1105CodeFixProvider.cs
@@ -40,7 +40,12 @@ namespace StyleCop.Analyzers.ReadabilityRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1104SA1105CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1104SA1105CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        ReadabilityResources.SA1104SA1105CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1104SA1105CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1107CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1107CodeFixProvider.cs
@@ -46,7 +46,12 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
                 if (node?.Parent as BlockSyntax != null)
                 {
-                    context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1107CodeFix, token => GetTransformedDocumentAsync(context.Document, root, node), equivalenceKey: nameof(SA1107CodeFixProvider)), diagnostic);
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            ReadabilityResources.SA1107CodeFix,
+                            cancellationToken => GetTransformedDocumentAsync(context.Document, root, node),
+                            nameof(SA1107CodeFixProvider)),
+                        diagnostic);
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1116CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1116CodeFixProvider.cs
@@ -44,7 +44,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
                     CodeAction.Create(
                         ReadabilityResources.SA1116CodeFix,
                         cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
-                        equivalenceKey: nameof(SA1116CodeFixProvider)),
+                        nameof(SA1116CodeFixProvider)),
                     diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1120CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1120CodeFixProvider.cs
@@ -37,7 +37,12 @@ namespace StyleCop.Analyzers.ReadabilityRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1120CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), nameof(SA1120CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        ReadabilityResources.SA1120CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1120CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1121CodeFixProvider.cs
@@ -61,7 +61,12 @@ namespace StyleCop.Analyzers.ReadabilityRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(ReadabilityResources.SA1121CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1121CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        ReadabilityResources.SA1121CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1121CodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1122CodeFixProvider.cs
@@ -56,7 +56,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
                     CodeAction.Create(
                         ReadabilityResources.SA1122CodeFix,
                         cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
-                        equivalenceKey: nameof(SA1122CodeFixProvider)),
+                        nameof(SA1122CodeFixProvider)),
                     diagnostic);
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1127CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1127CodeFixProvider.cs
@@ -45,7 +45,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
                     CodeAction.Create(
                         ReadabilityResources.SA1127CodeFix,
                         cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
-                        equivalenceKey: nameof(SA1127CodeFixProvider)),
+                        nameof(SA1127CodeFixProvider)),
                     diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1128CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1128CodeFixProvider.cs
@@ -44,7 +44,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
                     CodeAction.Create(
                         ReadabilityResources.SA1128CodeFix,
                         cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
-                        equivalenceKey: nameof(SA1128CodeFixProvider)),
+                        nameof(SA1128CodeFixProvider)),
                     diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1129CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1129CodeFixProvider.cs
@@ -39,7 +39,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
                     CodeAction.Create(
                         ReadabilityResources.SA1129CodeFix,
                         cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
-                        equivalenceKey: nameof(SA1129CodeFixProvider)),
+                        nameof(SA1129CodeFixProvider)),
                     diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1131CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1131CodeFixProvider.cs
@@ -44,7 +44,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
                     CodeAction.Create(
                         ReadabilityResources.SA1131CodeFix,
                         cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
-                        equivalenceKey: nameof(SA1131CodeFixProvider)),
+                        nameof(SA1131CodeFixProvider)),
                     diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1132CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1132CodeFixProvider.cs
@@ -46,7 +46,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
                     CodeAction.Create(
                         ReadabilityResources.SA1132CodeFix,
                         cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
-                        equivalenceKey: nameof(SA1132CodeFixProvider)),
+                        nameof(SA1132CodeFixProvider)),
                     diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/SettingsFileCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/SettingsFileCodeFixProvider.cs
@@ -71,7 +71,12 @@ namespace StyleCop.Analyzers.Settings
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(SettingsResources.SettingsFileCodeFix, token => GetTransformedSolutionAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SettingsFileCodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        SettingsResources.SettingsFileCodeFix,
+                        cancellationToken => GetTransformedSolutionAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SettingsFileCodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003CodeFixProvider.cs
@@ -43,7 +43,12 @@ namespace StyleCop.Analyzers.SpacingRules
             {
                 if (diagnostic.Properties.ContainsKey(SA1003SymbolsMustBeSpacedCorrectly.CodeFixAction))
                 {
-                    context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1003CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1003CodeFixProvider)), diagnostic);
+                    context.RegisterCodeFix(
+                        CodeAction.Create(
+                            SpacingResources.SA1003CodeFix,
+                            cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                            nameof(SA1003CodeFixProvider)),
+                        diagnostic);
                 }
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1004CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1004CodeFixProvider.cs
@@ -45,7 +45,7 @@ namespace StyleCop.Analyzers.SpacingRules
                     CodeAction.Create(
                         SpacingResources.SA1004CodeFix,
                         cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
-                        equivalenceKey: nameof(SA1004CodeFixProvider)),
+                        nameof(SA1004CodeFixProvider)),
                     diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1005CodeFixProvider.cs
@@ -43,7 +43,12 @@ namespace StyleCop.Analyzers.SpacingRules
 
             foreach (var diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1005CodeFix, t => GetTransformedDocumentAsync(context.Document, diagnostic.Location, t), equivalenceKey: nameof(SA1005CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        SpacingResources.SA1005CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic.Location, cancellationToken),
+                        nameof(SA1005CodeFixProvider)),
+                    diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1018CodeFixProvider.cs
@@ -60,7 +60,12 @@ namespace StyleCop.Analyzers.SpacingRules
                     continue;
                 }
 
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1018CodeFix, cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken), equivalenceKey: nameof(SA1018CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        SpacingResources.SA1018CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1018CodeFixProvider)),
+                    diagnostic);
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1025CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1025CodeFixProvider.cs
@@ -45,7 +45,7 @@ namespace StyleCop.Analyzers.SpacingRules
                     CodeAction.Create(
                         SpacingResources.SA1025CodeFix,
                         cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
-                        equivalenceKey: nameof(SA1025CodeFixProvider)),
+                        nameof(SA1025CodeFixProvider)),
                     diagnostic);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1027CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1027CodeFixProvider.cs
@@ -38,7 +38,12 @@ namespace StyleCop.Analyzers.SpacingRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.SA1027CodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(SA1027CodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        SpacingResources.SA1027CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1027CodeFixProvider)), 
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1028CodeFixProvider.cs
@@ -44,7 +44,7 @@ namespace StyleCop.Analyzers.SpacingRules
                     CodeAction.Create(
                         SpacingResources.SA1028CodeFix,
                         ct => RemoveWhitespaceAsync(context.Document, diagnostic, ct),
-                        equivalenceKey: nameof(SA1028CodeFixProvider)),
+                        nameof(SA1028CodeFixProvider)),
                     diagnostic);
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/TokenSpacingCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/TokenSpacingCodeFixProvider.cs
@@ -118,7 +118,12 @@ namespace StyleCop.Analyzers.SpacingRules
         {
             foreach (var diagnostic in context.Diagnostics)
             {
-                context.RegisterCodeFix(CodeAction.Create(SpacingResources.TokenSpacingCodeFix, token => GetTransformedDocumentAsync(context.Document, diagnostic, token), equivalenceKey: nameof(TokenSpacingCodeFixProvider)), diagnostic);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        SpacingResources.TokenSpacingCodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(TokenSpacingCodeFixProvider)),
+                    diagnostic);
             }
 
             return SpecializedTasks.CompletedTask;


### PR DESCRIPTION
- Reformatted all `RegisterCodeFix` calls to use the same layout
- renamed all `t` or `token` to the proper `cancellationToken`
- removed `equivalenceKey:` as it was unnecessary
- added missing equivalence key for `SA1302CodeFixProvider`

This is part 3 of the breakup of #1452