### PR TITLE
Use legally-correct copyright notices.

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1633UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1633UnitTests.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CodeFixes;
@@ -38,8 +39,8 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [Fact]
         public async Task TestValidFileHeaderNoContentAsync()
         {
-            var testCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-//   Copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 ";
 
@@ -53,26 +54,26 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [Fact]
         public async Task TestValidMultilineCommentFileHeadersAsync()
         {
-            var testCode1 = @"/* <copyright file=""Test0.cs"" company=""FooCorp"">
-  Copyright (c) FooCorp. All rights reserved.
+            var testCode1 = $@"/* <copyright file=""Test0.cs"" company=""FooCorp"">
+  Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 </copyright> */
 ";
 
-            var testCode2 = @"/*
+            var testCode2 = $@"/*
 <copyright file=""Test1.cs"" company=""FooCorp"">
-  Copyright (c) FooCorp. All rights reserved.
+  Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 </copyright>
 */
 ";
 
-            var testCode3 = @"/*<copyright file=""Test2.cs"" company=""FooCorp"">
-  Copyright (c) FooCorp. All rights reserved.
+            var testCode3 = $@"/*<copyright file=""Test2.cs"" company=""FooCorp"">
+  Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 </copyright>*/
 ";
 
-            var testCode4 = @"/*
+            var testCode4 = $@"/*
  * <copyright file=""Test3.cs"" company=""FooCorp"">
- *   Copyright (c) FooCorp. All rights reserved.
+ *   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
  * </copyright>
 */
 ";
@@ -87,17 +88,17 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [Fact]
         public async Task TestValidFileHeaderWithDirectivesAsync()
         {
-            var testCode = @"#define MYDEFINE
+            var testCode = $@"#define MYDEFINE
 #if (IGNORE_FILE_HEADERS)
 #pragma warning disable SA1633
 #endif
 // <copyright file=""Test0.cs"" company=""FooCorp"">
-//   Copyright (c) FooCorp. All rights reserved.
+//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expected = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1633DescriptorMissing).WithLocation(1, 1);
@@ -111,13 +112,13 @@ namespace Bar
         [Fact]
         public async Task TestValidFileHeaderWithWhitespaceAsync()
         {
-            var testCode = @"    // <copyright file=""Test0.cs"" company=""FooCorp"">
-    //   Copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"    // <copyright file=""Test0.cs"" company=""FooCorp"">
+    //   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
     // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
@@ -136,15 +137,15 @@ namespace Foo
 {
 }
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 #define MYDEFINE
 
 namespace Foo
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1633DescriptorMissing).WithLocation(1, 1);
@@ -160,19 +161,19 @@ namespace Foo
         [Fact]
         public async Task TestNonXmlFileHeaderAsync()
         {
-            var testCode = @"// Copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 
 namespace Foo
-{
-}
+{{
+}}
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Foo
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1633DescriptorMalformed).WithLocation(1, 1);
@@ -188,20 +189,20 @@ namespace Foo
         [Fact]
         public async Task TestInvalidXmlFileHeaderAsync()
         {
-            var testCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 
 namespace Foo
-{
-}
+{{
+}}
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Foo
-{
-}
+{{
+}}
 ";
 
             var expected = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1633DescriptorMalformed).WithLocation(1, 1);
@@ -217,22 +218,22 @@ namespace Foo
         [Fact]
         public async Task TestMalformedHeaderAsync()
         {
-            var testCode = @"// <copyright test0.cs company=""FooCorp"">
+            var testCode = $@"// <copyright test0.cs company=""FooCorp"">
 #define MYDEFINE
 
 namespace Foo
-{
-}
+{{
+}}
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 #define MYDEFINE
 
 namespace Foo
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1633DescriptorMalformed).WithLocation(1, 1);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1634UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1634UnitTests.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CodeFixes;
@@ -32,8 +33,8 @@ namespace Bar
 {
 }
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 // <author>
 //   John Doe
@@ -41,8 +42,8 @@ namespace Bar
 // <summary>This is a test file.</summary>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1634Descriptor).WithLocation(1, 1);
@@ -58,16 +59,16 @@ namespace Bar
         [Fact]
         public async Task TestValidFileHeaderWithCopyrightLastAsync()
         {
-            var testCode = @"// <author>
+            var testCode = $@"// <author>
 //   John Doe
 // </author>
 // <copyright file=""Test0.cs"" company=""FooCorp"">
-//   Copyright (c) FooCorp. All rights reserved.
+//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
@@ -86,13 +87,13 @@ namespace Bar
 {
 }
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1635Descriptor).WithLocation(1, 4);
@@ -108,24 +109,24 @@ namespace Bar
         [Fact]
         public async Task TestInvalidFileHeaderWithCopyrightInWrongCaseAsync()
         {
-            var testCode = @"// <Copyright file=""Test0.cs"" company=""FooCorp"">
-//   Copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"// <Copyright file=""Test0.cs"" company=""FooCorp"">
+//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </Copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 // <Copyright file=""Test0.cs"" company=""FooCorp"">
-//   Copyright (c) FooCorp. All rights reserved.
+//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </Copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1634Descriptor).WithLocation(1, 1);
@@ -141,25 +142,25 @@ namespace Bar
         [Fact]
         public async Task TestValidMultiLineFileHeaderWithCopyrightLastAsync()
         {
-            var testCode = @"// <author>
+            var testCode = $@"// <author>
 //   John Doe
 // </author>
 // <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 //
 // Licence is FooBar MIT.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
             this.multiLineSettings = @"
 {
   ""settings"": {
     ""documentationRules"": {
       ""companyName"": ""FooCorp"",
-      ""copyrightText"": ""Copyright (c) FooCorp. All rights reserved.\n\nLicence is FooBar MIT.""
+      ""copyrightText"": ""{copyright} FooCorp. All rights reserved.\n\nLicence is FooBar MIT.""
     }
   }
 }
@@ -183,8 +184,8 @@ namespace Bar
 {
 }
 ";
-            var fixedCode = @"    // <copyright file=""Test0.cs"" company=""FooCorp"">
-    // Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"    // <copyright file=""Test0.cs"" company=""FooCorp"">
+    // Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
     // </copyright>
     // <author>FooCorp</author>
     // <summary>
@@ -192,8 +193,8 @@ namespace Bar
     // </summary>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1634Descriptor).WithLocation(1, 5);
@@ -218,8 +219,8 @@ namespace Bar
 {
 }
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 // <author>
 //   John Doe
@@ -227,8 +228,8 @@ namespace Bar
 // <summary>This is a test file.</summary>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1634Descriptor).WithLocation(1, 1);
@@ -254,8 +255,8 @@ namespace Bar
 {
 }
 ";
-            var fixedCode = @"/* <copyright file=""Test0.cs"" company=""FooCorp"">
-   Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"/* <copyright file=""Test0.cs"" company=""FooCorp"">
+   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
    </copyright>
    <author>
      John Doe
@@ -264,8 +265,8 @@ namespace Bar
  */
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1634Descriptor).WithLocation(1, 1);
@@ -291,8 +292,8 @@ namespace Bar
 {
 }
 ";
-            var fixedCode = @"/* <copyright file=""Test0.cs"" company=""FooCorp"">
- * Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"/* <copyright file=""Test0.cs"" company=""FooCorp"">
+ * Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
  * </copyright>
  * <author>
  *   John Doe
@@ -301,8 +302,8 @@ namespace Bar
  */
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1634Descriptor).WithLocation(1, 1);
@@ -323,7 +324,7 @@ namespace Bar
   ""settings"": {
     ""documentationRules"": {
       ""companyName"": ""Foo & Bar \""quote\"" Corp"",
-      ""copyrightText"": ""copyright (c) {companyName}. All rights reserved.\n\nLine #3""
+      ""copyrightText"": ""{copyright} {companyName}. All rights reserved.\n\nLine #3""
     }
   }
 }
@@ -337,8 +338,8 @@ namespace Bar
 }
 ";
 
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""Foo &amp; Bar &quot;quote&quot; Corp"">
-// copyright (c) Foo &amp; Bar ""quote"" Corp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""Foo &amp; Bar &quot;quote&quot; Corp"">
+// Copyright © {DateTime.Now.Year} Foo &amp; Bar ""quote"" Corp. All rights reserved.
 //
 // Line #3
 // </copyright>
@@ -346,8 +347,8 @@ namespace Bar
 // <summary>Foo &amp; Bar Corp Bar Class</summary>
  
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1634Descriptor).WithLocation(1, 1);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1635UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1635UnitTests.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CodeFixes;
@@ -27,13 +28,13 @@ namespace Bar
 {
 }
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1635Descriptor).WithLocation(1, 4);
@@ -59,7 +60,7 @@ namespace Bar
                 "}\r\n";
             string fixedCode =
                 "// <copyright file=\"Test0.cs\" company=\"FooCorp\">\r\n" +
-                "// Copyright (c) FooCorp. All rights reserved.\r\n" +
+                $"// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.\r\n" +
                 "// </copyright>\r\n" +
                 "\r\n" +
                 "namespace Bar\r\n" +

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1636UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1636UnitTests.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CodeFixes;
@@ -19,7 +20,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
   ""settings"": {
     ""documentationRules"": {
       ""companyName"": ""FooCorp"",
-      ""copyrightText"": ""copyright (c) {companyName}. All rights reserved.\n\nLine #3""
+      ""copyrightText"": ""{copyright} {companyName}. All rights reserved.\n\nLine #3""
     }
   }
 }
@@ -30,7 +31,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
   ""settings"": {
     ""documentationRules"": {
       ""companyName"": ""FooCorp"",
-      ""copyrightText"": ""copyright (c) {companyName}. All rights reserved.\n\nLine #3"",
+      ""copyrightText"": ""{copyright} {companyName}. All rights reserved.\n\nLine #3"",
       ""xmlHeader"": false
     }
   }
@@ -55,13 +56,13 @@ namespace Bar
 {
 }
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1636Descriptor).WithLocation(1, 4);
@@ -77,21 +78,21 @@ namespace Bar
         [Fact]
         public async Task TestFileHeaderWithInvalidCaseCopyrightMessageAsync()
         {
-            var testCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-//   copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+//   Copyright © {DateTime.Now.Year} FooCorp. all rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1636Descriptor).WithLocation(1, 4);
@@ -110,39 +111,39 @@ namespace Bar
         {
             this.useMultiLineHeaderTestSettings = true;
 
-            var testCode1 = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-//   copyright (c) FooCorp. All rights reserved.
+            var testCode1 = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 //
 //   Line #3
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
-            var testCode2 = @"/* <copyright file=""Test1.cs"" company=""FooCorp"">
-  copyright (c) FooCorp. All rights reserved.
+            var testCode2 = $@"/* <copyright file=""Test1.cs"" company=""FooCorp"">
+  Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 
   Line #3
 </copyright> */
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
-            var testCode3 = @"/*
+            var testCode3 = $@"/*
  * <copyright file=""Test2.cs"" company=""FooCorp"">
- *   copyright (c) FooCorp. All rights reserved.
+ *   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
  *
  *   Line #3
  * </copyright>
  */
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             await this.VerifyCSharpDiagnosticAsync(new[] { testCode1, testCode2, testCode3 }, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
@@ -158,35 +159,35 @@ namespace Bar
         {
             this.useNoXmlMultiLineHeaderTestSettings = true;
 
-            var testCode1 = @"//   copyright (c) FooCorp. All rights reserved.
+            var testCode1 = $@"//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 //
 //   Line #3
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
-            var testCode2 = @"/*
- *   copyright (c) FooCorp. All rights reserved.
+            var testCode2 = $@"/*
+ *   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
  *
  *   Line #3
  */
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
-            var testCode3 = @"/*
-  copyright (c) FooCorp. All rights reserved.
+            var testCode3 = $@"/*
+  Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 
   Line #3
 */
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             await this.VerifyCSharpDiagnosticAsync(new[] { testCode1, testCode2, testCode3 }, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
@@ -199,29 +200,29 @@ namespace Bar
         [Fact]
         public async Task TestFileHeaderFixWithReplaceCopyrightTagTextAsync()
         {
-            var testCode = @"// <author>
+            var testCode = $@"// <author>
 //   John Doe
 // </author>
 // <copyright file=""Test0.cs"" company=""FooCorp"">
-//   Copyright (c) Not FooCorp. All rights reserved.
+//   Copyright © {DateTime.Now.Year} Not FooCorp. All rights reserved.
 // </copyright>
 // <summary>This is a test file.</summary>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
-            var fixedCode = @"// <author>
+            var fixedCode = $@"// <author>
 //   John Doe
 // </author>
 // <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 // <summary>This is a test file.</summary>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1636Descriptor).WithLocation(4, 4);
@@ -239,9 +240,9 @@ namespace Bar
         {
             this.useMultiLineHeaderTestSettings = true;
 
-            var testCode = @"    // <author>FooCorp</author>
+            var testCode = $@"    // <author>FooCorp</author>
     // <copyright file=""Test0.cs"" company=""FooCorp"">
-    //  Not copyright (c) FooCorp. All rights reserved.
+    //  Not Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
     //
     //  Line #3
     // </copyright>
@@ -250,12 +251,12 @@ namespace Bar
     // </summary>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
-            var fixedCode = @"    // <author>FooCorp</author>
+            var fixedCode = $@"    // <author>FooCorp</author>
     // <copyright file=""Test0.cs"" company=""FooCorp"">
-    // copyright (c) FooCorp. All rights reserved.
+    // Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
     //
     // Line #3
     // </copyright>
@@ -264,8 +265,8 @@ namespace Bar
     // </summary>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1636Descriptor).WithLocation(2, 8);
@@ -283,10 +284,10 @@ namespace Bar
         {
             this.useMultiLineHeaderTestSettings = true;
 
-            var testCode = @"/*
+            var testCode = $@"/*
    <author>FooCorp</author>
    <copyright file=""Test0.cs"" company=""FooCorp"">
-     NOT copyright (c) FooCorp. All rights reserved.
+     NOT Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 
      Line #3
    </copyright>
@@ -294,14 +295,14 @@ namespace Bar
  */
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
-            var fixedCode = @"/*
+            var fixedCode = $@"/*
    <author>FooCorp</author>
    <copyright file=""Test0.cs"" company=""FooCorp"">
-   copyright (c) FooCorp. All rights reserved.
+   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 
    Line #3
    </copyright>
@@ -309,8 +310,8 @@ namespace Bar
  */
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1636Descriptor).WithLocation(3, 4);
@@ -328,10 +329,10 @@ namespace Bar
         {
             this.useMultiLineHeaderTestSettings = true;
 
-            var testCode = @"/*
+            var testCode = $@"/*
  * <author>FooCorp</author>
  * <copyright file=""Test0.cs"" company=""FooCorp"">
- *   NOT copyright (c) FooCorp. All rights reserved.
+ *   NOT Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
  *
  *   Line #3
  * </copyright>
@@ -339,14 +340,14 @@ namespace Bar
  */
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
-            var fixedCode = @"/*
+            var fixedCode = $@"/*
  * <author>FooCorp</author>
  * <copyright file=""Test0.cs"" company=""FooCorp"">
- * copyright (c) FooCorp. All rights reserved.
+ * Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
  *
  * Line #3
  * </copyright>
@@ -354,8 +355,8 @@ namespace Bar
  */
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1636Descriptor).WithLocation(3, 4);
@@ -374,9 +375,9 @@ namespace Bar
         {
             this.useMultiLineHeaderTestSettings = true;
 
-            var testCode = @"/* <author>FooCorp</author>
+            var testCode = $@"/* <author>FooCorp</author>
  * <copyright file=""Test0.cs"" company=""FooCorp"">
- *   NOT copyright (c) FooCorp. All rights reserved.
+ *   NOT Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
  *
  *   Line #3
  * </copyright>
@@ -384,13 +385,13 @@ namespace Bar
  */
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
-            var fixedCode = @"/* <author>FooCorp</author>
+            var fixedCode = $@"/* <author>FooCorp</author>
  * <copyright file=""Test0.cs"" company=""FooCorp"">
- * copyright (c) FooCorp. All rights reserved.
+ * Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
  *
  * Line #3
  * </copyright>
@@ -398,8 +399,8 @@ namespace Bar
  */
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1636Descriptor).WithLocation(2, 4);
@@ -418,8 +419,8 @@ namespace Bar
         {
             this.useMultiLineHeaderTestSettings = true;
 
-            var testCode = @"/* <copyright file=""Test0.cs"" company=""FooCorp"">
- *   NOT copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"/* <copyright file=""Test0.cs"" company=""FooCorp"">
+ *   NOT Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
  *
  *   Line #3
  * </copyright>
@@ -428,12 +429,12 @@ namespace Bar
  */
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
-            var fixedCode = @"/* <copyright file=""Test0.cs"" company=""FooCorp"">
- * copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"/* <copyright file=""Test0.cs"" company=""FooCorp"">
+ * Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
  *
  * Line #3
  * </copyright>
@@ -442,8 +443,8 @@ namespace Bar
  */
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1636Descriptor).WithLocation(1, 4);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1637UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1637UnitTests.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CodeFixes;
@@ -21,21 +22,21 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [Fact]
         public async Task TestCopyrightElementWithoutFileAttributeAsync()
         {
-            var testCode = @"// <copyright company=""FooCorp"">
-//   Copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"// <copyright company=""FooCorp"">
+//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1637Descriptor).WithLocation(1, 4);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1638UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1638UnitTests.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CodeFixes;
@@ -21,21 +22,21 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [Fact]
         public async Task TestCopyrightElementWithMismatchingFileAttributeAsync()
         {
-            var testCode = @"// <copyright file=""wrongfile.cs"" company=""FooCorp"">
-//   Copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"// <copyright file=""wrongfile.cs"" company=""FooCorp"">
+//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1638Descriptor).WithLocation(1, 4);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1639UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1639UnitTests.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
@@ -23,13 +24,13 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [Fact]
         public async Task TestFileHeaderWithoutSummaryTagAsync()
         {
-            var testCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-//   Copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1639Descriptor).WithLocation(1, 1);
@@ -43,14 +44,14 @@ namespace Bar
         [Fact]
         public async Task TestFileHeaderWithEmptySummaryTagAsync()
         {
-            var testCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-//   Copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 // <summary/>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1639Descriptor).WithLocation(4, 4);
@@ -64,14 +65,14 @@ namespace Bar
         [Fact]
         public async Task TestFileHeaderWithWhitespaceOnlySummaryTagAsync()
         {
-            var testCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-//   Copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 // <summary>   </summary>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1639Descriptor).WithLocation(4, 4);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1640UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1640UnitTests.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CodeFixes;
@@ -21,21 +22,21 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [Fact]
         public async Task TestCopyrightElementWithoutCompanyAttributeAsync()
         {
-            var testCode = @"// <copyright file=""Test0.cs"">
-//   Copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"// <copyright file=""Test0.cs"">
+//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1640Descriptor).WithLocation(1, 4);
@@ -51,21 +52,21 @@ namespace Bar
         [Fact]
         public async Task TestCopyrightElementWithEmptyCompanyAttributeAsync()
         {
-            var testCode = @"// <copyright file=""Test0.cs"" company="""">
-//   Copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"// <copyright file=""Test0.cs"" company="""">
+//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1640Descriptor).WithLocation(1, 4);
@@ -81,21 +82,21 @@ namespace Bar
         [Fact]
         public async Task TestCopyrightElementWithWhitespaceOnlyCompanyAttributeAsync()
         {
-            var testCode = @"// <copyright file=""Test0.cs"" company=""   "">
-//   Copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"// <copyright file=""Test0.cs"" company=""   "">
+//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1640Descriptor).WithLocation(1, 4);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1641UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1641UnitTests.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CodeFixes;
@@ -21,21 +22,21 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [Fact]
         public async Task TestCopyrightElementWithWrongCompanyAttributeAsync()
         {
-            var testCode = @"// <copyright file=""Test0.cs"" company=""WrongCompany"">
-//   Copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"// <copyright file=""Test0.cs"" company=""WrongCompany"">
+//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1641Descriptor).WithLocation(1, 4);
@@ -51,21 +52,21 @@ namespace Bar
         [Fact]
         public async Task TestCopyrightElementWithInvalidCaseCompanyAttributeAsync()
         {
-            var testCode = @"// <copyright file=""Test0.cs"" company=""foocorp"">
-//   Copyright (c) FooCorp. All rights reserved.
+            var testCode = $@"// <copyright file=""Test0.cs"" company=""foocorp"">
+//   Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
-            var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
-// Copyright (c) FooCorp. All rights reserved.
+            var fixedCode = $@"// <copyright file=""Test0.cs"" company=""FooCorp"">
+// Copyright © {DateTime.Now.Year} FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
-{
-}
+{{
+}}
 ";
 
             var expectedDiagnostic = this.CSharpDiagnostic(FileHeaderAnalyzers.SA1641Descriptor).WithLocation(1, 4);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Settings/SettingsUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Settings/SettingsUnitTests.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.Test.Settings
 {
+    using System;
     using System.Collections.Immutable;
     using System.Threading;
     using System.Threading.Tasks;
@@ -24,7 +25,7 @@ namespace StyleCop.Analyzers.Test.Settings
             var styleCopSettings = SettingsHelper.GetStyleCopSettings(default(SyntaxTreeAnalysisContext));
 
             Assert.Equal("PlaceholderCompany", styleCopSettings.DocumentationRules.CompanyName);
-            Assert.Equal("Copyright (c) PlaceholderCompany. All rights reserved.", styleCopSettings.DocumentationRules.CopyrightText);
+            Assert.Equal($"Copyright © {DateTime.Now.Year} PlaceholderCompany. All rights reserved.", styleCopSettings.DocumentationRules.CopyrightText);
             Assert.True(styleCopSettings.NamingRules.AllowCommonHungarianPrefixes);
             Assert.Equal(0, styleCopSettings.NamingRules.AllowedHungarianPrefixes.Length);
 
@@ -86,7 +87,7 @@ namespace StyleCop.Analyzers.Test.Settings
             var styleCopSettings = context.GetStyleCopSettings();
 
             Assert.Equal("TestCompany", styleCopSettings.DocumentationRules.CompanyName);
-            Assert.Equal("Copyright (c) TestCompany. All rights reserved.", styleCopSettings.DocumentationRules.CopyrightText);
+            Assert.Equal($"Copyright © {DateTime.Now.Year} TestCompany. All rights reserved.", styleCopSettings.DocumentationRules.CopyrightText);
         }
 
         [Fact]
@@ -137,7 +138,7 @@ namespace StyleCop.Analyzers.Test.Settings
 
             // The result is the same as the default settings.
             Assert.Equal("PlaceholderCompany", styleCopSettings.DocumentationRules.CompanyName);
-            Assert.Equal("Copyright (c) PlaceholderCompany. All rights reserved.", styleCopSettings.DocumentationRules.CopyrightText);
+            Assert.Equal($"Copyright © {DateTime.Now.Year} PlaceholderCompany. All rights reserved.", styleCopSettings.DocumentationRules.CopyrightText);
         }
 
         private static async Task<SyntaxTreeAnalysisContext> CreateAnalysisContextAsync(string stylecopJSON)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
@@ -6,6 +6,7 @@ namespace StyleCop.Analyzers.DocumentationRules
     using System;
     using System.Collections.Immutable;
     using System.IO;
+    using System.Text.RegularExpressions;
     using System.Xml.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Diagnostics;
@@ -82,6 +83,8 @@ namespace StyleCop.Analyzers.DocumentationRules
         private static readonly LocalizableString SA1641MessageFormat = new LocalizableResourceString(nameof(DocumentationResources.SA1641MessageFormat), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1641Description = new LocalizableResourceString(nameof(DocumentationResources.SA1641Description), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly string SA1641HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1641.md";
+
+        private static readonly Regex Copyright = new Regex("Copyright © [0-9]{4}((, [0-9]{4})|(-[0-9]{4}(?!-)))*");
 
         /// <summary>
         /// Gets the diagnostic descriptor for SA1633 with a missing header.
@@ -374,10 +377,10 @@ namespace StyleCop.Analyzers.DocumentationRules
 
         private static bool CompareCopyrightText(string copyrightText, StyleCopSettings settings)
         {
-            // make sure that both \n and \r\n are accepted from the settings.
+            // Make sure that both \n and \r\n are accepted from the settings.
+            // Convert the file header's copyright declarations into a string that will match the header.
             var reformattedCopyrightTextParts = settings.DocumentationRules.CopyrightText.Replace("\r\n", "\n").Split('\n');
-            var fileHeaderCopyrightTextParts = copyrightText.Replace("\r\n", "\n").Split('\n');
-
+            var fileHeaderCopyrightTextParts = Copyright.Replace(copyrightText.Replace("\r\n", "\n"), $"Copyright © {DateTime.Now.Year}").Split('\n');
             if (reformattedCopyrightTextParts.Length != fileHeaderCopyrightTextParts.Length)
             {
                 return false;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/DocumentationSettings.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/DocumentationSettings.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.Settings.ObjectModel
 {
+    using System;
     using System.Collections.Immutable;
     using System.Text.RegularExpressions;
     using Newtonsoft.Json;
@@ -18,7 +19,7 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
         /// <summary>
         /// The default value for the <see cref="CopyrightText"/> property.
         /// </summary>
-        internal const string DefaultCopyrightText = "Copyright (c) {companyName}. All rights reserved.";
+        internal const string DefaultCopyrightText = "{copyright} {companyName}. All rights reserved.";
 
         /// <summary>
         /// This is the backing field for the <see cref="CompanyName"/> property.
@@ -167,13 +168,16 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
                 match =>
                 {
                     string key = match.Groups["Property"].Value;
-                    switch (key)
-                    {
+                switch (key)
+                {
                     case "companyName":
                         return this.CompanyName;
 
                     case "copyrightText":
                         return "[CircularReference]";
+
+                    case "copyright":
+                        return $"Copyright © {DateTime.Now.Year}";
 
                     default:
                         string value;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json
@@ -98,7 +98,7 @@
             "copyrightText": {
               "type": "string",
               "description": "The copyright text which should appear in file headers.",
-              "default": "Copyright (c) {companyName}. All rights reserved."
+              "default": "{copyright} {companyName}. All rights reserved."
             },
             "variables": {
               "type": "object",

--- a/documentation/Configuration.md
+++ b/documentation/Configuration.md
@@ -157,9 +157,18 @@ The following properties are used to configure copyright headers in StyleCop Ana
 | Property | Default Value | Summary |
 | --- | --- | --- |
 | `companyName` | `"PlaceholderCompany"` | Specifies the company name which should appear in copyright notices |
+| `copyright` | `"Copyright © 2015"` | Specifies a copyright declaration. The year matches the current year. |
 | `copyrightText` | `"Copyright (c) {companyName}. All rights reserved."` | Specifies the default copyright text which should appear in copyright headers |
 | `xmlHeader` | **true** | Specifies whether file headers should use standard StyleCop XML format, where the copyright notice is wrapped in a `<copyright>` element |
 | `variables` | n/a | Specifies replacement variables which can be referenced in the `copyrightText` value |
+
+The `copyright` property is special, in that it will match any single four-digit year, or any comma-separated list of years or year ranges. Thus, all of the following would match the {copyright} variable:
+
+* Copyright © 2015
+* Copyright © 2010-2015
+* Copyright © 2010, 2012-2013, 2015
+
+When the `copyright` variable is in use, suggested fixes will use the current year.
 
 #### Configuring Copyright Text
 
@@ -167,14 +176,14 @@ In order to successfully use StyleCop-checked file headers, most projects will n
 
 > The `companyName` property is so frequently customized that it is included in the default **stylecop.json** file produced by the code fix.
 
-The `copyrightText` property is a string which may contain placeholders. Each placeholder has the form `{variable}`, where `variable` is either `companyName` or the name of a property in the `variables` property. The following sample file shows a custom **stylecop.json** file which references both `companyName` and two custom variables within the `copyrightText`.
+The `copyrightText` property is a string which may contain placeholders. Each placeholder has the form `{variable}`, where `variable` is either `companyName`, `copyright`, or the name of a property in the `variables` property. The following sample file shows a custom **stylecop.json** file which references `companyName`, `copyright` and two custom variables within the `copyrightText`.
 
 ```json
 {
   "settings": {
     "documentationRules": {
       "companyName": "FooCorp",
-      "copyrightText": "Copyright (c) {companyName}. All rights reserved.\nLicensed under the {licenseName} license. See {licenseFile} file in the project root for full license information.",
+      "copyrightText": "{copyright} {companyName}. All rights reserved.\nLicensed under the {licenseName} license. See {licenseFile} file in the project root for full license information.",
       "variables": {
         "licenseName": "MIT",
         "licenseFile": "LICENSE",
@@ -188,7 +197,7 @@ With the above configuration, a file **TypeName.cs** would be expected to have t
 
 ```csharp
 // <copyright file="TypeName.cs" company="FooCorp">
-// Copyright (c) FooCorp. All rights reserved.
+// Copyright © 2015 FooCorp. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 // </copyright>
 ```


### PR DESCRIPTION
The existing copyright support uses the (legally-unrecognized) (C), and does not support year lists due to the literal-matching nature of copyrightText.

This change fixes the above problems by adding a new {copyright} variable for use with copyrightText. The default value for copyrightText is also updated to use {copyright} instead of the hard-coded "Copyright (C)" text.

{copyright} provides the following features:
- When suggesting a fix, automatically expands to "Copyright © " followed by the current year.
- When checking copyright headers, {copyright} matches "Copyright © " followed by a comma-separated list of four-digit years, and/or year-ranges (two four-digit years separated with a hyphen).

This change adds new unit tests to verify this new functionality, and updates the existing tests to work correctly with the new behaviors.