### PR TITLE
Enabled SA1627 by default, moved text strings to resources.

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
@@ -107,6 +107,33 @@ namespace StyleCop.Analyzers.DocumentationRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The XML header documentation for a C# code element contains an empty tag..
+        /// </summary>
+        internal static string SA1627Description {
+            get {
+                return ResourceManager.GetString("SA1627Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The documentation text within the \&apos;{0}\&apos; tag must not be empty..
+        /// </summary>
+        internal static string SA1627MessageFormat {
+            get {
+                return ResourceManager.GetString("SA1627MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Documentation text must not be empty.
+        /// </summary>
+        internal static string SA1627Title {
+            get {
+                return ResourceManager.GetString("SA1627Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add file header.
         /// </summary>
         internal static string SA1633CodeFix {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
@@ -132,6 +132,15 @@
   <data name="SA1626CodeFix" xml:space="preserve">
     <value>Convert to line comment</value>
   </data>
+  <data name="SA1627Description" xml:space="preserve">
+    <value>The XML header documentation for a C# code element contains an empty tag.</value>
+  </data>
+  <data name="SA1627MessageFormat" xml:space="preserve">
+    <value>The documentation text within the \'{0}\' tag must not be empty.</value>
+  </data>
+  <data name="SA1627Title" xml:space="preserve">
+    <value>Documentation text must not be empty</value>
+  </data>
   <data name="SA1633CodeFix" xml:space="preserve">
     <value>Add file header</value>
   </data>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1627DocumentationTextMustNotBeEmpty.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1627DocumentationTextMustNotBeEmpty.cs
@@ -47,13 +47,13 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// The ID for diagnostics produced by the <see cref="SA1627DocumentationTextMustNotBeEmpty"/> analyzer.
         /// </summary>
         public const string DiagnosticId = "SA1627";
-        private const string Title = "Documentation text must not be empty";
-        private const string MessageFormat = "The documentation text within the \'{0}\' tag must not be empty.";
-        private const string Description = "The XML header documentation for a C# code element contains an empty tag.";
-        private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1627.md";
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(DocumentationResources.SA1627Title), DocumentationResources.ResourceManager, typeof(DocumentationResources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(DocumentationResources.SA1627MessageFormat), DocumentationResources.ResourceManager, typeof(DocumentationResources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(DocumentationResources.SA1627Description), DocumentationResources.ResourceManager, typeof(DocumentationResources));
+        private static readonly string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1627.md";
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.DocumentationRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledNoTests, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.DocumentationRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
         private static readonly Action<CompilationStartAnalysisContext> CompilationStartAction = HandleCompilationStart;
         private static readonly Action<SyntaxNodeAnalysisContext> XmlElementAction = HandleXmlElement;


### PR DESCRIPTION
Fixes #1692 
Also moved the text strings to the resources.