### PR TITLE
Fixed issue in UsingCodeFixProvider where a file header followed by …

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/UsingCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/UsingCodeFixProvider.cs
@@ -154,7 +154,8 @@ namespace StyleCop.Analyzers.OrderingRules
             }
 
             var newFirstToken = newSyntaxRoot.GetFirstToken();
-            return newSyntaxRoot.ReplaceToken(newFirstToken, newFirstToken.WithLeadingTrivia(fileHeader));
+            var newLeadingTrivia = newFirstToken.LeadingTrivia.InsertRange(0, fileHeader);
+            return newSyntaxRoot.ReplaceToken(newFirstToken, newFirstToken.WithLeadingTrivia(newLeadingTrivia));
         }
 
         private static int CountNamespaces(SyntaxList<MemberDeclarationSyntax> members)


### PR DESCRIPTION
…directive trivia would result in loss of the directive trivia.

Fixes #1733
