### PR TITLE
Fix for 1507

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
@@ -929,6 +929,43 @@ public class TestClass : TestInterface
 {
     private string Test;
     public string
+    private string
+}
+";
+
+            // We don't care about the syntax errors.
+            var expected = new[]
+            {
+                 new DiagnosticResult
+                 {
+                     Id = "CS1585",
+                     Message = "Member modifier 'public' must precede the member type and name",
+                     Severity = DiagnosticSeverity.Error,
+                     Locations = new[] { new DiagnosticResultLocation("Test0.cs", 5, 5) }
+                 },
+                 new DiagnosticResult
+                 {
+                     Id = "CS1519",
+                     Message = "Invalid token '}' in class, struct, or interface member declaration",
+                     Severity = DiagnosticSeverity.Error,
+                     Locations = new[] { new DiagnosticResultLocation("Test0.cs", 6, 1) }
+                 }
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the analyzer will properly handle incomplete members.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task Issue150RegressionAsync()
+        {
+            string testCode = @"public class OuterType
+{
+    private string Test;
+    private string
     public string
 }
 ";

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
@@ -960,7 +960,7 @@ public class TestClass : TestInterface
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
-        public async Task Issue150RegressionAsync()
+        public async Task Issue1507RegressionAsync()
         {
             string testCode = @"public class OuterType
 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
@@ -929,7 +929,7 @@ public class TestClass : TestInterface
 {
     private string Test;
     public string
-    private string
+    public string
 }
 ";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1202ElementsMustBeOrderedByAccess.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1202ElementsMustBeOrderedByAccess.cs
@@ -122,6 +122,14 @@ namespace StyleCop.Analyzers.OrderingRules
             {
                 var currentSyntaxKind = member.Kind();
                 currentSyntaxKind = currentSyntaxKind == SyntaxKind.EventFieldDeclaration ? SyntaxKind.EventDeclaration : currentSyntaxKind;
+
+                // if the syntaxkind of this member (e.g. SyntaxKind.IncompleteMember) will not
+                // be handled, skip early.
+                if (!((ICollection<SyntaxKind>)MemberNames.Keys).Contains(currentSyntaxKind))
+                {
+                    continue;
+                }
+
                 AccessLevel currentAccessLevel;
                 var modifiers = member.GetModifiers();
                 if ((currentSyntaxKind == SyntaxKind.ConstructorDeclaration && modifiers.Any(SyntaxKind.StaticKeyword))

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1202ElementsMustBeOrderedByAccess.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1202ElementsMustBeOrderedByAccess.cs
@@ -123,7 +123,7 @@ namespace StyleCop.Analyzers.OrderingRules
                 var currentSyntaxKind = member.Kind();
                 currentSyntaxKind = currentSyntaxKind == SyntaxKind.EventFieldDeclaration ? SyntaxKind.EventDeclaration : currentSyntaxKind;
 
-                // if the syntaxkind of this member (e.g. SyntaxKind.IncompleteMember) will not
+                // if the SyntaxKind of this member (e.g. SyntaxKind.IncompleteMember) will not
                 // be handled, skip early.
                 if (!MemberNames.ContainsKey(currentSyntaxKind))
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1202ElementsMustBeOrderedByAccess.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1202ElementsMustBeOrderedByAccess.cs
@@ -125,7 +125,7 @@ namespace StyleCop.Analyzers.OrderingRules
 
                 // if the syntaxkind of this member (e.g. SyntaxKind.IncompleteMember) will not
                 // be handled, skip early.
-                if (MemberNames.ContainsKey(currentSyntaxKind))
+                if (!MemberNames.ContainsKey(currentSyntaxKind))
                 {
                     continue;
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1202ElementsMustBeOrderedByAccess.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1202ElementsMustBeOrderedByAccess.cs
@@ -125,7 +125,7 @@ namespace StyleCop.Analyzers.OrderingRules
 
                 // if the syntaxkind of this member (e.g. SyntaxKind.IncompleteMember) will not
                 // be handled, skip early.
-                if (!((ICollection<SyntaxKind>)MemberNames.Keys).Contains(currentSyntaxKind))
+                if (MemberNames.ContainsKey(currentSyntaxKind))
                 {
                     continue;
                 }


### PR DESCRIPTION
Need to skip all non handled syntax kinds early to avoid looking them up in a dictionary and thus causing a key not found exception.
 
Fixes #1507