### PR TITLE
Improved indentation handling of IndentationHelper.GetIndentationSteps

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/HelperTests/IndentationHelperTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/HelperTests/IndentationHelperTests.cs
@@ -1,0 +1,163 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.HelperTests
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Formatting;
+    using Microsoft.CodeAnalysis.Text;
+    using StyleCop.Analyzers.Helpers;
+    using StyleCop.Analyzers.Test.Helpers;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for the <see cref="IndentationHelper"/> class.
+    /// </summary>
+    public class IndentationHelperTests
+    {
+        public static readonly IEnumerable<object[]> IndentationTestData = new[]
+        {
+            // no indentation
+            new object[] { string.Empty, 0, 4, 4 },
+
+            // 1 space
+            new object[] { " ", 0, 4, 4 },
+
+            // 2 spaces
+            new object[] { "  ", 1, 4, 4 },
+
+            // 3 spaces
+            new object[] { "   ", 1, 4, 4 },
+
+            // 3 spaces, indentation size = 2
+            new object[] { "   ", 1, 4, 4 },
+
+            // 4 spaces
+            new object[] { "    ", 1, 4, 4 },
+
+            // 5 spaces
+            new object[] { "     ", 1, 4, 4 },
+
+            // 6 spaces
+            new object[] { "      ", 2, 4, 4 },
+
+            // 7 spaces
+            new object[] { "       ", 2, 4, 4 },
+
+            // 8 spaces
+            new object[] { "        ", 2, 4, 4 },
+
+            // 8 spaces indentation, indentation size = 2
+            new object[] { "        ", 4, 2, 4 },
+
+            // 9 spaces indentation, indentation size = 3
+            new object[] { "         ", 3, 3, 4 },
+
+            // single tab
+            new object[] { "\t", 1, 4, 4 },
+
+            // multiple tabs
+            new object[] { "\t\t\t", 3, 4, 4 },
+
+            // multiple tabs (difference between indentation size and tab size)
+            new object[] { "\t\t\t", 6, 3, 6 },
+
+            // spaces + tabs mix (regression for #1036)
+            new object[] { " \t \t \t \t", 4, 4, 4 },
+
+            // 1 space followed by a tab
+            new object[] { " \t", 1, 4, 4 },
+
+            // 2 spaces followed by a tab
+            new object[] { "  \t", 1, 4, 4 },
+
+            // 3 spaces followed by a tab
+            new object[] { "   \t", 1, 4, 4 },
+
+            // 4 spaces followed by a tab
+            new object[] { "    \t", 2, 4, 4 },
+
+            // tab followed by 1 space
+            new object[] { "\t ", 1, 4, 4 },
+
+            // tab followed by 2 space
+            new object[] { "\t  ", 2, 4, 4 },
+
+            // tab followed by 3 spaces
+            new object[] { "\t   ", 2, 4, 4 },
+
+            // tab followed by 4 spaces
+            new object[] { "\t    ", 2, 4, 4 }
+        };
+
+        private const string TestProjectName = "TestProject";
+        private const string TestFilename = "Test0.cs";
+
+        /// <summary>
+        /// Verify the workings of IndentationHelper.GetIndentationSteps./>
+        /// </summary>
+        /// <param name="indentationString">The indentation string to use with the test.</param>
+        /// <param name="expectedIndentationSteps">The expected number of indentation steps.</param>
+        /// <param name="indentationSize">The indentation size to use.</param>
+        /// <param name="tabSize">The tab size to use.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(IndentationTestData))]
+        public async Task VerifyGetIndentationStepsAsync(string indentationString, int expectedIndentationSteps, int indentationSize, int tabSize)
+        {
+            var testSource = $"{indentationString}public class TestClass {{}}";
+            var document = CreateTestDocument(testSource, indentationSize, false, tabSize);
+            var indentationOptions = IndentationOptions.FromDocument(document);
+
+            var syntaxRoot = await document.GetSyntaxRootAsync().ConfigureAwait(false);
+            var firstToken = syntaxRoot.GetFirstToken();
+
+            Assert.Equal(expectedIndentationSteps, IndentationHelper.GetIndentationSteps(indentationOptions, firstToken));
+        }
+
+        /// <summary>
+        /// Verify the that IndentationHelper.GetIndentationSteps will return zero (0) for tokens that are not the first token on a line.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task VerifyGetIndentationStepsForTokenNotAtStartOfLineAsync()
+        {
+            var testSource = "    public class TestClass {}";
+            var document = CreateTestDocument(testSource);
+            var indentationOptions = IndentationOptions.FromDocument(document);
+
+            var syntaxRoot = await document.GetSyntaxRootAsync().ConfigureAwait(false);
+            var secondToken = syntaxRoot.GetFirstToken().GetNextToken();
+
+            Assert.Equal(0, IndentationHelper.GetIndentationSteps(indentationOptions, secondToken));
+        }
+
+        private static Document CreateTestDocument(string source, int indentationSize = 4, bool useTabs = false, int tabSize = 4)
+        {
+            var workspace = new AdhocWorkspace();
+            workspace.Options = workspace.Options
+                .WithChangedOption(FormattingOptions.IndentationSize, LanguageNames.CSharp, indentationSize)
+                .WithChangedOption(FormattingOptions.UseTabs, LanguageNames.CSharp, useTabs)
+                .WithChangedOption(FormattingOptions.TabSize, LanguageNames.CSharp, tabSize);
+
+            var projectId = ProjectId.CreateNewId();
+            var documentId = DocumentId.CreateNewId(projectId);
+            var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true);
+
+            var solution = workspace.CurrentSolution
+                .AddProject(projectId, TestProjectName, TestProjectName, LanguageNames.CSharp)
+                .WithProjectCompilationOptions(projectId, compilationOptions)
+                .AddMetadataReference(projectId, MetadataReferences.CorlibReference)
+                .AddMetadataReference(projectId, MetadataReferences.SystemReference)
+                .AddMetadataReference(projectId, MetadataReferences.SystemCoreReference)
+                .AddMetadataReference(projectId, MetadataReferences.CSharpSymbolsReference)
+                .AddMetadataReference(projectId, MetadataReferences.CodeAnalysisReference)
+                .AddDocument(documentId, TestFilename, SourceText.From(source));
+
+            return solution.GetDocument(documentId);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -13,6 +13,7 @@ namespace TestHelper
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Diagnostics;
     using Microsoft.CodeAnalysis.Text;
+    using StyleCop.Analyzers.Test.Helpers;
 
     /// <summary>
     /// Class for turning strings into documents and getting the diagnostics on them.
@@ -21,12 +22,6 @@ namespace TestHelper
     public abstract partial class DiagnosticVerifier
     {
         private const string SettingsFileName = "stylecop.json";
-
-        private static readonly MetadataReference CorlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location).WithAliases(ImmutableArray.Create("global", "corlib"));
-        private static readonly MetadataReference SystemReference = MetadataReference.CreateFromFile(typeof(System.Diagnostics.Debug).Assembly.Location).WithAliases(ImmutableArray.Create("global", "system"));
-        private static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
-        private static readonly MetadataReference CSharpSymbolsReference = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
-        private static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
 
         private static readonly string DefaultFilePathPrefix = "Test";
         private static readonly string CSharpDefaultFileExt = "cs";
@@ -135,11 +130,11 @@ namespace TestHelper
                 .CurrentSolution
                 .AddProject(projectId, TestProjectName, TestProjectName, language)
                 .WithProjectCompilationOptions(projectId, compilationOptions)
-                .AddMetadataReference(projectId, CorlibReference)
-                .AddMetadataReference(projectId, SystemReference)
-                .AddMetadataReference(projectId, SystemCoreReference)
-                .AddMetadataReference(projectId, CSharpSymbolsReference)
-                .AddMetadataReference(projectId, CodeAnalysisReference);
+                .AddMetadataReference(projectId, MetadataReferences.CorlibReference)
+                .AddMetadataReference(projectId, MetadataReferences.SystemReference)
+                .AddMetadataReference(projectId, MetadataReferences.SystemCoreReference)
+                .AddMetadataReference(projectId, MetadataReferences.CSharpSymbolsReference)
+                .AddMetadataReference(projectId, MetadataReferences.CodeAnalysisReference);
 
             var settings = this.GetSettings();
             if (!string.IsNullOrEmpty(settings))

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/MetadataReferences.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/MetadataReferences.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.Helpers
+{
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+
+    /// <summary>
+    /// Metadata references used to create test projects.
+    /// </summary>
+    internal static class MetadataReferences
+    {
+        internal static readonly MetadataReference CorlibReference = MetadataReference.CreateFromFile(typeof(object).Assembly.Location).WithAliases(ImmutableArray.Create("global", "corlib"));
+        internal static readonly MetadataReference SystemReference = MetadataReference.CreateFromFile(typeof(System.Diagnostics.Debug).Assembly.Location).WithAliases(ImmutableArray.Create("global", "system"));
+        internal static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
+        internal static readonly MetadataReference CSharpSymbolsReference = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
+        internal static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -172,8 +172,10 @@
     <Compile Include="Helpers\DiagnosticResultLocation.cs" />
     <Compile Include="Helpers\DiagnosticVerifier.Helper.cs" />
     <Compile Include="Helpers\ExclusionTestAnalyzer.cs" />
+    <Compile Include="Helpers\MetadataReferences.cs" />
     <Compile Include="Helpers\TestDiagnosticProvider.cs" />
     <Compile Include="HelperTests\AccessLevelHelperTests.cs" />
+    <Compile Include="HelperTests\IndentationHelperTests.cs" />
     <Compile Include="HelperTests\TokenHelperTests.cs" />
     <Compile Include="HelperTests\TriviaHelperTests.cs" />
     <Compile Include="HelperTests\XmlSyntaxFactoryTests.cs" />


### PR DESCRIPTION
Fixes #1036
Fixes #1037

For #1037 I've implemented a fourth option: rounding. For indentation size 4 this means: 0-1 no indent, 2-3 single indent. This is my personal preference, as it is forgiving when there is one space to many / little. I'll be happy to adapt it if wanted.