### PR TITLE
Added checks of ArrowExpressionClausSyntax to ensure correct spacing

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1003UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1003UnitTests.cs
@@ -800,6 +800,59 @@ public class Foo : Exception
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verifies that unary plus expression will not trigger any diagnostics.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestExpressionBodiedMembersAsync()
+        {
+            var testCode = @"namespace N1
+{
+    public class C1
+    {
+        public int Answer=>42; // Property
+        public void DoStuff(int a)=>System.Console.WriteLine(a); // method
+        public static C1 operator +(C1 a, C1 b)=>a; // operator
+        public static explicit operator C1(int i)=>null; // conversion operator
+        public int this[int index]=>23; // indexer
+    }
+}
+";
+            var fixedTestCode = @"namespace N1
+{
+    public class C1
+    {
+        public int Answer => 42; // Property
+        public void DoStuff(int a) => System.Console.WriteLine(a); // method
+        public static C1 operator +(C1 a, C1 b) => a; // operator
+        public static explicit operator C1(int i) => null; // conversion operator
+        public int this[int index] => 23; // indexer
+    }
+}
+";
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic(DescriptorPrecededByWhitespace).WithLocation(5, 26).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorFollowedByWhitespace).WithLocation(5, 26).WithArguments("=>"),
+
+                this.CSharpDiagnostic(DescriptorPrecededByWhitespace).WithLocation(6, 35).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorFollowedByWhitespace).WithLocation(6, 35).WithArguments("=>"),
+
+                this.CSharpDiagnostic(DescriptorPrecededByWhitespace).WithLocation(7, 48).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorFollowedByWhitespace).WithLocation(7, 48).WithArguments("=>"),
+
+                this.CSharpDiagnostic(DescriptorPrecededByWhitespace).WithLocation(8, 50).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorFollowedByWhitespace).WithLocation(8, 50).WithArguments("=>"),
+
+                this.CSharpDiagnostic(DescriptorPrecededByWhitespace).WithLocation(9, 35).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorFollowedByWhitespace).WithLocation(9, 35).WithArguments("=>"),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
         /// <inheritdoc/>
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003SymbolsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003SymbolsMustBeSpacedCorrectly.cs
@@ -133,6 +133,11 @@ namespace StyleCop.Analyzers.SpacingRules
         private static readonly Action<SyntaxNodeAnalysisContext> CastExpressionAction = HandleCastExpression;
         private static readonly Action<SyntaxNodeAnalysisContext> EqualsValueClauseAction = HandleEqualsValueClause;
         private static readonly Action<SyntaxNodeAnalysisContext> LambdaExpressionAction = HandleLambdaExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> PropertyDeclarationAction = HandlePropertyDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext> MethodDeclarationAction = HandleMethodDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext> OperatorDeclarationAction = HandleOperatorDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext> ConversionOperatorDeclarationAction = HandleConversionOperatorDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext> IndexerDeclarationAction = HandleIndexerDeclaration;
 
         /// <summary>
         /// Gets the descriptor for prefix unary expression that may not be followed by a comment.
@@ -210,6 +215,11 @@ namespace StyleCop.Analyzers.SpacingRules
             context.RegisterSyntaxNodeActionHonorExclusions(CastExpressionAction, SyntaxKind.CastExpression);
             context.RegisterSyntaxNodeActionHonorExclusions(EqualsValueClauseAction, SyntaxKind.EqualsValueClause);
             context.RegisterSyntaxNodeActionHonorExclusions(LambdaExpressionAction, LambdaExpressionKinds);
+            context.RegisterSyntaxNodeActionHonorExclusions(PropertyDeclarationAction, SyntaxKind.PropertyDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(IndexerDeclarationAction, SyntaxKind.IndexerDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(MethodDeclarationAction, SyntaxKind.MethodDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(OperatorDeclarationAction, SyntaxKind.OperatorDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(ConversionOperatorDeclarationAction, SyntaxKind.ConversionOperatorDeclaration);
         }
 
         private static void HandleConstructorDeclaration(SyntaxNodeAnalysisContext context)
@@ -345,6 +355,44 @@ namespace StyleCop.Analyzers.SpacingRules
             var lambdaExpression = (LambdaExpressionSyntax)context.Node;
 
             CheckToken(context, lambdaExpression.ArrowToken, true, true, true);
+        }
+
+        private static void HandlePropertyDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
+            HandleArrowExpressionClause(context, propertyDeclaration.ExpressionBody);
+        }
+
+        private static void HandleIndexerDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var indexerDeclaration = (IndexerDeclarationSyntax)context.Node;
+            HandleArrowExpressionClause(context, indexerDeclaration.ExpressionBody);
+        }
+
+        private static void HandleMethodDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var methodDeclaration = (MethodDeclarationSyntax)context.Node;
+            HandleArrowExpressionClause(context, methodDeclaration.ExpressionBody);
+        }
+
+        private static void HandleOperatorDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var operatorDeclaration = (OperatorDeclarationSyntax)context.Node;
+            HandleArrowExpressionClause(context, operatorDeclaration.ExpressionBody);
+        }
+
+        private static void HandleConversionOperatorDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var conversionOperatorDeclaration = (ConversionOperatorDeclarationSyntax)context.Node;
+            HandleArrowExpressionClause(context, conversionOperatorDeclaration.ExpressionBody);
+        }
+
+        private static void HandleArrowExpressionClause(SyntaxNodeAnalysisContext context, ArrowExpressionClauseSyntax arrowExpressionClause)
+        {
+            if (arrowExpressionClause != null)
+            {
+                CheckToken(context, arrowExpressionClause.ArrowToken, true, true, true);
+            }
         }
 
         private static void CheckToken(SyntaxNodeAnalysisContext context, SyntaxToken token, bool withLeadingWhitespace, bool allowAtEndOfLine, bool withTrailingWhitespace, string tokenText = null)


### PR DESCRIPTION
Added checks of ArrowExpressionClausSyntax to ensure correct spacing + unit test.
Fixes already worked with the new diagnostic locations (yeah!).

This fixes issue #1764.