### PR TITLE
Fixes null reference exception in SA1129

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1129DoNotUseDefaultValueTypeConstructor.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1129DoNotUseDefaultValueTypeConstructor.cs
@@ -51,7 +51,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
             ObjectCreationExpressionSyntax newExpression = (ObjectCreationExpressionSyntax)context.Node;
 
             var typeToCreate = context.SemanticModel.GetTypeInfo(newExpression, context.CancellationToken);
-            if (typeToCreate.Type.IsReferenceType || IsReferenceTypeParameter(typeToCreate.Type))
+            if ((typeToCreate.Type == null) || typeToCreate.Type.IsReferenceType || IsReferenceTypeParameter(typeToCreate.Type))
             {
                 return;
             }


### PR DESCRIPTION
Fixes #1668

Fixed the only location in `HandleObjectCreationExpression` where a null pointer exception could theoretically occur. Any suggestions on how to reproduce this in a test case are welcome.