### PR TITLE
StyleCopSettings cache

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerExtensions.cs
@@ -6,9 +6,11 @@ namespace StyleCop.Analyzers
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Immutable;
+    using System.Runtime.CompilerServices;
     using System.Threading;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using Settings.ObjectModel;
 
     /// <summary>
     /// Provides extension methods to deal for analyzers.
@@ -24,6 +26,9 @@ namespace StyleCop.Analyzers
         /// </remarks>
         private static Tuple<WeakReference<Compilation>, ConcurrentDictionary<SyntaxTree, bool>> generatedHeaderCache
             = Tuple.Create(new WeakReference<Compilation>(null), default(ConcurrentDictionary<SyntaxTree, bool>));
+
+        private static Tuple<WeakReference<Compilation>, StrongBox<StyleCopSettings>> settingsCache
+            = Tuple.Create(new WeakReference<Compilation>(null), default(StrongBox<StyleCopSettings>));
 
         /// <summary>
         /// Register an action to be executed at completion of parsing of a code document. A syntax tree action reports
@@ -50,6 +55,43 @@ namespace StyleCop.Analyzers
                     //// TODO: code here
 
                     action(c);
+                });
+        }
+
+        /// <summary>
+        /// Register an action to be executed at completion of parsing of a code document. A syntax tree action reports
+        /// diagnostics about the <see cref="SyntaxTree"/> of a document.
+        /// </summary>
+        /// <remarks>This method honors exclusions.</remarks>
+        /// <param name="context">The analysis context.</param>
+        /// <param name="action">Action to be executed at completion of parsing of a document.</param>
+        public static void RegisterSyntaxTreeActionHonorExclusions(this CompilationStartAnalysisContext context, Action<SyntaxTreeAnalysisContext, StyleCopSettings> action)
+        {
+            Compilation compilation = context.Compilation;
+            ConcurrentDictionary<SyntaxTree, bool> cache = GetOrCreateGeneratedDocumentCache(compilation);
+            StrongBox<StyleCopSettings> settingsCache = GetOrCreateStyleCopSettingsCache(compilation);
+
+            context.RegisterSyntaxTreeAction(
+                c =>
+                {
+                    if (c.IsGeneratedDocument(cache))
+                    {
+                        return;
+                    }
+
+                    // Honor the containing document item's ExcludeFromStylecop=True
+                    // MSBuild metadata, if analyzers have access to it.
+                    //// TODO: code here
+
+                    StyleCopSettings settings = settingsCache.Value;
+                    if (settings == null)
+                    {
+                        StyleCopSettings updatedSettings = SettingsHelper.GetStyleCopSettings(c.Options, c.CancellationToken);
+                        StyleCopSettings previous = Interlocked.CompareExchange(ref settingsCache.Value, updatedSettings, null);
+                        settings = previous ?? updatedSettings;
+                    }
+
+                    action(c, settings);
                 });
         }
 
@@ -88,6 +130,40 @@ namespace StyleCop.Analyzers
         }
 
         /// <summary>
+        /// Gets a <see cref="StrongBox{T}"/> which can store a <see cref="StyleCopSettings"/> instance to improve
+        /// efficiency across multiple analyzers which examine settings.
+        /// </summary>
+        /// <param name="compilation">The compilation which the cache applies to.</param>
+        /// <returns>A <see cref="StrongBox{T}"/> which can store a <see cref="StyleCopSettings"/> instance.</returns>
+        public static StrongBox<StyleCopSettings> GetOrCreateStyleCopSettingsCache(this Compilation compilation)
+        {
+            var currentSettingsCache = settingsCache;
+
+            Compilation cachedCompilation;
+            if (!currentSettingsCache.Item1.TryGetTarget(out cachedCompilation) || cachedCompilation != compilation)
+            {
+                var replacementCache = Tuple.Create(new WeakReference<Compilation>(compilation), new StrongBox<StyleCopSettings>(null));
+                while (true)
+                {
+                    var prior = Interlocked.CompareExchange(ref settingsCache, replacementCache, currentSettingsCache);
+                    if (prior == currentSettingsCache)
+                    {
+                        currentSettingsCache = replacementCache;
+                        break;
+                    }
+
+                    currentSettingsCache = prior;
+                    if (currentSettingsCache.Item1.TryGetTarget(out cachedCompilation) && cachedCompilation == compilation)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            return currentSettingsCache.Item2;
+        }
+
+        /// <summary>
         /// Register an action to be executed at completion of semantic analysis of a <see cref="SyntaxNode"/> with an
         /// appropriate kind. A syntax node action can report diagnostics about a <see cref="SyntaxNode"/>, and can also
         /// collect state information to be used by other syntax node actions or code block end actions.
@@ -101,6 +177,25 @@ namespace StyleCop.Analyzers
         /// <typeparam name="TLanguageKindEnum">Enum type giving the syntax node kinds of the source language for which
         /// the action applies.</typeparam>
         public static void RegisterSyntaxNodeActionHonorExclusions<TLanguageKindEnum>(this CompilationStartAnalysisContext context, Action<SyntaxNodeAnalysisContext> action, TLanguageKindEnum syntaxKind)
+            where TLanguageKindEnum : struct
+        {
+            context.RegisterSyntaxNodeActionHonorExclusions(action, LanguageKindArrays<TLanguageKindEnum>.GetOrCreateArray(syntaxKind));
+        }
+
+        /// <summary>
+        /// Register an action to be executed at completion of semantic analysis of a <see cref="SyntaxNode"/> with an
+        /// appropriate kind. A syntax node action can report diagnostics about a <see cref="SyntaxNode"/>, and can also
+        /// collect state information to be used by other syntax node actions or code block end actions.
+        /// </summary>
+        /// <remarks>This method honors exclusions.</remarks>
+        /// <param name="context">Action will be executed only if the kind of a <see cref="SyntaxNode"/> matches
+        /// <paramref name="syntaxKind"/>.</param>
+        /// <param name="action">Action to be executed at completion of semantic analysis of a
+        /// <see cref="SyntaxNode"/>.</param>
+        /// <param name="syntaxKind">The kind of syntax that should be analyzed.</param>
+        /// <typeparam name="TLanguageKindEnum">Enum type giving the syntax node kinds of the source language for which
+        /// the action applies.</typeparam>
+        public static void RegisterSyntaxNodeActionHonorExclusions<TLanguageKindEnum>(this CompilationStartAnalysisContext context, Action<SyntaxNodeAnalysisContext, StyleCopSettings> action, TLanguageKindEnum syntaxKind)
             where TLanguageKindEnum : struct
         {
             context.RegisterSyntaxNodeActionHonorExclusions(action, LanguageKindArrays<TLanguageKindEnum>.GetOrCreateArray(syntaxKind));
@@ -138,6 +233,51 @@ namespace StyleCop.Analyzers
                     //// TODO: code here
 
                     action(c);
+                },
+                syntaxKinds);
+        }
+
+        /// <summary>
+        /// Register an action to be executed at completion of semantic analysis of a <see cref="SyntaxNode"/> with an
+        /// appropriate kind. A syntax node action can report diagnostics about a <see cref="SyntaxNode"/>, and can also
+        /// collect state information to be used by other syntax node actions or code block end actions.
+        /// </summary>
+        /// <remarks>This method honors exclusions.</remarks>
+        /// <param name="context">Action will be executed only if the kind of a <see cref="SyntaxNode"/> matches one of
+        /// the <paramref name="syntaxKinds"/> values.</param>
+        /// <param name="action">Action to be executed at completion of semantic analysis of a
+        /// <see cref="SyntaxNode"/>.</param>
+        /// <param name="syntaxKinds">The kinds of syntax that should be analyzed.</param>
+        /// <typeparam name="TLanguageKindEnum">Enum type giving the syntax node kinds of the source language for which
+        /// the action applies.</typeparam>
+        public static void RegisterSyntaxNodeActionHonorExclusions<TLanguageKindEnum>(this CompilationStartAnalysisContext context, Action<SyntaxNodeAnalysisContext, StyleCopSettings> action, ImmutableArray<TLanguageKindEnum> syntaxKinds)
+            where TLanguageKindEnum : struct
+        {
+            Compilation compilation = context.Compilation;
+            ConcurrentDictionary<SyntaxTree, bool> cache = GetOrCreateGeneratedDocumentCache(compilation);
+            StrongBox<StyleCopSettings> settingsCache = GetOrCreateStyleCopSettingsCache(compilation);
+
+            context.RegisterSyntaxNodeAction(
+                c =>
+                {
+                    if (c.IsGenerated(cache))
+                    {
+                        return;
+                    }
+
+                    // Honor the containing document item's ExcludeFromStylecop=True
+                    // MSBuild metadata, if analyzers have access to it.
+                    //// TODO: code here
+
+                    StyleCopSettings settings = settingsCache.Value;
+                    if (settings == null)
+                    {
+                        StyleCopSettings updatedSettings = SettingsHelper.GetStyleCopSettings(c.Options, c.CancellationToken);
+                        StyleCopSettings previous = Interlocked.CompareExchange(ref settingsCache.Value, updatedSettings, null);
+                        settings = previous ?? updatedSettings;
+                    }
+
+                    action(c, settings);
                 },
                 syntaxKinds);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.DocumentationRules
     using System;
     using System.Collections.Immutable;
     using System.IO;
-    using System.Threading;
     using System.Xml.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Diagnostics;
@@ -182,22 +181,13 @@ namespace StyleCop.Analyzers.DocumentationRules
             // Disabling SA1633 will disable all other header related diagnostics.
             if (!compilation.IsAnalyzerSuppressed(SA1633Identifier))
             {
-                Analyzer analyzer = new Analyzer(context.Options, context.CancellationToken);
-                context.RegisterSyntaxTreeActionHonorExclusions(ctx => analyzer.HandleSyntaxTreeAction(ctx, compilation));
+                context.RegisterSyntaxTreeActionHonorExclusions((ctx, settings) => Analyzer.HandleSyntaxTree(ctx, settings, compilation));
             }
         }
 
-        private sealed class Analyzer
+        private static class Analyzer
         {
-            private readonly DocumentationSettings documentationSettings;
-
-            public Analyzer(AnalyzerOptions options, CancellationToken cancellationToken)
-            {
-                StyleCopSettings settings = options.GetStyleCopSettings(cancellationToken);
-                this.documentationSettings = settings.DocumentationRules;
-            }
-
-            public void HandleSyntaxTreeAction(SyntaxTreeAnalysisContext context, Compilation compilation)
+            public static void HandleSyntaxTree(SyntaxTreeAnalysisContext context, StyleCopSettings settings, Compilation compilation)
             {
                 var root = context.Tree.GetRoot(context.CancellationToken);
 
@@ -207,7 +197,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                     return;
                 }
 
-                if (this.documentationSettings.XmlHeader)
+                if (settings.DocumentationRules.XmlHeader)
                 {
                     var fileHeader = FileHeaderHelpers.ParseXmlFileHeader(root);
                     if (fileHeader.IsMissing)
@@ -224,12 +214,12 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                     if (!compilation.IsAnalyzerSuppressed(SA1634Identifier))
                     {
-                        this.CheckCopyrightHeader(context, compilation, fileHeader);
+                        CheckCopyrightHeader(context, settings.DocumentationRules, compilation, fileHeader);
                     }
 
                     if (!compilation.IsAnalyzerSuppressed(SA1639Identifier))
                     {
-                        this.CheckSummaryHeader(context, compilation, fileHeader);
+                        CheckSummaryHeader(context, compilation, fileHeader);
                     }
                 }
                 else
@@ -254,7 +244,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                             return;
                         }
 
-                        if (!this.CompareCopyrightText(fileHeader.CopyrightText))
+                        if (!CompareCopyrightText(settings.DocumentationRules, fileHeader.CopyrightText))
                         {
                             context.ReportDiagnostic(Diagnostic.Create(SA1636Descriptor, fileHeader.GetLocation(context.Tree)));
                             return;
@@ -263,7 +253,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                 }
             }
 
-            private void CheckCopyrightHeader(SyntaxTreeAnalysisContext context, Compilation compilation, XmlFileHeader fileHeader)
+            private static void CheckCopyrightHeader(SyntaxTreeAnalysisContext context, DocumentationSettings documentationSettings, Compilation compilation, XmlFileHeader fileHeader)
             {
                 var copyrightElement = fileHeader.GetElement("copyright");
                 if (copyrightElement == null)
@@ -274,21 +264,21 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                 if (!compilation.IsAnalyzerSuppressed(SA1637Identifier))
                 {
-                    this.CheckFile(context, compilation, fileHeader, copyrightElement);
+                    CheckFile(context, compilation, fileHeader, copyrightElement);
                 }
 
                 if (!compilation.IsAnalyzerSuppressed(SA1640Identifier))
                 {
-                    this.CheckCompanyName(context, compilation, fileHeader, copyrightElement);
+                    CheckCompanyName(context, documentationSettings, compilation, fileHeader, copyrightElement);
                 }
 
                 if (!compilation.IsAnalyzerSuppressed(SA1635Identifier))
                 {
-                    this.CheckCopyrightText(context, compilation, fileHeader, copyrightElement);
+                    CheckCopyrightText(context, documentationSettings, compilation, fileHeader, copyrightElement);
                 }
             }
 
-            private void CheckFile(SyntaxTreeAnalysisContext context, Compilation compilation, XmlFileHeader fileHeader, XElement copyrightElement)
+            private static void CheckFile(SyntaxTreeAnalysisContext context, Compilation compilation, XmlFileHeader fileHeader, XElement copyrightElement)
             {
                 var fileAttribute = copyrightElement.Attribute("file");
                 if (fileAttribute == null)
@@ -311,7 +301,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                 }
             }
 
-            private void CheckCopyrightText(SyntaxTreeAnalysisContext context, Compilation compilation, XmlFileHeader fileHeader, XElement copyrightElement)
+            private static void CheckCopyrightText(SyntaxTreeAnalysisContext context, DocumentationSettings documentationSettings, Compilation compilation, XmlFileHeader fileHeader, XElement copyrightElement)
             {
                 var copyrightText = copyrightElement.Value;
                 if (string.IsNullOrWhiteSpace(copyrightText))
@@ -326,7 +316,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                     return;
                 }
 
-                var settingsCopyrightText = this.documentationSettings.CopyrightText;
+                var settingsCopyrightText = documentationSettings.CopyrightText;
                 if (string.Equals(settingsCopyrightText, DocumentationSettings.DefaultCopyrightText, StringComparison.OrdinalIgnoreCase))
                 {
                     // The copyright text is meaningless until the company name is configured by the user.
@@ -334,14 +324,14 @@ namespace StyleCop.Analyzers.DocumentationRules
                 }
 
                 // trim any leading / trailing new line or whitespace characters (those are a result of the XML formatting)
-                if (!this.CompareCopyrightText(copyrightText.Trim('\r', '\n', ' ', '\t')))
+                if (!CompareCopyrightText(documentationSettings, copyrightText.Trim('\r', '\n', ' ', '\t')))
                 {
                     var location = fileHeader.GetElementLocation(context.Tree, copyrightElement);
                     context.ReportDiagnostic(Diagnostic.Create(SA1636Descriptor, location));
                 }
             }
 
-            private void CheckCompanyName(SyntaxTreeAnalysisContext context, Compilation compilation, XmlFileHeader fileHeader, XElement copyrightElement)
+            private static void CheckCompanyName(SyntaxTreeAnalysisContext context, DocumentationSettings documentationSettings, Compilation compilation, XmlFileHeader fileHeader, XElement copyrightElement)
             {
                 var companyName = copyrightElement.Attribute("company")?.Value;
                 if (string.IsNullOrWhiteSpace(companyName))
@@ -356,20 +346,20 @@ namespace StyleCop.Analyzers.DocumentationRules
                     return;
                 }
 
-                if (string.Equals(this.documentationSettings.CompanyName, DocumentationSettings.DefaultCompanyName, StringComparison.OrdinalIgnoreCase))
+                if (string.Equals(documentationSettings.CompanyName, DocumentationSettings.DefaultCompanyName, StringComparison.OrdinalIgnoreCase))
                 {
                     // The company name is meaningless until configured by the user.
                     return;
                 }
 
-                if (string.CompareOrdinal(companyName, this.documentationSettings.CompanyName) != 0)
+                if (string.CompareOrdinal(companyName, documentationSettings.CompanyName) != 0)
                 {
                     var location = fileHeader.GetElementLocation(context.Tree, copyrightElement);
                     context.ReportDiagnostic(Diagnostic.Create(SA1641Descriptor, location));
                 }
             }
 
-            private void CheckSummaryHeader(SyntaxTreeAnalysisContext context, Compilation compilation, XmlFileHeader fileHeader)
+            private static void CheckSummaryHeader(SyntaxTreeAnalysisContext context, Compilation compilation, XmlFileHeader fileHeader)
             {
                 var summaryElement = fileHeader.GetElement("summary");
                 if (summaryElement == null)
@@ -385,10 +375,10 @@ namespace StyleCop.Analyzers.DocumentationRules
                 }
             }
 
-            private bool CompareCopyrightText(string copyrightText)
+            private static bool CompareCopyrightText(DocumentationSettings documentationSettings, string copyrightText)
             {
                 // make sure that both \n and \r\n are accepted from the settings.
-                var reformattedCopyrightTextParts = this.documentationSettings.CopyrightText.Replace("\r\n", "\n").Split('\n');
+                var reformattedCopyrightTextParts = documentationSettings.CopyrightText.Replace("\r\n", "\n").Split('\n');
                 var fileHeaderCopyrightTextParts = copyrightText.Replace("\r\n", "\n").Split('\n');
 
                 if (reformattedCopyrightTextParts.Length != fileHeaderCopyrightTextParts.Length)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1601PartialElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1601PartialElementsMustBeDocumented.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.DocumentationRules
     using System;
     using System.Collections.Immutable;
     using System.Linq;
-    using System.Threading;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -87,6 +86,8 @@ namespace StyleCop.Analyzers.DocumentationRules
             ImmutableArray.Create(SyntaxKind.ClassDeclaration, SyntaxKind.StructDeclaration, SyntaxKind.InterfaceDeclaration);
 
         private static readonly Action<CompilationStartAnalysisContext> CompilationStartAction = HandleCompilationStart;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> BaseTypeDeclarationAction = Analyzer.HandleBaseTypeDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> MethodDeclarationAction = Analyzer.HandleMethodDeclaration;
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
@@ -100,22 +101,13 @@ namespace StyleCop.Analyzers.DocumentationRules
 
         private static void HandleCompilationStart(CompilationStartAnalysisContext context)
         {
-            Analyzer analyzer = new Analyzer(context.Options, context.CancellationToken);
-            context.RegisterSyntaxNodeActionHonorExclusions(analyzer.HandleBaseTypeDeclaration, BaseTypeDeclarationKinds);
-            context.RegisterSyntaxNodeActionHonorExclusions(analyzer.HandleMethodDeclaration, SyntaxKind.MethodDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(BaseTypeDeclarationAction, BaseTypeDeclarationKinds);
+            context.RegisterSyntaxNodeActionHonorExclusions(MethodDeclarationAction, SyntaxKind.MethodDeclaration);
         }
 
-        private class Analyzer
+        private static class Analyzer
         {
-            private readonly DocumentationSettings documentationSettings;
-
-            public Analyzer(AnalyzerOptions options, CancellationToken cancellationToken)
-            {
-                StyleCopSettings settings = options.GetStyleCopSettings(cancellationToken);
-                this.documentationSettings = settings.DocumentationRules;
-            }
-
-            public void HandleBaseTypeDeclaration(SyntaxNodeAnalysisContext context)
+            public static void HandleBaseTypeDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
             {
                 if (context.GetDocumentationMode() != DocumentationMode.Diagnose)
                 {
@@ -130,7 +122,7 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                 Accessibility declaredAccessibility = declaration.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
                 Accessibility effectiveAccessibility = declaration.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
-                if (this.NeedsComment(declaration.Kind(), declaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility))
+                if (NeedsComment(settings.DocumentationRules, declaration.Kind(), declaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility))
                 {
                     if (!XmlCommentHelper.HasDocumentation(declaration))
                     {
@@ -139,7 +131,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                 }
             }
 
-            public void HandleMethodDeclaration(SyntaxNodeAnalysisContext context)
+            public static void HandleMethodDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
             {
                 if (context.GetDocumentationMode() != DocumentationMode.Diagnose)
                 {
@@ -154,7 +146,7 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                 Accessibility declaredAccessibility = declaration.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
                 Accessibility effectiveAccessibility = declaration.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
-                if (this.NeedsComment(declaration.Kind(), declaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility))
+                if (NeedsComment(settings.DocumentationRules, declaration.Kind(), declaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility))
                 {
                     if (!XmlCommentHelper.HasDocumentation(declaration))
                     {
@@ -163,16 +155,16 @@ namespace StyleCop.Analyzers.DocumentationRules
                 }
             }
 
-            private bool NeedsComment(SyntaxKind syntaxKind, SyntaxKind parentSyntaxKind, Accessibility declaredAccessibility, Accessibility effectiveAccessibility)
+            private static bool NeedsComment(DocumentationSettings documentationSettings, SyntaxKind syntaxKind, SyntaxKind parentSyntaxKind, Accessibility declaredAccessibility, Accessibility effectiveAccessibility)
             {
-                if (this.documentationSettings.DocumentInterfaces
+                if (documentationSettings.DocumentInterfaces
                     && (syntaxKind == SyntaxKind.InterfaceDeclaration || parentSyntaxKind == SyntaxKind.InterfaceDeclaration))
                 {
                     // DocumentInterfaces => all interfaces must be documented
                     return true;
                 }
 
-                if (this.documentationSettings.DocumentPrivateElements)
+                if (documentationSettings.DocumentPrivateElements)
                 {
                     // DocumentPrivateMembers => everything except declared private fields must be documented
                     return true;
@@ -184,12 +176,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                 case Accessibility.Protected:
                 case Accessibility.ProtectedOrInternal:
                     // These items are part of the exposed API surface => document if configured
-                    return this.documentationSettings.DocumentExposedElements;
+                    return documentationSettings.DocumentExposedElements;
 
                 case Accessibility.ProtectedAndInternal:
                 case Accessibility.Internal:
                     // These items are part of the internal API surface => document if configured
-                    return this.documentationSettings.DocumentInternalElements;
+                    return documentationSettings.DocumentInternalElements;
 
                 case Accessibility.NotApplicable:
                 case Accessibility.Private:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1602EnumerationItemsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1602EnumerationItemsMustBeDocumented.cs
@@ -5,7 +5,6 @@ namespace StyleCop.Analyzers.DocumentationRules
 {
     using System;
     using System.Collections.Immutable;
-    using System.Threading;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -54,6 +53,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.DocumentationRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
         private static readonly Action<CompilationStartAnalysisContext> CompilationStartAction = HandleCompilationStart;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> EnumMemberDeclarationAction = Analyzer.HandleEnumMemberDeclaration;
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
@@ -67,21 +67,12 @@ namespace StyleCop.Analyzers.DocumentationRules
 
         private static void HandleCompilationStart(CompilationStartAnalysisContext context)
         {
-            Analyzer analyzer = new Analyzer(context.Options, context.CancellationToken);
-            context.RegisterSyntaxNodeActionHonorExclusions(analyzer.HandleEnumMember, SyntaxKind.EnumMemberDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(EnumMemberDeclarationAction, SyntaxKind.EnumMemberDeclaration);
         }
 
-        private class Analyzer
+        private static class Analyzer
         {
-            private readonly DocumentationSettings documentationSettings;
-
-            public Analyzer(AnalyzerOptions options, CancellationToken cancellationToken)
-            {
-                StyleCopSettings settings = options.GetStyleCopSettings(cancellationToken);
-                this.documentationSettings = settings.DocumentationRules;
-            }
-
-            public void HandleEnumMember(SyntaxNodeAnalysisContext context)
+            public static void HandleEnumMemberDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
             {
                 if (context.GetDocumentationMode() != DocumentationMode.Diagnose)
                 {
@@ -91,7 +82,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                 EnumMemberDeclarationSyntax declaration = (EnumMemberDeclarationSyntax)context.Node;
                 Accessibility declaredAccessibility = declaration.GetDeclaredAccessibility();
                 Accessibility effectiveAccessibility = declaration.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
-                if (this.NeedsComment(declaration.Kind(), declaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility))
+                if (NeedsComment(settings.DocumentationRules, declaration.Kind(), declaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility))
                 {
                     if (!XmlCommentHelper.HasDocumentation(declaration))
                     {
@@ -100,16 +91,16 @@ namespace StyleCop.Analyzers.DocumentationRules
                 }
             }
 
-            private bool NeedsComment(SyntaxKind syntaxKind, SyntaxKind parentSyntaxKind, Accessibility declaredAccessibility, Accessibility effectiveAccessibility)
+            private static bool NeedsComment(DocumentationSettings documentationSettings, SyntaxKind syntaxKind, SyntaxKind parentSyntaxKind, Accessibility declaredAccessibility, Accessibility effectiveAccessibility)
             {
-                if (this.documentationSettings.DocumentInterfaces
+                if (documentationSettings.DocumentInterfaces
                     && (syntaxKind == SyntaxKind.InterfaceDeclaration || parentSyntaxKind == SyntaxKind.InterfaceDeclaration))
                 {
                     // DocumentInterfaces => all interfaces must be documented
                     return true;
                 }
 
-                if (this.documentationSettings.DocumentPrivateElements)
+                if (documentationSettings.DocumentPrivateElements)
                 {
                     // DocumentPrivateMembers => everything except declared private fields must be documented
                     return true;
@@ -121,12 +112,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                 case Accessibility.Protected:
                 case Accessibility.ProtectedOrInternal:
                     // These items are part of the exposed API surface => document if configured
-                    return this.documentationSettings.DocumentExposedElements;
+                    return documentationSettings.DocumentExposedElements;
 
                 case Accessibility.ProtectedAndInternal:
                 case Accessibility.Internal:
                     // These items are part of the internal API surface => document if configured
-                    return this.documentationSettings.DocumentInternalElements;
+                    return documentationSettings.DocumentInternalElements;
 
                 case Accessibility.NotApplicable:
                 case Accessibility.Private:


### PR DESCRIPTION
Fixes #1803

:memo: To minimize the size of the diffs and make them easier to review, I left the `Analyzer` classes in place, but made them static. I may submit a future review to remove these classes and put the methods in the parent type.
