### PR TITLE
Add the `newlineAtEndOfFile` configuration property

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1518CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1518CodeFixProvider.cs
@@ -28,7 +28,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
         {
-            return CustomFixAllProviders.BatchFixer;
+            return FixAll.Instance;
         }
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1518UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1518UnitTests.cs
@@ -34,7 +34,12 @@ public class Foo
         public async Task TestWithBlankLinesAtEndOfFileAsync()
         {
             var testCode = BaseCode + "\r\n\r\n";
-            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(9, 1), CancellationToken.None).ConfigureAwait(false);
+            var fixedCode = BaseCode + "\r\n";
+
+            var expected = this.CSharpDiagnostic().WithLocation(8, 2);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -45,7 +50,12 @@ public class Foo
         public async Task TestWithLineFeedOnlyBlankLinesAtEndOfFileAsync()
         {
             var testCode = BaseCode + "\n\n";
-            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(9, 1), CancellationToken.None).ConfigureAwait(false);
+            var fixedCode = BaseCode + "\r\n";
+
+            var expected = this.CSharpDiagnostic().WithLocation(8, 2);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -88,7 +98,12 @@ public class Foo
         public async Task TestFileEndsWithSpacesAsync()
         {
             var testCode = BaseCode + "\r\n          ";
-            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(9, 1), CancellationToken.None).ConfigureAwait(false);
+            var fixedCode = BaseCode + "\r\n";
+
+            var expected = this.CSharpDiagnostic().WithLocation(8, 2);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -110,7 +125,12 @@ public class Foo
         public async Task TestFileEndingWithCommentAndSpuriousWhitespaceAsync()
         {
             var testCode = BaseCode + "\r\n// Test comment\r\n   \r\n";
-            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(10, 1), CancellationToken.None).ConfigureAwait(false);
+            var fixedCode = BaseCode + "\r\n// Test comment\r\n";
+
+            var expected = this.CSharpDiagnostic().WithLocation(9, 16);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -132,7 +152,12 @@ public class Foo
         public async Task TestFileEndingWithEndIfWithSpuriousWhitespaceAsync()
         {
             var testCode = "#if true\r\n" + BaseCode + "\r\n#endif\r\n   \r\n";
-            await this.VerifyCSharpDiagnosticAsync(testCode, this.GenerateExpectedWarning(11, 1), CancellationToken.None).ConfigureAwait(false);
+            var fixedCode = "#if true\r\n" + BaseCode + "\r\n#endif\r\n";
+
+            var expected = this.CSharpDiagnostic().WithLocation(10, 7);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -144,9 +169,12 @@ public class Foo
         public async Task TestCodeFixProviderStripsTrailingBlankLinesAsync()
         {
             var testCode = BaseCode + "\r\n\r\n";
-            var fixedTestCode = BaseCode + "\r\n";
+            var fixedCode = BaseCode + "\r\n";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+            var expected = this.CSharpDiagnostic().WithLocation(8, 2);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -158,9 +186,12 @@ public class Foo
         public async Task TestCodeFixProviderStripsTrailingBlankLinesIncludingWhitespaceAsync()
         {
             var testCode = BaseCode + "\r\n   \r\n   \r\n";
-            var fixedTestCode = BaseCode + "\r\n";
+            var fixedCode = BaseCode + "\r\n";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+            var expected = this.CSharpDiagnostic().WithLocation(8, 2);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -172,9 +203,12 @@ public class Foo
         public async Task TestCodeFixProviderStripsTrailingLinefeedOnlyBlankLinesIncludingWhitespaceAsync()
         {
             var testCode = BaseCode + "\n   \n   \n";
-            var fixedTestCode = BaseCode + "\n";
+            var fixedCode = BaseCode + "\r\n";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+            var expected = this.CSharpDiagnostic().WithLocation(8, 2);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -186,9 +220,12 @@ public class Foo
         public async Task TestCodeFixProviderOnlyStripsTrailingBlankLinesAsync()
         {
             var testCode = "#if true\r\n" + BaseCode + "\r\n#endif\r\n   \r\n";
-            var fixedTestCode = "#if true\r\n" + BaseCode + "\r\n#endif\r\n";
+            var fixedCode = "#if true\r\n" + BaseCode + "\r\n#endif\r\n";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+            var expected = this.CSharpDiagnostic().WithLocation(10, 7);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
@@ -201,11 +238,6 @@ public class Foo
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new SA1518CodeFixProvider();
-        }
-
-        private DiagnosticResult GenerateExpectedWarning(int line, int column)
-        {
-            return this.CSharpDiagnostic().WithLocation(line, column);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1518UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1518UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.LayoutRules;
+    using StyleCop.Analyzers.Settings.ObjectModel;
     using TestHelper;
     using Xunit;
 
@@ -26,15 +27,25 @@ public class Foo
     }
 }";
 
+        private EndOfFileHandling? newlineAtEndOfFile;
+
         /// <summary>
         /// Verifies that blank lines at the end of the file will produce a warning.
         /// </summary>
+        /// <param name="newlineAtEndOfFile">The effective <see cref="EndOfFileHandling"/> setting.</param>
+        /// <param name="result">The expected text to appear at the end of the file.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestWithBlankLinesAtEndOfFileAsync()
+        [Theory]
+        [InlineData(null, "\r\n")]
+        [InlineData(EndOfFileHandling.Allow, "\r\n")]
+        [InlineData(EndOfFileHandling.Require, "\r\n")]
+        [InlineData(EndOfFileHandling.Omit, "")]
+        internal async Task TestWithBlankLinesAtEndOfFileAsync(EndOfFileHandling? newlineAtEndOfFile, string result)
         {
+            this.newlineAtEndOfFile = newlineAtEndOfFile;
+
             var testCode = BaseCode + "\r\n\r\n";
-            var fixedCode = BaseCode + "\r\n";
+            var fixedCode = BaseCode + result;
 
             var expected = this.CSharpDiagnostic().WithLocation(8, 2);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -45,12 +56,20 @@ public class Foo
         /// <summary>
         /// Verifies that linefeed only blank lines at the end of the file will produce a warning.
         /// </summary>
+        /// <param name="newlineAtEndOfFile">The effective <see cref="EndOfFileHandling"/> setting.</param>
+        /// <param name="result">The expected text to appear at the end of the file.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestWithLineFeedOnlyBlankLinesAtEndOfFileAsync()
+        [Theory]
+        [InlineData(null, "\r\n")]
+        [InlineData(EndOfFileHandling.Allow, "\r\n")]
+        [InlineData(EndOfFileHandling.Require, "\r\n")]
+        [InlineData(EndOfFileHandling.Omit, "")]
+        internal async Task TestWithLineFeedOnlyBlankLinesAtEndOfFileAsync(EndOfFileHandling? newlineAtEndOfFile, string result)
         {
+            this.newlineAtEndOfFile = newlineAtEndOfFile;
+
             var testCode = BaseCode + "\n\n";
-            var fixedCode = BaseCode + "\r\n";
+            var fixedCode = BaseCode + result;
 
             var expected = this.CSharpDiagnostic().WithLocation(8, 2);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -61,44 +80,116 @@ public class Foo
         /// <summary>
         /// Verifies that a single carriage return / linefeed at the end of the file will not produce a warning.
         /// </summary>
+        /// <param name="newlineAtEndOfFile">The effective <see cref="EndOfFileHandling"/> setting.</param>
+        /// <param name="expectedText">The expected text to appear at the end of the file, or <see langword="null"/> if
+        /// the input text is already correct.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestWithSingleCarriageReturnLineFeedAtEndOfFileAsync()
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(EndOfFileHandling.Allow, null)]
+        [InlineData(EndOfFileHandling.Require, null)]
+        [InlineData(EndOfFileHandling.Omit, "")]
+        internal async Task TestWithSingleCarriageReturnLineFeedAtEndOfFileAsync(EndOfFileHandling? newlineAtEndOfFile, string expectedText)
         {
+            this.newlineAtEndOfFile = newlineAtEndOfFile;
+
             var testCode = BaseCode + "\r\n";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            var fixedCode = BaseCode + expectedText;
+
+            if (expectedText == null)
+            {
+                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            }
+            else
+            {
+                var expected = this.CSharpDiagnostic().WithLocation(8, 2);
+                await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+                await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
         /// Verifies that a single linefeed at the end of the file will not produce a warning.
         /// </summary>
+        /// <param name="newlineAtEndOfFile">The effective <see cref="EndOfFileHandling"/> setting.</param>
+        /// <param name="expectedText">The expected text to appear at the end of the file, or <see langword="null"/> if
+        /// the input text is already correct.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestWithSingleLineFeedAtEndOfFileAsync()
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(EndOfFileHandling.Allow, null)]
+        [InlineData(EndOfFileHandling.Require, null)]
+        [InlineData(EndOfFileHandling.Omit, "")]
+        internal async Task TestWithSingleLineFeedAtEndOfFileAsync(EndOfFileHandling? newlineAtEndOfFile, string expectedText)
         {
+            this.newlineAtEndOfFile = newlineAtEndOfFile;
+
             var testCode = BaseCode + "\n";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            var fixedCode = BaseCode + expectedText;
+
+            if (expectedText == null)
+            {
+                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            }
+            else
+            {
+                var expected = this.CSharpDiagnostic().WithLocation(8, 2);
+                await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+                await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
         /// Verifies that a source file that ends without a carriage return / linefeed at the end of the file will not produce a warning.
         /// </summary>
+        /// <param name="newlineAtEndOfFile">The effective <see cref="EndOfFileHandling"/> setting.</param>
+        /// <param name="expectedText">The expected text to appear at the end of the file, or <see langword="null"/> if
+        /// the input text is already correct.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestWithoutCarriageReturnLineFeedAtEndOfFileAsync()
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(EndOfFileHandling.Allow, null)]
+        [InlineData(EndOfFileHandling.Require, "\r\n")]
+        [InlineData(EndOfFileHandling.Omit, null)]
+        internal async Task TestWithoutCarriageReturnLineFeedAtEndOfFileAsync(EndOfFileHandling? newlineAtEndOfFile, string expectedText)
         {
-            await this.VerifyCSharpDiagnosticAsync(BaseCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            this.newlineAtEndOfFile = newlineAtEndOfFile;
+
+            var testCode = BaseCode;
+            var fixedCode = BaseCode + expectedText;
+
+            if (expectedText == null)
+            {
+                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            }
+            else
+            {
+                var expected = this.CSharpDiagnostic().WithLocation(8, 2);
+                await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+                await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
         /// Verifies that a source file that ends with spaces will produce a warning.
         /// </summary>
+        /// <param name="newlineAtEndOfFile">The effective <see cref="EndOfFileHandling"/> setting.</param>
+        /// <param name="expectedText">The expected text to appear at the end of the file.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestFileEndsWithSpacesAsync()
+        [Theory]
+        [InlineData(null, "\r\n")]
+        [InlineData(EndOfFileHandling.Allow, "\r\n")]
+        [InlineData(EndOfFileHandling.Require, "\r\n")]
+        [InlineData(EndOfFileHandling.Omit, "")]
+        internal async Task TestFileEndsWithSpacesAsync(EndOfFileHandling? newlineAtEndOfFile, string expectedText)
         {
+            this.newlineAtEndOfFile = newlineAtEndOfFile;
+
             var testCode = BaseCode + "\r\n          ";
-            var fixedCode = BaseCode + "\r\n";
+            var fixedCode = BaseCode + expectedText;
 
             var expected = this.CSharpDiagnostic().WithLocation(8, 2);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -109,23 +200,52 @@ public class Foo
         /// <summary>
         /// Verifies that a comment at the end of the file is not flagged.
         /// </summary>
+        /// <param name="newlineAtEndOfFile">The effective <see cref="EndOfFileHandling"/> setting.</param>
+        /// <param name="expectedText">The expected text to appear at the end of the file, or <see langword="null"/> if
+        /// the input text is already correct.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestFileEndingWithCommentAsync()
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(EndOfFileHandling.Allow, null)]
+        [InlineData(EndOfFileHandling.Require, "\r\n")]
+        [InlineData(EndOfFileHandling.Omit, null)]
+        internal async Task TestFileEndingWithCommentAsync(EndOfFileHandling? newlineAtEndOfFile, string expectedText)
         {
+            this.newlineAtEndOfFile = newlineAtEndOfFile;
+
             var testCode = BaseCode + "\r\n// Test comment";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            var fixedCode = BaseCode + "\r\n// Test comment" + expectedText;
+
+            if (expectedText == null)
+            {
+                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            }
+            else
+            {
+                var expected = this.CSharpDiagnostic().WithLocation(9, 16);
+                await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+                await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
         /// Verifies that spurious end of lines after a comment at the end of the file are flagged.
         /// </summary>
+        /// <param name="newlineAtEndOfFile">The effective <see cref="EndOfFileHandling"/> setting.</param>
+        /// <param name="expectedText">The expected text to appear at the end of the file.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestFileEndingWithCommentAndSpuriousWhitespaceAsync()
+        [Theory]
+        [InlineData(null, "\r\n")]
+        [InlineData(EndOfFileHandling.Allow, "\r\n")]
+        [InlineData(EndOfFileHandling.Require, "\r\n")]
+        [InlineData(EndOfFileHandling.Omit, "")]
+        internal async Task TestFileEndingWithCommentAndSpuriousWhitespaceAsync(EndOfFileHandling? newlineAtEndOfFile, string expectedText)
         {
+            this.newlineAtEndOfFile = newlineAtEndOfFile;
+
             var testCode = BaseCode + "\r\n// Test comment\r\n   \r\n";
-            var fixedCode = BaseCode + "\r\n// Test comment\r\n";
+            var fixedCode = BaseCode + "\r\n// Test comment" + expectedText;
 
             var expected = this.CSharpDiagnostic().WithLocation(9, 16);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -136,23 +256,52 @@ public class Foo
         /// <summary>
         /// Verifies that an endif at the end of the file is not flagged.
         /// </summary>
+        /// <param name="newlineAtEndOfFile">The effective <see cref="EndOfFileHandling"/> setting.</param>
+        /// <param name="expectedText">The expected text to appear at the end of the file, or <see langword="null"/> if
+        /// the input text is already correct.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestFileEndingWithEndIfAsync()
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData(EndOfFileHandling.Allow, null)]
+        [InlineData(EndOfFileHandling.Require, null)]
+        [InlineData(EndOfFileHandling.Omit, "")]
+        internal async Task TestFileEndingWithEndIfAsync(EndOfFileHandling? newlineAtEndOfFile, string expectedText)
         {
+            this.newlineAtEndOfFile = newlineAtEndOfFile;
+
             var testCode = "#if true\r\n" + BaseCode + "\r\n#endif\r\n";
-            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            var fixedCode = "#if true\r\n" + BaseCode + "\r\n#endif" + expectedText;
+
+            if (expectedText == null)
+            {
+                await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            }
+            else
+            {
+                var expected = this.CSharpDiagnostic().WithLocation(10, 7);
+                await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+                await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+                await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
         /// Verifies that an endif at the end of the file is not flagged.
         /// </summary>
+        /// <param name="newlineAtEndOfFile">The effective <see cref="EndOfFileHandling"/> setting.</param>
+        /// <param name="expectedText">The expected text to appear at the end of the file.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestFileEndingWithEndIfWithSpuriousWhitespaceAsync()
+        [Theory]
+        [InlineData(null, "\r\n")]
+        [InlineData(EndOfFileHandling.Allow, "\r\n")]
+        [InlineData(EndOfFileHandling.Require, "\r\n")]
+        [InlineData(EndOfFileHandling.Omit, "")]
+        internal async Task TestFileEndingWithEndIfWithSpuriousWhitespaceAsync(EndOfFileHandling? newlineAtEndOfFile, string expectedText)
         {
+            this.newlineAtEndOfFile = newlineAtEndOfFile;
+
             var testCode = "#if true\r\n" + BaseCode + "\r\n#endif\r\n   \r\n";
-            var fixedCode = "#if true\r\n" + BaseCode + "\r\n#endif\r\n";
+            var fixedCode = "#if true\r\n" + BaseCode + "\r\n#endif" + expectedText;
 
             var expected = this.CSharpDiagnostic().WithLocation(10, 7);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -163,13 +312,20 @@ public class Foo
         /// <summary>
         /// Verifies that the code fix provider will strip trailing blank lines.
         /// </summary>
-        /// <remarks>The CRLF after the last brace will not be stripped!</remarks>
+        /// <param name="newlineAtEndOfFile">The effective <see cref="EndOfFileHandling"/> setting.</param>
+        /// <param name="expectedText">The expected text to appear at the end of the file.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestCodeFixProviderStripsTrailingBlankLinesAsync()
+        [Theory]
+        [InlineData(null, "\r\n")]
+        [InlineData(EndOfFileHandling.Allow, "\r\n")]
+        [InlineData(EndOfFileHandling.Require, "\r\n")]
+        [InlineData(EndOfFileHandling.Omit, "")]
+        internal async Task TestCodeFixProviderStripsTrailingBlankLinesAsync(EndOfFileHandling? newlineAtEndOfFile, string expectedText)
         {
+            this.newlineAtEndOfFile = newlineAtEndOfFile;
+
             var testCode = BaseCode + "\r\n\r\n";
-            var fixedCode = BaseCode + "\r\n";
+            var fixedCode = BaseCode + expectedText;
 
             var expected = this.CSharpDiagnostic().WithLocation(8, 2);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -180,13 +336,20 @@ public class Foo
         /// <summary>
         /// Verifies that the code fix provider will strip trailing blank lines that include whitespace.
         /// </summary>
-        /// <remarks>The CRLF after the last brace will not be stripped!</remarks>
+        /// <param name="newlineAtEndOfFile">The effective <see cref="EndOfFileHandling"/> setting.</param>
+        /// <param name="expectedText">The expected text to appear at the end of the file.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestCodeFixProviderStripsTrailingBlankLinesIncludingWhitespaceAsync()
+        [Theory]
+        [InlineData(null, "\r\n")]
+        [InlineData(EndOfFileHandling.Allow, "\r\n")]
+        [InlineData(EndOfFileHandling.Require, "\r\n")]
+        [InlineData(EndOfFileHandling.Omit, "")]
+        internal async Task TestCodeFixProviderStripsTrailingBlankLinesIncludingWhitespaceAsync(EndOfFileHandling? newlineAtEndOfFile, string expectedText)
         {
+            this.newlineAtEndOfFile = newlineAtEndOfFile;
+
             var testCode = BaseCode + "\r\n   \r\n   \r\n";
-            var fixedCode = BaseCode + "\r\n";
+            var fixedCode = BaseCode + expectedText;
 
             var expected = this.CSharpDiagnostic().WithLocation(8, 2);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -197,13 +360,20 @@ public class Foo
         /// <summary>
         /// Verifies that the code fix provider will strip trailing linefeed only blank lines that include whitespace.
         /// </summary>
-        /// <remarks>The LF after the last brace will not be stripped!</remarks>
+        /// <param name="newlineAtEndOfFile">The effective <see cref="EndOfFileHandling"/> setting.</param>
+        /// <param name="expectedText">The expected text to appear at the end of the file.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestCodeFixProviderStripsTrailingLinefeedOnlyBlankLinesIncludingWhitespaceAsync()
+        [Theory]
+        [InlineData(null, "\r\n")]
+        [InlineData(EndOfFileHandling.Allow, "\r\n")]
+        [InlineData(EndOfFileHandling.Require, "\r\n")]
+        [InlineData(EndOfFileHandling.Omit, "")]
+        internal async Task TestCodeFixProviderStripsTrailingLinefeedOnlyBlankLinesIncludingWhitespaceAsync(EndOfFileHandling? newlineAtEndOfFile, string expectedText)
         {
+            this.newlineAtEndOfFile = newlineAtEndOfFile;
+
             var testCode = BaseCode + "\n   \n   \n";
-            var fixedCode = BaseCode + "\r\n";
+            var fixedCode = BaseCode + expectedText;
 
             var expected = this.CSharpDiagnostic().WithLocation(8, 2);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -214,18 +384,43 @@ public class Foo
         /// <summary>
         /// Verifies that the code fix provider will strip only trailing blank lines.
         /// </summary>
-        /// <remarks>The CRLF after the #endif will not be stripped!</remarks>
+        /// <param name="newlineAtEndOfFile">The effective <see cref="EndOfFileHandling"/> setting.</param>
+        /// <param name="expectedText">The expected text to appear at the end of the file.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestCodeFixProviderOnlyStripsTrailingBlankLinesAsync()
+        [Theory]
+        [InlineData(null, "\r\n")]
+        [InlineData(EndOfFileHandling.Allow, "\r\n")]
+        [InlineData(EndOfFileHandling.Require, "\r\n")]
+        [InlineData(EndOfFileHandling.Omit, "")]
+        internal async Task TestCodeFixProviderOnlyStripsTrailingBlankLinesAsync(EndOfFileHandling? newlineAtEndOfFile, string expectedText)
         {
+            this.newlineAtEndOfFile = newlineAtEndOfFile;
+
             var testCode = "#if true\r\n" + BaseCode + "\r\n#endif\r\n   \r\n";
-            var fixedCode = "#if true\r\n" + BaseCode + "\r\n#endif\r\n";
+            var fixedCode = "#if true\r\n" + BaseCode + "\r\n#endif" + expectedText;
 
             var expected = this.CSharpDiagnostic().WithLocation(10, 7);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        protected override string GetSettings()
+        {
+            if (this.newlineAtEndOfFile == null)
+            {
+                return base.GetSettings();
+            }
+
+            return $@"
+{{
+  ""settings"": {{
+    ""layoutRules"": {{
+      ""newlineAtEndOfFile"": ""{this.newlineAtEndOfFile.ToString().ToLowerInvariant()}""
+    }}
+  }}
+}}";
         }
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Settings/SettingsUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Settings/SettingsUnitTests.cs
@@ -32,6 +32,9 @@ namespace StyleCop.Analyzers.Test.Settings
             Assert.NotNull(styleCopSettings.OrderingRules);
             Assert.Equal(UsingDirectivesPlacement.InsideNamespace, styleCopSettings.OrderingRules.UsingDirectivesPlacement);
 
+            Assert.NotNull(styleCopSettings.LayoutRules);
+            Assert.Equal(EndOfFileHandling.Allow, styleCopSettings.LayoutRules.NewlineAtEndOfFile);
+
             Assert.NotNull(styleCopSettings.SpacingRules);
             Assert.NotNull(styleCopSettings.ReadabilityRules);
             Assert.NotNull(styleCopSettings.MaintainabilityRules);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/LayoutResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/LayoutResources.Designer.cs
@@ -260,7 +260,7 @@ namespace StyleCop.Analyzers.LayoutRules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove blank lines at the end of the file.
+        ///   Looks up a localized string similar to Fix whitespace at the end of the file.
         /// </summary>
         internal static string SA1518CodeFix {
             get {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/LayoutResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/LayoutResources.resx
@@ -184,6 +184,6 @@
     <value>Remove blank lines at the start of the file</value>
   </data>
   <data name="SA1518CodeFix" xml:space="preserve">
-    <value>Remove blank lines at the end of the file</value>
+    <value>Fix whitespace at the end of the file</value>
   </data>
 </root>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1518CodeMustNotContainBlankLinesAtEndOfFile.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1518CodeMustNotContainBlankLinesAtEndOfFile.cs
@@ -78,15 +78,8 @@ namespace StyleCop.Analyzers.LayoutRules
                 }
                 else
                 {
-                    if (leadingTrivia.Count == 0)
-                    {
-                        checkPrecedingToken = true;
-                    }
-                    else
-                    {
-                        checkPrecedingToken = false;
-                        precedingTrivia = leadingTrivia.Last();
-                    }
+                    checkPrecedingToken = false;
+                    precedingTrivia = leadingTrivia.Last();
                 }
             }
             else
@@ -149,7 +142,7 @@ namespace StyleCop.Analyzers.LayoutRules
                 break;
 
             case EndOfFileHandling.Require:
-                if (firstNewline > 0 && secondNewline < 0)
+                if (firstNewline >= 0 && firstNewline == trailingWhitespaceText.Length - 1)
                 {
                     return;
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1518CodeMustNotContainBlankLinesAtEndOfFile.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1518CodeMustNotContainBlankLinesAtEndOfFile.cs
@@ -6,9 +6,12 @@ namespace StyleCop.Analyzers.LayoutRules
     using System;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using Microsoft.CodeAnalysis.Text;
     using StyleCop.Analyzers.Helpers;
+    using StyleCop.Analyzers.Settings.ObjectModel;
 
     /// <summary>
     /// The code file has blank lines at the end.
@@ -34,7 +37,7 @@ namespace StyleCop.Analyzers.LayoutRules
             new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.LayoutRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
         private static readonly Action<CompilationStartAnalysisContext> CompilationStartAction = HandleCompilationStart;
-        private static readonly Action<SyntaxTreeAnalysisContext> SyntaxTreeAction = HandleSyntaxTree;
+        private static readonly Action<SyntaxTreeAnalysisContext, StyleCopSettings> SyntaxTreeAction = HandleSyntaxTree;
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
@@ -51,21 +54,124 @@ namespace StyleCop.Analyzers.LayoutRules
             context.RegisterSyntaxTreeActionHonorExclusions(SyntaxTreeAction);
         }
 
-        private static void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
+        private static void HandleSyntaxTree(SyntaxTreeAnalysisContext context, StyleCopSettings settings)
         {
-            var lastToken = context.Tree.GetRoot().GetLastToken(includeZeroWidth: true);
+            var endOfFileToken = context.Tree.GetRoot().GetLastToken(includeZeroWidth: true);
+            TextSpan reportedSpan = new TextSpan(endOfFileToken.SpanStart, 0);
 
-            if (lastToken.HasLeadingTrivia)
+            SyntaxTrivia precedingTrivia = default(SyntaxTrivia);
+            bool checkPrecedingToken;
+            if (endOfFileToken.HasLeadingTrivia)
             {
-                var leadingTrivia = lastToken.LeadingTrivia;
-
+                var leadingTrivia = endOfFileToken.LeadingTrivia;
                 var trailingWhitespaceIndex = TriviaHelper.IndexOfTrailingWhitespace(leadingTrivia);
-                if (trailingWhitespaceIndex != -1)
+                if (trailingWhitespaceIndex > 0)
                 {
-                    var textSpan = TextSpan.FromBounds(leadingTrivia[trailingWhitespaceIndex].SpanStart, leadingTrivia[leadingTrivia.Count - 1].Span.End);
-                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.Create(context.Tree, textSpan)));
+                    checkPrecedingToken = false;
+                    reportedSpan = TextSpan.FromBounds(leadingTrivia[trailingWhitespaceIndex].SpanStart, reportedSpan.End);
+                    precedingTrivia = leadingTrivia[trailingWhitespaceIndex - 1];
+                }
+                else if (trailingWhitespaceIndex == 0)
+                {
+                    checkPrecedingToken = true;
+                    reportedSpan = TextSpan.FromBounds(leadingTrivia[trailingWhitespaceIndex].SpanStart, reportedSpan.End);
+                }
+                else
+                {
+                    if (leadingTrivia.Count == 0)
+                    {
+                        checkPrecedingToken = true;
+                    }
+                    else
+                    {
+                        checkPrecedingToken = false;
+                        precedingTrivia = leadingTrivia.Last();
+                    }
                 }
             }
+            else
+            {
+                checkPrecedingToken = true;
+            }
+
+            if (checkPrecedingToken)
+            {
+                var previousToken = endOfFileToken.GetPreviousToken(includeZeroWidth: true, includeSkipped: true, includeDirectives: true, includeDocumentationComments: true);
+                var trailingWhitespaceIndex = TriviaHelper.IndexOfTrailingWhitespace(previousToken.TrailingTrivia);
+                if (trailingWhitespaceIndex > 0)
+                {
+                    reportedSpan = TextSpan.FromBounds(previousToken.TrailingTrivia[trailingWhitespaceIndex].SpanStart, reportedSpan.End);
+                    precedingTrivia = previousToken.TrailingTrivia[trailingWhitespaceIndex - 1];
+                }
+                else if (trailingWhitespaceIndex == 0)
+                {
+                    reportedSpan = TextSpan.FromBounds(previousToken.TrailingTrivia[trailingWhitespaceIndex].SpanStart, reportedSpan.End);
+                    precedingTrivia = default(SyntaxTrivia);
+                }
+                else
+                {
+                    if (previousToken.TrailingTrivia.Count > 0)
+                    {
+                        precedingTrivia = previousToken.TrailingTrivia.Last();
+                    }
+                }
+            }
+
+            if (precedingTrivia.IsDirective)
+            {
+                DirectiveTriviaSyntax directiveTriviaSyntax = precedingTrivia.GetStructure() as DirectiveTriviaSyntax;
+                if (directiveTriviaSyntax != null && directiveTriviaSyntax.EndOfDirectiveToken.HasTrailingTrivia)
+                {
+                    var trailingWhitespaceIndex = TriviaHelper.IndexOfTrailingWhitespace(directiveTriviaSyntax.EndOfDirectiveToken.TrailingTrivia);
+                    if (trailingWhitespaceIndex >= 0)
+                    {
+                        reportedSpan = TextSpan.FromBounds(directiveTriviaSyntax.EndOfDirectiveToken.TrailingTrivia[trailingWhitespaceIndex].SpanStart, reportedSpan.End);
+                    }
+                }
+            }
+            else if (precedingTrivia.IsKind(SyntaxKind.EndOfLineTrivia))
+            {
+                reportedSpan = TextSpan.FromBounds(precedingTrivia.SpanStart, reportedSpan.End);
+            }
+
+            SourceText sourceText = context.Tree.GetText(context.CancellationToken);
+            string trailingWhitespaceText = sourceText.ToString(reportedSpan);
+            int firstNewline = trailingWhitespaceText.IndexOf('\n');
+            int secondNewline = firstNewline >= 0 ? trailingWhitespaceText.IndexOf('\n', firstNewline + 1) : -1;
+            switch (settings.LayoutRules.NewlineAtEndOfFile)
+            {
+            case EndOfFileHandling.Omit:
+                if (firstNewline < 0)
+                {
+                    return;
+                }
+
+                break;
+
+            case EndOfFileHandling.Require:
+                if (firstNewline > 0 && secondNewline < 0)
+                {
+                    return;
+                }
+
+                break;
+
+            case EndOfFileHandling.Allow:
+            default:
+                if (secondNewline < 0)
+                {
+                    // 1. A newline is allowed but not required
+                    // 2. If a newline is included, it cannot be followed by whitespace
+                    if (firstNewline < 0 || firstNewline == trailingWhitespaceText.Length - 1)
+                    {
+                        return;
+                    }
+                }
+
+                break;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.Create(context.Tree, reportedSpan)));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/EndOfFileHandling.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/EndOfFileHandling.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Settings.ObjectModel
+{
+    /// <summary>
+    /// Specifies the handling for newline characters which appear at the end of a file.
+    /// </summary>
+    internal enum EndOfFileHandling
+    {
+        /// <summary>
+        /// Files are allowed to end with a single newline character, but it is not required.
+        /// </summary>
+        Allow,
+
+        /// <summary>
+        /// Files are required to end with a single newline character.
+        /// </summary>
+        Require,
+
+        /// <summary>
+        /// Files may not end with a newline character.
+        /// </summary>
+        Omit
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/LayoutSettings.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/LayoutSettings.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Settings.ObjectModel
+{
+    using Newtonsoft.Json;
+
+    [JsonObject(MemberSerialization.OptIn)]
+    internal class LayoutSettings
+    {
+        /// <summary>
+        /// This is the backing field for the <see cref="NewlineAtEndOfFile"/> property.
+        /// </summary>
+        [JsonProperty("newlineAtEndOfFile", DefaultValueHandling = DefaultValueHandling.Include)]
+        private EndOfFileHandling newlineAtEndOfFile;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LayoutSettings"/> class during JSON deserialization.
+        /// </summary>
+        [JsonConstructor]
+        protected internal LayoutSettings()
+        {
+            this.newlineAtEndOfFile = EndOfFileHandling.Allow;
+        }
+
+        public EndOfFileHandling NewlineAtEndOfFile =>
+            this.newlineAtEndOfFile;
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/StyleCopSettings.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/StyleCopSettings.cs
@@ -39,6 +39,12 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
         private MaintainabilitySettings maintainabilityRules;
 
         /// <summary>
+        /// This is the backing field for the <see cref="LayoutRules"/> property.
+        /// </summary>
+        [JsonProperty("layoutRules", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        private LayoutSettings layoutRules;
+
+        /// <summary>
         /// This is the backing field for the <see cref="DocumentationRules"/> property.
         /// </summary>
         [JsonProperty("documentationRules", DefaultValueHandling = DefaultValueHandling.Ignore)]
@@ -55,6 +61,7 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
             this.orderingRules = new OrderingSettings();
             this.namingRules = new NamingSettings();
             this.maintainabilityRules = new MaintainabilitySettings();
+            this.layoutRules = new LayoutSettings();
             this.documentationRules = new DocumentationSettings();
         }
 
@@ -72,6 +79,9 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
 
         public MaintainabilitySettings MaintainabilityRules =>
             this.maintainabilityRules;
+
+        public LayoutSettings LayoutRules =>
+            this.layoutRules;
 
         public DocumentationSettings DocumentationRules =>
             this.documentationRules;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json
@@ -75,6 +75,23 @@
           "properties": {
           }
         },
+        "layoutRules": {
+          "type": "object",
+          "description": "Configuration for layout rules (SA1500-)",
+          "additionalProperties": false,
+          "properties": {
+            "newlineAtEndOfFile": {
+              "type": "string",
+              "description": "Specifies the handling for newline characters which appear at the end of a file\r\nallow: Files are allowed to end with a single newline character, but it is not required\r\nrequire: Files are required to end with a single newline character\r\nomit: Files may not end with a newline character",
+              "enum": [
+                "allow",
+                "require",
+                "omit"
+              ],
+              "default": "allow"
+            }
+          }
+        },
         "documentationRules": {
           "type": "object",
           "description": "Configuration for documentation rules (SA1600-)",

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -270,7 +270,9 @@
     <Compile Include="ReadabilityRules\SA1134AttributesMustNotShareLine.cs" />
     <Compile Include="ReadabilityRules\SX1101DoNotPrefixLocalMembersWithThis.cs" />
     <Compile Include="Settings\ObjectModel\DocumentationSettings.cs" />
+    <Compile Include="Settings\ObjectModel\EndOfFileHandling.cs" />
     <Compile Include="Settings\ObjectModel\FileNamingConvention.cs" />
+    <Compile Include="Settings\ObjectModel\LayoutSettings.cs" />
     <Compile Include="Settings\ObjectModel\MaintainabilitySettings.cs" />
     <Compile Include="Settings\ObjectModel\NamingSettings.cs" />
     <Compile Include="Settings\ObjectModel\OrderingSettings.cs" />

--- a/documentation/Configuration.md
+++ b/documentation/Configuration.md
@@ -180,6 +180,34 @@ This section describes the features of maintainability rules which can be config
 
 > Currently there are no configurable settings for maintainability rules.
 
+## Layout Rules
+
+This section describes the features of layout rules which can be configured in **stylecop.json**. Each of the described properties are configured in the `layoutRules` object, which is shown in the following sample file.
+
+```json
+{
+  "settings": {
+    "layoutRules": {
+    }
+  }
+}
+```
+
+The following properties are used to configure layout rules in StyleCop Analyzers.
+
+| Property | Default Value | Summary |
+| --- | --- | --- |
+| `newlineAtEndOfFile` | `"allow"` | Specifies the handling for newline characters which appear at the end of a file |
+
+### Lines at End of File
+
+The behavior of [SA1518](SA1518.md) can be customized regarding the manner in which newline characters at the end of a
+file are handled. The `newlineAtEndOfFile` property supports the following values:
+
+* `"allow"`: Files are allowed to end with a single newline character, but it is not required
+* `"require"`: Files are required to end with a single newline character
+* `"omit"`: Files may not end with a newline character
+
 ## Documentation Rules
 
 This section describes the features of documentation rules which can be configured in **stylecop.json**. Each of the described properties are configured in the `documentationRules` object, which is shown in the following sample file.


### PR DESCRIPTION
This option allows users to configure the way SA1518 treats newline characters at the end of a file.

Fixes #1800

:memo: The default behavior of SA1518 remains the same as before. However, the location where violations are reported has changed slightly (typically on the line before where they were previously reported) since it greatly simplified the process of making the code fix adhere to the settings file.
