### PR TITLE
Update SA1302 code fix to support conflict resolution

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/NamingRules/SA1302CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/NamingRules/SA1302CodeFixProvider.cs
@@ -57,11 +57,21 @@ namespace StyleCop.Analyzers.NamingRules
             INamedTypeSymbol interfaceType = declaredSymbol as INamedTypeSymbol;
             if (interfaceType != null)
             {
-                var containingNamespace = semanticModel.Compilation.GetCompilationNamespace(interfaceType.ContainingNamespace);
-                while (containingNamespace.GetMembers(newName).Any())
+                var containingSymbol = interfaceType.ContainingSymbol as INamespaceOrTypeSymbol;
+                var containingNamespace = containingSymbol as INamespaceSymbol;
+                if (containingNamespace != null)
                 {
-                    index++;
-                    newName = baseName + index;
+                    // Make sure to use the compilation namespace so interfaces in referenced assemblies are considered
+                    containingSymbol = semanticModel.Compilation.GetCompilationNamespace(containingNamespace);
+                }
+
+                if (containingSymbol != null)
+                {
+                    while (containingSymbol.GetMembers(newName).Any())
+                    {
+                        index++;
+                        newName = baseName + index;
+                    }
                 }
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/NamingRules/SA1302CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/NamingRules/SA1302CodeFixProvider.cs
@@ -54,25 +54,10 @@ namespace StyleCop.Analyzers.NamingRules
 
             var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
             var declaredSymbol = semanticModel.GetDeclaredSymbol(token.Parent, cancellationToken);
-            INamedTypeSymbol interfaceType = declaredSymbol as INamedTypeSymbol;
-            if (interfaceType != null)
+            while (!RenameHelper.IsValidNewMemberName(semanticModel, declaredSymbol, newName))
             {
-                var containingSymbol = interfaceType.ContainingSymbol as INamespaceOrTypeSymbol;
-                var containingNamespace = containingSymbol as INamespaceSymbol;
-                if (containingNamespace != null)
-                {
-                    // Make sure to use the compilation namespace so interfaces in referenced assemblies are considered
-                    containingSymbol = semanticModel.Compilation.GetCompilationNamespace(containingNamespace);
-                }
-
-                if (containingSymbol != null)
-                {
-                    while (containingSymbol.GetMembers(newName).Any())
-                    {
-                        index++;
-                        newName = baseName + index;
-                    }
-                }
+                index++;
+                newName = baseName + index;
             }
 
             return await RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1302UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1302UnitTests.cs
@@ -185,6 +185,56 @@ public class MyNativeMethods
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        [Fact]
+        public async Task TestInterfaceDeclarationDoesNotStartWithIWithConflictAsync()
+        {
+            string testCode = @"
+public interface Foo
+{
+}
+
+public interface IFoo { }";
+            string fixedCode = @"
+public interface IFoo1
+{
+}
+
+public interface IFoo { }";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(2, 18);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInterfaceDeclarationDoesNotStartWithIWithConflictInAnotherAssemblyAsync()
+        {
+            string testCode = @"
+namespace System
+{
+    public interface Disposable
+    {
+    }
+}
+";
+            string fixedCode = @"
+namespace System
+{
+    public interface IDisposable1
+    {
+    }
+}
+";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 22);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
             yield return new SA1302InterfaceNamesMustBeginWithI();

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1302UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1302UnitTests.cs
@@ -209,6 +209,64 @@ public interface IFoo { }";
         }
 
         [Fact]
+        public async Task TestNestedInterfaceDeclarationDoesNotStartWithIWithConflictAsync()
+        {
+            string testCode = @"
+public class Outer
+{
+    public interface Foo
+    {
+    }
+
+    public interface IFoo { }
+}";
+            string fixedCode = @"
+public class Outer
+{
+    public interface IFoo1
+    {
+    }
+
+    public interface IFoo { }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 22);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestNestedInterfaceDeclarationDoesNotStartWithIWithNonInterfaceConflictAsync()
+        {
+            string testCode = @"
+public class Outer
+{
+    public interface Foo
+    {
+    }
+
+    private int IFoo => 0;
+}";
+            string fixedCode = @"
+public class Outer
+{
+    public interface IFoo1
+    {
+    }
+
+    private int IFoo => 0;
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 22);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestInterfaceDeclarationDoesNotStartWithIWithConflictInAnotherAssemblyAsync()
         {
             string testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1302UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1302UnitTests.cs
@@ -209,6 +209,27 @@ public interface IFoo { }";
         }
 
         [Fact]
+        public async Task TestInterfaceDeclarationDoesNotStartWithIWithMemberConflictAsync()
+        {
+            string testCode = @"
+public interface Foo
+{
+    int IFoo { get; }
+}";
+            string fixedCode = @"
+public interface IFoo1
+{
+    int IFoo { get; }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(2, 18);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestNestedInterfaceDeclarationDoesNotStartWithIWithConflictAsync()
         {
             string testCode = @"
@@ -228,6 +249,31 @@ public class Outer
     }
 
     public interface IFoo { }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 22);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestNestedInterfaceDeclarationDoesNotStartWithIWithContainingTypeConflictAsync()
+        {
+            string testCode = @"
+public class IFoo
+{
+    public interface Foo
+    {
+    }
+}";
+            string fixedCode = @"
+public class IFoo
+{
+    public interface IFoo1
+    {
+    }
 }";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(4, 22);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/NamingResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/NamingResources.Designer.cs
@@ -71,6 +71,15 @@ namespace StyleCop.Analyzers.NamingRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Prefix interface name with &apos;I&apos;.
+        /// </summary>
+        internal static string SA1302CodeFix {
+            get {
+                return ResourceManager.GetString("SA1302CodeFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The name of a variable in C# does not begin with a lower-case letter..
         /// </summary>
         internal static string SA1312Description {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/NamingResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/NamingResources.resx
@@ -120,6 +120,9 @@
   <data name="RenameToCodeFix" xml:space="preserve">
     <value>Rename To '{0}'</value>
   </data>
+  <data name="SA1302CodeFix" xml:space="preserve">
+    <value>Prefix interface name with 'I'</value>
+  </data>
   <data name="SA1312Description" xml:space="preserve">
     <value>The name of a variable in C# does not begin with a lower-case letter.</value>
   </data>


### PR DESCRIPTION
Fixes #436

Edit: ~~Need to update this to ensure a nested type isn't renamed to the same name as the enclosing type.~~ This is now working.