### PR TITLE
Add hint about how to refresh the JSON schema

### DIFF
--- a/documentation/Configuration.md
+++ b/documentation/Configuration.md
@@ -29,6 +29,7 @@ A JSON schema is available for **stylecop.json**. By including a reference in **
 ```
 
 > :bulb: The code fix described previously automatically configures **stylecop.json** to reference the schema.
+> If the schema appears to be out-of-date in Visual Studio, right click anywhere in the **stylecop.json** document and then select **Reload Schemas**.
 
 ### Source Control
 


### PR DESCRIPTION
Adds a hint about how to refresh the schema if it goes out of date in Visual Studio as suggested [here](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/1812#issuecomment-160184753).