### PR TITLE
Update SA1312 to check additional local variable declarations

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1312UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1312UnitTests.cs
@@ -178,6 +178,268 @@ public class TypeName
         }
 
         [Fact]
+        public async Task TestVariableInCatchDeclarationAsync()
+        {
+            var testCode = @"
+using System;
+public class TypeName
+{
+    public void MethodName()
+    {
+        try
+        {
+        }
+        catch (Exception Ex)
+        {
+        }
+    }
+}";
+            var fixedCode = @"
+using System;
+public class TypeName
+{
+    public void MethodName()
+    {
+        try
+        {
+        }
+        catch (Exception ex)
+        {
+        }
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithArguments("Ex").WithLocation(10, 26),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestVariableInForEachStatementAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        foreach (var X in new int[0])
+        {
+        }
+    }
+}";
+            var fixedCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        foreach (var x in new int[0])
+        {
+        }
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithArguments("X").WithLocation(5, 22),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestVariableInFromClauseAsync()
+        {
+            var testCode = @"
+using System.Linq;
+public class TypeName
+{
+    public void MethodName()
+    {
+        var result =
+            from X in new int[0]
+            select X;
+    }
+}";
+            var fixedCode = @"
+using System.Linq;
+public class TypeName
+{
+    public void MethodName()
+    {
+        var result =
+            from x in new int[0]
+            select x;
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithArguments("X").WithLocation(8, 18),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestVariableInQueryContinuationAsync()
+        {
+            var testCode = @"
+using System.Linq;
+public class TypeName
+{
+    public void MethodName()
+    {
+        var result =
+            from x in new int[0]
+            select x into Y
+            select Y;
+    }
+}";
+            var fixedCode = @"
+using System.Linq;
+public class TypeName
+{
+    public void MethodName()
+    {
+        var result =
+            from x in new int[0]
+            select x into y
+            select y;
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithArguments("Y").WithLocation(9, 27),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestVariableInLetClauseAsync()
+        {
+            var testCode = @"
+using System.Linq;
+public class TypeName
+{
+    public void MethodName()
+    {
+        var result =
+            from x in new int[0]
+            let Y = x
+            select Y;
+    }
+}";
+            var fixedCode = @"
+using System.Linq;
+public class TypeName
+{
+    public void MethodName()
+    {
+        var result =
+            from x in new int[0]
+            let y = x
+            select y;
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithArguments("Y").WithLocation(9, 17),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestVariableInJoinClauseAsync()
+        {
+            var testCode = @"
+using System.Linq;
+public class TypeName
+{
+    public void MethodName()
+    {
+        var result =
+            from x in new int[0]
+            join Y in new int[0] on x equals Y
+            select x;
+    }
+}";
+            var fixedCode = @"
+using System.Linq;
+public class TypeName
+{
+    public void MethodName()
+    {
+        var result =
+            from x in new int[0]
+            join y in new int[0] on x equals y
+            select x;
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithArguments("Y").WithLocation(9, 18),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestVariableInJoinIntoClauseAsync()
+        {
+            var testCode = @"
+using System.Linq;
+public class TypeName
+{
+    public void MethodName()
+    {
+        var result =
+            from x in new int[0]
+            join y in new int[0] on x equals y into Z
+            select Z;
+    }
+}";
+            var fixedCode = @"
+using System.Linq;
+public class TypeName
+{
+    public void MethodName()
+    {
+        var result =
+            from x in new int[0]
+            join y in new int[0] on x equals y into z
+            select z;
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithArguments("Z").WithLocation(9, 53),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestVariablePlacedInsideNativeMethodsClassAsync()
         {
             var testCode = @"public class FooNativeMethods

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1312VariableNamesMustBeginWithLowerCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1312VariableNamesMustBeginWithLowerCaseLetter.cs
@@ -40,6 +40,13 @@ namespace StyleCop.Analyzers.NamingRules
 
         private static readonly Action<CompilationStartAnalysisContext> CompilationStartAction = HandleCompilationStart;
         private static readonly Action<SyntaxNodeAnalysisContext> VariableDeclarationAction = HandleVariableDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext> CatchDeclarationAction = HandleCatchDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext> QueryContinuationAction = HandleQueryContinuation;
+        private static readonly Action<SyntaxNodeAnalysisContext> FromClauseAction = HandleFromClause;
+        private static readonly Action<SyntaxNodeAnalysisContext> LetClauseAction = HandleLetClause;
+        private static readonly Action<SyntaxNodeAnalysisContext> JoinClauseAction = HandleJoinClause;
+        private static readonly Action<SyntaxNodeAnalysisContext> JoinIntoClauseAction = HandleJoinIntoClause;
+        private static readonly Action<SyntaxNodeAnalysisContext> ForEachStatementAction = HandleForEachStatement;
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
@@ -54,6 +61,13 @@ namespace StyleCop.Analyzers.NamingRules
         private static void HandleCompilationStart(CompilationStartAnalysisContext context)
         {
             context.RegisterSyntaxNodeActionHonorExclusions(VariableDeclarationAction, SyntaxKind.VariableDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(CatchDeclarationAction, SyntaxKind.CatchDeclaration);
+            context.RegisterSyntaxNodeActionHonorExclusions(QueryContinuationAction, SyntaxKind.QueryContinuation);
+            context.RegisterSyntaxNodeActionHonorExclusions(FromClauseAction, SyntaxKind.FromClause);
+            context.RegisterSyntaxNodeActionHonorExclusions(LetClauseAction, SyntaxKind.LetClause);
+            context.RegisterSyntaxNodeActionHonorExclusions(JoinClauseAction, SyntaxKind.JoinClause);
+            context.RegisterSyntaxNodeActionHonorExclusions(JoinIntoClauseAction, SyntaxKind.JoinIntoClause);
+            context.RegisterSyntaxNodeActionHonorExclusions(ForEachStatementAction, SyntaxKind.ForEachStatement);
         }
 
         private static void HandleVariableDeclaration(SyntaxNodeAnalysisContext context)
@@ -86,20 +100,60 @@ namespace StyleCop.Analyzers.NamingRules
                 }
 
                 var identifier = variableDeclarator.Identifier;
-                if (identifier.IsMissing)
-                {
-                    continue;
-                }
-
-                string name = identifier.ValueText;
-                if (string.IsNullOrEmpty(name) || char.IsLower(name[0]))
-                {
-                    continue;
-                }
-
-                // Variable names must begin with lower-case letter
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, identifier.GetLocation(), name));
+                CheckIdentifier(context, identifier);
             }
+        }
+
+        private static void HandleCatchDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            CheckIdentifier(context, ((CatchDeclarationSyntax)context.Node).Identifier);
+        }
+
+        private static void HandleQueryContinuation(SyntaxNodeAnalysisContext context)
+        {
+            CheckIdentifier(context, ((QueryContinuationSyntax)context.Node).Identifier);
+        }
+
+        private static void HandleFromClause(SyntaxNodeAnalysisContext context)
+        {
+            CheckIdentifier(context, ((FromClauseSyntax)context.Node).Identifier);
+        }
+
+        private static void HandleLetClause(SyntaxNodeAnalysisContext context)
+        {
+            CheckIdentifier(context, ((LetClauseSyntax)context.Node).Identifier);
+        }
+
+        private static void HandleJoinClause(SyntaxNodeAnalysisContext context)
+        {
+            CheckIdentifier(context, ((JoinClauseSyntax)context.Node).Identifier);
+        }
+
+        private static void HandleJoinIntoClause(SyntaxNodeAnalysisContext context)
+        {
+            CheckIdentifier(context, ((JoinIntoClauseSyntax)context.Node).Identifier);
+        }
+
+        private static void HandleForEachStatement(SyntaxNodeAnalysisContext context)
+        {
+            CheckIdentifier(context, ((ForEachStatementSyntax)context.Node).Identifier);
+        }
+
+        private static void CheckIdentifier(SyntaxNodeAnalysisContext context, SyntaxToken identifier)
+        {
+            if (identifier.IsMissing)
+            {
+                return;
+            }
+
+            string name = identifier.ValueText;
+            if (string.IsNullOrEmpty(name) || char.IsLower(name[0]))
+            {
+                return;
+            }
+
+            // Variable names must begin with lower-case letter
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, identifier.GetLocation(), name));
         }
     }
 }


### PR DESCRIPTION
Fixes #1856 

:memo: Unfortunately it's not possible to just register a symbol action for `ILocalSymbol`, so instead this pull request operates on the additional types of syntax nodes which declare local variables.