### PR TITLE
Fix UsingCodeFixProvider handling of aliases

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/UsingCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/UsingCodeFixProvider.cs
@@ -690,7 +690,7 @@ namespace StyleCop.Analyzers.OrderingRules
                         .WithAdditionalAnnotations(UsingCodeFixAnnotation);
 
                     // filter duplicate using declarations, preferring to keep the one with an alias
-                    var existingUsing = result.Find(u => string.Equals(u.Name.ToUnaliasedString(), processedUsing.Name.ToUnaliasedString(), StringComparison.Ordinal));
+                    var existingUsing = result.Find(u => string.Equals(u.Name.ToNormalizedString(), processedUsing.Name.ToNormalizedString(), StringComparison.Ordinal));
                     if (existingUsing != null)
                     {
                         if (!existingUsing.HasNamespaceAliasQualifier() && processedUsing.HasNamespaceAliasQualifier())

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210CombinedSystemDirectivesUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210CombinedSystemDirectivesUnitTests.cs
@@ -102,6 +102,7 @@ namespace Food
     using global::System;
     using global::System.IO;
     using global::System.Linq;
+    using System;
     using System.Threading;
     using XYZ = System.IO;
 }";
@@ -135,10 +136,12 @@ namespace Food
 
             var fixedTestCode = @"namespace Food
 {
+    using Food;
     using global::Food;
     using global::System;
     using global::System.IO;
     using global::System.Linq;
+    using System;
     using System.Threading;
 }";
 
@@ -223,6 +226,13 @@ using Microsoft.CodeAnalysis;
 ";
 
             return CombinedUsingDirectivesTestSettings;
+        }
+
+        /// <inheritdoc/>
+        protected override IEnumerable<string> GetDisabledDiagnostics()
+        {
+            // Using directive appeared previously in this namespace
+            yield return "CS0105";
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
This change can result in the output of this code fix containing duplicate
using directives, but this situation does not break the semantics of code
and only produces a build warning.

Fixes #1770