### PR TITLE
Improve DocumentBasedFixAllProvider performance for multiple documents

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1626CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1626CodeFixProvider.cs
@@ -68,9 +68,8 @@ namespace StyleCop.Analyzers.DocumentationRules
             protected override string CodeActionTitle =>
                 DocumentationResources.SA1626CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/CustomBatchFixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/CustomBatchFixAllProvider.cs
@@ -210,93 +210,14 @@ namespace StyleCop.Analyzers.Helpers
             }
         }
 
-        public virtual async Task<ImmutableDictionary<Document, ImmutableArray<Diagnostic>>> GetDocumentDiagnosticsToFixAsync(FixAllContext fixAllContext)
+        public virtual Task<ImmutableDictionary<Document, ImmutableArray<Diagnostic>>> GetDocumentDiagnosticsToFixAsync(FixAllContext fixAllContext)
         {
-            var allDiagnostics = ImmutableArray<Diagnostic>.Empty;
-            var projectsToFix = ImmutableArray<Project>.Empty;
-
-            var document = fixAllContext.Document;
-            var project = fixAllContext.Project;
-
-            switch (fixAllContext.Scope)
-            {
-            case FixAllScope.Document:
-                if (document != null)
-                {
-                    var documentDiagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
-                    return ImmutableDictionary<Document, ImmutableArray<Diagnostic>>.Empty.SetItem(document, documentDiagnostics);
-                }
-
-                break;
-
-            case FixAllScope.Project:
-                projectsToFix = ImmutableArray.Create(project);
-                allDiagnostics = await fixAllContext.GetAllDiagnosticsAsync(project).ConfigureAwait(false);
-                break;
-
-            case FixAllScope.Solution:
-                projectsToFix = project.Solution.Projects
-                    .Where(p => p.Language == project.Language)
-                    .ToImmutableArray();
-
-                var diagnostics = new ConcurrentDictionary<ProjectId, ImmutableArray<Diagnostic>>();
-                var tasks = new Task[projectsToFix.Length];
-                for (int i = 0; i < projectsToFix.Length; i++)
-                {
-                    fixAllContext.CancellationToken.ThrowIfCancellationRequested();
-                    var projectToFix = projectsToFix[i];
-                    tasks[i] = Task.Run(
-                        async () =>
-                        {
-                            var projectDiagnostics = await fixAllContext.GetAllDiagnosticsAsync(projectToFix).ConfigureAwait(false);
-                            diagnostics.TryAdd(projectToFix.Id, projectDiagnostics);
-                        }, fixAllContext.CancellationToken);
-                }
-
-                await Task.WhenAll(tasks).ConfigureAwait(false);
-                allDiagnostics = allDiagnostics.AddRange(diagnostics.SelectMany(i => i.Value));
-                break;
-            }
-
-            if (allDiagnostics.IsEmpty)
-            {
-                return ImmutableDictionary<Document, ImmutableArray<Diagnostic>>.Empty;
-            }
-
-            return await GetDocumentDiagnosticsToFixAsync(allDiagnostics, projectsToFix, fixAllContext.CancellationToken).ConfigureAwait(false);
+            return FixAllContextHelper.GetDocumentDiagnosticsToFixAsync(fixAllContext);
         }
 
-        public virtual async Task<ImmutableDictionary<Project, ImmutableArray<Diagnostic>>> GetProjectDiagnosticsToFixAsync(FixAllContext fixAllContext)
+        public virtual Task<ImmutableDictionary<Project, ImmutableArray<Diagnostic>>> GetProjectDiagnosticsToFixAsync(FixAllContext fixAllContext)
         {
-            var project = fixAllContext.Project;
-            if (project != null)
-            {
-                switch (fixAllContext.Scope)
-                {
-                case FixAllScope.Project:
-                    var diagnostics = await fixAllContext.GetProjectDiagnosticsAsync(project).ConfigureAwait(false);
-                    return ImmutableDictionary<Project, ImmutableArray<Diagnostic>>.Empty.SetItem(project, diagnostics);
-
-                case FixAllScope.Solution:
-                    var projectsAndDiagnostics = new ConcurrentDictionary<Project, ImmutableArray<Diagnostic>>();
-                    var options = new ParallelOptions() { CancellationToken = fixAllContext.CancellationToken };
-                    Parallel.ForEach(project.Solution.Projects, options, proj =>
-                    {
-                        fixAllContext.CancellationToken.ThrowIfCancellationRequested();
-                        var projectDiagnosticsTask = fixAllContext.GetProjectDiagnosticsAsync(proj);
-                        projectDiagnosticsTask.Wait(fixAllContext.CancellationToken);
-                        var projectDiagnostics = projectDiagnosticsTask.Result;
-                        if (projectDiagnostics.Any())
-                        {
-                            projectsAndDiagnostics.TryAdd(proj, projectDiagnostics);
-                        }
-                    });
-
-                    return projectsAndDiagnostics.ToImmutableDictionary();
-                }
-            }
-
-            return ImmutableDictionary<Project, ImmutableArray<Diagnostic>>.Empty;
+            return FixAllContextHelper.GetProjectDiagnosticsToFixAsync(fixAllContext);
         }
 
         public virtual async Task<Solution> TryMergeFixesAsync(Solution oldSolution, IEnumerable<CodeAction> codeActions, CancellationToken cancellationToken)
@@ -427,57 +348,6 @@ namespace StyleCop.Analyzers.Helpers
             }
 
             return currentSolution;
-        }
-
-        private static async Task<ImmutableDictionary<Document, ImmutableArray<Diagnostic>>> GetDocumentDiagnosticsToFixAsync(
-            ImmutableArray<Diagnostic> diagnostics,
-            ImmutableArray<Project> projects,
-            CancellationToken cancellationToken)
-        {
-            var treeToDocumentMap = await GetTreeToDocumentMapAsync(projects, cancellationToken).ConfigureAwait(false);
-
-            var builder = ImmutableDictionary.CreateBuilder<Document, ImmutableArray<Diagnostic>>();
-            foreach (var documentAndDiagnostics in diagnostics.GroupBy(d => GetReportedDocument(d, treeToDocumentMap)))
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                var document = documentAndDiagnostics.Key;
-                var diagnosticsForDocument = documentAndDiagnostics.ToImmutableArray();
-                builder.Add(document, diagnosticsForDocument);
-            }
-
-            return builder.ToImmutable();
-        }
-
-        private static async Task<ImmutableDictionary<SyntaxTree, Document>> GetTreeToDocumentMapAsync(ImmutableArray<Project> projects, CancellationToken cancellationToken)
-        {
-            var builder = ImmutableDictionary.CreateBuilder<SyntaxTree, Document>();
-            foreach (var project in projects)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                foreach (var document in project.Documents)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
-                    builder.Add(tree, document);
-                }
-            }
-
-            return builder.ToImmutable();
-        }
-
-        private static Document GetReportedDocument(Diagnostic diagnostic, ImmutableDictionary<SyntaxTree, Document> treeToDocumentsMap)
-        {
-            var tree = diagnostic.Location.SourceTree;
-            if (tree != null)
-            {
-                Document document;
-                if (treeToDocumentsMap.TryGetValue(tree, out document))
-                {
-                    return document;
-                }
-            }
-
-            return null;
         }
 
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/FixAllContextHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/FixAllContextHelper.cs
@@ -1,0 +1,156 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Helpers
+{
+    using System.Collections.Concurrent;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeFixes;
+
+    internal static class FixAllContextHelper
+    {
+        public static async Task<ImmutableDictionary<Document, ImmutableArray<Diagnostic>>> GetDocumentDiagnosticsToFixAsync(FixAllContext fixAllContext)
+        {
+            var allDiagnostics = ImmutableArray<Diagnostic>.Empty;
+            var projectsToFix = ImmutableArray<Project>.Empty;
+
+            var document = fixAllContext.Document;
+            var project = fixAllContext.Project;
+
+            switch (fixAllContext.Scope)
+            {
+            case FixAllScope.Document:
+                if (document != null)
+                {
+                    var documentDiagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
+                    return ImmutableDictionary<Document, ImmutableArray<Diagnostic>>.Empty.SetItem(document, documentDiagnostics);
+                }
+
+                break;
+
+            case FixAllScope.Project:
+                projectsToFix = ImmutableArray.Create(project);
+                allDiagnostics = await fixAllContext.GetAllDiagnosticsAsync(project).ConfigureAwait(false);
+                break;
+
+            case FixAllScope.Solution:
+                projectsToFix = project.Solution.Projects
+                    .Where(p => p.Language == project.Language)
+                    .ToImmutableArray();
+
+                var diagnostics = new ConcurrentDictionary<ProjectId, ImmutableArray<Diagnostic>>();
+                var tasks = new Task[projectsToFix.Length];
+                for (int i = 0; i < projectsToFix.Length; i++)
+                {
+                    fixAllContext.CancellationToken.ThrowIfCancellationRequested();
+                    var projectToFix = projectsToFix[i];
+                    tasks[i] = Task.Run(
+                        async () =>
+                        {
+                            var projectDiagnostics = await fixAllContext.GetAllDiagnosticsAsync(projectToFix).ConfigureAwait(false);
+                            diagnostics.TryAdd(projectToFix.Id, projectDiagnostics);
+                        }, fixAllContext.CancellationToken);
+                }
+
+                await Task.WhenAll(tasks).ConfigureAwait(false);
+                allDiagnostics = allDiagnostics.AddRange(diagnostics.SelectMany(i => i.Value));
+                break;
+            }
+
+            if (allDiagnostics.IsEmpty)
+            {
+                return ImmutableDictionary<Document, ImmutableArray<Diagnostic>>.Empty;
+            }
+
+            return await GetDocumentDiagnosticsToFixAsync(allDiagnostics, projectsToFix, fixAllContext.CancellationToken).ConfigureAwait(false);
+        }
+
+        public static async Task<ImmutableDictionary<Project, ImmutableArray<Diagnostic>>> GetProjectDiagnosticsToFixAsync(FixAllContext fixAllContext)
+        {
+            var project = fixAllContext.Project;
+            if (project != null)
+            {
+                switch (fixAllContext.Scope)
+                {
+                case FixAllScope.Project:
+                    var diagnostics = await fixAllContext.GetProjectDiagnosticsAsync(project).ConfigureAwait(false);
+                    return ImmutableDictionary<Project, ImmutableArray<Diagnostic>>.Empty.SetItem(project, diagnostics);
+
+                case FixAllScope.Solution:
+                    var projectsAndDiagnostics = new ConcurrentDictionary<Project, ImmutableArray<Diagnostic>>();
+                    var options = new ParallelOptions() { CancellationToken = fixAllContext.CancellationToken };
+                    Parallel.ForEach(project.Solution.Projects, options, proj =>
+                    {
+                        fixAllContext.CancellationToken.ThrowIfCancellationRequested();
+                        var projectDiagnosticsTask = fixAllContext.GetProjectDiagnosticsAsync(proj);
+                        projectDiagnosticsTask.Wait(fixAllContext.CancellationToken);
+                        var projectDiagnostics = projectDiagnosticsTask.Result;
+                        if (projectDiagnostics.Any())
+                        {
+                            projectsAndDiagnostics.TryAdd(proj, projectDiagnostics);
+                        }
+                    });
+
+                    return projectsAndDiagnostics.ToImmutableDictionary();
+                }
+            }
+
+            return ImmutableDictionary<Project, ImmutableArray<Diagnostic>>.Empty;
+        }
+
+        private static async Task<ImmutableDictionary<Document, ImmutableArray<Diagnostic>>> GetDocumentDiagnosticsToFixAsync(
+            ImmutableArray<Diagnostic> diagnostics,
+            ImmutableArray<Project> projects,
+            CancellationToken cancellationToken)
+        {
+            var treeToDocumentMap = await GetTreeToDocumentMapAsync(projects, cancellationToken).ConfigureAwait(false);
+
+            var builder = ImmutableDictionary.CreateBuilder<Document, ImmutableArray<Diagnostic>>();
+            foreach (var documentAndDiagnostics in diagnostics.GroupBy(d => GetReportedDocument(d, treeToDocumentMap)))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var document = documentAndDiagnostics.Key;
+                var diagnosticsForDocument = documentAndDiagnostics.ToImmutableArray();
+                builder.Add(document, diagnosticsForDocument);
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private static async Task<ImmutableDictionary<SyntaxTree, Document>> GetTreeToDocumentMapAsync(ImmutableArray<Project> projects, CancellationToken cancellationToken)
+        {
+            var builder = ImmutableDictionary.CreateBuilder<SyntaxTree, Document>();
+            foreach (var project in projects)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                foreach (var document in project.Documents)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var tree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
+                    builder.Add(tree, document);
+                }
+            }
+
+            return builder.ToImmutable();
+        }
+
+        private static Document GetReportedDocument(Diagnostic diagnostic, ImmutableDictionary<SyntaxTree, Document> treeToDocumentsMap)
+        {
+            var tree = diagnostic.Location.SourceTree;
+            if (tree != null)
+            {
+                Document document;
+                if (treeToDocumentsMap.TryGetValue(tree, out document))
+                {
+                    return document;
+                }
+            }
+
+            return null;
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/FixAllContextHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/FixAllContextHelper.cs
@@ -143,21 +143,21 @@ namespace StyleCop.Analyzers.Helpers
 
             // Note that the following loop to obtain syntax and semantic diagnostics for each document cannot operate
             // on parallel due to our use of a single CompilationWithAnalyzers instance.
-            var diagnostics = ImmutableArray<Diagnostic>.Empty;
+            var diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
             foreach (var document in documents)
             {
                 var syntaxTree = await document.GetSyntaxTreeAsync(cancellationToken).ConfigureAwait(false);
                 var syntaxDiagnostics = await GetAnalyzerSyntaxDiagnosticsAsync(compilationWithAnalyzers, syntaxTree, cancellationToken).ConfigureAwait(false);
-                diagnostics = diagnostics.AddRange(syntaxDiagnostics);
+                diagnostics.AddRange(syntaxDiagnostics);
 
                 var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
                 var semanticDiagnostics = await GetAnalyzerSemanticDiagnosticsAsync(compilationWithAnalyzers, semanticModel, default(TextSpan?), cancellationToken).ConfigureAwait(false);
-                diagnostics = diagnostics.AddRange(semanticDiagnostics);
+                diagnostics.AddRange(semanticDiagnostics);
             }
 
             foreach (var analyzer in analyzers)
             {
-                diagnostics = diagnostics.AddRange(await GetAnalyzerCompilationDiagnosticsAsync(compilationWithAnalyzers, ImmutableArray.Create(analyzer), cancellationToken).ConfigureAwait(false));
+                diagnostics.AddRange(await GetAnalyzerCompilationDiagnosticsAsync(compilationWithAnalyzers, ImmutableArray.Create(analyzer), cancellationToken).ConfigureAwait(false));
             }
 
             if (includeCompilerDiagnostics)
@@ -165,10 +165,10 @@ namespace StyleCop.Analyzers.Helpers
                 // This is the special handling for cases where code fixes operate on warnings produced by the C#
                 // compiler, as opposed to being created by specific analyzers.
                 var compilerDiagnostics = compilation.GetDiagnostics(cancellationToken);
-                diagnostics = diagnostics.AddRange(compilerDiagnostics);
+                diagnostics.AddRange(compilerDiagnostics);
             }
 
-            return diagnostics;
+            return diagnostics.ToImmutable();
         }
 
         private static ImmutableDictionary<string, ImmutableArray<Type>> GetAllAnalyzers()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1500CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1500CodeFixProvider.cs
@@ -257,9 +257,8 @@ namespace StyleCop.Analyzers.LayoutRules
             protected override string CodeActionTitle =>
                 LayoutResources.SA1500CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1503CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1503CodeFixProvider.cs
@@ -94,9 +94,8 @@ namespace StyleCop.Analyzers.LayoutRules
             protected override string CodeActionTitle =>
                 LayoutResources.SA1503CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1507CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1507CodeFixProvider.cs
@@ -66,9 +66,8 @@ namespace StyleCop.Analyzers.LayoutRules
             protected override string CodeActionTitle =>
                 LayoutResources.SA1507CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1512CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1512CodeFixProvider.cs
@@ -126,9 +126,8 @@ namespace StyleCop.Analyzers.LayoutRules
             protected override string CodeActionTitle =>
                 LayoutResources.SA1512CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1515CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1515CodeFixProvider.cs
@@ -112,9 +112,8 @@ namespace StyleCop.Analyzers.LayoutRules
             protected override string CodeActionTitle =>
                 LayoutResources.SA1515CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1516CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1516CodeFixProvider.cs
@@ -114,9 +114,8 @@ namespace StyleCop.Analyzers.LayoutRules
             protected override string CodeActionTitle =>
                 LayoutResources.SA1516CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1518CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1518CodeFixProvider.cs
@@ -71,9 +71,8 @@ namespace StyleCop.Analyzers.LayoutRules
             protected override string CodeActionTitle =>
                 LayoutResources.SA1518CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/MaintainabilityRules/SA1119CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/MaintainabilityRules/SA1119CodeFixProvider.cs
@@ -89,9 +89,8 @@ namespace StyleCop.Analyzers.MaintainabilityRules
             protected override string CodeActionTitle
                 => MaintainabilityResources.SA1119CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/MaintainabilityRules/SA1407SA1408FixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/MaintainabilityRules/SA1407SA1408FixAllProvider.cs
@@ -4,6 +4,7 @@
 namespace StyleCop.Analyzers.MaintainabilityRules
 {
     using System.Collections.Generic;
+    using System.Collections.Immutable;
     using System.Threading.Tasks;
     using Helpers;
     using Microsoft.CodeAnalysis;
@@ -15,9 +16,8 @@ namespace StyleCop.Analyzers.MaintainabilityRules
     {
         protected override string CodeActionTitle => MaintainabilityResources.SA1407SA1408CodeFix;
 
-        protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+        protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
         {
-            var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
             if (diagnostics.IsEmpty)
             {
                 return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/MaintainabilityRules/SA1412FixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/MaintainabilityRules/SA1412FixAllProvider.cs
@@ -3,77 +3,111 @@
 
 namespace StyleCop.Analyzers.MaintainabilityRules
 {
+    using System.Collections.Immutable;
+    using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
+    using Helpers;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeActions;
     using Microsoft.CodeAnalysis.CodeFixes;
 
     internal sealed class SA1412FixAllProvider : FixAllProvider
     {
-        public override async Task<CodeAction> GetFixAsync(FixAllContext fixAllContext)
+        public override Task<CodeAction> GetFixAsync(FixAllContext fixAllContext)
         {
-            Solution newSolution;
+            string title = string.Format(MaintainabilityResources.SA1412CodeFix, fixAllContext.CodeActionEquivalenceKey.Substring(fixAllContext.CodeActionEquivalenceKey.IndexOf('.') + 1));
 
+            CodeAction fixAction;
             switch (fixAllContext.Scope)
             {
             case FixAllScope.Document:
-                newSolution = await FixDocumentAsync(fixAllContext, fixAllContext.Document).ConfigureAwait(false);
+                fixAction = CodeAction.Create(
+                    title,
+                    cancellationToken => this.GetDocumentFixesAsync(fixAllContext.WithCancellationToken(cancellationToken)),
+                    nameof(SA1412FixAllProvider));
                 break;
 
             case FixAllScope.Project:
-                newSolution = await GetProjectFixesAsync(fixAllContext, fixAllContext.Project).ConfigureAwait(false);
+                fixAction = CodeAction.Create(
+                    title,
+                    cancellationToken => this.GetProjectFixesAsync(fixAllContext.WithCancellationToken(cancellationToken), fixAllContext.Project),
+                    nameof(SA1412FixAllProvider));
                 break;
 
             case FixAllScope.Solution:
-                newSolution = fixAllContext.Solution;
-                var projectIds = newSolution.ProjectIds;
-                for (int i = 0; i < projectIds.Count; i++)
-                {
-                    newSolution = await GetProjectFixesAsync(fixAllContext, newSolution.GetProject(projectIds[i])).ConfigureAwait(false);
-                }
-
+                fixAction = CodeAction.Create(
+                    title,
+                    cancellationToken => this.GetSolutionFixesAsync(fixAllContext.WithCancellationToken(cancellationToken)),
+                    nameof(SA1412FixAllProvider));
                 break;
 
             case FixAllScope.Custom:
             default:
-                return null;
+                fixAction = null;
+                break;
             }
 
-            return CodeAction.Create(
-                string.Format(MaintainabilityResources.SA1412CodeFix, fixAllContext.CodeActionEquivalenceKey.Substring(fixAllContext.CodeActionEquivalenceKey.IndexOf('.') + 1)),
-                token => Task.FromResult(newSolution));
+            return Task.FromResult(fixAction);
         }
 
-        private static async Task<Solution> FixDocumentAsync(FixAllContext fixAllContext, Document document)
+        private static async Task<Solution> FixDocumentAsync(Solution solution, DocumentId documentId, ImmutableArray<Diagnostic> diagnostics, string codeActionEquivalenceKey, CancellationToken cancellationToken)
         {
-            Solution solution = document.Project.Solution;
-            var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
-            if (diagnostics.Length == 0)
+            if (diagnostics.IsEmpty)
             {
                 return solution;
             }
 
             string equivalenceKey = nameof(SA1412CodeFixProvider) + "." + diagnostics[0].Properties[SA1412StoreFilesAsUtf8.EncodingProperty];
-            if (fixAllContext.CodeActionEquivalenceKey != equivalenceKey)
+            if (codeActionEquivalenceKey != equivalenceKey)
             {
                 return solution;
             }
 
-            return await SA1412CodeFixProvider.GetTransformedSolutionAsync(document, fixAllContext.CancellationToken).ConfigureAwait(false);
+            Document document = solution.GetDocument(documentId);
+            return await SA1412CodeFixProvider.GetTransformedSolutionAsync(document, cancellationToken).ConfigureAwait(false);
         }
 
-        private static async Task<Solution> GetProjectFixesAsync(FixAllContext fixAllContext, Project project)
+        private async Task<Solution> GetDocumentFixesAsync(FixAllContext fixAllContext)
         {
-            Solution solution = project.Solution;
-
-            var documentIds = project.DocumentIds;
-
-            foreach (var documentId in documentIds)
+            var documentDiagnosticsToFix = await FixAllContextHelper.GetDocumentDiagnosticsToFixAsync(fixAllContext).ConfigureAwait(false);
+            ImmutableArray<Diagnostic> diagnostics;
+            if (!documentDiagnosticsToFix.TryGetValue(fixAllContext.Document, out diagnostics))
             {
-                solution = await FixDocumentAsync(fixAllContext, solution.GetDocument(documentId)).ConfigureAwait(false);
+                return fixAllContext.Document.Project.Solution;
+            }
+
+            return await FixDocumentAsync(fixAllContext.Document.Project.Solution, fixAllContext.Document.Id, diagnostics, fixAllContext.CodeActionEquivalenceKey, fixAllContext.CancellationToken).ConfigureAwait(false);
+        }
+
+        private async Task<Solution> GetSolutionFixesAsync(FixAllContext fixAllContext, ImmutableArray<Document> documents)
+        {
+            var documentDiagnosticsToFix = await FixAllContextHelper.GetDocumentDiagnosticsToFixAsync(fixAllContext).ConfigureAwait(false);
+
+            Solution solution = fixAllContext.Solution;
+            foreach (var document in documents)
+            {
+                ImmutableArray<Diagnostic> diagnostics;
+                if (!documentDiagnosticsToFix.TryGetValue(document, out diagnostics))
+                {
+                    continue;
+                }
+
+                solution = await FixDocumentAsync(solution, document.Id, diagnostics, fixAllContext.CodeActionEquivalenceKey, fixAllContext.CancellationToken).ConfigureAwait(false);
             }
 
             return solution;
+        }
+
+        private Task<Solution> GetProjectFixesAsync(FixAllContext fixAllContext, Project project)
+        {
+            return this.GetSolutionFixesAsync(fixAllContext, project.Documents.ToImmutableArray());
+        }
+
+        private Task<Solution> GetSolutionFixesAsync(FixAllContext fixAllContext)
+        {
+            ImmutableArray<Document> documents = fixAllContext.Solution.Projects.SelectMany(i => i.Documents).ToImmutableArray();
+            return this.GetSolutionFixesAsync(fixAllContext, documents);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/MaintainabilityRules/SA1412FixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/MaintainabilityRules/SA1412FixAllProvider.cs
@@ -24,21 +24,21 @@ namespace StyleCop.Analyzers.MaintainabilityRules
             case FixAllScope.Document:
                 fixAction = CodeAction.Create(
                     title,
-                    cancellationToken => this.GetDocumentFixesAsync(fixAllContext.WithCancellationToken(cancellationToken)),
+                    cancellationToken => GetDocumentFixesAsync(fixAllContext.WithCancellationToken(cancellationToken)),
                     nameof(SA1412FixAllProvider));
                 break;
 
             case FixAllScope.Project:
                 fixAction = CodeAction.Create(
                     title,
-                    cancellationToken => this.GetProjectFixesAsync(fixAllContext.WithCancellationToken(cancellationToken), fixAllContext.Project),
+                    cancellationToken => GetProjectFixesAsync(fixAllContext.WithCancellationToken(cancellationToken)),
                     nameof(SA1412FixAllProvider));
                 break;
 
             case FixAllScope.Solution:
                 fixAction = CodeAction.Create(
                     title,
-                    cancellationToken => this.GetSolutionFixesAsync(fixAllContext.WithCancellationToken(cancellationToken)),
+                    cancellationToken => GetSolutionFixesAsync(fixAllContext.WithCancellationToken(cancellationToken)),
                     nameof(SA1412FixAllProvider));
                 break;
 
@@ -68,7 +68,7 @@ namespace StyleCop.Analyzers.MaintainabilityRules
             return await SA1412CodeFixProvider.GetTransformedSolutionAsync(document, cancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<Solution> GetDocumentFixesAsync(FixAllContext fixAllContext)
+        private static async Task<Solution> GetDocumentFixesAsync(FixAllContext fixAllContext)
         {
             var documentDiagnosticsToFix = await FixAllContextHelper.GetDocumentDiagnosticsToFixAsync(fixAllContext).ConfigureAwait(false);
             ImmutableArray<Diagnostic> diagnostics;
@@ -80,7 +80,7 @@ namespace StyleCop.Analyzers.MaintainabilityRules
             return await FixDocumentAsync(fixAllContext.Document.Project.Solution, fixAllContext.Document.Id, diagnostics, fixAllContext.CodeActionEquivalenceKey, fixAllContext.CancellationToken).ConfigureAwait(false);
         }
 
-        private async Task<Solution> GetSolutionFixesAsync(FixAllContext fixAllContext, ImmutableArray<Document> documents)
+        private static async Task<Solution> GetSolutionFixesAsync(FixAllContext fixAllContext, ImmutableArray<Document> documents)
         {
             var documentDiagnosticsToFix = await FixAllContextHelper.GetDocumentDiagnosticsToFixAsync(fixAllContext).ConfigureAwait(false);
 
@@ -99,15 +99,15 @@ namespace StyleCop.Analyzers.MaintainabilityRules
             return solution;
         }
 
-        private Task<Solution> GetProjectFixesAsync(FixAllContext fixAllContext, Project project)
+        private static Task<Solution> GetProjectFixesAsync(FixAllContext fixAllContext)
         {
-            return this.GetSolutionFixesAsync(fixAllContext, project.Documents.ToImmutableArray());
+            return GetSolutionFixesAsync(fixAllContext, fixAllContext.Project.Documents.ToImmutableArray());
         }
 
-        private Task<Solution> GetSolutionFixesAsync(FixAllContext fixAllContext)
+        private static Task<Solution> GetSolutionFixesAsync(FixAllContext fixAllContext)
         {
             ImmutableArray<Document> documents = fixAllContext.Solution.Projects.SelectMany(i => i.Documents).ToImmutableArray();
-            return this.GetSolutionFixesAsync(fixAllContext, documents);
+            return GetSolutionFixesAsync(fixAllContext, documents);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/ElementOrderCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/ElementOrderCodeFixProvider.cs
@@ -257,9 +257,8 @@ namespace StyleCop.Analyzers.OrderingRules
 
             protected override string CodeActionTitle => OrderingResources.ElementOrderCodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/UsingCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/UsingCodeFixProvider.cs
@@ -975,9 +975,8 @@ namespace StyleCop.Analyzers.OrderingRules
                 => OrderingResources.UsingCodeFix;
 
             /// <inheritdoc/>
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/RemoveRegionFixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/RemoveRegionFixAllProvider.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.ReadabilityRules
 {
+    using System.Collections.Immutable;
     using System.Linq;
     using System.Threading.Tasks;
     using Helpers;
@@ -14,9 +15,8 @@ namespace StyleCop.Analyzers.ReadabilityRules
     {
         protected override string CodeActionTitle => "Remove region";
 
-        protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+        protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
         {
-            var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
             if (diagnostics.IsEmpty)
             {
                 return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1100CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1100CodeFixProvider.cs
@@ -82,9 +82,8 @@ namespace StyleCop.Analyzers.ReadabilityRules
             protected override string CodeActionTitle
                 => ReadabilityResources.SA1100CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1101CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1101CodeFixProvider.cs
@@ -79,9 +79,8 @@ namespace StyleCop.Analyzers.ReadabilityRules
             protected override string CodeActionTitle =>
                 ReadabilityResources.SA1101CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1107FixAllProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1107FixAllProvider.cs
@@ -15,9 +15,8 @@ namespace StyleCop.Analyzers.ReadabilityRules
     {
         protected override string CodeActionTitle => ReadabilityResources.SA1107CodeFix;
 
-        protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+        protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
         {
-            var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
             if (diagnostics.IsEmpty)
             {
                 return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1121CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1121CodeFixProvider.cs
@@ -109,9 +109,8 @@ namespace StyleCop.Analyzers.ReadabilityRules
             protected override string CodeActionTitle
                 => ReadabilityResources.SA1121CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1122CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1122CodeFixProvider.cs
@@ -77,9 +77,8 @@ namespace StyleCop.Analyzers.ReadabilityRules
             protected override string CodeActionTitle
                 => ReadabilityResources.SA1122CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1128CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1128CodeFixProvider.cs
@@ -99,9 +99,8 @@ namespace StyleCop.Analyzers.ReadabilityRules
             protected override string CodeActionTitle { get; } =
                 ReadabilityResources.SA1128CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1129CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1129CodeFixProvider.cs
@@ -72,9 +72,8 @@ namespace StyleCop.Analyzers.ReadabilityRules
             protected override string CodeActionTitle =>
                 ReadabilityResources.SA1129CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1131CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1131CodeFixProvider.cs
@@ -102,9 +102,8 @@ namespace StyleCop.Analyzers.ReadabilityRules
             protected override string CodeActionTitle =>
                 ReadabilityResources.SA1131CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1133CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1133CodeFixProvider.cs
@@ -102,9 +102,8 @@ namespace StyleCop.Analyzers.ReadabilityRules
             protected override string CodeActionTitle =>
                 ReadabilityResources.SA1133CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SX1101CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SX1101CodeFixProvider.cs
@@ -73,9 +73,8 @@ namespace StyleCop.Analyzers.ReadabilityRules
             protected override string CodeActionTitle =>
                 ReadabilityResources.SX1101CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/SpacingRules/SA1004CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/SpacingRules/SA1004CodeFixProvider.cs
@@ -80,9 +80,8 @@ namespace StyleCop.Analyzers.SpacingRules
             protected override string CodeActionTitle =>
                 SpacingResources.SA1004CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/SpacingRules/SA1005CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/SpacingRules/SA1005CodeFixProvider.cs
@@ -84,9 +84,8 @@ namespace StyleCop.Analyzers.SpacingRules
             protected override string CodeActionTitle =>
                 SpacingResources.SA1005CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/SpacingRules/SA1025CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/SpacingRules/SA1025CodeFixProvider.cs
@@ -71,9 +71,8 @@ namespace StyleCop.Analyzers.SpacingRules
             protected override string CodeActionTitle
                 => SpacingResources.SA1025CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/SpacingRules/SA1027CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/SpacingRules/SA1027CodeFixProvider.cs
@@ -108,9 +108,8 @@ namespace StyleCop.Analyzers.SpacingRules
             protected override string CodeActionTitle
                 => SpacingResources.SA1027CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/SpacingRules/SA1028CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/SpacingRules/SA1028CodeFixProvider.cs
@@ -71,9 +71,8 @@ namespace StyleCop.Analyzers.SpacingRules
             protected override string CodeActionTitle =>
                 SpacingResources.SA1028CodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/SpacingRules/TokenSpacingCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/SpacingRules/TokenSpacingCodeFixProvider.cs
@@ -248,9 +248,8 @@ namespace StyleCop.Analyzers.SpacingRules
 
             protected override string CodeActionTitle => SpacingResources.TokenSpacingCodeFix;
 
-            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document)
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                var diagnostics = await fixAllContext.GetDocumentDiagnosticsAsync(document).ConfigureAwait(false);
                 if (diagnostics.IsEmpty)
                 {
                     return null;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/StyleCop.Analyzers.CodeFixes.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/StyleCop.Analyzers.CodeFixes.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Helpers\CustomBatchFixAllProvider.cs" />
     <Compile Include="Helpers\CustomFixAllProviders.cs" />
     <Compile Include="Helpers\DocumentBasedFixAllProvider.cs" />
+    <Compile Include="Helpers\FixAllContextHelper.cs" />
     <Compile Include="Helpers\FormattingHelper.cs" />
     <Compile Include="Helpers\IndentationHelper.cs" />
     <Compile Include="Helpers\IndentationOptions.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/InheritdocCodeFixProviderUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/InheritdocCodeFixProviderUnitTests.cs
@@ -6,6 +6,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.DocumentationRules;
@@ -17,12 +18,22 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     /// </summary>
     public class InheritdocCodeFixProviderUnitTests : CodeFixVerifier
     {
+        private static readonly DiagnosticDescriptor SA1600 = new SA1600ElementsMustBeDocumented().SupportedDiagnostics[0];
+        private static readonly DiagnosticDescriptor CS1591 =
+            new DiagnosticDescriptor(nameof(CS1591), "Title", "Missing XML comment for publicly visible type or member '{0}'", "Category", DiagnosticSeverity.Error, AnalyzerConstants.EnabledByDefault);
+
+        private DiagnosticDescriptor descriptor = SA1600;
+
         [Theory]
-        [InlineData("string             TestMember { get; set; }")]
-        [InlineData("string             TestMember() { return null; }")]
-        [InlineData("string             this[int a] { get { return \"a\"; } set { } }")]
-        [InlineData("event EventHandler TestMember { add { } remove { } }")]
-        public async Task TestClassVirtualInheritedMembersAsync(string memberData)
+        [InlineData(false, null, "string             TestMember { get; set; }")]
+        [InlineData(false, null, "string             TestMember() { return null; }")]
+        [InlineData(false, null, "string             this[int a] { get { return \"a\"; } set { } }")]
+        [InlineData(false, null, "event EventHandler TestMember { add { } remove { } }")]
+        [InlineData(true, "ChildClass.TestMember", "string             TestMember { get; set; }")]
+        [InlineData(true, "ChildClass.TestMember()", "string             TestMember() { return null; }")]
+        [InlineData(true, "ChildClass.this[int]", "string             this[int a] { get { return \"a\"; } set { } }")]
+        [InlineData(true, "ChildClass.TestMember", "event EventHandler TestMember { add { } remove { } }")]
+        public async Task TestClassVirtualInheritedMembersAsync(bool compilerWarning, string memberName, string memberData)
         {
             var testCode = $@"using System;
 public class ParentClass
@@ -55,17 +66,22 @@ public class ChildClass : ParentClass
 }}
 ";
 
+            if (compilerWarning)
+            {
+                this.descriptor = CS1591;
+            }
+
             DiagnosticResult[] expected =
             {
-                this.CSharpDiagnostic().WithLocation(2, 14),
-                this.CSharpDiagnostic().WithLocation(10, 14),
-                this.CSharpDiagnostic().WithLocation(12, 40),
+                this.CSharpDiagnostic(this.descriptor).WithArguments("ParentClass").WithLocation(2, 14),
+                this.CSharpDiagnostic(this.descriptor).WithArguments("ChildClass").WithLocation(10, 14),
+                this.CSharpDiagnostic(this.descriptor).WithArguments(memberName).WithLocation(12, 40),
             };
 
             DiagnosticResult[] expectedFixed =
             {
-                this.CSharpDiagnostic().WithLocation(2, 14),
-                this.CSharpDiagnostic().WithLocation(10, 14),
+                this.CSharpDiagnostic(this.descriptor).WithArguments("ParentClass").WithLocation(2, 14),
+                this.CSharpDiagnostic(this.descriptor).WithArguments("ChildClass").WithLocation(10, 14),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -74,11 +90,15 @@ public class ChildClass : ParentClass
         }
 
         [Theory]
-        [InlineData("string             TestMember { get; set; }", "string             TestMember { get; set; }")]
-        [InlineData("string             TestMember();", "string             TestMember() { return null; }")]
-        [InlineData("string             this[int a] { get; set; }", "string             this[int a] { get { return \"a\"; } set { } }")]
-        [InlineData("event EventHandler TestMember;", "event EventHandler TestMember { add { } remove { } }")]
-        public async Task TestInterfaceInheritedMembersAsync(string parentData, string childData)
+        [InlineData(false, null, "string             TestMember { get; set; }", "string             TestMember { get; set; }")]
+        [InlineData(false, null, "string             TestMember();", "string             TestMember() { return null; }")]
+        [InlineData(false, null, "string             this[int a] { get; set; }", "string             this[int a] { get { return \"a\"; } set { } }")]
+        [InlineData(false, null, "event EventHandler TestMember;", "event EventHandler TestMember { add { } remove { } }")]
+        [InlineData(true, "ChildClass.TestMember", "string             TestMember { get; set; }", "string             TestMember { get; set; }")]
+        [InlineData(true, "ChildClass.TestMember()", "string             TestMember();", "string             TestMember() { return null; }")]
+        [InlineData(true, "ChildClass.this[int]", "string             this[int a] { get; set; }", "string             this[int a] { get { return \"a\"; } set { } }")]
+        [InlineData(true, "ChildClass.TestMember", "event EventHandler TestMember;", "event EventHandler TestMember { add { } remove { } }")]
+        public async Task TestInterfaceInheritedMembersAsync(bool compilerWarning, string memberName, string parentData, string childData)
         {
             var testCode = $@"using System;
 public interface IParent
@@ -111,17 +131,22 @@ public class ChildClass : IParent
 }}
 ";
 
+            if (compilerWarning)
+            {
+                this.descriptor = CS1591;
+            }
+
             DiagnosticResult[] expected =
             {
-                this.CSharpDiagnostic().WithLocation(2, 18),
-                this.CSharpDiagnostic().WithLocation(10, 14),
-                this.CSharpDiagnostic().WithLocation(12, 31),
+                this.CSharpDiagnostic(this.descriptor).WithArguments("IParent").WithLocation(2, 18),
+                this.CSharpDiagnostic(this.descriptor).WithArguments("ChildClass").WithLocation(10, 14),
+                this.CSharpDiagnostic(this.descriptor).WithArguments(memberName).WithLocation(12, 31),
             };
 
             DiagnosticResult[] expectedFixed =
             {
-                this.CSharpDiagnostic().WithLocation(2, 18),
-                this.CSharpDiagnostic().WithLocation(10, 14),
+                this.CSharpDiagnostic(this.descriptor).WithArguments("IParent").WithLocation(2, 18),
+                this.CSharpDiagnostic(this.descriptor).WithArguments("ChildClass").WithLocation(10, 14),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -153,9 +178,9 @@ public class ChildClass : ParentClass
 
             DiagnosticResult[] expected =
             {
-                this.CSharpDiagnostic().WithLocation(2, 14),
-                this.CSharpDiagnostic().WithLocation(10, 14),
-                this.CSharpDiagnostic().WithLocation(12, 35),
+                this.CSharpDiagnostic(this.descriptor).WithLocation(2, 14),
+                this.CSharpDiagnostic(this.descriptor).WithLocation(10, 14),
+                this.CSharpDiagnostic(this.descriptor).WithLocation(12, 35),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -188,13 +213,43 @@ public class ChildClass : ParentClass
 
             DiagnosticResult[] expected =
             {
-                this.CSharpDiagnostic().WithLocation(2, 14),
-                this.CSharpDiagnostic().WithLocation(10, 14),
-                this.CSharpDiagnostic().WithLocation(12, 35),
+                this.CSharpDiagnostic(this.descriptor).WithLocation(2, 14),
+                this.CSharpDiagnostic(this.descriptor).WithLocation(10, 14),
+                this.CSharpDiagnostic(this.descriptor).WithLocation(12, 35),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        protected override IEnumerable<string> GetDisabledDiagnostics()
+        {
+            if (this.descriptor == CS1591)
+            {
+                yield return SA1600.Id;
+            }
+        }
+
+        /// <inheritdoc/>
+        protected override Project ApplyCompilationOptions(Project project)
+        {
+            project = base.ApplyCompilationOptions(project);
+
+            if (this.descriptor == CS1591)
+            {
+                var supportedDiagnosticsSpecificOptions = new Dictionary<string, ReportDiagnostic>();
+                supportedDiagnosticsSpecificOptions.Add(CS1591.Id, ReportDiagnostic.Error);
+
+                // update the project compilation options
+                var modifiedSpecificDiagnosticOptions = project.CompilationOptions.SpecificDiagnosticOptions.SetItem(CS1591.Id, ReportDiagnostic.Error);
+                var modifiedCompilationOptions = project.CompilationOptions.WithSpecificDiagnosticOptions(modifiedSpecificDiagnosticOptions);
+
+                Solution solution = project.Solution.WithProjectCompilationOptions(project.Id, modifiedCompilationOptions);
+                project = solution.GetProject(project.Id);
+            }
+
+            return project;
         }
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/InheritdocCodeFixProviderUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/InheritdocCodeFixProviderUnitTests.cs
@@ -4,6 +4,7 @@
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
@@ -17,9 +18,9 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     public class InheritdocCodeFixProviderUnitTests : CodeFixVerifier
     {
         [Theory]
-        [InlineData("string TestMember { get; set; }")]
-        [InlineData("string TestMember() { return null; }")]
-        [InlineData("string this[int a] { get { return \"a\"; } set { } }")]
+        [InlineData("string             TestMember { get; set; }")]
+        [InlineData("string             TestMember() { return null; }")]
+        [InlineData("string             this[int a] { get { return \"a\"; } set { } }")]
         [InlineData("event EventHandler TestMember { add { } remove { } }")]
         public async Task TestClassVirtualInheritedMembersAsync(string memberData)
         {
@@ -54,13 +55,28 @@ public class ChildClass : ParentClass
 }}
 ";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(2, 14),
+                this.CSharpDiagnostic().WithLocation(10, 14),
+                this.CSharpDiagnostic().WithLocation(12, 40),
+            };
+
+            DiagnosticResult[] expectedFixed =
+            {
+                this.CSharpDiagnostic().WithLocation(2, 14),
+                this.CSharpDiagnostic().WithLocation(10, 14),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, expectedFixed, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
-        [InlineData("string TestMember { get; set; }", "string TestMember { get; set; }")]
-        [InlineData("string TestMember();", "string TestMember() { return null; }")]
-        [InlineData("string this[int a] { get; set; }", "string this[int a] { get { return \"a\"; } set { } }")]
+        [InlineData("string             TestMember { get; set; }", "string             TestMember { get; set; }")]
+        [InlineData("string             TestMember();", "string             TestMember() { return null; }")]
+        [InlineData("string             this[int a] { get; set; }", "string             this[int a] { get { return \"a\"; } set { } }")]
         [InlineData("event EventHandler TestMember;", "event EventHandler TestMember { add { } remove { } }")]
         public async Task TestInterfaceInheritedMembersAsync(string parentData, string childData)
         {
@@ -95,13 +111,28 @@ public class ChildClass : IParent
 }}
 ";
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(2, 18),
+                this.CSharpDiagnostic().WithLocation(10, 14),
+                this.CSharpDiagnostic().WithLocation(12, 31),
+            };
+
+            DiagnosticResult[] expectedFixed =
+            {
+                this.CSharpDiagnostic().WithLocation(2, 18),
+                this.CSharpDiagnostic().WithLocation(10, 14),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, expectedFixed, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
-        [InlineData("string TestMember { get; set; }")]
-        [InlineData("string TestMember() { return null; }")]
-        [InlineData("string this[int a] { get { return \"a\"; } set { } }")]
+        [InlineData("string             TestMember { get; set; }")]
+        [InlineData("string             TestMember() { return null; }")]
+        [InlineData("string             this[int a] { get { return \"a\"; } set { } }")]
         [InlineData("event EventHandler TestMember { add { } remove { } }")]
         public async Task TestNonvirtualHiddenInheritedMembersAsync(string memberData)
         {
@@ -120,28 +151,21 @@ public class ChildClass : ParentClass
 }}
 ";
 
-            var fixedCode = $@"using System;
-public class ParentClass
-{{
-    /// <summary>
-    /// Some documentation.
-    /// </summary>
-    public {memberData}
-}}
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(2, 14),
+                this.CSharpDiagnostic().WithLocation(10, 14),
+                this.CSharpDiagnostic().WithLocation(12, 35),
+            };
 
-public class ChildClass : ParentClass
-{{
-    public new {memberData}
-}}
-";
-
-            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, testCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
-        [InlineData("string TestMember { get; set; }")]
-        [InlineData("string TestMember() { return null; }")]
-        [InlineData("string this[int a] { get { return \"a\"; } set { } }")]
+        [InlineData("string             TestMember { get; set; }")]
+        [InlineData("string             TestMember() { return null; }")]
+        [InlineData("string             this[int a] { get { return \"a\"; } set { } }")]
         [InlineData("event EventHandler TestMember { add { } remove { } }")]
         public async Task TestVirtualHiddenInheritedMembersAsync(string memberData)
         {
@@ -160,22 +184,17 @@ public class ChildClass : ParentClass
 }}
 ";
 
-            var fixedCode = $@"using System;
-public class ParentClass
-{{
-    /// <summary>
-    /// Some documentation.
-    /// </summary>
-    public virtual {memberData}
-}}
+            var fixedCode = testCode;
 
-public class ChildClass : ParentClass
-{{
-    public new {memberData}
-}}
-";
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(2, 14),
+                this.CSharpDiagnostic().WithLocation(10, 14),
+                this.CSharpDiagnostic().WithLocation(12, 35),
+            };
 
-            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1604UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1604UnitTests.cs
@@ -722,7 +722,7 @@ class Class1
         }
 
         /// <inheritdoc/>
-        protected override Project CreateProject(string[] sources, string language = "C#", string[] filenames = null)
+        protected override Project ApplyCompilationOptions(Project project)
         {
             var resolver = new TestXmlReferenceResolver();
             string contentWithSummary = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
@@ -759,7 +759,7 @@ class Class1
 ";
             resolver.XmlReferences.Add("ClassWithoutSummary.xml", contentWithoutSummary);
 
-            Project project = base.CreateProject(sources, language, filenames);
+            project = base.ApplyCompilationOptions(project);
             project = project.WithCompilationOptions(project.CompilationOptions.WithXmlReferenceResolver(resolver));
             return project;
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1606UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1606UnitTests.cs
@@ -746,7 +746,7 @@ class Class1
         }
 
         /// <inheritdoc/>
-        protected override Project CreateProject(string[] sources, string language = "C#", string[] filenames = null)
+        protected override Project ApplyCompilationOptions(Project project)
         {
             var resolver = new TestXmlReferenceResolver();
             string contentWithSummary = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
@@ -785,7 +785,7 @@ class Class1
 ";
             resolver.XmlReferences.Add("ClassWithEmptySummary.xml", contentWithEmptySummary);
 
-            Project project = base.CreateProject(sources, language, filenames);
+            project = base.ApplyCompilationOptions(project);
             project = project.WithCompilationOptions(project.CompilationOptions.WithXmlReferenceResolver(resolver));
             return project;
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1615UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1615UnitTests.cs
@@ -331,7 +331,7 @@ class Class1
         }
 
         /// <inheritdoc/>
-        protected override Project CreateProject(string[] sources, string language = "C#", string[] filenames = null)
+        protected override Project ApplyCompilationOptions(Project project)
         {
             var resolver = new TestXmlReferenceResolver();
             string contentWithReturns = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
@@ -368,7 +368,7 @@ class Class1
 ";
             resolver.XmlReferences.Add("MethodWithoutReturns.xml", contentWithoutReturns);
 
-            Project project = base.CreateProject(sources, language, filenames);
+            project = base.ApplyCompilationOptions(project);
             project = project.WithCompilationOptions(project.CompilationOptions.WithXmlReferenceResolver(resolver));
             return project;
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -47,29 +47,11 @@ namespace TestHelper
                 projects.Add(document.Project);
             }
 
-            var supportedDiagnosticsSpecificOptions = new Dictionary<string, ReportDiagnostic>();
-            foreach (var analyzer in analyzers)
-            {
-                foreach (var diagnostic in analyzer.SupportedDiagnostics)
-                {
-                    // make sure the analyzers we are testing are enabled
-                    supportedDiagnosticsSpecificOptions[diagnostic.Id] = ReportDiagnostic.Default;
-                }
-            }
-
-            // Report exceptions during the analysis process as errors
-            supportedDiagnosticsSpecificOptions.Add("AD0001", ReportDiagnostic.Error);
-
             var diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
             foreach (var project in projects)
             {
-                // update the project compilation options
-                var modifiedSpecificDiagnosticOptions = supportedDiagnosticsSpecificOptions.ToImmutableDictionary().SetItems(project.CompilationOptions.SpecificDiagnosticOptions);
-                var modifiedCompilationOptions = project.CompilationOptions.WithSpecificDiagnosticOptions(modifiedSpecificDiagnosticOptions);
-                var processedProject = project.WithCompilationOptions(modifiedCompilationOptions);
-
-                var compilation = await processedProject.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
-                var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, processedProject.AnalyzerOptions, cancellationToken);
+                var compilation = await project.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
+                var compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, project.AnalyzerOptions, cancellationToken);
                 var compilerDiagnostics = compilation.GetDiagnostics(cancellationToken);
                 var compilerErrors = compilerDiagnostics.Where(i => i.Severity == DiagnosticSeverity.Error);
                 var diags = await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync().ConfigureAwait(false);
@@ -129,10 +111,6 @@ namespace TestHelper
         protected virtual Solution CreateSolution(ProjectId projectId, string language)
         {
             var compilationOptions = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, allowUnsafe: true);
-
-            var additionalDiagnosticOptions = this.GetDisabledDiagnostics().Select(id => new KeyValuePair<string, ReportDiagnostic>(id, ReportDiagnostic.Suppress));
-            var newSpecificOptions = compilationOptions.SpecificDiagnosticOptions.AddRange(additionalDiagnosticOptions);
-            compilationOptions = compilationOptions.WithSpecificDiagnosticOptions(newSpecificOptions);
 
             Solution solution = new AdhocWorkspace()
                 .CurrentSolution
@@ -195,13 +173,32 @@ namespace TestHelper
         /// <summary>
         /// Create a project using the input strings as sources.
         /// </summary>
+        /// <remarks>
+        /// <para>This method first creates a <see cref="Project"/> by calling <see cref="CreateProjectImpl"/>, and then
+        /// applies compilation options to the project by calling <see cref="ApplyCompilationOptions"/>.</para>
+        /// </remarks>
         /// <param name="sources">Classes in the form of strings.</param>
         /// <param name="language">The language the source classes are in. Values may be taken from the
         /// <see cref="LanguageNames"/> class.</param>
         /// <param name="filenames">The filenames or null if the default filename should be used</param>
         /// <returns>A <see cref="Project"/> created out of the <see cref="Document"/>s created from the source
         /// strings.</returns>
-        protected virtual Project CreateProject(string[] sources, string language = LanguageNames.CSharp, string[] filenames = null)
+        protected Project CreateProject(string[] sources, string language = LanguageNames.CSharp, string[] filenames = null)
+        {
+            Project project = this.CreateProjectImpl(sources, language, filenames);
+            return this.ApplyCompilationOptions(project);
+        }
+
+        /// <summary>
+        /// Create a project using the input strings as sources.
+        /// </summary>
+        /// <param name="sources">Classes in the form of strings.</param>
+        /// <param name="language">The language the source classes are in. Values may be taken from the
+        /// <see cref="LanguageNames"/> class.</param>
+        /// <param name="filenames">The filenames or null if the default filename should be used</param>
+        /// <returns>A <see cref="Project"/> created out of the <see cref="Document"/>s created from the source
+        /// strings.</returns>
+        protected virtual Project CreateProjectImpl(string[] sources, string language, string[] filenames)
         {
             string fileNamePrefix = DefaultFilePathPrefix;
             string fileExt = language == LanguageNames.CSharp ? CSharpDefaultFileExt : VisualBasicDefaultExt;
@@ -220,6 +217,47 @@ namespace TestHelper
             }
 
             return solution.GetProject(projectId);
+        }
+
+        /// <summary>
+        /// Applies compilation options to a project.
+        /// </summary>
+        /// <remarks>
+        /// <para>The default implementation configures the project by enabling all supported diagnostics of analyzers
+        /// included in <see cref="GetCSharpDiagnosticAnalyzers"/> as well as <c>AD0001</c>. After configuring these
+        /// diagnostics, any diagnostic IDs indicated in <see cref="GetDisabledDiagnostics"/> are explictly supressed
+        /// using <see cref="ReportDiagnostic.Suppress"/>.</para>
+        /// </remarks>
+        /// <param name="project">The project.</param>
+        /// <returns>The modified project.</returns>
+        protected virtual Project ApplyCompilationOptions(Project project)
+        {
+            var analyzers = this.GetCSharpDiagnosticAnalyzers();
+
+            var supportedDiagnosticsSpecificOptions = new Dictionary<string, ReportDiagnostic>();
+            foreach (var analyzer in analyzers)
+            {
+                foreach (var diagnostic in analyzer.SupportedDiagnostics)
+                {
+                    // make sure the analyzers we are testing are enabled
+                    supportedDiagnosticsSpecificOptions[diagnostic.Id] = ReportDiagnostic.Default;
+                }
+            }
+
+            // Report exceptions during the analysis process as errors
+            supportedDiagnosticsSpecificOptions.Add("AD0001", ReportDiagnostic.Error);
+
+            foreach (var id in this.GetDisabledDiagnostics())
+            {
+                supportedDiagnosticsSpecificOptions[id] = ReportDiagnostic.Suppress;
+            }
+
+            // update the project compilation options
+            var modifiedSpecificDiagnosticOptions = supportedDiagnosticsSpecificOptions.ToImmutableDictionary().SetItems(project.CompilationOptions.SpecificDiagnosticOptions);
+            var modifiedCompilationOptions = project.CompilationOptions.WithSpecificDiagnosticOptions(modifiedSpecificDiagnosticOptions);
+
+            Solution solution = project.Solution.WithProjectCompilationOptions(project.Id, modifiedCompilationOptions);
+            return solution.GetProject(project.Id);
         }
 
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -157,17 +157,17 @@ namespace TestHelper
             var supportedDiagnostics = analyzers.SelectMany(analyzer => analyzer.SupportedDiagnostics);
             if (diagnosticId == null)
             {
-                return new DiagnosticResult(supportedDiagnostics.Single());
+                return this.CSharpDiagnostic(supportedDiagnostics.Single());
             }
             else
             {
-                return new DiagnosticResult(supportedDiagnostics.Single(i => i.Id == diagnosticId));
+                return this.CSharpDiagnostic(supportedDiagnostics.Single(i => i.Id == diagnosticId));
             }
         }
 
         protected DiagnosticResult CSharpDiagnostic(DiagnosticDescriptor descriptor)
         {
-            return this.CSharpDiagnostic(descriptor.Id).WithMessageFormat(descriptor.MessageFormat);
+            return new DiagnosticResult(descriptor);
         }
 
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1412UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1412UnitTests.cs
@@ -131,7 +131,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
             return new SA1412CodeFixProvider();
         }
 
-        protected override Project CreateProject(string[] sources, string language = "C#", string[] filenames = null)
+        protected override Project CreateProjectImpl(string[] sources, string language, string[] filenames)
         {
             string fileNamePrefix = "Test";
             string fileExt = "cs";

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
@@ -289,7 +289,11 @@ namespace TestHelper
 
                 FixAllContext.DiagnosticProvider fixAllDiagnosticProvider = TestDiagnosticProvider.Create(analyzerDiagnostics);
 
-                FixAllContext fixAllContext = new FixAllContext(document, codeFixProvider, scope, equivalenceKey, analyzers.SelectMany(x => x.SupportedDiagnostics).Select(x => x.Id), fixAllDiagnosticProvider, cancellationToken);
+                IEnumerable<string> analyzerDiagnosticIds = analyzers.SelectMany(x => x.SupportedDiagnostics).Select(x => x.Id);
+                IEnumerable<string> compilerDiagnosticIds = codeFixProvider.FixableDiagnosticIds.Where(x => x.StartsWith("CS", StringComparison.Ordinal));
+                IEnumerable<string> disabledDiagnosticIds = document.Project.CompilationOptions.SpecificDiagnosticOptions.Where(x => x.Value == ReportDiagnostic.Suppress).Select(x => x.Key);
+                IEnumerable<string> relevantIds = analyzerDiagnosticIds.Concat(compilerDiagnosticIds).Except(disabledDiagnosticIds).Distinct();
+                FixAllContext fixAllContext = new FixAllContext(document, codeFixProvider, scope, equivalenceKey, relevantIds, fixAllDiagnosticProvider, cancellationToken);
 
                 CodeAction action = await fixAllProvider.GetFixAsync(fixAllContext).ConfigureAwait(false);
                 if (action == null)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
@@ -289,7 +289,7 @@ namespace TestHelper
 
                 FixAllContext.DiagnosticProvider fixAllDiagnosticProvider = TestDiagnosticProvider.Create(analyzerDiagnostics);
 
-                FixAllContext fixAllContext = new FixAllContext(document, codeFixProvider, scope, equivalenceKey, codeFixProvider.FixableDiagnosticIds, fixAllDiagnosticProvider, cancellationToken);
+                FixAllContext fixAllContext = new FixAllContext(document, codeFixProvider, scope, equivalenceKey, analyzers.SelectMany(x => x.SupportedDiagnostics).Select(x => x.Id), fixAllDiagnosticProvider, cancellationToken);
 
                 CodeAction action = await fixAllProvider.GetFixAsync(fixAllContext).ConfigureAwait(false);
                 if (action == null)

--- a/StyleCop.Analyzers/StyleCopTester/Program.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Program.cs
@@ -328,7 +328,7 @@ namespace StyleCopTester
 
             var diagnosticAnalyzerType = typeof(DiagnosticAnalyzer);
 
-            List<DiagnosticAnalyzer> analyzers = new List<DiagnosticAnalyzer>();
+            var analyzers = ImmutableArray.CreateBuilder<DiagnosticAnalyzer>();
 
             foreach (var type in assembly.GetTypes())
             {
@@ -338,7 +338,7 @@ namespace StyleCopTester
                 }
             }
 
-            return analyzers.ToImmutableArray();
+            return analyzers.ToImmutable();
         }
 
         private static ImmutableDictionary<string, ImmutableList<CodeFixProvider>> GetAllCodeFixers()

--- a/StyleCop.Analyzers/StyleCopTester/Program.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Program.cs
@@ -438,7 +438,7 @@ namespace StyleCopTester
             Compilation compilation = await processedProject.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
             CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, cancellationToken: cancellationToken);
 
-            var diagnostics = await FixAllContextHelper.GetAllDiagnosticsAsync(compilation, compilationWithAnalyzers, project.Documents, true, cancellationToken).ConfigureAwait(false);
+            var diagnostics = await FixAllContextHelper.GetAllDiagnosticsAsync(compilation, compilationWithAnalyzers, analyzers, project.Documents, true, cancellationToken).ConfigureAwait(false);
             return diagnostics;
         }
 

--- a/StyleCop.Analyzers/StyleCopTester/Program.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Program.cs
@@ -19,6 +19,8 @@ namespace StyleCopTester
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using Microsoft.CodeAnalysis.MSBuild;
+    using Microsoft.CodeAnalysis.Text;
+    using StyleCop.Analyzers.Helpers;
     using File = System.IO.File;
     using Path = System.IO.Path;
 
@@ -436,8 +438,8 @@ namespace StyleCopTester
             Compilation compilation = await processedProject.GetCompilationAsync(cancellationToken).ConfigureAwait(false);
             CompilationWithAnalyzers compilationWithAnalyzers = compilation.WithAnalyzers(analyzers, cancellationToken: cancellationToken);
 
-            var allDiagnostics = await compilationWithAnalyzers.GetAllDiagnosticsAsync().ConfigureAwait(false);
-            return allDiagnostics;
+            var diagnostics = await FixAllContextHelper.GetAllDiagnosticsAsync(compilation, compilationWithAnalyzers, project.Documents, true, cancellationToken).ConfigureAwait(false);
+            return diagnostics;
         }
 
         private static void PrintHelp()

--- a/StyleCop.Analyzers/StyleCopTester/TesterDiagnosticProvider.cs
+++ b/StyleCop.Analyzers/StyleCopTester/TesterDiagnosticProvider.cs
@@ -24,7 +24,19 @@ namespace StyleCopTester
 
         public override Task<IEnumerable<Diagnostic>> GetAllDiagnosticsAsync(Project project, CancellationToken cancellationToken)
         {
-            return Task.FromResult(this.projectDiagnostics.Values.SelectMany(i => i).Concat(this.documentDiagnostics.Values.SelectMany(i => i.Values).SelectMany(i => i)));
+            ImmutableArray<Diagnostic> filteredProjectDiagnostics;
+            if (!this.projectDiagnostics.TryGetValue(project.Id, out filteredProjectDiagnostics))
+            {
+                filteredProjectDiagnostics = ImmutableArray<Diagnostic>.Empty;
+            }
+
+            ImmutableDictionary<string, ImmutableArray<Diagnostic>> filteredDocumentDiagnostics;
+            if (!this.documentDiagnostics.TryGetValue(project.Id, out filteredDocumentDiagnostics))
+            {
+                filteredDocumentDiagnostics = ImmutableDictionary<string, ImmutableArray<Diagnostic>>.Empty;
+            }
+
+            return Task.FromResult(filteredProjectDiagnostics.Concat(filteredDocumentDiagnostics.Values.SelectMany(i => i)));
         }
 
         public override Task<IEnumerable<Diagnostic>> GetDocumentDiagnosticsAsync(Document document, CancellationToken cancellationToken)


### PR DESCRIPTION
Previously, custom fix all providers called `FixAllContext.GetDocumentDiagnosticsAsync` for every document in the fix all scope. This change first replaces those calls with a single call to `FixAllContextHelpers.GetDocumentDiagnosticsToFixAsync`, which was extracted from `CustomBatchFixAllProvider`. It goes on to instead operate on a `CompilationWithAnalyzers` following the commentary in #1979. The result is improved performance when fixing violations in large projects, especially when only a few documents in the project contained violations.

Fixes #1974.