### PR TITLE
Fix handling of Incremental switch in build.ps1

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -76,7 +76,7 @@ If (-not $?) {
 	exit $LASTEXITCODE
 }
 
-if (-not $Incremental) {
+if ($Incremental) {
 	# Skip NuGet validation and copying packages to the output directory
 	exit 0
 }


### PR DESCRIPTION
The build script was failing to copy the build output to the intermediate output directory.