### PR TITLE
Fix SA1516 inconsistency with classic StyleCop (fixes #1923)

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1516UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1516UnitTests.cs
@@ -543,6 +543,45 @@ public class TestClass
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verifies consistency with classic StyleCop when assembly-wide attribute is not separated by a blank line from the class definition.
+        /// Regression test for #1923
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestWithAssemblyWideAttributeAndClassAsync()
+        {
+            var testCode = @"using System;
+
+[assembly: CLSCompliant(false)]
+namespace SomeNamespace
+{
+    public class Startup
+    {
+    }
+}";
+            var expected = new[]
+            {
+                this.CSharpDiagnostic().WithLocation(2, 1)
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            var fixedCode = @"using System;
+
+[assembly: CLSCompliant(false)]
+
+namespace SomeNamespace
+{
+    public class Startup
+    {
+    }
+}";
+
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
             yield return new SA1516ElementsMustBeSeparatedByBlankLine();

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1516UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1516UnitTests.cs
@@ -551,9 +551,7 @@ public class TestClass
         [Fact]
         public async Task TestWithAssemblyWideAttributeAndClassAsync()
         {
-            var testCode = @"using System;
-
-[assembly: CLSCompliant(false)]
+            var testCode = @"[assembly: System.CLSCompliant(false)]
 namespace SomeNamespace
 {
     public class Startup
@@ -567,9 +565,7 @@ namespace SomeNamespace
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
-            var fixedCode = @"using System;
-
-[assembly: CLSCompliant(false)]
+            var fixedCode = @"[assembly: System.CLSCompliant(false)]
 
 namespace SomeNamespace
 {


### PR DESCRIPTION
Fix #1923 SA1516 inconsistency with classic StyleCop when assembly-wide attribute is not separated by a blank line from the class definition

- [x] Add regression test
- [ ] Fix the bug

