### PR TITLE
Add /apply option to write /fixall changes back to disk

### DIFF
--- a/StyleCop.Analyzers/StyleCopTester/Program.cs
+++ b/StyleCop.Analyzers/StyleCopTester/Program.cs
@@ -86,7 +86,7 @@ namespace StyleCopTester
 
                 Console.WriteLine($"Loaded solution in {stopwatch.ElapsedMilliseconds}ms");
 
-                if (!args.Contains("/nostats"))
+                if (args.Contains("/stats"))
                 {
                     List<Project> csharpProjects = solution.Projects.Where(i => i.Language == LanguageNames.CSharp).ToList();
 
@@ -447,7 +447,7 @@ namespace StyleCopTester
             Console.WriteLine("Usage: StyleCopTester [options] <Solution>");
             Console.WriteLine("Options:");
             Console.WriteLine("/all       Run all StyleCopAnalyzers analyzers, including ones that are disabled by default");
-            Console.WriteLine("/nostats   Disable the display of statistics");
+            Console.WriteLine("/stats     Display statistics of the solution");
             Console.WriteLine("/codefixes Test single code fixes");
             Console.WriteLine("/fixall    Test fix all providers");
             Console.WriteLine("/id:<id>   Enable analyzer with diagnostic ID < id > (when this is specified, only this analyzer is enabled)");

--- a/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
+++ b/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
@@ -37,7 +37,7 @@
     <CodeAnalysisRuleSet>..\StyleCop.Analyzers.Internal.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup>
-    <StartArguments>..\..\StyleCopAnalyzers.sln</StartArguments>
+    <StartArguments>..\..\StyleCopAnalyzers.sln /stats</StartArguments>
     <StartWorkingDirectory>$(MSBuildProjectDirectory)</StartWorkingDirectory>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
This update to StyleCopTester allows it to be used to automate the correction of specific style violations in a solution.

Currently only one type of diagnostic can be fixed at a time, but it would be easy to create a script that invokes the tool multiple times to cover a set of diagnostics.