### PR TITLE
Make SA0000 hidden but enabled by default

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpecialRules/SA0000Roslyn7446Workaround.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpecialRules/SA0000Roslyn7446Workaround.cs
@@ -22,7 +22,7 @@ namespace StyleCop.Analyzers.SpecialRules
         private static readonly string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA0000Roslyn7446Workaround.md";
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.SpecialRules, DiagnosticSeverity.Info, AnalyzerConstants.DisabledByDefault, Description, HelpLink);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.SpecialRules, DiagnosticSeverity.Hidden, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
         private static readonly Action<CompilationStartAnalysisContext> CompilationStartAction = HandleCompilationStart;
 


### PR DESCRIPTION
This change balances performance with usability of the workaround by ensuring that all diagnostics are reported for files that are open in the editor, without the performance overhead of enabling the workaround for every file in the project.

After SA0000 was made available, I found myself consistently enabling it in this manner via rule set files. However, it may not be obvious to other users that this is the best practice for handling this bug in Visual Studio 2015 Update 1. By changing the default values of the diagnostic to match the ones used in practice, everyone gets the benefit right out of the box. :+1: 