### PR TITLE
Improve performance of IsPrecededByWhitespace

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TokenHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TokenHelper.cs
@@ -62,11 +62,11 @@ namespace StyleCop.Analyzers.Helpers
         /// Gets a value indicating whether the <paramref name="token"/> is preceded by a whitespace.
         /// </summary>
         /// <param name="token">The token to process.</param>
-        /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
+        /// <param name="cancellationToken">The cancellation token that the operation will observe.</param>
         /// <returns>true if token is preceded by a whitespace, otherwise false.</returns>
         internal static bool IsPrecededByWhitespace(this SyntaxToken token, CancellationToken cancellationToken)
         {
-            // Perf directly access the text instead of trivia
+            // Perf: Directly access the text instead of the trivia.
             int pos = token.Span.Start - 1;
 
             if (pos < 0 || token.SyntaxTree == null)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TokenHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TokenHelper.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.Helpers
 {
+    using System.Threading;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
 
@@ -61,17 +62,19 @@ namespace StyleCop.Analyzers.Helpers
         /// Gets a value indicating whether the <paramref name="token"/> is preceded by a whitespace.
         /// </summary>
         /// <param name="token">The token to process.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/>.</param>
         /// <returns>true if token is preceded by a whitespace, otherwise false.</returns>
-        internal static bool IsPrecededByWhitespace(this SyntaxToken token)
+        internal static bool IsPrecededByWhitespace(this SyntaxToken token, CancellationToken cancellationToken)
         {
-            SyntaxTriviaList triviaList = token.LeadingTrivia;
-            if (triviaList.Count > 0)
+            // Perf directly access the text instead of trivia
+            int pos = token.Span.Start - 1;
+
+            if (pos < 0 || token.SyntaxTree == null)
             {
-                return triviaList.Last().IsKind(SyntaxKind.WhitespaceTrivia);
+                return false;
             }
 
-            triviaList = token.GetPreviousToken().TrailingTrivia;
-            return triviaList.Count > 0 && triviaList.Last().IsKind(SyntaxKind.WhitespaceTrivia);
+            return char.IsWhiteSpace(token.SyntaxTree.GetText(cancellationToken)[pos]);
         }
 
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CommasMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CommasMustBeSpacedCorrectly.cs
@@ -99,7 +99,7 @@ namespace StyleCop.Analyzers.SpacingRules
                 }
             }
 
-            if (token.IsFirstInLine() || token.IsPrecededByWhitespace())
+            if (token.IsFirstInLine() || token.IsPrecededByWhitespace(context.CancellationToken))
             {
                 // comma must{ not} be {preceded} by whitespace
                 context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), TokenSpacingProperties.RemovePrecedingPreserveLayout, " not", "preceded"));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
@@ -79,7 +79,7 @@ namespace StyleCop.Analyzers.SpacingRules
                 return;
             }
 
-            bool precededBySpace = token.IsFirstInLine() || token.IsPrecededByWhitespace();
+            bool precededBySpace = token.IsFirstInLine() || token.IsPrecededByWhitespace(context.CancellationToken);
             bool followedBySpace = token.IsFollowedByWhitespace();
             bool lastInLine = token.IsLastInLine();
             bool precedesStickyCharacter;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010OpeningSquareBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010OpeningSquareBracketsMustBeSpacedCorrectly.cs
@@ -79,7 +79,7 @@ namespace StyleCop.Analyzers.SpacingRules
 
             if (!firstInLine)
             {
-                precededBySpace = token.IsPrecededByWhitespace();
+                precededBySpace = token.IsPrecededByWhitespace(context.CancellationToken);
 
                 // ignore if handled by SA1026
                 ignorePrecedingSpaceProblem = precededBySpace && token.GetPreviousToken().IsKind(SyntaxKind.NewKeyword);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011ClosingSquareBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011ClosingSquareBracketsMustBeSpacedCorrectly.cs
@@ -85,7 +85,7 @@ namespace StyleCop.Analyzers.SpacingRules
             }
 
             bool firstInLine = token.IsFirstInLine();
-            bool precededBySpace = firstInLine || token.IsPrecededByWhitespace();
+            bool precededBySpace = firstInLine || token.IsPrecededByWhitespace(context.CancellationToken);
             bool followedBySpace = token.IsFollowedByWhitespace();
             bool lastInLine = token.IsLastInLine();
             bool precedesSpecialCharacter;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1012OpeningBracesMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1012OpeningBracesMustBeSpacedCorrectly.cs
@@ -91,7 +91,7 @@ namespace StyleCop.Analyzers.SpacingRules
                 return;
             }
 
-            bool precededBySpace = token.IsFirstInLine() || token.IsPrecededByWhitespace();
+            bool precededBySpace = token.IsFirstInLine() || token.IsPrecededByWhitespace(context.CancellationToken);
 
             if (!precededBySpace)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1013ClosingBracesMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1013ClosingBracesMustBeSpacedCorrectly.cs
@@ -76,7 +76,7 @@ namespace StyleCop.Analyzers.SpacingRules
                 return;
             }
 
-            bool precededBySpace = token.IsFirstInLine() || token.IsPrecededByWhitespace();
+            bool precededBySpace = token.IsFirstInLine() || token.IsPrecededByWhitespace(context.CancellationToken);
 
             if (token.Parent is InterpolationSyntax)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1014OpeningGenericBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1014OpeningGenericBracketsMustBeSpacedCorrectly.cs
@@ -84,7 +84,7 @@ namespace StyleCop.Analyzers.SpacingRules
             }
 
             bool firstInLine = token.IsFirstInLine();
-            bool precededBySpace = firstInLine || token.IsPrecededByWhitespace();
+            bool precededBySpace = firstInLine || token.IsPrecededByWhitespace(context.CancellationToken);
             bool followedBySpace = token.IsFollowedByWhitespace();
 
             if (!firstInLine && precededBySpace)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1015ClosingGenericBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1015ClosingGenericBracketsMustBeSpacedCorrectly.cs
@@ -87,7 +87,7 @@ namespace StyleCop.Analyzers.SpacingRules
 
             bool firstInLine = token.IsFirstInLine();
             bool lastInLine = token.IsLastInLine();
-            bool precededBySpace = firstInLine || token.IsPrecededByWhitespace();
+            bool precededBySpace = firstInLine || token.IsPrecededByWhitespace(context.CancellationToken);
             bool followedBySpace = token.IsFollowedByWhitespace();
             bool allowTrailingNoSpace;
             bool allowTrailingSpace;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1019MemberAccessSymbolsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1019MemberAccessSymbolsMustBeSpacedCorrectly.cs
@@ -101,7 +101,7 @@ namespace StyleCop.Analyzers.SpacingRules
         private static void HandleMemberAccessSymbol(SyntaxTreeAnalysisContext context, SyntaxToken token)
         {
             bool firstInLine = token.IsFirstInLine();
-            bool precededBySpace = firstInLine || token.IsPrecededByWhitespace();
+            bool precededBySpace = firstInLine || token.IsPrecededByWhitespace(context.CancellationToken);
             bool followedBySpace = token.IsFollowedByWhitespace();
 
             if (!firstInLine && precededBySpace)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021NegativeSignsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021NegativeSignsMustBeSpacedCorrectly.cs
@@ -93,7 +93,7 @@ namespace StyleCop.Analyzers.SpacingRules
 
             if (!firstInLine)
             {
-                precededBySpace = token.IsPrecededByWhitespace();
+                precededBySpace = token.IsPrecededByWhitespace(context.CancellationToken);
                 SyntaxToken precedingToken = token.GetPreviousToken();
 
                 followsSpecialCharacter =

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022PositiveSignsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022PositiveSignsMustBeSpacedCorrectly.cs
@@ -93,7 +93,7 @@ namespace StyleCop.Analyzers.SpacingRules
 
             if (!firstInLine)
             {
-                precededBySpace = token.IsPrecededByWhitespace();
+                precededBySpace = token.IsPrecededByWhitespace(context.CancellationToken);
                 SyntaxToken precedingToken = token.GetPreviousToken();
 
                 followsSpecialCharacter =

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly.cs
@@ -142,7 +142,7 @@ namespace StyleCop.Analyzers.SpacingRules
             }
 
             bool firstInLine = token.IsFirstInLine();
-            bool precededBySpace = firstInLine || token.IsPrecededByWhitespace();
+            bool precededBySpace = firstInLine || token.IsPrecededByWhitespace(context.CancellationToken);
             bool followedBySpace = token.IsFollowedByWhitespace();
             bool lastInLine = token.IsLastInLine();
 


### PR DESCRIPTION
When analyzing performance the IsPrecededByWhitespace was using about ~3.5% total time when running our analyzers on Roslyn.sln.

After this change it is under 0.1%