### PR TITLE
Improved SA1501 codefix to allow for a single pass fix-all

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/IndentationHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/IndentationHelper.cs
@@ -56,7 +56,11 @@ namespace StyleCop.Analyzers.Helpers
         /// <returns>The number of steps that the token is indented.</returns>
         public static int GetIndentationSteps(IndentationSettings indentationSettings, SyntaxToken token)
         {
-            return GetIndentationSteps(indentationSettings, token.SyntaxTree, token.LeadingTrivia);
+            // If the token does not belong to a syntax tree, it is a modified token and it is assumed that
+            // the caller makes sure that the token is the first token on a line.
+            return token.SyntaxTree != null
+                ? GetIndentationSteps(indentationSettings, token.SyntaxTree, token.LeadingTrivia)
+                : GetIndentationStepsUnchecked(indentationSettings, token.LeadingTrivia);
         }
 
         /// <summary>
@@ -104,6 +108,11 @@ namespace StyleCop.Analyzers.Helpers
                 return 0;
             }
 
+            return GetIndentationStepsUnchecked(indentationSettings, leadingTrivia);
+        }
+
+        private static int GetIndentationStepsUnchecked(IndentationSettings indentationSettings, SyntaxTriviaList leadingTrivia)
+        {
             var builder = StringBuilderPool.Allocate();
 
             foreach (SyntaxTrivia trivia in leadingTrivia.Reverse())

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1501CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1501CodeFixProvider.cs
@@ -3,18 +3,19 @@
 
 namespace StyleCop.Analyzers.LayoutRules
 {
+    using System;
+    using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Composition;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using Helpers;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeActions;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Settings.ObjectModel;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// Implements a code fix for <see cref="SA1501StatementMustNotBeOnASingleLine"/>.
@@ -30,7 +31,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// <inheritdoc/>
         public override FixAllProvider GetFixAllProvider()
         {
-            return CustomFixAllProviders.BatchFixer;
+            return FixAll.Instance;
         }
 
         /// <inheritdoc/>
@@ -59,113 +60,80 @@ namespace StyleCop.Analyzers.LayoutRules
                 return document;
             }
 
-            SyntaxNode newSyntaxRoot;
-            BlockSyntax block = statement as BlockSyntax;
-            if (block != null)
-            {
-                newSyntaxRoot = ReformatBlockAndParent(document, settings.Indentation, syntaxRoot, block);
-            }
-            else
-            {
-                newSyntaxRoot = ReformatStatementAndParent(document, settings.Indentation, syntaxRoot, statement);
-            }
+            var tokenReplaceMap = new Dictionary<SyntaxToken, SyntaxToken>();
 
-            var newDocument = document.WithSyntaxRoot(newSyntaxRoot);
+            ReformatStatementAndSurroundings(statement, settings.Indentation, tokenReplaceMap);
+
+            var newSyntaxRoot = syntaxRoot.ReplaceTokens(tokenReplaceMap.Keys, (original, rewritten) => tokenReplaceMap[original]);
+            var newDocument = document.WithSyntaxRoot(newSyntaxRoot.WithoutFormatting());
             return newDocument;
         }
 
-        private static SyntaxNode ReformatBlockAndParent(Document document, IndentationSettings indentationSettings, SyntaxNode syntaxRoot, BlockSyntax block)
+        private static void ReformatStatementAndSurroundings(StatementSyntax statement, IndentationSettings indentationSettings, Dictionary<SyntaxToken, SyntaxToken> tokenReplaceMap)
         {
-            var parentLastToken = block.OpenBraceToken.GetPreviousToken();
+            var block = statement as BlockSyntax;
 
-            var parentEndLine = parentLastToken.GetEndLine();
-            var blockStartLine = block.OpenBraceToken.GetLine();
-
-            var newParentLastToken = parentLastToken;
-            if (parentEndLine == blockStartLine)
-            {
-                var newTrailingTrivia = parentLastToken.TrailingTrivia
-                    .WithoutTrailingWhitespace()
-                    .Add(SyntaxFactory.CarriageReturnLineFeed);
-
-                newParentLastToken = newParentLastToken.WithTrailingTrivia(newTrailingTrivia);
-            }
-
-            var parentNextToken = block.CloseBraceToken.GetNextToken();
-
-            var nextTokenLine = parentNextToken.GetLine();
-            var blockCloseLine = block.CloseBraceToken.GetEndLine();
-
-            var newParentNextToken = parentNextToken;
-            if (nextTokenLine == blockCloseLine)
-            {
-                newParentNextToken = newParentNextToken.WithLeadingTrivia(parentLastToken.LeadingTrivia);
-            }
-
-            var newBlock = ReformatBlock(document, indentationSettings, block);
-            var rewriter = new BlockRewriter(parentLastToken, newParentLastToken, block, newBlock, parentNextToken, newParentNextToken);
-
-            var newSyntaxRoot = rewriter.Visit(syntaxRoot);
-            return newSyntaxRoot.WithoutFormatting();
-        }
-
-        private static SyntaxNode ReformatStatementAndParent(Document document, IndentationSettings indentationSettings, SyntaxNode syntaxRoot, StatementSyntax statement)
-        {
-            var parentLastToken = statement.GetFirstToken().GetPreviousToken();
-
-            var parentEndLine = parentLastToken.GetEndLine();
+            var previousToken = statement.GetFirstToken().GetPreviousToken();
+            var previousTokenEndLine = previousToken.GetEndLine();
             var statementStartLine = statement.GetFirstToken().GetLine();
 
-            var newParentLastToken = parentLastToken;
-            if (parentEndLine == statementStartLine)
+            if (previousTokenEndLine == statementStartLine)
             {
-                var newTrailingTrivia = parentLastToken.TrailingTrivia
+                var newTrailingTrivia = previousToken.TrailingTrivia
                     .WithoutTrailingWhitespace()
                     .Add(SyntaxFactory.CarriageReturnLineFeed);
 
-                newParentLastToken = newParentLastToken.WithTrailingTrivia(newTrailingTrivia);
+                AddToReplaceMap(tokenReplaceMap, previousToken, previousToken.WithTrailingTrivia(newTrailingTrivia));
             }
 
-            var parentNextToken = statement.GetLastToken().GetNextToken();
-
-            var nextTokenLine = parentNextToken.GetLine();
-            var statementCloseLine = statement.GetLastToken().GetEndLine();
-
-            var newParentNextToken = parentNextToken;
-            if (nextTokenLine == statementCloseLine)
+            if (block != null)
             {
-                var parentIndentationLevel = IndentationHelper.GetIndentationSteps(indentationSettings, GetStatementParent(statement.Parent));
-                var indentationString = IndentationHelper.GenerateIndentationString(indentationSettings, parentIndentationLevel);
-                newParentNextToken = newParentNextToken.WithLeadingTrivia(SyntaxFactory.Whitespace(indentationString));
+                ReformatBlock(indentationSettings, block, tokenReplaceMap);
+            }
+            else
+            {
+                ReformatStatement(indentationSettings, statement, tokenReplaceMap);
             }
 
-            var newStatement = ReformatStatement(document, indentationSettings, statement);
-            var newSyntaxRoot = syntaxRoot.ReplaceSyntax(
-                new[] { statement },
-                (originalNode, rewrittenNode) => originalNode == statement ? newStatement : rewrittenNode,
-                new[] { parentLastToken, parentNextToken },
-                (originalToken, rewrittenToken) =>
-                {
-                    if (originalToken == parentLastToken)
-                    {
-                        return newParentLastToken;
-                    }
-                    else if (originalToken == parentNextToken)
-                    {
-                        return newParentNextToken;
-                    }
-                    else
-                    {
-                        return rewrittenToken;
-                    }
-                },
-                Enumerable.Empty<SyntaxTrivia>(),
-                (originalTrivia, rewrittenTrivia) => rewrittenTrivia);
+            var nextToken = statement.GetLastToken().GetNextToken();
+            if ((block != null) && nextToken.IsKind(SyntaxKind.SemicolonToken))
+            {
+                // skip trailing semicolon tokens for blocks
+                nextToken = nextToken.GetNextToken();
+            }
 
-            return newSyntaxRoot.WithoutFormatting();
+            var nextTokenStartLine = nextToken.GetLine();
+            var statementEndLine = statement.GetLastToken().GetEndLine();
+
+            if (nextTokenStartLine == statementEndLine)
+            {
+                var indentationLevel = DetermineIndentationLevel(indentationSettings, tokenReplaceMap, statement);
+                var indentationTrivia = IndentationHelper.GenerateWhitespaceTrivia(indentationSettings, indentationLevel);
+
+                AddToReplaceMap(tokenReplaceMap, nextToken, nextToken.WithLeadingTrivia(indentationTrivia));
+            }
         }
 
-        private static BlockSyntax ReformatBlock(Document document, IndentationSettings indentationSettings, BlockSyntax block)
+        private static int DetermineIndentationLevel(IndentationSettings indentationSettings, Dictionary<SyntaxToken, SyntaxToken> tokenReplaceMap, StatementSyntax statement)
+        {
+            var parent = GetStatementParent(statement.Parent);
+            int parentIndentationLevel;
+
+            SyntaxToken replacementToken;
+            if (tokenReplaceMap.TryGetValue(parent.GetFirstToken(), out replacementToken))
+            {
+                // if the parent is being modified, use the new leading trivia from the parent for determining the indentation
+                parentIndentationLevel = IndentationHelper.GetIndentationSteps(indentationSettings, replacementToken);
+            }
+            else
+            {
+                parentIndentationLevel = IndentationHelper.GetIndentationSteps(indentationSettings, GetFirstOnLineParent(parent));
+            }
+
+            return parentIndentationLevel;
+        }
+
+        private static void ReformatBlock(IndentationSettings indentationSettings, BlockSyntax block, Dictionary<SyntaxToken, SyntaxToken> tokenReplaceMap)
         {
             var parentIndentationLevel = IndentationHelper.GetIndentationSteps(indentationSettings, GetStatementParent(block.Parent));
 
@@ -215,38 +183,30 @@ namespace StyleCop.Analyzers.LayoutRules
                 newCloseBraceTrailingTrivia = newCloseBraceTrailingTrivia.Add(SyntaxFactory.CarriageReturnLineFeed);
             }
 
-            var openBraceToken = SyntaxFactory.Token(SyntaxKind.OpenBraceToken)
-                .WithLeadingTrivia(newOpenBraceLeadingTrivia)
-                .WithTrailingTrivia(newOpenBraceTrailingTrivia);
+            AddToReplaceMap(tokenReplaceMap, block.OpenBraceToken, block.OpenBraceToken.WithLeadingTrivia(newOpenBraceLeadingTrivia).WithTrailingTrivia(newOpenBraceTrailingTrivia));
+            AddToReplaceMap(tokenReplaceMap, block.CloseBraceToken, block.CloseBraceToken.WithLeadingTrivia(newCloseBraceLeadingTrivia).WithTrailingTrivia(newCloseBraceTrailingTrivia));
 
-            var closeBraceToken = SyntaxFactory.Token(SyntaxKind.CloseBraceToken)
-                .WithLeadingTrivia(newCloseBraceLeadingTrivia)
-                .WithTrailingTrivia(newCloseBraceTrailingTrivia);
-
-            var statements = SyntaxFactory.List<StatementSyntax>();
             foreach (var statement in block.Statements)
             {
-                var newLeadingTrivia = statement.GetLeadingTrivia()
+                var firstToken = statement.GetFirstToken();
+                var lastToken = statement.GetLastToken();
+
+                var newLeadingTrivia = firstToken.LeadingTrivia
                     .WithoutTrailingWhitespace()
                     .Add(SyntaxFactory.Whitespace(statementIndentationString));
 
-                var newTrailingTrivia = statement.GetTrailingTrivia()
+                var newTrailingTrivia = lastToken.TrailingTrivia
                     .WithoutTrailingWhitespace()
                     .Add(SyntaxFactory.CarriageReturnLineFeed);
 
-                var modifiedStatement = statement
-                    .WithLeadingTrivia(newLeadingTrivia)
-                    .WithTrailingTrivia(newTrailingTrivia);
-
-                statements = statements.Add(modifiedStatement);
+                AddToReplaceMap(tokenReplaceMap, firstToken, firstToken.WithLeadingTrivia(newLeadingTrivia));
+                AddToReplaceMap(tokenReplaceMap, lastToken, lastToken.WithTrailingTrivia(newTrailingTrivia));
             }
-
-            return SyntaxFactory.Block(openBraceToken, statements, closeBraceToken);
         }
 
-        private static StatementSyntax ReformatStatement(Document document, IndentationSettings indentationSettings, StatementSyntax statement)
+        private static void ReformatStatement(IndentationSettings indentationSettings, StatementSyntax statement, Dictionary<SyntaxToken, SyntaxToken> tokenReplaceMap)
         {
-            var parentIndentationLevel = IndentationHelper.GetIndentationSteps(indentationSettings, GetStatementParent(statement.Parent));
+            var indentationLevel = DetermineIndentationLevel(indentationSettings, tokenReplaceMap, statement);
 
             // use one additional step of indentation for lambdas / anonymous methods
             switch (statement.Parent.Kind())
@@ -254,40 +214,43 @@ namespace StyleCop.Analyzers.LayoutRules
             case SyntaxKind.AnonymousMethodExpression:
             case SyntaxKind.SimpleLambdaExpression:
             case SyntaxKind.ParenthesizedLambdaExpression:
-                parentIndentationLevel++;
+                indentationLevel++;
                 break;
             }
 
-            var statementIndentationString = IndentationHelper.GenerateIndentationString(indentationSettings, parentIndentationLevel + 1);
+            var statementIndentationTrivia = IndentationHelper.GenerateWhitespaceTrivia(indentationSettings, indentationLevel + 1);
 
             var newFirstTokenLeadingTrivia = statement.GetFirstToken().LeadingTrivia
                 .WithoutTrailingWhitespace()
-                .Add(SyntaxFactory.Whitespace(statementIndentationString));
+                .Add(statementIndentationTrivia);
 
             var newLastTokenTrailingTrivia = statement.GetLastToken().TrailingTrivia
                 .WithoutTrailingWhitespace()
                 .Add(SyntaxFactory.CarriageReturnLineFeed);
 
-            var firstToken = statement.GetFirstToken().WithLeadingTrivia(newFirstTokenLeadingTrivia);
-            var lastToken = statement.GetLastToken().WithTrailingTrivia(newLastTokenTrailingTrivia);
+            AddToReplaceMap(tokenReplaceMap, statement.GetFirstToken(), statement.GetFirstToken().WithLeadingTrivia(newFirstTokenLeadingTrivia));
+            AddToReplaceMap(tokenReplaceMap, statement.GetLastToken(), statement.GetLastToken().WithTrailingTrivia(newLastTokenTrailingTrivia));
+        }
 
-            return statement.ReplaceTokens(
-                new[] { statement.GetFirstToken(), statement.GetLastToken() },
-                (originalToken, rewrittenToken) =>
-                {
-                    if (originalToken == statement.GetFirstToken())
-                    {
-                        return firstToken;
-                    }
-                    else if (originalToken == statement.GetLastToken())
-                    {
-                        return lastToken;
-                    }
-                    else
-                    {
-                        return rewrittenToken;
-                    }
-                });
+        private static void AddToReplaceMap(Dictionary<SyntaxToken, SyntaxToken> tokenReplaceMap, SyntaxToken original, SyntaxToken replacement)
+        {
+            SyntaxToken existingReplacement;
+            SyntaxToken reprocessedReplacement = replacement;
+
+            // Check if there is already a replacement for the token. If so -> merge the replacements.
+            // This assumes that the overlapping token replacements do not overlap in trivia replacements.
+            if (tokenReplaceMap.TryGetValue(original, out existingReplacement))
+            {
+                reprocessedReplacement = AreTriviaEqual(original.LeadingTrivia, existingReplacement.LeadingTrivia) ? replacement : existingReplacement;
+                reprocessedReplacement = reprocessedReplacement.WithTrailingTrivia(AreTriviaEqual(original.TrailingTrivia, existingReplacement.TrailingTrivia) ? replacement.TrailingTrivia : existingReplacement.TrailingTrivia);
+            }
+
+            tokenReplaceMap[original] = reprocessedReplacement;
+        }
+
+        private static bool AreTriviaEqual(SyntaxTriviaList left, SyntaxTriviaList right)
+        {
+            return string.Equals(left.ToString(), right.ToString(), StringComparison.Ordinal);
         }
 
         private static SyntaxNode GetStatementParent(SyntaxNode node)
@@ -306,48 +269,61 @@ namespace StyleCop.Analyzers.LayoutRules
             return statementSyntax;
         }
 
-        private class BlockRewriter : CSharpSyntaxRewriter
+        private static SyntaxNode GetFirstOnLineParent(SyntaxNode parent)
         {
-            private readonly SyntaxToken parentToken;
-            private readonly SyntaxToken newParentToken;
-            private readonly BlockSyntax block;
-            private readonly BlockSyntax newBlock;
-            private readonly SyntaxToken nextToken;
-            private readonly SyntaxToken newNextToken;
-
-            public BlockRewriter(SyntaxToken parentToken, SyntaxToken newParentToken, BlockSyntax block, BlockSyntax newBlock, SyntaxToken nextToken, SyntaxToken newNextToken)
+            // if the parent is not the first on a line, find the parent that is.
+            // This mainly happens for 'else if' statements.
+            while (!parent.GetFirstToken().IsFirstInLine())
             {
-                this.parentToken = parentToken;
-                this.newParentToken = newParentToken;
-                this.block = block;
-                this.newBlock = newBlock;
-                this.nextToken = nextToken;
-                this.newNextToken = newNextToken;
+                parent = parent.Parent;
             }
 
-            public override SyntaxToken VisitToken(SyntaxToken token)
+            return parent;
+        }
+
+        private class FixAll : DocumentBasedFixAllProvider
+        {
+            public static FixAllProvider Instance { get; } =
+                new FixAll();
+
+            protected override string CodeActionTitle =>
+                LayoutResources.SA1501CodeFixAll;
+
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
             {
-                if (token == this.parentToken)
+                if (diagnostics.IsEmpty)
                 {
-                    return this.newParentToken;
+                    return null;
                 }
 
-                if (token == this.nextToken)
+                var tokenReplaceMap = new Dictionary<SyntaxToken, SyntaxToken>();
+                var settings = SettingsHelper.GetStyleCopSettings(document.Project.AnalyzerOptions, fixAllContext.CancellationToken);
+                SyntaxNode syntaxRoot = await document.GetSyntaxRootAsync(fixAllContext.CancellationToken).ConfigureAwait(false);
+
+                foreach (var diagnostic in diagnostics.Sort(DiagnosticComparer.Instance))
                 {
-                    return this.newNextToken;
+                    var statement = syntaxRoot.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true) as StatementSyntax;
+                    if (statement == null)
+                    {
+                        continue;
+                    }
+
+                    ReformatStatementAndSurroundings(statement, settings.Indentation, tokenReplaceMap);
                 }
 
-                return base.VisitToken(token);
+                var newSyntaxRoot = syntaxRoot.ReplaceTokens(tokenReplaceMap.Keys, (original, rewritten) => tokenReplaceMap[original]);
+                return newSyntaxRoot.WithoutFormatting();
             }
 
-            public override SyntaxNode VisitBlock(BlockSyntax node)
+            private class DiagnosticComparer : IComparer<Diagnostic>
             {
-                if (node == this.block)
-                {
-                    return this.newBlock;
-                }
+                public static DiagnosticComparer Instance { get; } = new DiagnosticComparer();
 
-                return base.VisitBlock(node);
+                /// <inheritdoc/>
+                public int Compare(Diagnostic x, Diagnostic y)
+                {
+                    return x.Location.SourceSpan.Start - y.Location.SourceSpan.Start;
+                }
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1501CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1501CodeFixProvider.cs
@@ -39,6 +39,11 @@ namespace StyleCop.Analyzers.LayoutRules
         {
             foreach (Diagnostic diagnostic in context.Diagnostics)
             {
+                if (diagnostic.Properties.GetValueOrDefault(SA1501StatementMustNotBeOnASingleLine.SuppressCodeFixKey) == SA1501StatementMustNotBeOnASingleLine.SuppressCodeFixValue)
+                {
+                    continue;
+                }
+
                 context.RegisterCodeFix(
                     CodeAction.Create(
                         LayoutResources.SA1501CodeFix,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
@@ -4,7 +4,6 @@
 namespace StyleCop.Analyzers.Test.LayoutRules
 {
     using System.Collections.Generic;
-    using System.Collections.Immutable;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -646,7 +645,66 @@ public class TypeName
     }
 }";
 
-            var fixedCode = @"using System.Diagnostics;
+            var incrementalFixedCode = @"using System.Diagnostics;
+public class TypeName
+{
+    public void Bar(int i)
+    {
+        if (i == 0)
+            Debug.Assert(true);
+        else
+            Debug.Assert(false);//8
+
+
+        if (i == 1)
+            Debug.Assert(true);
+        else if (i == 2)
+            Debug.Assert(false);//10
+
+
+        if (i == 3)
+            Debug.Assert(true);
+        else if (i == 4)
+            Debug.Assert(false);//14
+
+
+        if (i == 5)
+            Debug.Assert(true);
+        else if (i == 6)
+            Debug.Assert(false);
+        else
+            Debug.Assert(false);//16
+
+
+        if (i == 7)
+            if (i == 8)
+                Debug.Assert(false);
+            else
+                Debug.Assert(false);
+        else
+            Debug.Assert(true);//18
+
+
+        if (i == 9)
+            if (i == 10)
+                Debug.Assert(false);
+            else
+                Debug.Assert(false);
+            else
+            Debug.Assert(true);//21
+
+
+        if (i == 11) if (i == 12)
+            Debug.Assert(false);
+            else
+            Debug.Assert(false);
+        else if (i == 13)
+            Debug.Assert(true);//24
+
+    }
+}";
+
+            var batchFixedCode = @"using System.Diagnostics;
 public class TypeName
 {
     public void Bar(int i)
@@ -710,27 +768,30 @@ public class TypeName
             {
                 this.CSharpDiagnostic().WithLocation(8, 14),
                 this.CSharpDiagnostic().WithLocation(10, 21),
-                this.CSharpDiagnostic().WithLocation(10, 58).WithSeverity(DiagnosticSeverity.Hidden),
+                this.CSharpDiagnostic().WithLocation(10, 58),
                 this.CSharpDiagnostic().WithLocation(14, 26),
                 this.CSharpDiagnostic().WithLocation(16, 21),
-                this.CSharpDiagnostic().WithLocation(16, 58).WithSeverity(DiagnosticSeverity.Hidden),
-                this.CSharpDiagnostic().WithLocation(16, 84).WithSeverity(DiagnosticSeverity.Hidden),
+                this.CSharpDiagnostic().WithLocation(16, 58),
+                this.CSharpDiagnostic().WithLocation(16, 84),
                 this.CSharpDiagnostic().WithLocation(18, 21),
-                this.CSharpDiagnostic().WithLocation(18, 33).WithSeverity(DiagnosticSeverity.Hidden),
-                this.CSharpDiagnostic().WithLocation(18, 59).WithSeverity(DiagnosticSeverity.Hidden),
-                this.CSharpDiagnostic().WithLocation(18, 85).WithSeverity(DiagnosticSeverity.Hidden),
-                this.CSharpDiagnostic().WithLocation(21, 26).WithSeverity(DiagnosticSeverity.Hidden),
-                this.CSharpDiagnostic().WithLocation(21, 52).WithSeverity(DiagnosticSeverity.Hidden),
+                this.CSharpDiagnostic().WithLocation(18, 33),
+                this.CSharpDiagnostic().WithLocation(18, 59),
+                this.CSharpDiagnostic().WithLocation(18, 85),
+                this.CSharpDiagnostic().WithLocation(21, 26),
+                this.CSharpDiagnostic().WithLocation(21, 52),
                 this.CSharpDiagnostic().WithLocation(21, 78),
                 this.CSharpDiagnostic().WithLocation(23, 22).WithSeverity(DiagnosticSeverity.Hidden),
                 this.CSharpDiagnostic().WithLocation(23, 35),
-                this.CSharpDiagnostic().WithLocation(24, 18).WithSeverity(DiagnosticSeverity.Hidden),
+                this.CSharpDiagnostic().WithLocation(24, 18),
                 this.CSharpDiagnostic().WithLocation(24, 57),
             };
 
+            DiagnosticResult incrementalFixExpected = this.CSharpDiagnostic().WithLocation(50, 22).WithSeverity(DiagnosticSeverity.Hidden);
+
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(incrementalFixedCode, incrementalFixExpected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(batchFixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, incrementalFixedCode, batchFixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -781,7 +842,7 @@ public class TypeName
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(6, 21),
-                this.CSharpDiagnostic().WithLocation(6, 46).WithSeverity(DiagnosticSeverity.Hidden),
+                this.CSharpDiagnostic().WithLocation(6, 46),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -880,7 +941,7 @@ public class TypeName
             DiagnosticResult[] expected =
             {
                 this.CSharpDiagnostic().WithLocation(6, 21),
-                this.CSharpDiagnostic().WithLocation(6, 33).WithSeverity(DiagnosticSeverity.Hidden),
+                this.CSharpDiagnostic().WithLocation(6, 33),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
@@ -695,11 +695,13 @@ public class TypeName
             Debug.Assert(true);//21
 
 
-        if (i == 11) if (i == 12) Debug.Assert(false);
+        if (i == 11)
+            if (i == 12)
+                Debug.Assert(false);
             else
-    Debug.Assert(false);
-else if (i == 13)
-    Debug.Assert(true);//24
+                Debug.Assert(false);
+        else if (i == 13)
+            Debug.Assert(true);//24
 
     }
 }";
@@ -708,16 +710,27 @@ else if (i == 13)
             {
                 this.CSharpDiagnostic().WithLocation(8, 14),
                 this.CSharpDiagnostic().WithLocation(10, 21),
+                this.CSharpDiagnostic().WithLocation(10, 58).WithSeverity(DiagnosticSeverity.Hidden),
                 this.CSharpDiagnostic().WithLocation(14, 26),
                 this.CSharpDiagnostic().WithLocation(16, 21),
+                this.CSharpDiagnostic().WithLocation(16, 58).WithSeverity(DiagnosticSeverity.Hidden),
+                this.CSharpDiagnostic().WithLocation(16, 84).WithSeverity(DiagnosticSeverity.Hidden),
                 this.CSharpDiagnostic().WithLocation(18, 21),
-                this.CSharpDiagnostic().WithLocation(21, 26),
-                this.CSharpDiagnostic().WithLocation(24, 18),
+                this.CSharpDiagnostic().WithLocation(18, 33).WithSeverity(DiagnosticSeverity.Hidden),
+                this.CSharpDiagnostic().WithLocation(18, 59).WithSeverity(DiagnosticSeverity.Hidden),
+                this.CSharpDiagnostic().WithLocation(18, 85).WithSeverity(DiagnosticSeverity.Hidden),
+                this.CSharpDiagnostic().WithLocation(21, 26).WithSeverity(DiagnosticSeverity.Hidden),
+                this.CSharpDiagnostic().WithLocation(21, 52).WithSeverity(DiagnosticSeverity.Hidden),
+                this.CSharpDiagnostic().WithLocation(21, 78),
+                this.CSharpDiagnostic().WithLocation(23, 22).WithSeverity(DiagnosticSeverity.Hidden),
+                this.CSharpDiagnostic().WithLocation(23, 35),
+                this.CSharpDiagnostic().WithLocation(24, 18).WithSeverity(DiagnosticSeverity.Hidden),
+                this.CSharpDiagnostic().WithLocation(24, 57),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpFixAsync(testCode, fixedCode, numberOfFixAllIterations: 3, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -765,11 +778,15 @@ public class TypeName
     }
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 21);
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(6, 21),
+                this.CSharpDiagnostic().WithLocation(6, 46).WithSeverity(DiagnosticSeverity.Hidden),
+            };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode, numberOfFixAllIterations: 2, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -860,10 +877,15 @@ public class TypeName
     }
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 21);
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(6, 21),
+                this.CSharpDiagnostic().WithLocation(6, 33).WithSeverity(DiagnosticSeverity.Hidden),
+            };
+
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpFixAsync(testCode, fixedTestCode, numberOfFixAllIterations: 2, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/LayoutResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/LayoutResources.Designer.cs
@@ -80,6 +80,15 @@ namespace StyleCop.Analyzers.LayoutRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Expand all single line blocks.
+        /// </summary>
+        internal static string SA1501CodeFixAll {
+            get {
+                return ResourceManager.GetString("SA1501CodeFixAll", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Expand element.
         /// </summary>
         internal static string SA1502CodeFix {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/LayoutResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/LayoutResources.resx
@@ -123,6 +123,9 @@
   <data name="SA1501CodeFix" xml:space="preserve">
     <value>Expand single line block</value>
   </data>
+  <data name="SA1501CodeFixAll" xml:space="preserve">
+    <value>Expand all single line blocks</value>
+  </data>
   <data name="SA1502CodeFix" xml:space="preserve">
     <value>Expand element</value>
   </data>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501StatementMustNotBeOnASingleLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501StatementMustNotBeOnASingleLine.cs
@@ -94,7 +94,7 @@ namespace StyleCop.Analyzers.LayoutRules
 
         private class AnalyzerContext
         {
-            private List<Diagnostic> reportedDiagnostics = new List<Diagnostic>();
+            private readonly List<Diagnostic> reportedDiagnostics = new List<Diagnostic>();
 
             public void HandleBlock(SyntaxNodeAnalysisContext context)
             {
@@ -230,30 +230,34 @@ namespace StyleCop.Analyzers.LayoutRules
             {
                 Diagnostic newDiagnostic;
 
-                var locationLine = location.GetLineSpan().StartLinePosition.Line;
-                var notFirstDiagnosticOnLine = this.reportedDiagnostics.Any(rd => (rd.Severity != DiagnosticSeverity.Hidden) && (rd.Location.GetLineSpan().StartLinePosition.Line == locationLine));
-
-                if (alwaysReportAsHidden || notFirstDiagnosticOnLine)
+                lock (this.reportedDiagnostics)
                 {
-                    newDiagnostic = Diagnostic.Create(
-                        Descriptor.Id,
-                        Descriptor.Category,
-                        Descriptor.MessageFormat,
-                        DiagnosticSeverity.Hidden,
-                        Descriptor.DefaultSeverity,
-                        Descriptor.IsEnabledByDefault,
-                        1,
-                        Descriptor.Title,
-                        Descriptor.Description,
-                        Descriptor.HelpLinkUri,
-                        location);
-                }
-                else
-                {
-                    newDiagnostic = Diagnostic.Create(Descriptor, location);
+                    var locationLine = location.GetLineSpan().StartLinePosition.Line;
+                    var notFirstDiagnosticOnLine = this.reportedDiagnostics.Any(rd => (rd.Severity != DiagnosticSeverity.Hidden) && (rd.Location.GetLineSpan().StartLinePosition.Line == locationLine));
+
+                    if (alwaysReportAsHidden || notFirstDiagnosticOnLine)
+                    {
+                        newDiagnostic = Diagnostic.Create(
+                            Descriptor.Id,
+                            Descriptor.Category,
+                            Descriptor.MessageFormat,
+                            DiagnosticSeverity.Hidden,
+                            Descriptor.DefaultSeverity,
+                            Descriptor.IsEnabledByDefault,
+                            1,
+                            Descriptor.Title,
+                            Descriptor.Description,
+                            Descriptor.HelpLinkUri,
+                            location);
+                    }
+                    else
+                    {
+                        newDiagnostic = Diagnostic.Create(Descriptor, location);
+                    }
+
+                    this.reportedDiagnostics.Add(newDiagnostic);
                 }
 
-                this.reportedDiagnostics.Add(newDiagnostic);
                 context.ReportDiagnostic(newDiagnostic);
             }
         }


### PR DESCRIPTION
Closes #2010 

I've removed the non-determinism in the SA1501 code fix by making it a single pass fix-all.

In order to make that work properly, the analyzer now generates more warnings, so that the code fix can use all the warnings to make a proper fix. I've tried a new concept here of reporting only one warning per code line as warning and reporting the others as hidden, to minimize the impact for the end user.

The code fix was refactored to only use a token replacement strategy, instead of the previous node + token replacement strategy. This was necessary to allow for interaction between fix steps in the fix-all scenario.
