### PR TITLE
Fix expression body property documentation checks

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1624UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1624UnitTests.cs
@@ -27,7 +27,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         /// <param name="expectedArgument1">The first expected argument for the diagnostic.</param>
         /// <param name="expectedArgument2">The second expected argument for the diagnostic.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Theory]
+        [Theory(DisplayName = "Property Findings")]
         [InlineData("public", "int", "get; internal set;", "Gets or sets", "get", "Gets")]
         [InlineData("public", "int", "get; private set;", "Gets or sets", "get", "Gets")]
         [InlineData("public", "int", "internal get; set;", "Gets or sets", "set", "Sets")]
@@ -85,13 +85,13 @@ public class TestClass
         /// <param name="type">The type to use for the property.</param>
         /// <param name="summaryPrefix">The prefix to use in the summary text.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Theory]
-        [InlineData("public", "int", "Gets or sets")]
-        [InlineData("public", "bool", "Gets or sets a value indicating whether")]
-        [InlineData("protected", "int", "Gets or sets")]
-        [InlineData("protected internal", "int", "Gets or sets")]
-        [InlineData("internal", "int", "Gets or sets")]
-        public async Task VerifyThatInvalidDocumentationWillReportDiagnosticForExpressionBodyAsync(string accessibility, string type, string summaryPrefix)
+        [Theory(DisplayName = "ExpressionBody Gets")]
+        [InlineData("public", "int", "Gets")]
+        [InlineData("public", "bool", "Gets a value indicating whether")]
+        [InlineData("protected", "int", "Gets")]
+        [InlineData("protected internal", "int", "Gets")]
+        [InlineData("internal", "int", "Gets")]
+        public async Task VerifyThatValidDocumentationOnExpressionBodyIsAcceptedAsync(string accessibility, string type, string summaryPrefix)
         {
             var testCode = $@"
 public class TestClass
@@ -108,11 +108,57 @@ public class TestClass
         }
 
         /// <summary>
+        /// Verifies that documentation that starts with the proper text for multiple accessors will produce a diagnostic for expression body properties.
+        /// </summary>
+        /// <param name="accessibility">The accessibility of the property.</param>
+        /// <param name="type">The type to use for the property.</param>
+        /// <param name="summaryPrefix">The prefix to use in the summary text.</param>
+        /// <param name="expectedArgument1">The first expected argument for the diagnostic.</param>
+        /// <param name="expectedArgument2">The second expected argument for the diagnostic.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory(DisplayName = "ExpressionBody Gets&Sets")]
+        [InlineData("public", "int", "Gets or sets", "get", "Gets")]
+        [InlineData("public", "bool", "Gets or sets a value indicating whether", "get", "Gets a value indicating whether")]
+        [InlineData("protected", "int", "Gets or sets", "get", "Gets")]
+        [InlineData("protected internal", "int", "Gets or sets", "get", "Gets")]
+        [InlineData("internal", "int", "Gets or sets", "get", "Gets")]
+        public async Task VerifyThatInvalidDocumentationWillReportDiagnosticForExpressionBodyAsync(string accessibility, string type, string summaryPrefix, string expectedArgument1, string expectedArgument2)
+        {
+            var testCode = $@"
+public class TestClass
+{{
+    /// <summary>
+    /// {summaryPrefix} the test property.
+    /// </summary>
+    {accessibility} {type} TestProperty =>
+        default({type});
+}}
+";
+
+            var fixedTestCode = $@"
+public class TestClass
+{{
+    /// <summary>
+    /// {expectedArgument2} the test property.
+    /// </summary>
+    {accessibility} {type} TestProperty =>
+        default({type});
+}}
+";
+
+            var expected = this.CSharpDiagnostic(PropertySummaryDocumentationAnalyzer.SA1624Descriptor).WithLocation(7, 7 + accessibility.Length + type.Length).WithArguments(expectedArgument1, expectedArgument2);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Verify that no diagnostic will be reported when a public and a private accessor are present within a property that is defined in a contained class of a private class.
         /// </summary>
         /// <param name="typeKeyword">The type keyword to use.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Theory]
+        [Theory(DisplayName = "PrivateContainer Findings")]
         [InlineData("class")]
         [InlineData("struct")]
         public async Task VerifyPrivateAccessorInPrivateContainerAsync(string typeKeyword)
@@ -137,12 +183,6 @@ public class ContainerTestClass
 ";
 
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        /// <inheritdoc/>
-        protected override IEnumerable<string> GetDisabledDiagnostics()
-        {
-            yield return PropertySummaryDocumentationAnalyzer.SA1623Descriptor.Id;
         }
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
@@ -216,21 +216,32 @@ namespace StyleCop.Analyzers.DocumentationRules
                 }
             }
 
-            if (getterVisible && !setterVisible)
+            if (getterVisible)
             {
-                if (startsWithGetOrSet)
+                if (setterVisible)
                 {
-                    diagnosticProperties.Add(ExpectedTextKey, startingTextGets);
-                    diagnosticProperties.Add(TextToRemoveKey, startingTextGetsOrSets);
-                    context.ReportDiagnostic(Diagnostic.Create(SA1624Descriptor, diagnosticLocation, diagnosticProperties.ToImmutable(), "get", startingTextGets));
+                    if (!startsWithGetOrSet)
+                    {
+                        diagnosticProperties.Add(ExpectedTextKey, startingTextGetsOrSets);
+                        context.ReportDiagnostic(Diagnostic.Create(SA1623Descriptor, diagnosticLocation, diagnosticProperties.ToImmutable(), startingTextGetsOrSets));
+                    }
                 }
-                else if (!text.StartsWith(startingTextGets, StringComparison.Ordinal))
+                else
                 {
-                    diagnosticProperties.Add(ExpectedTextKey, startingTextGets);
-                    context.ReportDiagnostic(Diagnostic.Create(SA1623Descriptor, diagnosticLocation, diagnosticProperties.ToImmutable(), startingTextGets));
+                    if (startsWithGetOrSet)
+                    {
+                        diagnosticProperties.Add(ExpectedTextKey, startingTextGets);
+                        diagnosticProperties.Add(TextToRemoveKey, startingTextGetsOrSets);
+                        context.ReportDiagnostic(Diagnostic.Create(SA1624Descriptor, diagnosticLocation, diagnosticProperties.ToImmutable(), "get", startingTextGets));
+                    }
+                    else if (!text.StartsWith(startingTextGets, StringComparison.Ordinal))
+                    {
+                        diagnosticProperties.Add(ExpectedTextKey, startingTextGets);
+                        context.ReportDiagnostic(Diagnostic.Create(SA1623Descriptor, diagnosticLocation, diagnosticProperties.ToImmutable(), startingTextGets));
+                    }
                 }
             }
-            else if (!getterVisible && setterVisible)
+            else if (setterVisible)
             {
                 if (startsWithGetOrSet)
                 {
@@ -242,14 +253,6 @@ namespace StyleCop.Analyzers.DocumentationRules
                 {
                     diagnosticProperties.Add(ExpectedTextKey, startingTextSets);
                     context.ReportDiagnostic(Diagnostic.Create(SA1623Descriptor, diagnosticLocation, diagnosticProperties.ToImmutable(), startingTextSets));
-                }
-            }
-            else
-            {
-                if (!startsWithGetOrSet)
-                {
-                    diagnosticProperties.Add(ExpectedTextKey, startingTextGetsOrSets);
-                    context.ReportDiagnostic(Diagnostic.Create(SA1623Descriptor, diagnosticLocation, diagnosticProperties.ToImmutable(), startingTextGetsOrSets));
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
@@ -241,7 +241,13 @@ namespace StyleCop.Analyzers.DocumentationRules
                 }
                 else
                 {
-                    if (startsWithGetOrSet || !text.StartsWith(startingTextGets, StringComparison.Ordinal))
+                    if (startsWithGetOrSet)
+                    {
+                        diagnosticProperties.Add(ExpectedTextKey, startingTextGets);
+                        diagnosticProperties.Add(TextToRemoveKey, startingTextGetsOrSets);
+                        context.ReportDiagnostic(Diagnostic.Create(SA1624Descriptor, diagnosticLocation, diagnosticProperties.ToImmutable(), "get", startingTextGets));
+                    }
+                    else if (!text.StartsWith(startingTextGets, StringComparison.Ordinal))
                     {
                         diagnosticProperties.Add(ExpectedTextKey, startingTextGets);
                         context.ReportDiagnostic(Diagnostic.Create(SA1623Descriptor, diagnosticLocation, diagnosticProperties.ToImmutable(), startingTextGets));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
@@ -203,16 +203,10 @@ namespace StyleCop.Analyzers.DocumentationRules
                     getterVisible = true;
                     setterVisible = false;
                 }
-                else if (setter != null)
-                {
-                    getterVisible = false;
-                    setterVisible = true;
-                }
                 else
                 {
-                    // TODO Raise a NotImplementedException?
                     getterVisible = false;
-                    setterVisible = false;
+                    setterVisible = setter != null;
                 }
             }
 


### PR DESCRIPTION
I found, that documentation on expression body properties will not be checked correctly, if documentation starts with "Gets or sets". Expression body properties are read-only properties, so "or sets" is simply wrong.

The problem was introduced with pull request #1825, I guess just a misunderstanding.

Hope this fix is welcome and fulfill the coding guide. I currently see the following TODOs

1. Is it possible to have getter AND setter inaccessible, somehow? I wrote a TODO statement to raise e.g. an NotImplementedException. Needed this branch to ensure initialization of getterVisible and setterVisible.
2. I added DisplayName to the test methods. For me, this is helpful to identify individual tests in the Test Explorer of VS2015. I do not know, if there are side effects.