### PR TITLE
Remove link to "browse source code"

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,3 @@ See [Contributing](CONTRIBUTING.md)
 ## Current status
 
 An up-to-date list of which StyleCop rules are implemented and which have code fixes can be found [here](https://stylecop.pdelvo.com/).
-
-## Source browser
-
-The up-to-date source code can be browsed [here](https://source.pdelvo.com/).


### PR DESCRIPTION
This link is dead. I don't know what functionality it offered originally but it is no longer useful.