### PR TITLE
Corrected SA1205 code fix for nested partial types

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/SA1205CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/SA1205CodeFixProvider.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.OrderingRules
 {
+    using System;
     using System.Collections.Immutable;
     using System.Composition;
     using System.Threading;
@@ -59,7 +60,7 @@ namespace StyleCop.Analyzers.OrderingRules
             }
 
             var symbol = semanticModel.GetDeclaredSymbol(typeDeclarationNode);
-            var accessModifierKind = (symbol.DeclaredAccessibility == Accessibility.Public) ? SyntaxKind.PublicKeyword : SyntaxKind.InternalKeyword;
+            var accessModifierKind = GetMissingAccessModifier(symbol.DeclaredAccessibility);
 
             var keywordToken = typeDeclarationNode.Keyword;
 
@@ -68,6 +69,21 @@ namespace StyleCop.Analyzers.OrderingRules
             replacementNode = ReplaceKeyword(replacementNode, keywordToken);
             var newSyntaxRoot = syntaxRoot.ReplaceNode(typeDeclarationNode, replacementNode);
             return document.WithSyntaxRoot(newSyntaxRoot);
+        }
+
+        private static SyntaxKind GetMissingAccessModifier(Accessibility accessibility)
+        {
+            switch (accessibility)
+            {
+                case Accessibility.Public:
+                    return SyntaxKind.PublicKeyword;
+                case Accessibility.Internal:
+                    return SyntaxKind.InternalKeyword;
+                case Accessibility.Private:
+                    return SyntaxKind.PrivateKeyword;
+                default:
+                    throw new InvalidOperationException("Unexpected accessibility " + accessibility);
+            }
         }
 
         // This code was copied from the Roslyn code base (and slightly modified). It can be removed if

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1205UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1205UnitTests.cs
@@ -200,6 +200,38 @@ internal static partial class TestPartial
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verifies that a nested type without access modifiers will produce a diagnostic and can be fixed correctly.
+        /// </summary>
+        /// <param name="declaration">The declaration to verify.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(InvalidDeclarations))]
+        public async Task TestNestedTypeWithoutAccessModifierAsync(string declaration)
+        {
+            var testCode = $@"
+public class Foo
+{{
+    {declaration} Bar
+    {{
+    }}
+}}
+";
+
+            var fixedTestCode = $@"
+public class Foo
+{{
+    private {declaration} Bar
+    {{
+    }}
+}}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, this.CSharpDiagnostic().WithLocation(4, 6 + declaration.Length), CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
         /// <inheritdoc/>
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1205UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1205UnitTests.cs
@@ -59,6 +59,30 @@ namespace StyleCop.Analyzers.Test.OrderingRules
             }
         }
 
+        public static IEnumerable<object[]> ValidNestedDeclarations
+        {
+            get
+            {
+                yield return new object[] { "public", "class" };
+                yield return new object[] { "protected", "class" };
+                yield return new object[] { "internal", "class" };
+                yield return new object[] { "protected internal", "class" };
+                yield return new object[] { "private", "class" };
+
+                yield return new object[] { "public", "struct" };
+                yield return new object[] { "protected", "struct" };
+                yield return new object[] { "internal", "struct" };
+                yield return new object[] { "protected internal", "struct" };
+                yield return new object[] { "private", "struct" };
+
+                yield return new object[] { "public", "interface" };
+                yield return new object[] { "protected", "interface" };
+                yield return new object[] { "internal", "interface" };
+                yield return new object[] { "protected internal", "interface" };
+                yield return new object[] { "private", "interface" };
+            }
+        }
+
         /// <summary>
         /// Verifies that a valid declaration (with an access modifier or not a partial type) will not produce a diagnostic.
         /// </summary>
@@ -171,21 +195,7 @@ public partial class Foo
         /// <param name="typeKeyword">The type keyword to use.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory]
-        [InlineData("public", "class")]
-        [InlineData("protected", "class")]
-        [InlineData("internal", "class")]
-        [InlineData("protected internal", "class")]
-        [InlineData("private", "class")]
-        [InlineData("public", "struct")]
-        [InlineData("protected", "struct")]
-        [InlineData("internal", "struct")]
-        [InlineData("protected internal", "struct")]
-        [InlineData("private", "struct")]
-        [InlineData("public", "interface")]
-        [InlineData("protected", "interface")]
-        [InlineData("internal", "interface")]
-        [InlineData("protected internal", "interface")]
-        [InlineData("private", "interface")]
+        [MemberData(nameof(ValidNestedDeclarations))]
         public async Task TestNestedTypeAccessModifiersAsync(string accessModifier, string typeKeyword)
         {
             var testCode = $@"
@@ -228,6 +238,47 @@ public class Foo
 ";
 
             await this.VerifyCSharpDiagnosticAsync(testCode, this.CSharpDiagnostic().WithLocation(4, 6 + declaration.Length), CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the code fix will properly copy over the access modifier defined in another fragment of the nested partial element.
+        /// </summary>
+        /// <param name="accessModifier">The access modifier to use for the nested type.</param>
+        /// <param name="typeKeyword">The type keyword to use.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [MemberData(nameof(ValidNestedDeclarations))]
+        public async Task TestProperNestedAccessModifierPropagationAsync(string accessModifier, string typeKeyword)
+        {
+            var testCode = $@"
+public class Foo
+{{
+    {accessModifier} partial {typeKeyword} Bar
+    {{
+    }}
+
+    partial {typeKeyword} Bar
+    {{
+    }}
+}}
+";
+
+            var fixedTestCode = $@"
+public class Foo
+{{
+    {accessModifier} partial {typeKeyword} Bar
+    {{
+    }}
+
+    {accessModifier} partial {typeKeyword} Bar
+    {{
+    }}
+}}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, this.CSharpDiagnostic().WithLocation(8, 14 + typeKeyword.Length), CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1205UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1205UnitTests.cs
@@ -86,6 +86,7 @@ namespace StyleCop.Analyzers.Test.OrderingRules
 
             await this.VerifyCSharpDiagnosticAsync(testCode, this.CSharpDiagnostic().WithLocation(1, 2 + declaration.Length), CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -180,6 +181,11 @@ public partial class Foo
         [InlineData("internal", "struct")]
         [InlineData("protected internal", "struct")]
         [InlineData("private", "struct")]
+        [InlineData("public", "interface")]
+        [InlineData("protected", "interface")]
+        [InlineData("internal", "interface")]
+        [InlineData("protected internal", "interface")]
+        [InlineData("private", "interface")]
         public async Task TestNestedTypeAccessModifiersAsync(string accessModifier, string typeKeyword)
         {
             var testCode = $@"
@@ -187,10 +193,6 @@ internal static partial class TestPartial
 {{
     {accessModifier} partial {typeKeyword} PartialInner
     {{
-        public int Do()
-        {{
-            return 2;
-        }}
     }}
 }}
 ";

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DeclarationModifiersHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DeclarationModifiersHelper.cs
@@ -3,6 +3,8 @@
 
 namespace StyleCop.Analyzers.Helpers
 {
+    using System.Collections.Generic;
+    using System.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -66,6 +68,28 @@ namespace StyleCop.Analyzers.Helpers
             {
                 modifiers = SyntaxTokenList.Create(modifier.WithLeadingTrivia(leadingTriviaToken.LeadingTrivia));
                 leadingTriviaToken = leadingTriviaToken.WithLeadingTrivia(SyntaxFactory.ElasticSpace);
+            }
+
+            return modifiers;
+        }
+
+        /// <summary>
+        /// Adds a number of modifier tokens for <paramref name="modifierKeywords"/> to the beginning of
+        /// <paramref name="modifiers"/>. The trivia for the new modifier and the trivia for the token that follows it
+        /// are updated to ensure that the new modifier is placed immediately before the syntax token that follows it,
+        /// separated by exactly one space.
+        /// </summary>
+        /// <param name="modifiers">The existing modifiers. This may be empty if no modifiers are present.</param>
+        /// <param name="leadingTriviaToken">The syntax token which follows the modifiers. The trivia for this token is
+        /// updated if (and only if) the existing <paramref name="modifiers"/> list is empty.</param>
+        /// <param name="modifierKeywords">The modifier keywords to add.</param>
+        /// <returns>A <see cref="SyntaxTokenList"/> representing the original modifiers (if any) with the addition of a
+        /// modifier of the specified <paramref name="modifierKeywords"/> at the beginning of the list.</returns>
+        internal static SyntaxTokenList AddModifiers(SyntaxTokenList modifiers, ref SyntaxToken leadingTriviaToken, IEnumerable<SyntaxKind> modifierKeywords)
+        {
+            foreach (var modifierKeyword in modifierKeywords.Reverse())
+            {
+                modifiers = AddModifier(modifiers, ref leadingTriviaToken, modifierKeyword);
             }
 
             return modifiers;


### PR DESCRIPTION
Fixes https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2114.
Code fix updated and new unit tests added. Also updated some existing unit tests to verify more cases.
