### PR TITLE
Include .g.cs files as generated.

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/GeneratedCodeAnalysisExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/GeneratedCodeAnalysisExtensions.cs
@@ -157,7 +157,7 @@ namespace StyleCop.Analyzers
         {
             return Regex.IsMatch(
                 Path.GetFileName(filePath),
-                @"\.designer\.cs$",
+                @"\.(designer|g)\.cs$",
                 RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture);
         }
 


### PR DESCRIPTION
Refit (https://github.com/paulcbetts/refit) uses the ".g.cs" file extension to indicate the file is auto-generated. I know the file name detection was simplified until examples could be shown for each. I hope this is an acceptable example.