### PR TITLE
Documentation - properly escaped backtick in "Class`1"

### DIFF
--- a/documentation/SA1649.md
+++ b/documentation/SA1649.md
@@ -18,7 +18,7 @@
 ## Cause
 
 The file name of a C# code file does not match the first type declared in the file. For generics that are defined as
-`Class1<T>` the name of the file needs to be `Class1{T}.cs` or `Class1``1.cs` depending on the `fileNamingConvention`
+`Class1<T>` the name of the file needs to be `Class1{T}.cs` or `Class1```1.cs` depending on the `fileNamingConvention`
 setting. See [Configuration.md](Configuration.md) for more information.
 
 Partial classes are ignored.

--- a/documentation/SA1649.md
+++ b/documentation/SA1649.md
@@ -18,7 +18,7 @@
 ## Cause
 
 The file name of a C# code file does not match the first type declared in the file. For generics that are defined as
-`Class1<T>` the name of the file needs to be `Class1{T}.cs` or `Class1```1.cs` depending on the `fileNamingConvention`
+`Class1<T>` the name of the file needs to be `Class1{T}.cs` or ``Class1`1.cs`` depending on the `fileNamingConvention`
 setting. See [Configuration.md](Configuration.md) for more information.
 
 Partial classes are ignored.


### PR DESCRIPTION
The original had incorrectly escaped backtick which was not shown ourside of edit form. I've updated the code to properly print it.