### PR TITLE
Implement #1143: custom culture/locale for documentation texts

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -99,12 +99,12 @@ namespace StyleCop.Analyzers.DocumentationRules
             ImmutableArray<string> standardText;
             if (declarationSyntax is ConstructorDeclarationSyntax)
             {
-                var typeKindText = resourceManager.GetString(isStruct ? "TypeTextStruct" : "TypeTextClass", culture);
+                var typeKindText = resourceManager.GetString(isStruct ? nameof(DocumentationResources.TypeTextStruct) : nameof(DocumentationResources.TypeTextClass), culture);
                 if (declarationSyntax.Modifiers.Any(SyntaxKind.StaticKeyword))
                 {
                     standardText = ImmutableArray.Create(
-                        string.Format(resourceManager.GetString("StaticConstructorStandardTextFirstPart", culture), typeKindText),
-                        string.Format(resourceManager.GetString("StaticConstructorStandardTextSecondPart", culture), typeKindText));
+                        string.Format(resourceManager.GetString(nameof(DocumentationResources.StaticConstructorStandardTextFirstPart), culture), typeKindText),
+                        string.Format(resourceManager.GetString(nameof(DocumentationResources.StaticConstructorStandardTextSecondPart), culture), typeKindText));
                 }
                 else
                 {
@@ -112,16 +112,16 @@ namespace StyleCop.Analyzers.DocumentationRules
                     // acceptable for private constructors by the diagnostic.
                     // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/413
                     standardText = ImmutableArray.Create(
-                        string.Format(resourceManager.GetString("NonPrivateConstructorStandardTextFirstPart", culture), typeKindText),
-                        string.Format(resourceManager.GetString("NonPrivateConstructorStandardTextSecondPart", culture), typeKindText));
+                        string.Format(resourceManager.GetString(nameof(DocumentationResources.NonPrivateConstructorStandardTextFirstPart), culture), typeKindText),
+                        string.Format(resourceManager.GetString(nameof(DocumentationResources.NonPrivateConstructorStandardTextSecondPart), culture), typeKindText));
                 }
             }
             else if (declarationSyntax is DestructorDeclarationSyntax)
             {
                 standardText =
                     ImmutableArray.Create(
-                        resourceManager.GetString("DestructorStandardTextFirstPart", culture),
-                        resourceManager.GetString("DestructorStandardTextSecondPart", culture));
+                        resourceManager.GetString(nameof(DocumentationResources.DestructorStandardTextFirstPart), culture),
+                        resourceManager.GetString(nameof(DocumentationResources.DestructorStandardTextSecondPart), culture));
             }
             else
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -99,30 +99,21 @@ namespace StyleCop.Analyzers.DocumentationRules
             ImmutableArray<string> standardText;
             if (declarationSyntax is ConstructorDeclarationSyntax)
             {
+                var typeKindText = resourceManager.GetString(isStruct ? "TypeTextStruct" : "TypeTextClass", culture);
                 if (declarationSyntax.Modifiers.Any(SyntaxKind.StaticKeyword))
                 {
-                    if (isStruct)
-                    {
-                        standardText = ImmutableArray.Create(SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.StaticConstructorStandardText, " struct.");
-                    }
-                    else
-                    {
-                        standardText = ImmutableArray.Create(SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.StaticConstructorStandardText, " class.");
-                    }
+                    standardText = ImmutableArray.Create(
+                        resourceManager.GetString("StaticConstructorStandardTextFirstPart", culture),
+                        string.Format(resourceManager.GetString("StaticConstructorStandardTextSecondPart", culture), typeKindText));
                 }
                 else
                 {
                     // Prefer to insert the "non-private" wording for all constructors, even though both are considered
                     // acceptable for private constructors by the diagnostic.
                     // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/413
-                    if (isStruct)
-                    {
-                        standardText = ImmutableArray.Create(SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.NonPrivateConstructorStandardText, " struct.");
-                    }
-                    else
-                    {
-                        standardText = ImmutableArray.Create(SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.NonPrivateConstructorStandardText, " class.");
-                    }
+                    standardText = ImmutableArray.Create(
+                        resourceManager.GetString("NonPrivateConstructorStandardTextFirstPart", culture),
+                        string.Format(resourceManager.GetString("NonPrivateConstructorStandardTextSecondPart", culture), typeKindText));
                 }
             }
             else if (declarationSyntax is DestructorDeclarationSyntax)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -59,7 +59,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                     context.RegisterCodeFix(
                         CodeAction.Create(
                             DocumentationResources.SA1642SA1643CodeFix,
-                            cancellationToken => GetTransformedDocumentAsync(context.Document, root, xmlElementSyntax),
+                            cancellationToken => GetTransformedDocumentAsync(context.Document, root, xmlElementSyntax, cancellationToken),
                             nameof(SA1642SA1643CodeFixProvider)),
                         diagnostic);
                 }
@@ -76,12 +76,12 @@ namespace StyleCop.Analyzers.DocumentationRules
             }
         }
 
-        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, XmlElementSyntax node)
+        private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, XmlElementSyntax node, CancellationToken cancellationToken)
         {
             var typeDeclaration = node.FirstAncestorOrSelf<BaseTypeDeclarationSyntax>();
             var declarationSyntax = node.FirstAncestorOrSelf<BaseMethodDeclarationSyntax>();
             bool isStruct = typeDeclaration.IsKind(SyntaxKind.StructDeclaration);
-            var settings = document.Project.AnalyzerOptions.GetStyleCopSettings(CancellationToken.None);
+            var settings = document.Project.AnalyzerOptions.GetStyleCopSettings(cancellationToken);
             var culture = new CultureInfo(settings.DocumentationRules.DocumentationCulture);
             var resourceManager = DocumentationResources.ResourceManager;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -103,7 +103,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                 if (declarationSyntax.Modifiers.Any(SyntaxKind.StaticKeyword))
                 {
                     standardText = ImmutableArray.Create(
-                        resourceManager.GetString("StaticConstructorStandardTextFirstPart", culture),
+                        string.Format(resourceManager.GetString("StaticConstructorStandardTextFirstPart", culture), typeKindText),
                         string.Format(resourceManager.GetString("StaticConstructorStandardTextSecondPart", culture), typeKindText));
                 }
                 else
@@ -112,7 +112,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                     // acceptable for private constructors by the diagnostic.
                     // https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/413
                     standardText = ImmutableArray.Create(
-                        resourceManager.GetString("NonPrivateConstructorStandardTextFirstPart", culture),
+                        string.Format(resourceManager.GetString("NonPrivateConstructorStandardTextFirstPart", culture), typeKindText),
                         string.Format(resourceManager.GetString("NonPrivateConstructorStandardTextSecondPart", culture), typeKindText));
                 }
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -6,8 +6,10 @@ namespace StyleCop.Analyzers.DocumentationRules
     using System;
     using System.Collections.Immutable;
     using System.Composition;
+    using System.Globalization;
     using System.Linq;
     using System.Text.RegularExpressions;
+    using System.Threading;
     using System.Threading.Tasks;
     using Helpers;
     using Microsoft.CodeAnalysis;
@@ -79,6 +81,9 @@ namespace StyleCop.Analyzers.DocumentationRules
             var typeDeclaration = node.FirstAncestorOrSelf<BaseTypeDeclarationSyntax>();
             var declarationSyntax = node.FirstAncestorOrSelf<BaseMethodDeclarationSyntax>();
             bool isStruct = typeDeclaration.IsKind(SyntaxKind.StructDeclaration);
+            var settings = document.Project.AnalyzerOptions.GetStyleCopSettings(CancellationToken.None);
+            var culture = new CultureInfo(settings.DocumentationRules.DocumentationCulture);
+            var resourceManager = DocumentationResources.ResourceManager;
 
             TypeParameterListSyntax typeParameterList;
             ClassDeclarationSyntax classDeclaration = typeDeclaration as ClassDeclarationSyntax;
@@ -122,7 +127,10 @@ namespace StyleCop.Analyzers.DocumentationRules
             }
             else if (declarationSyntax is DestructorDeclarationSyntax)
             {
-                standardText = SA1643DestructorSummaryDocumentationMustBeginWithStandardText.DestructorStandardText;
+                standardText =
+                    ImmutableArray.Create(
+                        resourceManager.GetString("DestructorStandardTextFirstPart", culture),
+                        resourceManager.GetString("DestructorStandardTextSecondPart", culture));
             }
             else
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/StyleCop.Analyzers.nuspec
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/StyleCop.Analyzers.nuspec
@@ -19,8 +19,10 @@
 
     <!-- Binaries and symbols -->
     <file src="bin\$Configuration$\StyleCop.Analyzers.dll" target="analyzers\dotnet\cs" />
+    <file src="bin\$Configuration$\**\StyleCop.Analyzers.resources.dll" target="analyzers\dotnet\cs" />
     <file src="bin\$Configuration$\StyleCop.Analyzers.pdb" target="analyzers\dotnet\cs" />
     <file src="bin\$Configuration$\StyleCop.Analyzers.CodeFixes.dll" target="analyzers\dotnet\cs" />
+    <file src="bin\$Configuration$\**\StyleCop.Analyzers.CodeFixes.resources.dll" target="analyzers\dotnet\cs" />
     <file src="bin\$Configuration$\StyleCop.Analyzers.CodeFixes.pdb" target="analyzers\dotnet\cs" />
     <file src="..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll" target="analyzers\dotnet\cs" />
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
@@ -10,7 +10,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Helpers;
-
     using TestHelper;
     using Xunit;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
@@ -9,13 +9,15 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.DocumentationRules;
+    using StyleCop.Analyzers.Test.Helpers;
+
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.DocumentationRules.SA1642ConstructorSummaryDocumentationMustBeginWithStandardText;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1642ConstructorSummaryDocumentationMustBeginWithStandardText"/>-
     /// </summary>
+    [UseCulture("en-US")]
     public class SA1642UnitTests : CodeFixVerifier
     {
         [Theory]
@@ -64,7 +66,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestNonPrivateConstructorCorrectDocumentationSimpleAsync(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationSimpleAsync(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationSimpleAsync(
+                typeKind,
+                "public",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                false).ConfigureAwait(false);
         }
 
         [Theory]
@@ -72,7 +79,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestNonPrivateConstructorCorrectDocumentationCustomizedAsync(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationCustomizedAsync(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationCustomizedAsync(
+                typeKind,
+                "public",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                false).ConfigureAwait(false);
         }
 
         [Theory]
@@ -80,7 +92,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestNonPrivateConstructorCorrectDocumentationGenericSimpleAsync(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationSimpleAsync(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationSimpleAsync(
+                typeKind,
+                "public",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                true).ConfigureAwait(false);
         }
 
         [Theory]
@@ -88,7 +105,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestNonPrivateConstructorCorrectDocumentationGenericCustomizedAsync(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationCustomizedAsync(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationCustomizedAsync(
+                typeKind,
+                "public",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                true).ConfigureAwait(false);
         }
 
         [Theory]
@@ -96,7 +118,13 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestPrivateConstructorCorrectDocumentationAsync(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationAsync(typeKind, "private", PrivateConstructorStandardText[0], $" {typeKind} from being created.", string.Empty, false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationAsync(
+                typeKind,
+                "private",
+                DocumentationResources.PrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.PrivateConstructorStandardTextSecondPart, typeKind),
+                string.Empty,
+                false).ConfigureAwait(false);
         }
 
         [Theory]
@@ -104,7 +132,13 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestPrivateConstructorCorrectExtendedDocumentationAsync(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationAsync(typeKind, "private", PrivateConstructorStandardText[0], $" {typeKind} from being created externally.", string.Empty, false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationAsync(
+                typeKind,
+                "private",
+                DocumentationResources.PrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.PrivateConstructorStandardTextSecondPart, typeKind) + " externally",
+                string.Empty,
+                false).ConfigureAwait(false);
         }
 
         [Theory]
@@ -112,7 +146,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestPrivateConstructorCorrectDocumentation_NonPrivateSimpleAsync(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationSimpleAsync(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationSimpleAsync(
+                typeKind,
+                "private",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                false).ConfigureAwait(false);
         }
 
         [Theory]
@@ -120,7 +159,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestPrivateConstructorCorrectDocumentation_NonPrivateCustomizedAsync(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationCustomizedAsync(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationCustomizedAsync(
+                typeKind,
+                "private",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                false).ConfigureAwait(false);
         }
 
         [Theory]
@@ -128,7 +172,13 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestPrivateConstructorCorrectDocumentationGenericAsync(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationAsync(typeKind, "private", PrivateConstructorStandardText[0], $" {typeKind} from being created.", string.Empty, true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationAsync(
+                typeKind,
+                "private",
+                DocumentationResources.PrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.PrivateConstructorStandardTextSecondPart, typeKind),
+                string.Empty,
+                true).ConfigureAwait(false);
         }
 
         [Theory]
@@ -136,7 +186,13 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestPrivateConstructorCorrectExtendedDocumentationGenericAsync(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationAsync(typeKind, "private", PrivateConstructorStandardText[0], $" {typeKind} from being created externally.", string.Empty, true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationAsync(
+                typeKind,
+                "private",
+                DocumentationResources.PrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.PrivateConstructorStandardTextSecondPart, typeKind) + " externally",
+                string.Empty,
+                true).ConfigureAwait(false);
         }
 
         [Theory]
@@ -144,7 +200,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestPrivateConstructorCorrectDocumentationGeneric_NonPrivateSimpleAsync(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationSimpleAsync(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationSimpleAsync(
+                typeKind,
+                "private",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                true).ConfigureAwait(false);
         }
 
         [Theory]
@@ -152,7 +213,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestPrivateConstructorCorrectDocumentationGeneric_NonPrivateCustomizedAsync(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationCustomizedAsync(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationCustomizedAsync(
+                typeKind,
+                "private",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                true).ConfigureAwait(false);
         }
 
         [Theory]
@@ -160,7 +226,13 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestStaticConstructorCorrectDocumentationAsync(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationAsync(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", string.Empty, false).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationAsync(
+                typeKind,
+                "static",
+                DocumentationResources.StaticConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.StaticConstructorStandardTextSecondPart, typeKind),
+                string.Empty,
+                false).ConfigureAwait(false);
         }
 
         [Theory]
@@ -168,7 +240,13 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestStaticConstructorCorrectDocumentationGenericAsync(string typeKind)
         {
-            await this.TestConstructorCorrectDocumentationAsync(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", string.Empty, true).ConfigureAwait(false);
+            await this.TestConstructorCorrectDocumentationAsync(
+                typeKind,
+                "static",
+                DocumentationResources.StaticConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.StaticConstructorStandardTextSecondPart, typeKind),
+                string.Empty,
+                true).ConfigureAwait(false);
         }
 
         [Theory]
@@ -176,7 +254,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestNonPrivateConstructorMissingDocumentationAsync(string typeKind)
         {
-            await this.TestConstructorMissingDocumentationAsync(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentationAsync(
+                typeKind,
+                "public",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                false).ConfigureAwait(false);
         }
 
         [Theory]
@@ -184,7 +267,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestNonPrivateConstructorMissingDocumentationGenericAsync(string typeKind)
         {
-            await this.TestConstructorMissingDocumentationAsync(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentationAsync(
+                typeKind,
+                "public",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                true).ConfigureAwait(false);
         }
 
         [Theory]
@@ -192,7 +280,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestPrivateConstructorMissingDocumentationAsync(string typeKind)
         {
-            await this.TestConstructorMissingDocumentationAsync(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentationAsync(
+                typeKind,
+                "private",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                false).ConfigureAwait(false);
         }
 
         [Theory]
@@ -200,7 +293,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestPrivateConstructorMissingDocumentationGenericAsync(string typeKind)
         {
-            await this.TestConstructorMissingDocumentationAsync(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentationAsync(
+                typeKind,
+                "private",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                true).ConfigureAwait(false);
         }
 
         [Theory]
@@ -208,7 +306,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestStaticConstructorMissingDocumentationAsync(string typeKind)
         {
-            await this.TestConstructorMissingDocumentationAsync(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", false).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentationAsync(
+                typeKind,
+                "static",
+                DocumentationResources.StaticConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.StaticConstructorStandardTextSecondPart, typeKind),
+                false).ConfigureAwait(false);
         }
 
         [Theory]
@@ -216,7 +319,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestStaticConstructorMissingDocumentationGenericAsync(string typeKind)
         {
-            await this.TestConstructorMissingDocumentationAsync(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", true).ConfigureAwait(false);
+            await this.TestConstructorMissingDocumentationAsync(
+                typeKind,
+                "static",
+                DocumentationResources.StaticConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.StaticConstructorStandardTextSecondPart, typeKind),
+                true).ConfigureAwait(false);
         }
 
         [Theory]
@@ -224,7 +332,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestNonPrivateConstructorSimpleDocumentationAsync(string typeKind)
         {
-            await this.TestConstructorSimpleDocumentationAsync(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
+            await this.TestConstructorSimpleDocumentationAsync(
+                typeKind,
+                "public",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                false).ConfigureAwait(false);
         }
 
         [Theory]
@@ -232,7 +345,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestNonPrivateConstructorSimpleDocumentationGenericAsync(string typeKind)
         {
-            await this.TestConstructorSimpleDocumentationAsync(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
+            await this.TestConstructorSimpleDocumentationAsync(
+                typeKind,
+                "public",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                true).ConfigureAwait(false);
         }
 
         [Theory]
@@ -240,7 +358,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestPrivateConstructorSimpleDocumentationAsync(string typeKind)
         {
-            await this.TestConstructorSimpleDocumentationAsync(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
+            await this.TestConstructorSimpleDocumentationAsync(
+                typeKind,
+                "private",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                false).ConfigureAwait(false);
         }
 
         [Theory]
@@ -248,7 +371,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestPrivateConstructorSimpleDocumentationGenericAsync(string typeKind)
         {
-            await this.TestConstructorSimpleDocumentationAsync(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
+            await this.TestConstructorSimpleDocumentationAsync(
+                typeKind,
+                "private",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                true).ConfigureAwait(false);
         }
 
         [Theory]
@@ -256,7 +384,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestStaticConstructorSimpleDocumentationAsync(string typeKind)
         {
-            await this.TestConstructorSimpleDocumentationAsync(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", false).ConfigureAwait(false);
+            await this.TestConstructorSimpleDocumentationAsync(
+                typeKind,
+                "static",
+                DocumentationResources.StaticConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.StaticConstructorStandardTextSecondPart, typeKind),
+                false).ConfigureAwait(false);
         }
 
         [Theory]
@@ -264,7 +397,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestStaticConstructorSimpleDocumentationGenericAsync(string typeKind)
         {
-            await this.TestConstructorSimpleDocumentationAsync(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", true).ConfigureAwait(false);
+            await this.TestConstructorSimpleDocumentationAsync(
+                typeKind,
+                "static",
+                DocumentationResources.StaticConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.StaticConstructorStandardTextSecondPart, typeKind),
+                true).ConfigureAwait(false);
         }
 
         [Theory]
@@ -272,7 +410,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestNonPrivateConstructorSimpleDocumentationWrongTypeNameAsync(string typeKind)
         {
-            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
+            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(
+                typeKind,
+                "public",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                false).ConfigureAwait(false);
         }
 
         [Theory]
@@ -280,7 +423,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestNonPrivateConstructorSimpleDocumentationGenericWrongTypeNameAsync(string typeKind)
         {
-            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(typeKind, "public", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
+            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(
+                typeKind,
+                "public",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                true).ConfigureAwait(false);
         }
 
         [Theory]
@@ -288,7 +436,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestPrivateConstructorSimpleDocumentationWrongTypeNameAsync(string typeKind)
         {
-            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", false).ConfigureAwait(false);
+            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(
+                typeKind,
+                "private",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                false).ConfigureAwait(false);
         }
 
         [Theory]
@@ -296,7 +449,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestPrivateConstructorSimpleDocumentationGenericWrongTypeNameAsync(string typeKind)
         {
-            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(typeKind, "private", NonPrivateConstructorStandardText, $" {typeKind}", true).ConfigureAwait(false);
+            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(
+                typeKind,
+                "private",
+                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
+                true).ConfigureAwait(false);
         }
 
         [Theory]
@@ -304,7 +462,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestStaticConstructorSimpleDocumentationWrongTypeNameAsync(string typeKind)
         {
-            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", false).ConfigureAwait(false);
+            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(
+                typeKind,
+                "static",
+                DocumentationResources.StaticConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.StaticConstructorStandardTextSecondPart, typeKind),
+                false).ConfigureAwait(false);
         }
 
         [Theory]
@@ -312,7 +475,12 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("struct")]
         public async Task TestStaticConstructorSimpleDocumentationGenericWrongTypeNameAsync(string typeKind)
         {
-            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(typeKind, "static", StaticConstructorStandardText, $" {typeKind}.", true).ConfigureAwait(false);
+            await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(
+                typeKind,
+                "static",
+                DocumentationResources.StaticConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.StaticConstructorStandardTextSecondPart, typeKind),
+                true).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
@@ -69,7 +69,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorCorrectDocumentationSimpleAsync(
                 typeKind,
                 "public",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 false).ConfigureAwait(false);
         }
@@ -82,7 +82,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorCorrectDocumentationCustomizedAsync(
                 typeKind,
                 "public",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 false).ConfigureAwait(false);
         }
@@ -95,7 +95,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorCorrectDocumentationSimpleAsync(
                 typeKind,
                 "public",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 true).ConfigureAwait(false);
         }
@@ -108,7 +108,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorCorrectDocumentationCustomizedAsync(
                 typeKind,
                 "public",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 true).ConfigureAwait(false);
         }
@@ -121,7 +121,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorCorrectDocumentationAsync(
                 typeKind,
                 "private",
-                DocumentationResources.PrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.PrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.PrivateConstructorStandardTextSecondPart, typeKind),
                 string.Empty,
                 false).ConfigureAwait(false);
@@ -135,7 +135,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorCorrectDocumentationAsync(
                 typeKind,
                 "private",
-                DocumentationResources.PrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.PrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.PrivateConstructorStandardTextSecondPart, typeKind) + " externally",
                 string.Empty,
                 false).ConfigureAwait(false);
@@ -149,7 +149,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorCorrectDocumentationSimpleAsync(
                 typeKind,
                 "private",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 false).ConfigureAwait(false);
         }
@@ -162,7 +162,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorCorrectDocumentationCustomizedAsync(
                 typeKind,
                 "private",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 false).ConfigureAwait(false);
         }
@@ -175,7 +175,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorCorrectDocumentationAsync(
                 typeKind,
                 "private",
-                DocumentationResources.PrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.PrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.PrivateConstructorStandardTextSecondPart, typeKind),
                 string.Empty,
                 true).ConfigureAwait(false);
@@ -189,7 +189,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorCorrectDocumentationAsync(
                 typeKind,
                 "private",
-                DocumentationResources.PrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.PrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.PrivateConstructorStandardTextSecondPart, typeKind) + " externally",
                 string.Empty,
                 true).ConfigureAwait(false);
@@ -203,7 +203,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorCorrectDocumentationSimpleAsync(
                 typeKind,
                 "private",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 true).ConfigureAwait(false);
         }
@@ -216,7 +216,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorCorrectDocumentationCustomizedAsync(
                 typeKind,
                 "private",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 true).ConfigureAwait(false);
         }
@@ -229,7 +229,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorCorrectDocumentationAsync(
                 typeKind,
                 "static",
-                DocumentationResources.StaticConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.StaticConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.StaticConstructorStandardTextSecondPart, typeKind),
                 string.Empty,
                 false).ConfigureAwait(false);
@@ -243,7 +243,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorCorrectDocumentationAsync(
                 typeKind,
                 "static",
-                DocumentationResources.StaticConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.StaticConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.StaticConstructorStandardTextSecondPart, typeKind),
                 string.Empty,
                 true).ConfigureAwait(false);
@@ -257,7 +257,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorMissingDocumentationAsync(
                 typeKind,
                 "public",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 false).ConfigureAwait(false);
         }
@@ -270,7 +270,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorMissingDocumentationAsync(
                 typeKind,
                 "public",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 true).ConfigureAwait(false);
         }
@@ -283,7 +283,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorMissingDocumentationAsync(
                 typeKind,
                 "private",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 false).ConfigureAwait(false);
         }
@@ -296,7 +296,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorMissingDocumentationAsync(
                 typeKind,
                 "private",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 true).ConfigureAwait(false);
         }
@@ -309,7 +309,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorMissingDocumentationAsync(
                 typeKind,
                 "static",
-                DocumentationResources.StaticConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.StaticConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.StaticConstructorStandardTextSecondPart, typeKind),
                 false).ConfigureAwait(false);
         }
@@ -322,7 +322,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorMissingDocumentationAsync(
                 typeKind,
                 "static",
-                DocumentationResources.StaticConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.StaticConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.StaticConstructorStandardTextSecondPart, typeKind),
                 true).ConfigureAwait(false);
         }
@@ -335,7 +335,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorSimpleDocumentationAsync(
                 typeKind,
                 "public",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 false).ConfigureAwait(false);
         }
@@ -348,7 +348,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorSimpleDocumentationAsync(
                 typeKind,
                 "public",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 true).ConfigureAwait(false);
         }
@@ -361,7 +361,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorSimpleDocumentationAsync(
                 typeKind,
                 "private",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 false).ConfigureAwait(false);
         }
@@ -374,7 +374,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorSimpleDocumentationAsync(
                 typeKind,
                 "private",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 true).ConfigureAwait(false);
         }
@@ -387,7 +387,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorSimpleDocumentationAsync(
                 typeKind,
                 "static",
-                DocumentationResources.StaticConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.StaticConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.StaticConstructorStandardTextSecondPart, typeKind),
                 false).ConfigureAwait(false);
         }
@@ -400,7 +400,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorSimpleDocumentationAsync(
                 typeKind,
                 "static",
-                DocumentationResources.StaticConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.StaticConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.StaticConstructorStandardTextSecondPart, typeKind),
                 true).ConfigureAwait(false);
         }
@@ -413,7 +413,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(
                 typeKind,
                 "public",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 false).ConfigureAwait(false);
         }
@@ -426,7 +426,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(
                 typeKind,
                 "public",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 true).ConfigureAwait(false);
         }
@@ -439,7 +439,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(
                 typeKind,
                 "private",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 false).ConfigureAwait(false);
         }
@@ -452,7 +452,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(
                 typeKind,
                 "private",
-                DocumentationResources.NonPrivateConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.NonPrivateConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.NonPrivateConstructorStandardTextSecondPart, typeKind),
                 true).ConfigureAwait(false);
         }
@@ -465,7 +465,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(
                 typeKind,
                 "static",
-                DocumentationResources.StaticConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.StaticConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.StaticConstructorStandardTextSecondPart, typeKind),
                 false).ConfigureAwait(false);
         }
@@ -478,7 +478,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.TestConstructorSimpleDocumentationWrongTypeNameAsync(
                 typeKind,
                 "static",
-                DocumentationResources.StaticConstructorStandardTextFirstPart,
+                string.Format(DocumentationResources.StaticConstructorStandardTextFirstPart, typeKind),
                 string.Format(DocumentationResources.StaticConstructorStandardTextSecondPart, typeKind),
                 true).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1643UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1643UnitTests.cs
@@ -4,18 +4,21 @@
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.DocumentationRules;
+    using StyleCop.Analyzers.Test.Helpers;
+
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.DocumentationRules.SA1643DestructorSummaryDocumentationMustBeginWithStandardText;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1643DestructorSummaryDocumentationMustBeginWithStandardText"/>-
     /// </summary>
+    [UseCulture("en-US")]
     public class SA1643UnitTests : CodeFixVerifier
     {
         [Fact]
@@ -37,37 +40,37 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [Fact]
         public async Task TestDestructorCorrectDocumentationSimpleAsync()
         {
-            await this.TestDestructorCorrectDocumentationSimpleImplAsync(DestructorStandardText[0], DestructorStandardText[1], false).ConfigureAwait(false);
+            await this.TestDestructorCorrectDocumentationSimpleImplAsync(DocumentationResources.DestructorStandardTextFirstPart, DocumentationResources.DestructorStandardTextSecondPart, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDestructorCorrectDocumentationCustomizedAsync()
         {
-            await this.TestDestructorCorrectDocumentationCustomizedImplAsync(DestructorStandardText[0], DestructorStandardText[1], false).ConfigureAwait(false);
+            await this.TestDestructorCorrectDocumentationCustomizedImplAsync(DocumentationResources.DestructorStandardTextFirstPart, DocumentationResources.DestructorStandardTextSecondPart, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestNonPrivateConstructorCorrectDocumentationGenericSimpleAsync()
         {
-            await this.TestDestructorCorrectDocumentationSimpleImplAsync(DestructorStandardText[0], DestructorStandardText[1], true).ConfigureAwait(false);
+            await this.TestDestructorCorrectDocumentationSimpleImplAsync(DocumentationResources.DestructorStandardTextFirstPart, DocumentationResources.DestructorStandardTextSecondPart, true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDestructorCorrectDocumentationGenericCustomizedAsync()
         {
-            await this.TestDestructorCorrectDocumentationCustomizedImplAsync(DestructorStandardText[0], DestructorStandardText[1], true).ConfigureAwait(false);
+            await this.TestDestructorCorrectDocumentationCustomizedImplAsync(DocumentationResources.DestructorStandardTextFirstPart, DocumentationResources.DestructorStandardTextSecondPart, true).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDestructorMissingDocumentationAsync()
         {
-            await this.TestDestructorMissingDocumentationImplAsync(DestructorStandardText[0], DestructorStandardText[1], false).ConfigureAwait(false);
+            await this.TestDestructorMissingDocumentationImplAsync(DocumentationResources.DestructorStandardTextFirstPart, DocumentationResources.DestructorStandardTextSecondPart, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestDestructorMissingDocumentationGenericAsync()
         {
-            await this.TestDestructorMissingDocumentationImplAsync(DestructorStandardText[0], DestructorStandardText[1], true).ConfigureAwait(false);
+            await this.TestDestructorMissingDocumentationImplAsync(DocumentationResources.DestructorStandardTextFirstPart, DocumentationResources.DestructorStandardTextSecondPart, true).ConfigureAwait(false);
         }
 
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1643UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1643UnitTests.cs
@@ -4,14 +4,12 @@
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
     using System.Collections.Generic;
-    using System.Globalization;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Helpers;
-
     using TestHelper;
     using Xunit;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/UseCultureAttribute.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/UseCultureAttribute.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.Helpers
+{
+    using System;
+    using System.Globalization;
+    using System.Reflection;
+    using System.Threading;
+
+    using Xunit.Sdk;
+
+    /// <summary>
+    /// Apply this attribute to your test method to replace the
+    /// <see cref="Thread.CurrentThread" /> <see cref="CultureInfo.CurrentCulture" /> and
+    /// <see cref="CultureInfo.CurrentUICulture" /> with another culture.
+    /// </summary>
+    /// <remarks>
+    /// This code was adapted from
+    /// https://github.com/xunit/samples.xunit/blob/885edfc/UseCulture/UseCultureAttribute.cs.
+    /// The original code is (c) 2014 Outercurve Foundation and licensed under the Apache License,
+    /// Version 2.0.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+    public class UseCultureAttribute : BeforeAfterTestAttribute
+    {
+        private readonly Lazy<CultureInfo> culture;
+
+#pragma warning disable SA1305
+        private readonly Lazy<CultureInfo> uiCulture;
+#pragma warning restore SA1305
+
+        private CultureInfo originalCulture;
+
+        private CultureInfo originalUiCulture;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UseCultureAttribute"/>
+        /// class with a culture.
+        /// </summary>
+        /// <param name="culture">The name of the culture.</param>
+        /// <remarks>
+        /// <para>
+        /// This constructor overload uses <paramref name="culture" /> for both
+        /// <see cref="Culture" /> and <see cref="UiCulture" />.
+        /// </para>
+        /// </remarks>
+        public UseCultureAttribute(string culture)
+            : this(culture, culture)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UseCultureAttribute"/>
+        /// class with a culture and a UI culture.
+        /// </summary>
+        /// <param name="culture">The name of the culture.</param>
+        /// <param name="uiCulture">The name of the UI culture.</param>
+        public UseCultureAttribute(string culture, string uiCulture)
+        {
+            this.culture = new Lazy<CultureInfo>(() => new CultureInfo(culture));
+            this.uiCulture = new Lazy<CultureInfo>(() => new CultureInfo(uiCulture));
+        }
+
+        /// <summary>
+        /// Gets the culture.
+        /// </summary>
+        /// <value>The culture.</value>
+        public CultureInfo Culture => this.culture.Value;
+
+        /// <summary>
+        /// Gets the UI culture.
+        /// </summary>
+        /// <value>The UI culture.</value>
+        public CultureInfo UiCulture => this.uiCulture.Value;
+
+        /// <summary>
+        /// Stores the current <see cref="Thread.CurrentPrincipal" />
+        /// <see cref="CultureInfo.CurrentCulture" /> and <see cref="CultureInfo.CurrentUICulture" />
+        /// and replaces them with the new cultures defined in the constructor.
+        /// </summary>
+        /// <param name="methodUnderTest">The method under test</param>
+        public override void Before(MethodInfo methodUnderTest)
+        {
+            this.originalCulture = Thread.CurrentThread.CurrentCulture;
+            this.originalUiCulture = Thread.CurrentThread.CurrentUICulture;
+
+            Thread.CurrentThread.CurrentCulture = this.Culture;
+            Thread.CurrentThread.CurrentUICulture = this.UiCulture;
+        }
+
+        /// <summary>
+        /// Restores the original <see cref="CultureInfo.CurrentCulture" /> and
+        /// <see cref="CultureInfo.CurrentUICulture" /> to <see cref="Thread.CurrentPrincipal" />
+        /// </summary>
+        /// <param name="methodUnderTest">The method under test</param>
+        public override void After(MethodInfo methodUnderTest)
+        {
+            Thread.CurrentThread.CurrentCulture = this.originalCulture;
+            Thread.CurrentThread.CurrentUICulture = this.originalUiCulture;
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/UseCultureAttribute.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/UseCultureAttribute.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.Helpers
     using System.Globalization;
     using System.Reflection;
     using System.Threading;
-
     using Xunit.Sdk;
 
     /// <summary>
@@ -26,9 +25,9 @@ namespace StyleCop.Analyzers.Test.Helpers
     {
         private readonly Lazy<CultureInfo> culture;
 
-#pragma warning disable SA1305
+#pragma warning disable SA1305 // Field names must not use Hungarian notation
         private readonly Lazy<CultureInfo> uiCulture;
-#pragma warning restore SA1305
+#pragma warning restore SA1305 // Field names must not use Hungarian notation
 
         private CultureInfo originalCulture;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -180,6 +180,7 @@
     <Compile Include="Helpers\MetadataReferences.cs" />
     <Compile Include="Helpers\TestDiagnosticProvider.cs" />
     <Compile Include="Helpers\TestXmlReferenceResolver.cs" />
+    <Compile Include="Helpers\UseCultureAttribute.cs" />
     <Compile Include="HelperTests\AccessLevelHelperTests.cs" />
     <Compile Include="HelperTests\IndentationHelperTests.cs" />
     <Compile Include="HelperTests\TokenHelperTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
@@ -89,6 +89,42 @@ namespace StyleCop.Analyzers.DocumentationRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Initializes a new instance of the .
+        /// </summary>
+        internal static string NonPrivateConstructorStandardTextFirstPart {
+            get {
+                return ResourceManager.GetString("NonPrivateConstructorStandardTextFirstPart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  {0}.
+        /// </summary>
+        internal static string NonPrivateConstructorStandardTextSecondPart {
+            get {
+                return ResourceManager.GetString("NonPrivateConstructorStandardTextSecondPart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Prevents a default instance of the .
+        /// </summary>
+        internal static string PrivateConstructorStandardTextFirstPart {
+            get {
+                return ResourceManager.GetString("PrivateConstructorStandardTextFirstPart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  {0} from being created.
+        /// </summary>
+        internal static string PrivateConstructorStandardTextSecondPart {
+            get {
+                return ResourceManager.GetString("PrivateConstructorStandardTextSecondPart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add standard text.
         /// </summary>
         internal static string PropertySummaryStartTextCodeFix {
@@ -634,6 +670,42 @@ namespace StyleCop.Analyzers.DocumentationRules {
         internal static string StartingTextSetsWhether {
             get {
                 return ResourceManager.GetString("StartingTextSetsWhether", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Initializes static members of the .
+        /// </summary>
+        internal static string StaticConstructorStandardTextFirstPart {
+            get {
+                return ResourceManager.GetString("StaticConstructorStandardTextFirstPart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  {0}..
+        /// </summary>
+        internal static string StaticConstructorStandardTextSecondPart {
+            get {
+                return ResourceManager.GetString("StaticConstructorStandardTextSecondPart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to class.
+        /// </summary>
+        internal static string TypeTextClass {
+            get {
+                return ResourceManager.GetString("TypeTextClass", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to struct.
+        /// </summary>
+        internal static string TypeTextStruct {
+            get {
+                return ResourceManager.GetString("TypeTextStruct", resourceCulture);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
@@ -62,6 +62,24 @@ namespace StyleCop.Analyzers.DocumentationRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Finalizes an instance of the .
+        /// </summary>
+        internal static string DestructorStandardTextFirstPart {
+            get {
+                return ResourceManager.GetString("DestructorStandardTextFirstPart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to  class..
+        /// </summary>
+        internal static string DestructorStandardTextSecondPart {
+            get {
+                return ResourceManager.GetString("DestructorStandardTextSecondPart", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Inherit documentation.
         /// </summary>
         internal static string InheritdocCodeFix {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.de-DE.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.de-DE.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="DestructorStandardTextFirstPart" xml:space="preserve">
+    <value>Finalisiert eine Instanz der </value>
+  </data>
+  <data name="DestructorStandardTextSecondPart" xml:space="preserve">
+    <value> Klasse.</value>
+  </data>
   <data name="StartingTextGets" xml:space="preserve">
     <value>Holt</value>
   </data>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.de-DE.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.de-DE.resx
@@ -1,0 +1,138 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="StartingTextGets" xml:space="preserve">
+    <value>Holt</value>
+  </data>
+  <data name="StartingTextGetsOrSets" xml:space="preserve">
+    <value>Holt oder setzt</value>
+  </data>
+  <data name="StartingTextGetsOrSetsWhether" xml:space="preserve">
+    <value>Holt oder setzt einen Wert, der angibt, ob</value>
+  </data>
+  <data name="StartingTextGetsWhether" xml:space="preserve">
+    <value>Holt einen Wert, der angibt, ob</value>
+  </data>
+  <data name="StartingTextSets" xml:space="preserve">
+    <value>Setzt</value>
+  </data>
+  <data name="StartingTextSetsWhether" xml:space="preserve">
+    <value>Setzt einen Wert, der angibt, ob</value>
+  </data>
+</root>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.de-DE.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.de-DE.resx
@@ -123,6 +123,18 @@
   <data name="DestructorStandardTextSecondPart" xml:space="preserve">
     <value> Klasse.</value>
   </data>
+  <data name="NonPrivateConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Initialisiert eine neue Instanz der </value>
+  </data>
+  <data name="NonPrivateConstructorStandardTextSecondPart" xml:space="preserve">
+    <value> {0}</value>
+  </data>
+  <data name="PrivateConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Verhindert, dass eine Standardinstanz der </value>
+  </data>
+  <data name="PrivateConstructorStandardTextSecondPart" xml:space="preserve">
+    <value> {0} erstellt wird</value>
+  </data>
   <data name="StartingTextGets" xml:space="preserve">
     <value>Holt</value>
   </data>
@@ -140,5 +152,17 @@
   </data>
   <data name="StartingTextSetsWhether" xml:space="preserve">
     <value>Setzt einen Wert, der angibt, ob</value>
+  </data>
+  <data name="StaticConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Initialisiert statische Member der </value>
+  </data>
+  <data name="StaticConstructorStandardTextSecondPart" xml:space="preserve">
+    <value> {0}.</value>
+  </data>
+  <data name="TypeTextClass" xml:space="preserve">
+    <value>Klasse</value>
+  </data>
+  <data name="TypeTextStruct" xml:space="preserve">
+    <value>Struktur</value>
   </data>
 </root>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.en-GB.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.en-GB.resx
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DestructorStandardTextFirstPart" xml:space="preserve">
+    <value>Finalises an instance of the </value>
+  </data>
+  <data name="DestructorStandardTextSecondPart" xml:space="preserve">
+    <value> class.</value>
+  </data>
+  <data name="NonPrivateConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Initialises a new instance of the </value>
+  </data>
+  <data name="NonPrivateConstructorStandardTextSecondPart" xml:space="preserve">
+    <value> {0}</value>
+  </data>
+  <data name="PrivateConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Prevents a default instance of the </value>
+  </data>
+  <data name="PrivateConstructorStandardTextSecondPart" xml:space="preserve">
+    <value> {0} from being created</value>
+  </data>
+  <data name="StartingTextGets" xml:space="preserve">
+    <value>Gets</value>
+  </data>
+  <data name="StartingTextGetsOrSets" xml:space="preserve">
+    <value>Gets or sets</value>
+  </data>
+  <data name="StartingTextGetsOrSetsWhether" xml:space="preserve">
+    <value>Gets or sets a value indicating whether</value>
+  </data>
+  <data name="StartingTextGetsWhether" xml:space="preserve">
+    <value>Gets a value indicating whether</value>
+  </data>
+  <data name="StartingTextSets" xml:space="preserve">
+    <value>Sets</value>
+  </data>
+  <data name="StartingTextSetsWhether" xml:space="preserve">
+    <value>Sets a value indicating whether</value>
+  </data>
+  <data name="StaticConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Initialises static members of the </value>
+  </data>
+  <data name="StaticConstructorStandardTextSecondPart" xml:space="preserve">
+    <value> {0}.</value>
+  </data>
+  <data name="TypeTextClass" xml:space="preserve">
+    <value>class</value>
+  </data>
+  <data name="TypeTextStruct" xml:space="preserve">
+    <value>struct</value>
+  </data>
+</root>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.es-MX.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.es-MX.resx
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DestructorStandardTextFirstPart" xml:space="preserve">
+    <value>Finaliza una instancia de la clase </value>
+  </data>
+  <data name="DestructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="NonPrivateConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Inicializa una nueva instancia de la {0} </value>
+  </data>
+  <data name="NonPrivateConstructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="PrivateConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Previene una instancia por defecto de la {0} </value>
+  </data>
+  <data name="PrivateConstructorStandardTextSecondPart" xml:space="preserve">
+    <value> sea creada</value>
+  </data>
+  <data name="StartingTextGets" xml:space="preserve">
+    <value>Obtiene</value>
+  </data>
+  <data name="StartingTextGetsOrSets" xml:space="preserve">
+    <value>Obtiene o establece</value>
+  </data>
+  <data name="StartingTextGetsOrSetsWhether" xml:space="preserve">
+    <value>Obtiene o establece un valor que indica si</value>
+  </data>
+  <data name="StartingTextGetsWhether" xml:space="preserve">
+    <value>Obtiene un valor que indica si</value>
+  </data>
+  <data name="StartingTextSets" xml:space="preserve">
+    <value>Establece</value>
+  </data>
+  <data name="StartingTextSetsWhether" xml:space="preserve">
+    <value>Establece un valor que indica si</value>
+  </data>
+  <data name="StaticConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Inicializa miembros estáticos de la {0} </value>
+  </data>
+  <data name="StaticConstructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="TypeTextClass" xml:space="preserve">
+    <value>clase</value>
+  </data>
+  <data name="TypeTextStruct" xml:space="preserve">
+    <value>struct</value>
+  </data>
+</root>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.fr-FR.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.fr-FR.resx
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DestructorStandardTextFirstPart" xml:space="preserve">
+    <value>Finalise une instance de la classe </value>
+  </data>
+  <data name="DestructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="NonPrivateConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Initialise une nouvelle instance de la {0} </value>
+  </data>
+  <data name="NonPrivateConstructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="PrivateConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Empêche la création d'une instance par défaut de la {0} </value>
+  </data>
+  <data name="PrivateConstructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="StartingTextGets" xml:space="preserve">
+    <value>Obtient</value>
+  </data>
+  <data name="StartingTextGetsOrSets" xml:space="preserve">
+    <value>Obtient ou définit</value>
+  </data>
+  <data name="StartingTextGetsOrSetsWhether" xml:space="preserve">
+    <value>Obtient ou définit une valeur indiquant si</value>
+  </data>
+  <data name="StartingTextGetsWhether" xml:space="preserve">
+    <value>Obtient une valeur indiquant si</value>
+  </data>
+  <data name="StartingTextSets" xml:space="preserve">
+    <value>Définit</value>
+  </data>
+  <data name="StartingTextSetsWhether" xml:space="preserve">
+    <value>Définit une valeur indiquant si</value>
+  </data>
+  <data name="StaticConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Initialise les membres statiques de la {0} </value>
+  </data>
+  <data name="StaticConstructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="TypeTextClass" xml:space="preserve">
+    <value>classe</value>
+  </data>
+  <data name="TypeTextStruct" xml:space="preserve">
+    <value>structure</value>
+  </data>
+</root>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.pl-PL.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.pl-PL.resx
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DestructorStandardTextFirstPart" xml:space="preserve">
+    <value>Finalizuje instancję klasy </value>
+  </data>
+  <data name="DestructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="NonPrivateConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Inicjalizuje nową instancję {0} </value>
+  </data>
+  <data name="NonPrivateConstructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="PrivateConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Uniemożliwia utworzenie domyślnej instancji {0} </value>
+  </data>
+  <data name="PrivateConstructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="StartingTextGets" xml:space="preserve">
+    <value>Pobiera</value>
+  </data>
+  <data name="StartingTextGetsOrSets" xml:space="preserve">
+    <value>Pobiera lub ustawia</value>
+  </data>
+  <data name="StartingTextGetsOrSetsWhether" xml:space="preserve">
+    <value>Pobiera lub ustawia wartość wskazującą czy</value>
+  </data>
+  <data name="StartingTextGetsWhether" xml:space="preserve">
+    <value>Pobiera wartość wskazującą czy</value>
+  </data>
+  <data name="StartingTextSets" xml:space="preserve">
+    <value>Ustawia</value>
+  </data>
+  <data name="StartingTextSetsWhether" xml:space="preserve">
+    <value>Ustawia wartość wskazującą czy</value>
+  </data>
+  <data name="StaticConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Inicjalizuje statyczne składowe {0} </value>
+  </data>
+  <data name="StaticConstructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="TypeTextClass" xml:space="preserve">
+    <value>klasy</value>
+  </data>
+  <data name="TypeTextStruct" xml:space="preserve">
+    <value>struktury</value>
+  </data>
+</root>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.pt-BR.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.pt-BR.resx
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DestructorStandardTextFirstPart" xml:space="preserve">
+    <value>Finaliza uma instância da classe </value>
+  </data>
+  <data name="DestructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="NonPrivateConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Inicia uma nova instância da {0} </value>
+  </data>
+  <data name="NonPrivateConstructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="PrivateConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Evita que uma instância default da {0} </value>
+  </data>
+  <data name="PrivateConstructorStandardTextSecondPart" xml:space="preserve">
+    <value> seja criada</value>
+  </data>
+  <data name="StartingTextGets" xml:space="preserve">
+    <value>Obtém</value>
+  </data>
+  <data name="StartingTextGetsOrSets" xml:space="preserve">
+    <value>Obtém ou define</value>
+  </data>
+  <data name="StartingTextGetsOrSetsWhether" xml:space="preserve">
+    <value>Obtém ou define um valor que indica se</value>
+  </data>
+  <data name="StartingTextGetsWhether" xml:space="preserve">
+    <value>Obtém um valor que indica se</value>
+  </data>
+  <data name="StartingTextSets" xml:space="preserve">
+    <value>Define</value>
+  </data>
+  <data name="StartingTextSetsWhether" xml:space="preserve">
+    <value>Define um valor que indica se</value>
+  </data>
+  <data name="StaticConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Inicia os membros estáticos da {0} </value>
+  </data>
+  <data name="StaticConstructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="TypeTextClass" xml:space="preserve">
+    <value>classe</value>
+  </data>
+  <data name="TypeTextStruct" xml:space="preserve">
+    <value>estrutura</value>
+  </data>
+</root>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="DestructorStandardTextFirstPart" xml:space="preserve">
+    <value>Finalizes an instance of the </value>
+  </data>
+  <data name="DestructorStandardTextSecondPart" xml:space="preserve">
+    <value> class.</value>
+  </data>
   <data name="InheritdocCodeFix" xml:space="preserve">
     <value>Inherit documentation</value>
   </data>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
@@ -126,6 +126,18 @@
   <data name="InheritdocCodeFix" xml:space="preserve">
     <value>Inherit documentation</value>
   </data>
+  <data name="NonPrivateConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Initializes a new instance of the </value>
+  </data>
+  <data name="NonPrivateConstructorStandardTextSecondPart" xml:space="preserve">
+    <value> {0}</value>
+  </data>
+  <data name="PrivateConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Prevents a default instance of the </value>
+  </data>
+  <data name="PrivateConstructorStandardTextSecondPart" xml:space="preserve">
+    <value> {0} from being created</value>
+  </data>
   <data name="PropertySummaryStartTextCodeFix" xml:space="preserve">
     <value>Add standard text</value>
   </data>
@@ -308,5 +320,17 @@
   </data>
   <data name="StartingTextSetsWhether" xml:space="preserve">
     <value>Sets a value indicating whether</value>
+  </data>
+  <data name="StaticConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Initializes static members of the </value>
+  </data>
+  <data name="StaticConstructorStandardTextSecondPart" xml:space="preserve">
+    <value> {0}.</value>
+  </data>
+  <data name="TypeTextClass" xml:space="preserve">
+    <value>class</value>
+  </data>
+  <data name="TypeTextStruct" xml:space="preserve">
+    <value>struct</value>
   </data>
 </root>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.ru-RU.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.ru-RU.resx
@@ -1,0 +1,168 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="DestructorStandardTextFirstPart" xml:space="preserve">
+    <value>Уничтожает экземпляр класса </value>
+  </data>
+  <data name="DestructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="NonPrivateConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Инициализирует новый экземпляр {0} </value>
+  </data>
+  <data name="NonPrivateConstructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="PrivateConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Предотвращает вызов конструктора по умолчанию для {0} </value>
+  </data>
+  <data name="PrivateConstructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="StartingTextGets" xml:space="preserve">
+    <value>Получает</value>
+  </data>
+  <data name="StartingTextGetsOrSets" xml:space="preserve">
+    <value>Получает или задает</value>
+  </data>
+  <data name="StartingTextGetsOrSetsWhether" xml:space="preserve">
+    <value>Получает или задает значение, показывающее,</value>
+  </data>
+  <data name="StartingTextGetsWhether" xml:space="preserve">
+    <value>Получает значение, показывающее,</value>
+  </data>
+  <data name="StartingTextSets" xml:space="preserve">
+    <value>Задает</value>
+  </data>
+  <data name="StartingTextSetsWhether" xml:space="preserve">
+    <value>Задает значение, показывающее,</value>
+  </data>
+  <data name="StaticConstructorStandardTextFirstPart" xml:space="preserve">
+    <value>Инициализирует статические поля {0} </value>
+  </data>
+  <data name="StaticConstructorStandardTextSecondPart" xml:space="preserve">
+    <value />
+  </data>
+  <data name="TypeTextClass" xml:space="preserve">
+    <value>класса</value>
+  </data>
+  <data name="TypeTextStruct" xml:space="preserve">
+    <value>структуры</value>
+  </data>
+</root>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
@@ -5,6 +5,8 @@ namespace StyleCop.Analyzers.DocumentationRules
 {
     using System;
     using System.Collections.Immutable;
+    using System.Globalization;
+    using System.Threading;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -28,13 +30,6 @@ namespace StyleCop.Analyzers.DocumentationRules
         private static readonly LocalizableString SA1623MessageFormat = new LocalizableResourceString(nameof(DocumentationResources.SA1623MessageFormat), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1623Description = new LocalizableResourceString(nameof(DocumentationResources.SA1623Description), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly string SA1623HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1623.md";
-
-        private static readonly string StartingTextGets = DocumentationResources.StartingTextGets;
-        private static readonly string StartingTextSets = DocumentationResources.StartingTextSets;
-        private static readonly string StartingTextGetsOrSets = DocumentationResources.StartingTextGetsOrSets;
-        private static readonly string StartingTextGetsWhether = DocumentationResources.StartingTextGetsWhether;
-        private static readonly string StartingTextSetsWhether = DocumentationResources.StartingTextSetsWhether;
-        private static readonly string StartingTextGetsOrSetsWhether = DocumentationResources.StartingTextGetsOrSetsWhether;
 
         private static readonly LocalizableString SA1624Title = new LocalizableResourceString(nameof(DocumentationResources.SA1624Title), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString SA1624MessageFormat = new LocalizableResourceString(nameof(DocumentationResources.SA1624MessageFormat), DocumentationResources.ResourceManager, typeof(DocumentationResources));
@@ -67,14 +62,31 @@ namespace StyleCop.Analyzers.DocumentationRules
         {
             var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
             var propertyType = context.SemanticModel.GetTypeInfo(propertyDeclaration.Type);
+            var settings = context.Options.GetStyleCopSettings(CancellationToken.None);
+            var culture = new CultureInfo(settings.DocumentationRules.DocumentationCulture);
+            var resourceManager = DocumentationResources.ResourceManager;
 
             if (propertyType.Type.SpecialType == SpecialType.System_Boolean)
             {
-                AnalyzeSummaryElement(context, syntax, diagnosticLocation, propertyDeclaration, StartingTextGetsWhether, StartingTextSetsWhether, StartingTextGetsOrSetsWhether);
+                AnalyzeSummaryElement(
+                    context,
+                    syntax,
+                    diagnosticLocation,
+                    propertyDeclaration,
+                    resourceManager.GetString("StartingTextGetsWhether", culture),
+                    resourceManager.GetString("StartingTextSetsWhether", culture),
+                    resourceManager.GetString("StartingTextGetsOrSetsWhether", culture));
             }
             else
             {
-                AnalyzeSummaryElement(context, syntax, diagnosticLocation, propertyDeclaration, StartingTextGets, StartingTextSets, StartingTextGetsOrSets);
+                AnalyzeSummaryElement(
+                    context,
+                    syntax,
+                    diagnosticLocation,
+                    propertyDeclaration,
+                    resourceManager.GetString("StartingTextGets", culture),
+                    resourceManager.GetString("StartingTextSets", culture),
+                    resourceManager.GetString("StartingTextGetsOrSets", culture));
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.DocumentationRules
     using System;
     using System.Collections.Immutable;
     using System.Globalization;
-    using System.Threading;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -62,7 +61,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         {
             var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
             var propertyType = context.SemanticModel.GetTypeInfo(propertyDeclaration.Type);
-            var settings = context.Options.GetStyleCopSettings(CancellationToken.None);
+            var settings = context.Options.GetStyleCopSettings(context.CancellationToken);
             var culture = new CultureInfo(settings.DocumentationRules.DocumentationCulture);
             var resourceManager = DocumentationResources.ResourceManager;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
@@ -72,9 +72,9 @@ namespace StyleCop.Analyzers.DocumentationRules
                     syntax,
                     diagnosticLocation,
                     propertyDeclaration,
-                    resourceManager.GetString("StartingTextGetsWhether", culture),
-                    resourceManager.GetString("StartingTextSetsWhether", culture),
-                    resourceManager.GetString("StartingTextGetsOrSetsWhether", culture));
+                    resourceManager.GetString(nameof(DocumentationResources.StartingTextGetsWhether), culture),
+                    resourceManager.GetString(nameof(DocumentationResources.StartingTextSetsWhether), culture),
+                    resourceManager.GetString(nameof(DocumentationResources.StartingTextGetsOrSetsWhether), culture));
             }
             else
             {
@@ -83,9 +83,9 @@ namespace StyleCop.Analyzers.DocumentationRules
                     syntax,
                     diagnosticLocation,
                     propertyDeclaration,
-                    resourceManager.GetString("StartingTextGets", culture),
-                    resourceManager.GetString("StartingTextSets", culture),
-                    resourceManager.GetString("StartingTextGetsOrSets", culture));
+                    resourceManager.GetString(nameof(DocumentationResources.StartingTextGets), culture),
+                    resourceManager.GetString(nameof(DocumentationResources.StartingTextSets), culture),
+                    resourceManager.GetString(nameof(DocumentationResources.StartingTextGetsOrSets), culture));
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -140,7 +140,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             {
                 HandleDeclaration(
                     context,
-                    resourceManager.GetString("StaticConstructorStandardTextFirstPart", culture),
+                    string.Format(resourceManager.GetString("StaticConstructorStandardTextFirstPart", culture), typeKindText),
                     string.Format(resourceManager.GetString("StaticConstructorStandardTextSecondPart", culture), typeKindText),
                     Descriptor);
             }
@@ -148,7 +148,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             {
                 var privateConstructorMatch = HandleDeclaration(
                     context,
-                    resourceManager.GetString("PrivateConstructorStandardTextFirstPart", culture),
+                    string.Format(resourceManager.GetString("PrivateConstructorStandardTextFirstPart", culture), typeKindText),
                     string.Format(
                         resourceManager.GetString("PrivateConstructorStandardTextSecondPart", culture),
                         typeKindText),
@@ -162,7 +162,8 @@ namespace StyleCop.Analyzers.DocumentationRules
                 // also allow the non-private wording for private constructors
                 HandleDeclaration(
                     context,
-                    resourceManager.GetString("NonPrivateConstructorStandardTextFirstPart", culture),
+                    string.Format(resourceManager.GetString("NonPrivateConstructorStandardTextFirstPart", culture),
+                        typeKindText),
                     string.Format(
                         resourceManager.GetString("NonPrivateConstructorStandardTextSecondPart", culture),
                         typeKindText),
@@ -172,7 +173,8 @@ namespace StyleCop.Analyzers.DocumentationRules
             {
                 HandleDeclaration(
                     context,
-                    resourceManager.GetString("NonPrivateConstructorStandardTextFirstPart", culture),
+                    string.Format(resourceManager.GetString("NonPrivateConstructorStandardTextFirstPart", culture),
+                        typeKindText),
                     string.Format(
                         resourceManager.GetString("NonPrivateConstructorStandardTextSecondPart", culture),
                         typeKindText),

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -7,8 +7,6 @@ namespace StyleCop.Analyzers.DocumentationRules
     using System.Collections.Immutable;
     using System.Globalization;
     using System.Linq;
-    using System.Threading;
-
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -129,7 +127,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         {
             var constructorDeclarationSyntax = (ConstructorDeclarationSyntax)context.Node;
 
-            var settings = context.Options.GetStyleCopSettings(CancellationToken.None);
+            var settings = context.Options.GetStyleCopSettings(context.CancellationToken);
             var culture = new CultureInfo(settings.DocumentationRules.DocumentationCulture);
             var resourceManager = DocumentationResources.ResourceManager;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -162,7 +162,8 @@ namespace StyleCop.Analyzers.DocumentationRules
                 // also allow the non-private wording for private constructors
                 HandleDeclaration(
                     context,
-                    string.Format(resourceManager.GetString("NonPrivateConstructorStandardTextFirstPart", culture),
+                    string.Format(
+                        resourceManager.GetString("NonPrivateConstructorStandardTextFirstPart", culture),
                         typeKindText),
                     string.Format(
                         resourceManager.GetString("NonPrivateConstructorStandardTextSecondPart", culture),
@@ -173,7 +174,8 @@ namespace StyleCop.Analyzers.DocumentationRules
             {
                 HandleDeclaration(
                     context,
-                    string.Format(resourceManager.GetString("NonPrivateConstructorStandardTextFirstPart", culture),
+                    string.Format(
+                        resourceManager.GetString("NonPrivateConstructorStandardTextFirstPart", culture),
                         typeKindText),
                     string.Format(
                         resourceManager.GetString("NonPrivateConstructorStandardTextSecondPart", culture),

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -132,23 +132,23 @@ namespace StyleCop.Analyzers.DocumentationRules
             var resourceManager = DocumentationResources.ResourceManager;
 
             bool isStruct = constructorDeclarationSyntax.Parent?.IsKind(SyntaxKind.StructDeclaration) ?? false;
-            var typeKindText = resourceManager.GetString(isStruct ? "TypeTextStruct" : "TypeTextClass", culture);
+            var typeKindText = resourceManager.GetString(isStruct ? nameof(DocumentationResources.TypeTextStruct) : nameof(DocumentationResources.TypeTextClass), culture);
 
             if (constructorDeclarationSyntax.Modifiers.Any(SyntaxKind.StaticKeyword))
             {
                 HandleDeclaration(
                     context,
-                    string.Format(resourceManager.GetString("StaticConstructorStandardTextFirstPart", culture), typeKindText),
-                    string.Format(resourceManager.GetString("StaticConstructorStandardTextSecondPart", culture), typeKindText),
+                    string.Format(resourceManager.GetString(nameof(DocumentationResources.StaticConstructorStandardTextFirstPart), culture), typeKindText),
+                    string.Format(resourceManager.GetString(nameof(DocumentationResources.StaticConstructorStandardTextSecondPart), culture), typeKindText),
                     Descriptor);
             }
             else if (constructorDeclarationSyntax.Modifiers.Any(SyntaxKind.PrivateKeyword))
             {
                 var privateConstructorMatch = HandleDeclaration(
                     context,
-                    string.Format(resourceManager.GetString("PrivateConstructorStandardTextFirstPart", culture), typeKindText),
+                    string.Format(resourceManager.GetString(nameof(DocumentationResources.PrivateConstructorStandardTextFirstPart), culture), typeKindText),
                     string.Format(
-                        resourceManager.GetString("PrivateConstructorStandardTextSecondPart", culture),
+                        resourceManager.GetString(nameof(DocumentationResources.PrivateConstructorStandardTextSecondPart), culture),
                         typeKindText),
                     null);
 
@@ -161,10 +161,10 @@ namespace StyleCop.Analyzers.DocumentationRules
                 HandleDeclaration(
                     context,
                     string.Format(
-                        resourceManager.GetString("NonPrivateConstructorStandardTextFirstPart", culture),
+                        resourceManager.GetString(nameof(DocumentationResources.NonPrivateConstructorStandardTextFirstPart), culture),
                         typeKindText),
                     string.Format(
-                        resourceManager.GetString("NonPrivateConstructorStandardTextSecondPart", culture),
+                        resourceManager.GetString(nameof(DocumentationResources.NonPrivateConstructorStandardTextSecondPart), culture),
                         typeKindText),
                     Descriptor);
             }
@@ -173,10 +173,10 @@ namespace StyleCop.Analyzers.DocumentationRules
                 HandleDeclaration(
                     context,
                     string.Format(
-                        resourceManager.GetString("NonPrivateConstructorStandardTextFirstPart", culture),
+                        resourceManager.GetString(nameof(DocumentationResources.NonPrivateConstructorStandardTextFirstPart), culture),
                         typeKindText),
                     string.Format(
-                        resourceManager.GetString("NonPrivateConstructorStandardTextSecondPart", culture),
+                        resourceManager.GetString(nameof(DocumentationResources.NonPrivateConstructorStandardTextSecondPart), culture),
                         typeKindText),
                     Descriptor);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -112,50 +112,6 @@ namespace StyleCop.Analyzers.DocumentationRules
 
         private static readonly Action<SyntaxNodeAnalysisContext> ConstructorDeclarationAction = HandleConstructorDeclaration;
 
-        /// <summary>
-        /// Gets the standard text which is expected to appear at the beginning of the <c>&lt;summary&gt;</c>
-        /// documentation for a non-private constructor.
-        /// </summary>
-        /// <value>
-        /// The standard text which is expected to appear at the beginning of the <c>&lt;summary&gt;</c> documentation
-        /// for a non-private constructor. This text appears before the name of the containing class, followed by a
-        /// <c>&lt;see&gt;</c> element targeting the containing type, and finally followed by <c>class</c> or
-        /// <c>struct</c> as appropriate for the containing type.
-        /// </value>
-        public static string NonPrivateConstructorStandardText { get; } = "Initializes a new instance of the ";
-
-        /// <summary>
-        /// Gets the standard text which is expected to appear at the beginning of the <c>&lt;summary&gt;</c>
-        /// documentation for a private constructor.
-        /// </summary>
-        /// <remarks>
-        /// <para>In addition to the format given in <see cref="PrivateConstructorStandardText"/>, a private constructor
-        /// may choose to use <see cref="NonPrivateConstructorStandardText"/> instead. The code fix provided for this
-        /// diagnostic uses <see cref="NonPrivateConstructorStandardText"/> by default, since this is generally a more
-        /// accurate representation of a user's intent. In new code, <see langword="static"/> classes provide a
-        /// superior alternative to private constructors for the purpose of declaring utility types that cannot be
-        /// instantiated.</para>
-        /// </remarks>
-        /// <value>
-        /// The standard text which is expected to appear at the beginning of the <c>&lt;summary&gt;</c> documentation
-        /// for a private constructor. The first element appears before the name of the containing class, followed by a
-        /// <c>&lt;see&gt;</c> element targeting the containing type, then by <c>class</c> or <c>struct</c> as
-        /// appropriate for the containing type, and finally followed by the second element of this array.
-        /// </value>
-        public static ImmutableArray<string> PrivateConstructorStandardText { get; } = ImmutableArray.Create("Prevents a default instance of the ", " from being created");
-
-        /// <summary>
-        /// Gets the standard text which is expected to appear at the beginning of the <c>&lt;summary&gt;</c>
-        /// documentation for a static constructor.
-        /// </summary>
-        /// <value>
-        /// The standard text which is expected to appear at the beginning of the <c>&lt;summary&gt;</c> documentation
-        /// for a static constructor. The first element appears before the name of the containing class, followed by a
-        /// <c>&lt;see&gt;</c> element targeting the containing type, and finally followed by <c>class</c> or
-        /// <c>struct</c> as appropriate for the containing type.
-        /// </value>
-        public static string StaticConstructorStandardText { get; } = "Initializes static members of the ";
-
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
             ImmutableArray.Create(Descriptor);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1643DestructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1643DestructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -5,6 +5,9 @@ namespace StyleCop.Analyzers.DocumentationRules
 {
     using System;
     using System.Collections.Immutable;
+    using System.Globalization;
+    using System.Threading;
+
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -96,7 +99,15 @@ namespace StyleCop.Analyzers.DocumentationRules
 
             if (destructorDeclaration != null)
             {
-                HandleDeclaration(context, DestructorStandardText[0], DestructorStandardText[1], Descriptor);
+                var settings = context.Options.GetStyleCopSettings(CancellationToken.None);
+                var culture = new CultureInfo(settings.DocumentationRules.DocumentationCulture);
+                var resourceManager = DocumentationResources.ResourceManager;
+
+                HandleDeclaration(
+                    context,
+                    resourceManager.GetString("DestructorStandardTextFirstPart", culture),
+                    resourceManager.GetString("DestructorStandardTextSecondPart", culture),
+                    Descriptor);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1643DestructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1643DestructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -91,8 +91,8 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                 HandleDeclaration(
                     context,
-                    resourceManager.GetString("DestructorStandardTextFirstPart", culture),
-                    resourceManager.GetString("DestructorStandardTextSecondPart", culture),
+                    resourceManager.GetString(nameof(DocumentationResources.DestructorStandardTextFirstPart), culture),
+                    resourceManager.GetString(nameof(DocumentationResources.DestructorStandardTextSecondPart), culture),
                     Descriptor);
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1643DestructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1643DestructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -6,8 +6,6 @@ namespace StyleCop.Analyzers.DocumentationRules
     using System;
     using System.Collections.Immutable;
     using System.Globalization;
-    using System.Threading;
-
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -87,7 +85,7 @@ namespace StyleCop.Analyzers.DocumentationRules
 
             if (destructorDeclaration != null)
             {
-                var settings = context.Options.GetStyleCopSettings(CancellationToken.None);
+                var settings = context.Options.GetStyleCopSettings(context.CancellationToken);
                 var culture = new CultureInfo(settings.DocumentationRules.DocumentationCulture);
                 var resourceManager = DocumentationResources.ResourceManager;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1643DestructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1643DestructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -68,18 +68,6 @@ namespace StyleCop.Analyzers.DocumentationRules
 
         private static readonly Action<SyntaxNodeAnalysisContext> DestructorDeclarationAction = HandleDestructor;
 
-        /// <summary>
-        /// Gets the standard text which is expected to appear at the beginning of the <c>&lt;summary&gt;</c>
-        /// documentation for a destructor.
-        /// </summary>
-        /// <value>
-        /// A two-element array containing the standard text which is expected to appear at the beginning of the
-        /// <c>&lt;summary&gt;</c> documentation for a destructor. The first element appears before the name of the
-        /// containing class, followed by a <c>&lt;see&gt;</c> element targeting the containing type, and finally
-        /// followed by the second element of this array.
-        /// </value>
-        public static ImmutableArray<string> DestructorStandardText { get; } = ImmutableArray.Create("Finalizes an instance of the ", " class.");
-
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
             ImmutableArray.Create(Descriptor);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/DocumentationSettings.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/DocumentationSettings.cs
@@ -100,7 +100,7 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
         /// <summary>
         /// This is the backing field for the <see cref="DocumentationCulture"/> property.
         /// </summary>
-        [JsonProperty("documentationCulture", DefaultValueHandling = DefaultValueHandling.Include)]
+        [JsonProperty("documentationCulture", DefaultValueHandling = DefaultValueHandling.Ignore)]
         private string documentationCulture;
 
         /// <summary>
@@ -121,9 +121,9 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
             this.documentInterfaces = true;
             this.documentPrivateFields = false;
 
-            this.documentationCulture = DefaultDocumentationCulture;
-
             this.fileNamingConvention = FileNamingConvention.StyleCop;
+
+            this.documentationCulture = DefaultDocumentationCulture;
         }
 
         public string CompanyName

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/DocumentationSettings.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/DocumentationSettings.cs
@@ -22,6 +22,11 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
         internal const string DefaultCopyrightText = "Copyright (c) {companyName}. All rights reserved.";
 
         /// <summary>
+        /// The default value for the <see cref="DocumentationCulture"/> property.
+        /// </summary>
+        internal const string DefaultDocumentationCulture = "en-US";
+
+        /// <summary>
         /// This is the backing field for the <see cref="CompanyName"/> property.
         /// </summary>
         [JsonProperty("companyName", DefaultValueHandling = DefaultValueHandling.Ignore)]
@@ -93,6 +98,12 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
         private FileNamingConvention fileNamingConvention;
 
         /// <summary>
+        /// This is the backing field for the <see cref="DocumentationCulture"/> property.
+        /// </summary>
+        [JsonProperty("documentationCulture", DefaultValueHandling = DefaultValueHandling.Include)]
+        private string documentationCulture;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="DocumentationSettings"/> class during JSON deserialization.
         /// </summary>
         [JsonConstructor]
@@ -109,6 +120,8 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
             this.documentPrivateElements = false;
             this.documentInterfaces = true;
             this.documentPrivateFields = false;
+
+            this.documentationCulture = DefaultDocumentationCulture;
 
             this.fileNamingConvention = FileNamingConvention.StyleCop;
         }
@@ -162,6 +175,9 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
 
         public FileNamingConvention FileNamingConvention =>
             this.fileNamingConvention;
+
+        public string DocumentationCulture =>
+            this.documentationCulture;
 
         public string GetCopyrightText(string fileName)
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json
@@ -204,6 +204,11 @@
               "description": "Specifies the preferred naming convention for files. The default value \"stylecop\" uses the naming convention defined by StyleCop Classic, while \"metadata\" uses a file naming convention that matches the metadata names of types.",
               "default": "stylecop",
               "enum": [ "stylecop", "metadata" ]
+            },
+            "documentationCulture": {
+                "type": "string",
+                "description": "The culture that should be used for documentation comments.",
+                "default": "en-US"
             }
           }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -61,6 +61,11 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>DocumentationResources.de-DE.resx</DependentUpon>
     </Compile>
+    <Compile Include="DocumentationRules\DocumentationResources.en-GB.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>DocumentationResources.en-GB.resx</DependentUpon>
+    </Compile>
     <Compile Include="DocumentationRules\ElementDocumentationBase.cs" />
     <Compile Include="DocumentationRules\ElementDocumentationSummaryBase.cs" />
     <Compile Include="DocumentationRules\FileHeaderAnalyzers.cs" />
@@ -404,6 +409,10 @@
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="DocumentationRules\DocumentationResources.en-GB.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>DocumentationResources.en-GB.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
     <EmbeddedResource Include="DocumentationRules\DocumentationResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>DocumentationResources.Designer.cs</LastGenOutput>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -76,6 +76,16 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>DocumentationResources.fr-FR.resx</DependentUpon>
     </Compile>
+    <Compile Include="DocumentationRules\DocumentationResources.pl-PL.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>DocumentationResources.pl-PL.resx</DependentUpon>
+    </Compile>
+    <Compile Include="DocumentationRules\DocumentationResources.pt-BR.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>DocumentationResources.pt-BR.resx</DependentUpon>
+    </Compile>
     <Compile Include="DocumentationRules\ElementDocumentationBase.cs" />
     <Compile Include="DocumentationRules\ElementDocumentationSummaryBase.cs" />
     <Compile Include="DocumentationRules\FileHeaderAnalyzers.cs" />
@@ -430,6 +440,14 @@
     <EmbeddedResource Include="DocumentationRules\DocumentationResources.fr-FR.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>DocumentationResources.fr-FR.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="DocumentationRules\DocumentationResources.pl-PL.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>DocumentationResources.pl-PL.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="DocumentationRules\DocumentationResources.pt-BR.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>DocumentationResources.pt-BR.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="DocumentationRules\DocumentationResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -66,6 +66,11 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>DocumentationResources.en-GB.resx</DependentUpon>
     </Compile>
+    <Compile Include="DocumentationRules\DocumentationResources.es-MX.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>DocumentationResources.es-MX.resx</DependentUpon>
+    </Compile>
     <Compile Include="DocumentationRules\ElementDocumentationBase.cs" />
     <Compile Include="DocumentationRules\ElementDocumentationSummaryBase.cs" />
     <Compile Include="DocumentationRules\FileHeaderAnalyzers.cs" />
@@ -412,6 +417,10 @@
     <EmbeddedResource Include="DocumentationRules\DocumentationResources.en-GB.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>DocumentationResources.en-GB.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="DocumentationRules\DocumentationResources.es-MX.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>DocumentationResources.es-MX.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="DocumentationRules\DocumentationResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -56,36 +56,6 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>DocumentationResources.resx</DependentUpon>
     </Compile>
-    <Compile Include="DocumentationRules\DocumentationResources.de-DE.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>DocumentationResources.de-DE.resx</DependentUpon>
-    </Compile>
-    <Compile Include="DocumentationRules\DocumentationResources.en-GB.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>DocumentationResources.en-GB.resx</DependentUpon>
-    </Compile>
-    <Compile Include="DocumentationRules\DocumentationResources.es-MX.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>DocumentationResources.es-MX.resx</DependentUpon>
-    </Compile>
-    <Compile Include="DocumentationRules\DocumentationResources.fr-FR.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>DocumentationResources.fr-FR.resx</DependentUpon>
-    </Compile>
-    <Compile Include="DocumentationRules\DocumentationResources.pl-PL.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>DocumentationResources.pl-PL.resx</DependentUpon>
-    </Compile>
-    <Compile Include="DocumentationRules\DocumentationResources.pt-BR.Designer.cs">
-      <AutoGen>True</AutoGen>
-      <DesignTime>True</DesignTime>
-      <DependentUpon>DocumentationResources.pt-BR.resx</DependentUpon>
-    </Compile>
     <Compile Include="DocumentationRules\ElementDocumentationBase.cs" />
     <Compile Include="DocumentationRules\ElementDocumentationSummaryBase.cs" />
     <Compile Include="DocumentationRules\FileHeaderAnalyzers.cs" />
@@ -429,33 +399,30 @@
     <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.0.0\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="DocumentationRules\DocumentationResources.de-DE.resx">
+      <DependentUpon>DocumentationResources.resx</DependentUpon>
+    </EmbeddedResource>
     <EmbeddedResource Include="DocumentationRules\DocumentationResources.en-GB.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>DocumentationResources.en-GB.Designer.cs</LastGenOutput>
+      <DependentUpon>DocumentationResources.resx</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="DocumentationRules\DocumentationResources.es-MX.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>DocumentationResources.es-MX.Designer.cs</LastGenOutput>
+      <DependentUpon>DocumentationResources.resx</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="DocumentationRules\DocumentationResources.fr-FR.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>DocumentationResources.fr-FR.Designer.cs</LastGenOutput>
+      <DependentUpon>DocumentationResources.resx</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="DocumentationRules\DocumentationResources.pl-PL.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>DocumentationResources.pl-PL.Designer.cs</LastGenOutput>
+      <DependentUpon>DocumentationResources.resx</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="DocumentationRules\DocumentationResources.pt-BR.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>DocumentationResources.pt-BR.Designer.cs</LastGenOutput>
+      <DependentUpon>DocumentationResources.resx</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="DocumentationRules\DocumentationResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>DocumentationResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
-    <EmbeddedResource Include="DocumentationRules\DocumentationResources.de-DE.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>DocumentationResources.de-DE.Designer.cs</LastGenOutput>
+    <EmbeddedResource Include="DocumentationRules\DocumentationResources.ru-RU.resx">
+      <DependentUpon>DocumentationResources.resx</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="Helpers\HelpersResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -71,6 +71,11 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>DocumentationResources.es-MX.resx</DependentUpon>
     </Compile>
+    <Compile Include="DocumentationRules\DocumentationResources.fr-FR.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>DocumentationResources.fr-FR.resx</DependentUpon>
+    </Compile>
     <Compile Include="DocumentationRules\ElementDocumentationBase.cs" />
     <Compile Include="DocumentationRules\ElementDocumentationSummaryBase.cs" />
     <Compile Include="DocumentationRules\FileHeaderAnalyzers.cs" />
@@ -421,6 +426,10 @@
     <EmbeddedResource Include="DocumentationRules\DocumentationResources.es-MX.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>DocumentationResources.es-MX.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="DocumentationRules\DocumentationResources.fr-FR.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>DocumentationResources.fr-FR.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="DocumentationRules\DocumentationResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -56,6 +56,11 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>DocumentationResources.resx</DependentUpon>
     </Compile>
+    <Compile Include="DocumentationRules\DocumentationResources.de-DE.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>DocumentationResources.de-DE.resx</DependentUpon>
+    </Compile>
     <Compile Include="DocumentationRules\ElementDocumentationBase.cs" />
     <Compile Include="DocumentationRules\ElementDocumentationSummaryBase.cs" />
     <Compile Include="DocumentationRules\FileHeaderAnalyzers.cs" />
@@ -402,6 +407,10 @@
     <EmbeddedResource Include="DocumentationRules\DocumentationResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>DocumentationResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+    <EmbeddedResource Include="DocumentationRules\DocumentationResources.de-DE.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>DocumentationResources.de-DE.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="Helpers\HelpersResources.resx">
       <Generator>ResXFileCodeGenerator</Generator>

--- a/documentation/Configuration.md
+++ b/documentation/Configuration.md
@@ -454,6 +454,44 @@ The following example shows a configuration file which requires developers to do
 }
 ```
 
+### Documentation Culture
+
+Some documentation rules require summary texts to start with specific strings. To allow teams to document their code in their native language, **stylecop.json** contains the `documentationCulture` property.
+
+| Property | Default Value | Summary |
+| --- | --- | --- |
+| `documentationCulture` | `"en-US"` | Specifies the culture or language to be used for certain documentation texts. |
+
+This property affects the behavior of the following rules which report incorrect documentation.
+
+* [SA1623 Property summary documentation must match accessors](SA1623.md)
+* [SA1624 Property summary documentation must omit set accessor with restricted access](SA1624.md)
+* [SA1642 Constructor summary documentation must begin with standard text](SA1642.md)
+* [SA1643 Destructor summary documentation must begin with standard text](SA1643.md)
+
+> :memo: The default value for `documentationCulture` is fixed instead of reflecting the user's system language. This is to ensure that different developers working on the same project always use the same value.
+
+The following values are currently supported. Unsupported values will automatically fall back to the default value.
+
+* `"de-DE"`
+* `"en-GB"`
+* `"en-US"`
+* `"es-MX"`
+* `"fr-FR"`
+* `"pl-PL"`
+* `"pt-BR"`
+* `"ru-RU"`
+
+```json
+{
+  "settings": {
+    "documentationRules": {
+      "documentationCulture": "de-DE"
+    }
+  }
+}
+```
+
 ### File naming conventions
 
 The `fileNamingConvention` property will determine how the [SA1649 File name must match type name](SA1649.md) analyzer will check file names.


### PR DESCRIPTION
As described, this allows the user to set a culture for documentation texts (such as summary texts for properties and constructors) in `stylecop.json`

**Currently implemented:**
- [x] Add entry to settings file
- [x] Property summaries (SA1623, SA1624)
- [x] Constructor summaries (SA1642)
- [x] Destructor summaries (SA1643)
- [x] Resource file for `de-DE`
- [x] Resource file for `en-GB`
- [x] Resource file for `es-MX`
- [x] Resource file for `fr-FR`
- [x] Resource file for `pl-PL`
- [x] Resource file for `pt-BR`
- [x] Resource file for `ru-RU`
- [x] Update configuration documentation

Fixes #1143