### PR TITLE
Remove individual contributor name from file headers

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1139CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1139CodeFixProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-/* Contributor: Tomasz Maczyński */
-
 namespace StyleCop.Analyzers.ReadabilityRules
 {
     using System.Collections.Generic;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1139UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1139UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-/* Contributor: Tomasz Maczyński */
-
 namespace StyleCop.Analyzers.Test.ReadabilityRules
 {
     using System.Collections.Generic;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/LiteralExpressionHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/LiteralExpressionHelpers.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-/* Contributor: Tomasz Maczyński */
-
 namespace StyleCop.Analyzers.Helpers
 {
     using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1139UseLiteralSuffixNotationInsteadOfCasting.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1139UseLiteralSuffixNotationInsteadOfCasting.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-/* Contributor: Tomasz Maczyński */
-
 namespace StyleCop.Analyzers.ReadabilityRules
 {
     using System;


### PR DESCRIPTION
@tmaczynski This change removes the contributor comment you included in new files in #2148. My specific concerns here are the following:

1. You are the only contributor mentioned in this manner. Many other users have contributed code, but files they created are not identified in this way.
2. While you did *create* the file, this leaves a big question regarding how to handle *updates* to the file.

So far I've found it easier to include contributors in the following ways:

1. The source control history
2. An explicit mention of people involved with each release on the [release notes](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/releases) pages

:question: Do you have any objection to me removing these lines and proceeding with the existing mechanism for acknowledging contributions?