### PR TITLE
Updated unit tests for SA1402 and SA1649 to verify both file content and file names

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1649UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1649UnitTests.cs
@@ -4,12 +4,8 @@
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
     using System.Collections.Generic;
-    using System.Collections.Immutable;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CodeActions;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.DocumentationRules;
@@ -62,7 +58,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [MemberData(nameof(TypeKeywords))]
         public async Task VerifyWrongFileNameAsync(string typeKeyword)
         {
-            var testCode = $@"namespace TestNameSpace
+            var testCode = $@"namespace TestNamespace
 {{
     public {typeKeyword} TestType
     {{
@@ -81,7 +77,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             var expectedDiagnostic = this.CSharpDiagnostic().WithLocation("WrongFileName.cs", 3, 13 + typeKeyword.Length);
             await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None, "WrongFileName.cs").ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None, "TestType.cs").ConfigureAwait(false);
-            await this.VerifyRenameAsync(testCode, "WrongFileName.cs", "TestType.cs", CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, oldFileName: "WrongFileName.cs", newFileName: "TestType.cs", cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -94,7 +90,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [MemberData(nameof(TypeKeywords))]
         public async Task VerifyWrongFileNameMultipleExtensionsAsync(string typeKeyword)
         {
-            var testCode = $@"namespace TestNameSpace
+            var testCode = $@"namespace TestNamespace
 {{
     public {typeKeyword} TestType
     {{
@@ -113,7 +109,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             var expectedDiagnostic = this.CSharpDiagnostic().WithLocation("WrongFileName.svc.cs", 3, 13 + typeKeyword.Length);
             await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None, "WrongFileName.svc.cs").ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None, "TestType.svc.cs").ConfigureAwait(false);
-            await this.VerifyRenameAsync(testCode, "WrongFileName.svc.cs", "TestType.svc.cs", CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, oldFileName: "WrongFileName.svc.cs", newFileName: "TestType.svc.cs", cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -126,7 +122,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [MemberData(nameof(TypeKeywords))]
         public async Task VerifyWrongFileNameNoExtensionAsync(string typeKeyword)
         {
-            var testCode = $@"namespace TestNameSpace
+            var testCode = $@"namespace TestNamespace
 {{
     public {typeKeyword} TestType
     {{
@@ -145,7 +141,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             var expectedDiagnostic = this.CSharpDiagnostic().WithLocation("WrongFileName", 3, 13 + typeKeyword.Length);
             await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None, "WrongFileName").ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None, "TestType").ConfigureAwait(false);
-            await this.VerifyRenameAsync(testCode, "WrongFileName", "TestType", CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, oldFileName: "WrongFileName", newFileName: "TestType", cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -157,7 +153,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [MemberData(nameof(TypeKeywords))]
         public async Task VerifyCaseInsensitivityAsync(string typeKeyword)
         {
-            var testCode = $@"namespace TestNameSpace
+            var testCode = $@"namespace TestNamespace
 {{
     public {typeKeyword} TestType
     {{
@@ -177,7 +173,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [MemberData(nameof(TypeKeywords))]
         public async Task VerifyFirstTypeIsUsedAsync(string typeKeyword)
         {
-            var testCode = $@"namespace TestNameSpace
+            var testCode = $@"namespace TestNamespace
 {{
     public {typeKeyword} TestType
     {{
@@ -201,7 +197,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [MemberData(nameof(TypeKeywords))]
         public async Task VerifyThatPartialTypesAreIgnoredAsync(string typeKeyword)
         {
-            var testCode = $@"namespace TestNameSpace
+            var testCode = $@"namespace TestNamespace
 {{
     public partial {typeKeyword} TestType
     {{
@@ -223,7 +219,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         {
             this.useMetadataSettings = false;
 
-            var testCode = $@"namespace TestNameSpace
+            var testCode = $@"namespace TestNamespace
 {{
     public {typeKeyword} TestType<T1, T2, T3>
     {{
@@ -235,7 +231,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None, "TestType`3.cs").ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None, "TestType.cs").ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None, "TestType{T1,T2,T3}.cs").ConfigureAwait(false);
-            await this.VerifyRenameAsync(testCode, "TestType`3.cs", "TestType{T1,T2,T3}.cs", CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, testCode, oldFileName: "TestType`3.cs", newFileName: "TestType{T1,T2,T3}.cs", cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -249,7 +245,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         {
             this.useMetadataSettings = true;
 
-            var testCode = $@"namespace TestNameSpace
+            var testCode = $@"namespace TestNamespace
 {{
     public {typeKeyword} TestType<T1, T2, T3>
     {{
@@ -263,7 +259,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             expectedDiagnostic = this.CSharpDiagnostic().WithLocation("TestType.cs", 3, 13 + typeKeyword.Length);
             await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None, "TestType.cs").ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None, "TestType`3.cs").ConfigureAwait(false);
-            await this.VerifyRenameAsync(testCode, "TestType.cs", "TestType`3.cs", CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, testCode, oldFileName: "TestType.cs", newFileName: "TestType`3.cs", cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -278,7 +274,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         {
             this.useMetadataSettings = true;
 
-            var testCode = $@"namespace TestNameSpace
+            var testCode = $@"namespace TestNamespace
 {{
     public {typeKeyword} TestType<T>
     {{
@@ -297,7 +293,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             var expectedDiagnostic = this.CSharpDiagnostic().WithLocation("TestType.svc.cs", 3, 13 + typeKeyword.Length);
             await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None, "TestType.svc.cs").ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None, "TestType`1.svc.cs").ConfigureAwait(false);
-            await this.VerifyRenameAsync(testCode, "TestType.svc.cs", "TestType`1.svc.cs", CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, oldFileName: "TestType.svc.cs", newFileName: "TestType`1.svc.cs", cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -307,7 +303,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [Fact]
         public async Task VerifyWithoutFirstTypeAsync()
         {
-            var testCode = @"namespace TestNameSpace
+            var testCode = @"namespace TestNamespace
 {
 }
 ";
@@ -331,40 +327,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         protected override string GetSettings()
         {
             return this.useMetadataSettings ? MetadataSettings : StyleCopSettings;
-        }
-
-        private async Task VerifyRenameAsync(string source, string sourceFileName, string expectedFileName, CancellationToken cancellationToken)
-        {
-            var analyzers = this.GetCSharpDiagnosticAnalyzers().ToImmutableArray();
-            var document = this.CreateDocument(source, LanguageNames.CSharp, sourceFileName);
-            var analyzerDiagnostics = await GetSortedDiagnosticsFromDocumentsAsync(analyzers, new[] { document }, cancellationToken).ConfigureAwait(false);
-
-            Assert.Equal(1, analyzerDiagnostics.Length);
-
-            var actions = new List<CodeAction>();
-            var context = new CodeFixContext(document, analyzerDiagnostics[0], (a, d) => actions.Add(a), cancellationToken);
-            await this.GetCSharpCodeFixProvider().RegisterCodeFixesAsync(context).ConfigureAwait(false);
-
-            Assert.Equal(1, actions.Count);
-
-            var operations = await actions[0].GetOperationsAsync(cancellationToken).ConfigureAwait(false);
-
-            var changedSolution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
-
-            var solutionChanges = changedSolution.GetChanges(document.Project.Solution);
-            var projectChanges = solutionChanges.GetProjectChanges().ToArray();
-
-            Assert.Equal(1, projectChanges.Length);
-
-            var removedDocuments = projectChanges[0].GetRemovedDocuments().ToArray();
-            Assert.Equal(1, removedDocuments.Length);
-            Assert.Equal(document.Id, removedDocuments[0]);
-
-            var addedDocuments = projectChanges[0].GetAddedDocuments().ToArray();
-            Assert.Equal(1, addedDocuments.Length);
-
-            var newDocument = changedSolution.GetDocument(addedDocuments[0]);
-            Assert.Equal(expectedFileName, newDocument.Name);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402ForBlockDeclarationUnitTestsBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402ForBlockDeclarationUnitTestsBase.cs
@@ -134,6 +134,7 @@ public partial {this.Keyword} Bar
 
 }}";
 
+            var fixedFileNames = new[] { "Test0.cs", "Bar.cs" };
             var fixedCode = new[]
             {
                 $@"public partial {this.Keyword} Foo
@@ -150,7 +151,7 @@ public partial {this.Keyword} Bar
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, newFileNames: fixedFileNames, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -163,6 +164,7 @@ public {this.Keyword} Test0
 {{
 }}";
 
+            var fixedFileNames = new[] { "Test0.cs", "Foo.cs" };
             var fixedCode = new[]
             {
                 $@"public {this.Keyword} Test0
@@ -178,7 +180,7 @@ public {this.Keyword} Test0
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, newFileNames: fixedFileNames, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402ForDelegateUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402ForDelegateUnitTests.cs
@@ -27,6 +27,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 public delegate void Bar();
 ";
 
+            var fixedFileNames = new[] { "Test0.cs", "Bar.cs" };
             var fixedCode = new[]
             {
                 @"public delegate void Foo();
@@ -39,7 +40,7 @@ public delegate void Bar();
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, newFileNames: fixedFileNames, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -49,6 +50,7 @@ public delegate void Bar();
 public delegate void Bar<T1, T2, T3>(T1 x, T2 y, T3 z);
 ";
 
+            var fixedFileNames = new[] { "Test0.cs", "Bar.cs" };
             var fixedCode = new[]
             {
                 @"public delegate void Foo();
@@ -61,7 +63,7 @@ public delegate void Bar<T1, T2, T3>(T1 x, T2 y, T3 z);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, newFileNames: fixedFileNames, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -96,6 +98,7 @@ public delegate void Bar();
 public delegate void FooBar();
 ";
 
+            var fixedFileNames = new[] { "Test0.cs", "Bar.cs", "FooBar.cs" };
             var fixedCode = new[]
             {
                 @"public delegate void Foo();
@@ -114,7 +117,7 @@ public delegate void FooBar();
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, newFileNames: fixedFileNames, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -124,6 +127,7 @@ public delegate void FooBar();
 public delegate void Test0();
 ";
 
+            var fixedFileNames = new[] { "Test0.cs", "Foo.cs" };
             var fixedCode = new[]
             {
                 $@"public delegate void Test0();
@@ -136,7 +140,7 @@ public delegate void Test0();
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, newFileNames: fixedFileNames, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402ForEnumUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402ForEnumUnitTests.cs
@@ -37,6 +37,7 @@ enum Bar
 }
 ";
 
+            var fixedFileNames = new[] { "Test0.cs", "Bar.cs" };
             var fixedCode = new[]
             {
                 @"enum Foo
@@ -55,7 +56,7 @@ enum Bar
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, newFileNames: fixedFileNames, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -111,6 +112,7 @@ enum FooBar
 }
 ";
 
+            var fixedFileNames = new[] { "Test0.cs", "Bar.cs", "FooBar.cs" };
             var fixedCode = new[]
             {
                 @"enum Foo
@@ -138,7 +140,7 @@ enum FooBar
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, newFileNames: fixedFileNames, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -154,6 +156,7 @@ enum Test0
 }
 ";
 
+            var fixedFileNames = new[] { "Test0.cs", "Foo.cs" };
             var fixedCode = new[]
             {
                 @"enum Test0
@@ -172,7 +175,7 @@ enum Test0
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(new[] { testCode }, fixedCode, newFileNames: fixedFileNames, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
@@ -50,7 +50,7 @@ namespace TestHelper
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected Task VerifyCSharpFixAsync(string oldSource, string newSource, string batchNewSource = null, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, int numberOfIncrementalIterations = DefaultNumberOfIncrementalIterations, int numberOfFixAllIterations = 1, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.VerifyCSharpFixAsync(new[] { oldSource }, new[] { newSource }, batchNewSource == null ? null : new[] { batchNewSource }, codeFixIndex, allowNewCompilerDiagnostics, numberOfIncrementalIterations, numberOfFixAllIterations, cancellationToken);
+            return this.VerifyCSharpFixAsync(new[] { oldSource }, new[] { newSource }, batchNewSource == null ? null : new[] { batchNewSource }, null, codeFixIndex, allowNewCompilerDiagnostics, numberOfIncrementalIterations, numberOfFixAllIterations, cancellationToken);
         }
 
         /// <summary>
@@ -59,6 +59,7 @@ namespace TestHelper
         /// <param name="oldSources">An array of sources in the form of strings before the code fix was applied to them.</param>
         /// <param name="newSources">An array of sources in the form of strings after the code fix was applied to them.</param>
         /// <param name="batchNewSources">An array of sources in the form of a strings after the batch fixer was applied to them.</param>
+        /// <param name="newFileNames">An array of file names in the project after the code fix was applied.</param>
         /// <param name="codeFixIndex">Index determining which code fix to apply if there are multiple.</param>
         /// <param name="allowNewCompilerDiagnostics">A value indicating whether or not the test will fail if the code fix introduces other warnings after being applied.</param>
         /// <param name="numberOfIncrementalIterations">The number of iterations the incremental fixer will be called.
@@ -68,9 +69,9 @@ namespace TestHelper
         /// value is less than 0, the negated value is treated as an upper limit as opposed to an exact value.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that the task will observe.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected async Task VerifyCSharpFixAsync(string[] oldSources, string[] newSources, string[] batchNewSources = null, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, int numberOfIncrementalIterations = DefaultNumberOfIncrementalIterations, int numberOfFixAllIterations = 1, CancellationToken cancellationToken = default(CancellationToken))
+        protected async Task VerifyCSharpFixAsync(string[] oldSources, string[] newSources, string[] batchNewSources = null, string[] newFileNames = null, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, int numberOfIncrementalIterations = DefaultNumberOfIncrementalIterations, int numberOfFixAllIterations = 1, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var t1 = this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSources, newSources, codeFixIndex, allowNewCompilerDiagnostics, numberOfIncrementalIterations, FixEachAnalyzerDiagnosticAsync, cancellationToken).ConfigureAwait(false);
+            var t1 = this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSources, newSources, newFileNames, codeFixIndex, allowNewCompilerDiagnostics, numberOfIncrementalIterations, FixEachAnalyzerDiagnosticAsync, cancellationToken).ConfigureAwait(false);
 
             var fixAllProvider = this.GetCSharpCodeFixProvider().GetFixAllProvider();
             Assert.NotEqual(WellKnownFixAllProviders.BatchFixer, fixAllProvider);
@@ -86,19 +87,19 @@ namespace TestHelper
                     await t1;
                 }
 
-                var t2 = this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSources, batchNewSources ?? newSources, codeFixIndex, allowNewCompilerDiagnostics, numberOfFixAllIterations, FixAllAnalyzerDiagnosticsInDocumentAsync, cancellationToken).ConfigureAwait(false);
+                var t2 = this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSources, batchNewSources ?? newSources, newFileNames, codeFixIndex, allowNewCompilerDiagnostics, numberOfFixAllIterations, FixAllAnalyzerDiagnosticsInDocumentAsync, cancellationToken).ConfigureAwait(false);
                 if (Debugger.IsAttached)
                 {
                     await t2;
                 }
 
-                var t3 = this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSources, batchNewSources ?? newSources, codeFixIndex, allowNewCompilerDiagnostics, numberOfFixAllIterations, FixAllAnalyzerDiagnosticsInProjectAsync, cancellationToken).ConfigureAwait(false);
+                var t3 = this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSources, batchNewSources ?? newSources, newFileNames, codeFixIndex, allowNewCompilerDiagnostics, numberOfFixAllIterations, FixAllAnalyzerDiagnosticsInProjectAsync, cancellationToken).ConfigureAwait(false);
                 if (Debugger.IsAttached)
                 {
                     await t3;
                 }
 
-                var t4 = this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSources, batchNewSources ?? newSources, codeFixIndex, allowNewCompilerDiagnostics, numberOfFixAllIterations, FixAllAnalyzerDiagnosticsInSolutionAsync, cancellationToken).ConfigureAwait(false);
+                var t4 = this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSources, batchNewSources ?? newSources, newFileNames, codeFixIndex, allowNewCompilerDiagnostics, numberOfFixAllIterations, FixAllAnalyzerDiagnosticsInSolutionAsync, cancellationToken).ConfigureAwait(false);
                 if (Debugger.IsAttached)
                 {
                     await t4;
@@ -128,7 +129,7 @@ namespace TestHelper
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected async Task VerifyCSharpFixAllFixAsync(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, int numberOfIterations = 1, CancellationToken cancellationToken = default(CancellationToken))
         {
-            await this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), new[] { oldSource }, new[] { newSource }, codeFixIndex, allowNewCompilerDiagnostics, numberOfIterations, FixAllAnalyzerDiagnosticsInDocumentAsync, cancellationToken).ConfigureAwait(false);
+            await this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), new[] { oldSource }, new[] { newSource }, null, codeFixIndex, allowNewCompilerDiagnostics, numberOfIterations, FixAllAnalyzerDiagnosticsInDocumentAsync, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -348,12 +349,19 @@ namespace TestHelper
             CodeFixProvider codeFixProvider,
             string[] oldSources,
             string[] newSources,
+            string[] newFileNames,
             int? codeFixIndex,
             bool allowNewCompilerDiagnostics,
             int numberOfIterations,
             Func<ImmutableArray<DiagnosticAnalyzer>, CodeFixProvider, int?, Project, int, CancellationToken, Task<Project>> getFixedProject,
             CancellationToken cancellationToken)
         {
+            if (newFileNames != null)
+            {
+                // Make sure the test case is consistent regarding the number of expected sources and file names
+                Assert.Equal($"{newSources.Length} file names", $"{newFileNames.Length} file names");
+            }
+
             var project = this.CreateProject(oldSources, language);
             var compilerDiagnostics = await GetCompilerDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false);
 
@@ -390,6 +398,11 @@ namespace TestHelper
             {
                 var actual = await GetStringFromDocumentAsync(updatedDocuments[i], cancellationToken).ConfigureAwait(false);
                 Assert.Equal(newSources[i], actual);
+
+                if (newFileNames != null)
+                {
+                    Assert.Equal(newFileNames[i], updatedDocuments[i].Name);
+                }
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/CodeFixVerifier.cs
@@ -39,6 +39,8 @@ namespace TestHelper
         /// <param name="oldSource">A class in the form of a string before the code fix was applied to it.</param>
         /// <param name="newSource">A class in the form of a string after the code fix was applied to it.</param>
         /// <param name="batchNewSource">A class in the form of a string after the batch fixer was applied to it.</param>
+        /// <param name="oldFileName">The name of the file in the project before the code fix was applied.</param>
+        /// <param name="newFileName">The name of the file in the project after the code fix was applied.</param>
         /// <param name="codeFixIndex">Index determining which code fix to apply if there are multiple.</param>
         /// <param name="allowNewCompilerDiagnostics">A value indicating whether or not the test will fail if the code fix introduces other warnings after being applied.</param>
         /// <param name="numberOfIncrementalIterations">The number of iterations the incremental fixer will be called.
@@ -48,9 +50,12 @@ namespace TestHelper
         /// value is less than 0, the negated value is treated as an upper limit as opposed to an exact value.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that the task will observe.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected Task VerifyCSharpFixAsync(string oldSource, string newSource, string batchNewSource = null, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, int numberOfIncrementalIterations = DefaultNumberOfIncrementalIterations, int numberOfFixAllIterations = 1, CancellationToken cancellationToken = default(CancellationToken))
+        protected Task VerifyCSharpFixAsync(string oldSource, string newSource, string batchNewSource = null, string oldFileName = null, string newFileName = null, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, int numberOfIncrementalIterations = DefaultNumberOfIncrementalIterations, int numberOfFixAllIterations = 1, CancellationToken cancellationToken = default(CancellationToken))
         {
-            return this.VerifyCSharpFixAsync(new[] { oldSource }, new[] { newSource }, batchNewSource == null ? null : new[] { batchNewSource }, null, codeFixIndex, allowNewCompilerDiagnostics, numberOfIncrementalIterations, numberOfFixAllIterations, cancellationToken);
+            var batchNewSources = batchNewSource == null ? null : new[] { batchNewSource };
+            var oldFileNames = oldFileName == null ? null : new[] { oldFileName };
+            var newFileNames = newFileName == null ? null : new[] { newFileName };
+            return this.VerifyCSharpFixAsync(new[] { oldSource }, new[] { newSource }, batchNewSources, oldFileNames, newFileNames, codeFixIndex, allowNewCompilerDiagnostics, numberOfIncrementalIterations, numberOfFixAllIterations, cancellationToken);
         }
 
         /// <summary>
@@ -59,6 +64,7 @@ namespace TestHelper
         /// <param name="oldSources">An array of sources in the form of strings before the code fix was applied to them.</param>
         /// <param name="newSources">An array of sources in the form of strings after the code fix was applied to them.</param>
         /// <param name="batchNewSources">An array of sources in the form of a strings after the batch fixer was applied to them.</param>
+        /// <param name="oldFileNames">An array of file names in the project before the code fix was applied.</param>
         /// <param name="newFileNames">An array of file names in the project after the code fix was applied.</param>
         /// <param name="codeFixIndex">Index determining which code fix to apply if there are multiple.</param>
         /// <param name="allowNewCompilerDiagnostics">A value indicating whether or not the test will fail if the code fix introduces other warnings after being applied.</param>
@@ -69,9 +75,9 @@ namespace TestHelper
         /// value is less than 0, the negated value is treated as an upper limit as opposed to an exact value.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> that the task will observe.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        protected async Task VerifyCSharpFixAsync(string[] oldSources, string[] newSources, string[] batchNewSources = null, string[] newFileNames = null, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, int numberOfIncrementalIterations = DefaultNumberOfIncrementalIterations, int numberOfFixAllIterations = 1, CancellationToken cancellationToken = default(CancellationToken))
+        protected async Task VerifyCSharpFixAsync(string[] oldSources, string[] newSources, string[] batchNewSources = null, string[] oldFileNames = null, string[] newFileNames = null, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, int numberOfIncrementalIterations = DefaultNumberOfIncrementalIterations, int numberOfFixAllIterations = 1, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var t1 = this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSources, newSources, newFileNames, codeFixIndex, allowNewCompilerDiagnostics, numberOfIncrementalIterations, FixEachAnalyzerDiagnosticAsync, cancellationToken).ConfigureAwait(false);
+            var t1 = this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSources, newSources, oldFileNames, newFileNames, codeFixIndex, allowNewCompilerDiagnostics, numberOfIncrementalIterations, FixEachAnalyzerDiagnosticAsync, cancellationToken).ConfigureAwait(false);
 
             var fixAllProvider = this.GetCSharpCodeFixProvider().GetFixAllProvider();
             Assert.NotEqual(WellKnownFixAllProviders.BatchFixer, fixAllProvider);
@@ -87,19 +93,19 @@ namespace TestHelper
                     await t1;
                 }
 
-                var t2 = this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSources, batchNewSources ?? newSources, newFileNames, codeFixIndex, allowNewCompilerDiagnostics, numberOfFixAllIterations, FixAllAnalyzerDiagnosticsInDocumentAsync, cancellationToken).ConfigureAwait(false);
+                var t2 = this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSources, batchNewSources ?? newSources, oldFileNames, newFileNames, codeFixIndex, allowNewCompilerDiagnostics, numberOfFixAllIterations, FixAllAnalyzerDiagnosticsInDocumentAsync, cancellationToken).ConfigureAwait(false);
                 if (Debugger.IsAttached)
                 {
                     await t2;
                 }
 
-                var t3 = this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSources, batchNewSources ?? newSources, newFileNames, codeFixIndex, allowNewCompilerDiagnostics, numberOfFixAllIterations, FixAllAnalyzerDiagnosticsInProjectAsync, cancellationToken).ConfigureAwait(false);
+                var t3 = this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSources, batchNewSources ?? newSources, oldFileNames, newFileNames, codeFixIndex, allowNewCompilerDiagnostics, numberOfFixAllIterations, FixAllAnalyzerDiagnosticsInProjectAsync, cancellationToken).ConfigureAwait(false);
                 if (Debugger.IsAttached)
                 {
                     await t3;
                 }
 
-                var t4 = this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSources, batchNewSources ?? newSources, newFileNames, codeFixIndex, allowNewCompilerDiagnostics, numberOfFixAllIterations, FixAllAnalyzerDiagnosticsInSolutionAsync, cancellationToken).ConfigureAwait(false);
+                var t4 = this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), oldSources, batchNewSources ?? newSources, oldFileNames, newFileNames, codeFixIndex, allowNewCompilerDiagnostics, numberOfFixAllIterations, FixAllAnalyzerDiagnosticsInSolutionAsync, cancellationToken).ConfigureAwait(false);
                 if (Debugger.IsAttached)
                 {
                     await t4;
@@ -129,7 +135,7 @@ namespace TestHelper
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         protected async Task VerifyCSharpFixAllFixAsync(string oldSource, string newSource, int? codeFixIndex = null, bool allowNewCompilerDiagnostics = false, int numberOfIterations = 1, CancellationToken cancellationToken = default(CancellationToken))
         {
-            await this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), new[] { oldSource }, new[] { newSource }, null, codeFixIndex, allowNewCompilerDiagnostics, numberOfIterations, FixAllAnalyzerDiagnosticsInDocumentAsync, cancellationToken).ConfigureAwait(false);
+            await this.VerifyFixInternalAsync(LanguageNames.CSharp, this.GetCSharpDiagnosticAnalyzers().ToImmutableArray(), this.GetCSharpCodeFixProvider(), new[] { oldSource }, new[] { newSource }, null, null, codeFixIndex, allowNewCompilerDiagnostics, numberOfIterations, FixAllAnalyzerDiagnosticsInDocumentAsync, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -349,6 +355,7 @@ namespace TestHelper
             CodeFixProvider codeFixProvider,
             string[] oldSources,
             string[] newSources,
+            string[] oldFileNames,
             string[] newFileNames,
             int? codeFixIndex,
             bool allowNewCompilerDiagnostics,
@@ -356,13 +363,19 @@ namespace TestHelper
             Func<ImmutableArray<DiagnosticAnalyzer>, CodeFixProvider, int?, Project, int, CancellationToken, Task<Project>> getFixedProject,
             CancellationToken cancellationToken)
         {
-            if (newFileNames != null)
+            if (oldFileNames != null)
             {
-                // Make sure the test case is consistent regarding the number of expected sources and file names
-                Assert.Equal($"{newSources.Length} file names", $"{newFileNames.Length} file names");
+                // Make sure the test case is consistent regarding the number of sources and file names before the code fix
+                Assert.Equal($"{oldSources.Length} old file names", $"{oldFileNames.Length} old file names");
             }
 
-            var project = this.CreateProject(oldSources, language);
+            if (newFileNames != null)
+            {
+                // Make sure the test case is consistent regarding the number of sources and file names after the code fix
+                Assert.Equal($"{newSources.Length} new file names", $"{newFileNames.Length} new file names");
+            }
+
+            var project = this.CreateProject(oldSources, language, oldFileNames);
             var compilerDiagnostics = await GetCompilerDiagnosticsAsync(project, cancellationToken).ConfigureAwait(false);
 
             project = await getFixedProject(analyzers, codeFixProvider, codeFixIndex, project, numberOfIterations, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Fixes #352.

Updated unit tests for SA1402 to verify file names, in addition to file content.
Also updated unit tests for SA1649 to verify file content, in addition to file names.
