### PR TITLE
Implemented SA1628.

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1628CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1628CodeFixProvider.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.DocumentationRules
+{
+    using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.Composition;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.Text;
+    using StyleCop.Analyzers.Helpers;
+
+    /// <summary>
+    /// Implements a code fix for <see cref="SA1628CodeFixProvider"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>To fix a violation of this rule, start the sentence with a capital letter.</para>
+    /// </remarks>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SA1628CodeFixProvider))]
+    [Shared]
+    internal class SA1628CodeFixProvider : CodeFixProvider
+    {
+        /// <inheritdoc/>
+        public override ImmutableArray<string> FixableDiagnosticIds { get; }
+            = ImmutableArray.Create(SA1628DocumentationTextMustBeginWithACapitalLetter.DiagnosticId);
+
+        /// <inheritdoc/>
+        public override FixAllProvider GetFixAllProvider()
+        {
+            return FixAll.Instance;
+        }
+
+        /// <inheritdoc/>
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            foreach (Diagnostic diagnostic in context.Diagnostics)
+            {
+                if (diagnostic.Properties.ContainsKey("nofix"))
+                {
+                    continue;
+                }
+
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        DocumentationResources.SA1628CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SA1628CodeFixProvider)),
+                    diagnostic);
+            }
+
+            return SpecializedTasks.CompletedTask;
+        }
+
+        private static async Task<Document> GetTransformedDocumentAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+
+            TextChange textChange = CreateTextChange(text, diagnostic.Location.SourceSpan);
+            return document.WithText(text.WithChanges(textChange));
+        }
+
+        private static TextChange CreateTextChange(SourceText text, TextSpan sourceSpan)
+        {
+            var character = new char[1];
+            text.CopyTo(sourceSpan.Start, character, 0, 1);
+            character[0] = char.ToUpperInvariant(character[0]);
+
+            return new TextChange(new TextSpan(sourceSpan.Start, 1), new string(character));
+        }
+
+        private class FixAll : DocumentBasedFixAllProvider
+        {
+            public static FixAllProvider Instance { get; } =
+                new FixAll();
+
+            protected override string CodeActionTitle =>
+                DocumentationResources.SA1628CodeFix;
+
+            protected override async Task<SyntaxNode> FixAllInDocumentAsync(FixAllContext fixAllContext, Document document, ImmutableArray<Diagnostic> diagnostics)
+            {
+                if (diagnostics.IsEmpty)
+                {
+                    return null;
+                }
+
+                var text = await document.GetTextAsync().ConfigureAwait(false);
+
+                List<TextChange> changes = new List<TextChange>();
+                foreach (var diagnostic in diagnostics)
+                {
+                    TextChange textChange = CreateTextChange(text, diagnostic.Location.SourceSpan);
+                    changes.Add(textChange);
+                }
+
+                changes.Sort((left, right) => left.Span.Start.CompareTo(right.Span.Start));
+
+                var tree = await document.GetSyntaxTreeAsync().ConfigureAwait(false);
+                return await tree.WithChangedText(text.WithChanges(changes)).GetRootAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/StyleCop.Analyzers.CodeFixes.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/StyleCop.Analyzers.CodeFixes.csproj
@@ -54,6 +54,7 @@
     <Compile Include="DocumentationRules\SA1609SA1610CodeFixProvider.cs" />
     <Compile Include="DocumentationRules\SA1615SA1616CodeFixProvider.cs" />
     <Compile Include="DocumentationRules\SA1617CodeFixProvider.cs" />
+    <Compile Include="DocumentationRules\SA1628CodeFixProvider.cs" />
     <Compile Include="DocumentationRules\SA1626CodeFixProvider.cs" />
     <Compile Include="DocumentationRules\SA1642SA1643CodeFixProvider.cs" />
     <Compile Include="DocumentationRules\SA1649CodeFixProvider.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1628UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1628UnitTests.cs
@@ -5,24 +5,331 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.DocumentationRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using TestHelper;
     using Xunit;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1628DocumentationTextMustBeginWithACapitalLetter"/>.
     /// </summary>
-    public class SA1628UnitTests : DiagnosticVerifier
+    public class SA1628UnitTests : CodeFixVerifier
     {
         [Fact]
-        public void TestDisabledByDefaultAndNotConfigurable()
+        public void TestDisabledByDefault()
         {
             var analyzer = this.GetCSharpDiagnosticAnalyzers().Single();
             Assert.Equal(1, analyzer.SupportedDiagnostics.Length);
             Assert.False(analyzer.SupportedDiagnostics[0].IsEnabledByDefault);
-            Assert.Contains(WellKnownDiagnosticTags.NotConfigurable, analyzer.SupportedDiagnostics[0].CustomTags);
+        }
+
+        [Fact]
+        public async Task TestClassWithXmlCommentAsync()
+        {
+            var testCode = @"/// <summary>
+/// xML Documentation
+/// </summary>
+public class TypeName
+{
+}
+";
+            var fixedCode = @"/// <summary>
+/// XML Documentation
+/// </summary>
+public class TypeName
+{
+}
+";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(2, 5).WithArguments("summary");
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMethodWithTwoXmlCommentsAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    /// <summary>
+    /// xML Documentation
+    /// </summary>
+    /// <param name=""bar"">bar description</param>
+    public void Foo(string bar)
+    {
+    }
+}
+";
+            var fixedCode = @"public class TypeName
+{
+    /// <summary>
+    /// XML Documentation
+    /// </summary>
+    /// <param name=""bar"">Bar description</param>
+    public void Foo(string bar)
+    {
+    }
+}
+";
+
+            var expected = new DiagnosticResult[]
+            {
+                this.CSharpDiagnostic().WithLocation(4, 9).WithArguments("summary"),
+                this.CSharpDiagnostic().WithLocation(6, 27).WithArguments("param")
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMethodWithSingeLineDocumentationAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    /// <summary>summary text</summary>
+    public void Bar()
+    {
+    }
+}
+";
+            var fixedCode = @"public class TypeName
+{
+    /// <summary>Summary text</summary>
+    public void Bar()
+    {
+    }
+}
+";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 18).WithArguments("summary");
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMethodWithSummaryAndDocumentationThatStartsWithSeeAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    /// <summary>
+    /// <see cref=""Foo""/> text
+    /// </summary>
+    public void Bar()
+    {
+    }
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMethodWithEmptySummaryAndCDATADocumentationAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    /// <summary/>
+    /// <param name=""bar"">
+    /// <![CDATA[bar description]]>
+    /// </param>
+    public void Foo(string bar)
+    {
+    }
+}
+";
+            var fixedCode = @"public class TypeName
+{
+    /// <summary/>
+    /// <param name=""bar"">
+    /// <![CDATA[Bar description]]>
+    /// </param>
+    public void Foo(string bar)
+    {
+    }
+}
+";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 18).WithArguments("param");
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMethodWithEmptySummaryAndReturnsDocumentationAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    /// <summary>
+    /// </summary>
+    /// <returns>the bar</returns>
+    public string Foo()
+    {
+        return ""bar"";
+    }
+}
+";
+            var fixedCode = @"public class TypeName
+{
+    /// <summary>
+    /// </summary>
+    /// <returns>The bar</returns>
+    public string Foo()
+    {
+        return ""bar"";
+    }
+}
+";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 18).WithArguments("returns");
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestIncludedDocumentationAsync()
+        {
+            var testCode = @"
+class Class1
+{
+    /// <include file='ClassWithSummary.xml' path='/Class1/MethodName/*'/>
+    public void MethodName()
+    {
+    }
+}
+";
+            var fixedCode = @"
+class Class1
+{
+    /// <include file='ClassWithSummary.xml' path='/Class1/MethodName/*'/>
+    public void MethodName()
+    {
+    }
+}
+";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 17).WithArguments("summary");
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestIncludedCorrectDocumentationAsync()
+        {
+            var testCode = @"
+class Class1
+{
+    /// <include file='ClassWithCorrectSummary.xml' path='/Class1/MethodName/*'/>
+    public void MethodName()
+    {
+    }
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestIncludedEmptyDocumentationAsync()
+        {
+            var testCode = @"
+class Class1
+{
+    /// <include file='ClassWithEmptySummary.xml' path='/Class1/MethodName/*'/>
+    public void MethodName()
+    {
+    }
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestIncludedDocumentationThatStartsWithSeeAsync()
+        {
+            var testCode = @"
+class Class1
+{
+    /// <include file='ClassWithSummaryThatStartsWithSee.xml' path='/Class1/MethodName/*'/>
+    public void MethodName()
+    {
+    }
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        protected override Project ApplyCompilationOptions(Project project)
+        {
+            var resolver = new TestXmlReferenceResolver();
+            string contentWithSummary = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<Class1>
+  <MethodName>
+    <summary>
+      <![CDATA[sample method.]]>
+    </summary>
+    <returns>
+      a <see cref=""Task""/> representing the asynchronous operation.
+    </returns>
+  </MethodName>
+</Class1>
+";
+            resolver.XmlReferences.Add("ClassWithSummary.xml", contentWithSummary);
+
+            string contentWithCorrectSummary = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<Class1>
+  <MethodName>
+    <summary>Correct</summary>
+  </MethodName>
+</Class1>
+";
+            resolver.XmlReferences.Add("ClassWithCorrectSummary.xml", contentWithCorrectSummary);
+
+            string contentWithEmptySummary = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<Class1>
+  <MethodName>
+    <summary></summary>
+  </MethodName>
+</Class1>
+";
+            resolver.XmlReferences.Add("ClassWithEmptySummary.xml", contentWithEmptySummary);
+
+            string contentWithSummaryThatStartsWithSee = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<Class1>
+  <MethodName>
+    <summary><see cref=""Foo""/> text</summary>
+  </MethodName>
+</Class1>
+";
+            resolver.XmlReferences.Add("ClassWithSummaryThatStartsWithSee.xml", contentWithSummaryThatStartsWithSee);
+
+            project = base.ApplyCompilationOptions(project);
+            project = project.WithCompilationOptions(project.CompilationOptions.WithXmlReferenceResolver(resolver));
+            return project;
+        }
+
+        /// <inheritdoc/>
+        protected override CodeFixProvider GetCSharpCodeFixProvider()
+        {
+            return new SA1628CodeFixProvider();
         }
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
@@ -359,7 +359,7 @@ namespace StyleCop.Analyzers.DocumentationRules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The documentation text within the \&apos;{0}\&apos; tag must not be empty..
+        ///   Looks up a localized string similar to The documentation text within the &apos;{0}&apos; tag must not be empty..
         /// </summary>
         internal static string SA1627MessageFormat {
             get {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
@@ -377,6 +377,42 @@ namespace StyleCop.Analyzers.DocumentationRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Start with capital letter.
+        /// </summary>
+        internal static string SA1628CodeFix {
+            get {
+                return ResourceManager.GetString("SA1628CodeFix", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A section of the XML header documentation for a C# element does not begin with a capital letter..
+        /// </summary>
+        internal static string SA1628Description {
+            get {
+                return ResourceManager.GetString("SA1628Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The documentation text within the &apos;{0}&apos; tag should start with a capital letter.
+        /// </summary>
+        internal static string SA1628MessageFormat {
+            get {
+                return ResourceManager.GetString("SA1628MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Documentation text must begin with a capital letter.
+        /// </summary>
+        internal static string SA1628Title {
+            get {
+                return ResourceManager.GetString("SA1628Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Add file header.
         /// </summary>
         internal static string SA1633CodeFix {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
@@ -222,6 +222,18 @@
   <data name="SA1627Title" xml:space="preserve">
     <value>Documentation text must not be empty</value>
   </data>
+  <data name="SA1628CodeFix" xml:space="preserve">
+    <value>Start with capital letter</value>
+  </data>
+  <data name="SA1628Description" xml:space="preserve">
+    <value>A section of the XML header documentation for a C# element does not begin with a capital letter.</value>
+  </data>
+  <data name="SA1628MessageFormat" xml:space="preserve">
+    <value>The documentation text within the '{0}' tag should start with a capital letter</value>
+  </data>
+  <data name="SA1628Title" xml:space="preserve">
+    <value>Documentation text must begin with a capital letter</value>
+  </data>
   <data name="SA1633CodeFix" xml:space="preserve">
     <value>Add file header</value>
   </data>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
@@ -217,7 +217,7 @@
     <value>The XML header documentation for a C# code element contains an empty tag.</value>
   </data>
   <data name="SA1627MessageFormat" xml:space="preserve">
-    <value>The documentation text within the \'{0}\' tag must not be empty.</value>
+    <value>The documentation text within the '{0}' tag must not be empty.</value>
   </data>
   <data name="SA1627Title" xml:space="preserve">
     <value>Documentation text must not be empty</value>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1628DocumentationTextMustBeginWithACapitalLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1628DocumentationTextMustBeginWithACapitalLetter.cs
@@ -3,10 +3,15 @@
 
 namespace StyleCop.Analyzers.DocumentationRules
 {
+    using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
+    using System.Xml.Linq;
     using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using Microsoft.CodeAnalysis.Text;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// A section of the XML header documentation for a C# element does not begin with a capital letter.
@@ -38,30 +43,173 @@ namespace StyleCop.Analyzers.DocumentationRules
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     [NoDiagnostic("This diagnostic has an unacceptable rate of false positives.")]
-    internal class SA1628DocumentationTextMustBeginWithACapitalLetter : DiagnosticAnalyzer
+    internal class SA1628DocumentationTextMustBeginWithACapitalLetter : ElementDocumentationBase
     {
         /// <summary>
         /// The ID for diagnostics produced by the <see cref="SA1628DocumentationTextMustBeginWithACapitalLetter"/>
         /// analyzer.
         /// </summary>
         public const string DiagnosticId = "SA1628";
-        private const string Title = "Documentation text must begin with a capital letter";
-        private const string MessageFormat = "TODO: Message format";
-        private const string Description = "A section of the XML header documentation for a C# element does not begin with a capital letter.";
-        private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1628.md";
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(DocumentationResources.SA1628Title), DocumentationResources.ResourceManager, typeof(DocumentationResources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(DocumentationResources.SA1628MessageFormat), DocumentationResources.ResourceManager, typeof(DocumentationResources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(DocumentationResources.SA1628Description), DocumentationResources.ResourceManager, typeof(DocumentationResources));
+        private static readonly string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1628.md";
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.DocumentationRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledByDefault, Description, HelpLink, WellKnownDiagnosticTags.NotConfigurable);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.DocumentationRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledByDefault, Description, HelpLink);
+
+        private static readonly string[] SupportedTags =
+            {
+                XmlCommentHelper.SummaryXmlTag,
+                XmlCommentHelper.ReturnsXmlTag,
+                XmlCommentHelper.ParamXmlTag,
+                XmlCommentHelper.RemarksXmlTag,
+                XmlCommentHelper.ExampleXmlTag,
+                XmlCommentHelper.PermissionXmlTag,
+                XmlCommentHelper.ExceptionXmlTag,
+            };
+
+        public SA1628DocumentationTextMustBeginWithACapitalLetter()
+            : base(inheritDocSuppressesWarnings: false)
+        {
+        }
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
             ImmutableArray.Create(Descriptor);
 
-        /// <inheritdoc/>
-        [ExcludeFromCodeCoverage]
-        public override void Initialize(AnalysisContext context)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, IEnumerable<XmlNodeSyntax> syntaxList, params Location[] diagnosticLocations)
         {
-            // This diagnostic is not implemented (by design) in StyleCopAnalyzers.
+            foreach (var documentationSyntax in syntaxList)
+            {
+                CheckDocumentationSyntax(context, documentationSyntax);
+            }
+        }
+
+        protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, XElement completeDocumentation, params Location[] diagnosticLocations)
+        {
+            // We are working with an <include> element
+            foreach (string elementName in SupportedTags)
+            {
+                if (CheckElement(context, completeDocumentation, diagnosticLocations, elementName))
+                {
+                    break;
+                }
+            }
+        }
+
+        private static void CheckDocumentationSyntax(SyntaxNodeAnalysisContext context, XmlNodeSyntax documentationSyntax)
+        {
+            XmlElementStartTagSyntax startTagSyntax = documentationSyntax.ChildNodes().FirstOrDefault() as XmlElementStartTagSyntax;
+            if (startTagSyntax == null)
+            {
+                return;
+            }
+
+            foreach (var syntaxNode in documentationSyntax.ChildNodes().Skip(1))
+            {
+                var textSyntax = syntaxNode as XmlTextSyntax;
+                if (textSyntax == null)
+                {
+                    var cdataSyntax = syntaxNode as XmlCDataSectionSyntax;
+
+                    if (cdataSyntax != null)
+                    {
+                        CheckIfFirstLetterUppercase(context, startTagSyntax, cdataSyntax.TextTokens);
+                    }
+
+                    return;
+                }
+
+                if (!XmlCommentHelper.IsConsideredEmpty(textSyntax))
+                {
+                    CheckIfFirstLetterUppercase(context, startTagSyntax, textSyntax.TextTokens);
+                    return;
+                }
+            }
+        }
+
+        private static void CheckIfFirstLetterUppercase(SyntaxNodeAnalysisContext context, XmlElementStartTagSyntax startTagSyntax, SyntaxTokenList textTokens)
+        {
+            foreach (var textToken in textTokens)
+            {
+                string text = textToken.Text;
+
+                if (string.IsNullOrWhiteSpace(text))
+                {
+                    continue;
+                }
+
+                int index = GetInvalidFirstLetterIndex(text);
+                if (index != -1)
+                {
+                    // Add a diagnostic on the first character
+                    TextSpan location = textToken.GetLocation().SourceSpan;
+                    TextSpan character = TextSpan.FromBounds(location.Start + index, location.Start + index + 1);
+                    string elementName = startTagSyntax.Name.ToString();
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, Location.Create(textToken.SyntaxTree, character), elementName));
+                }
+            }
+        }
+
+        private static bool CheckElement(SyntaxNodeAnalysisContext context, XElement completeDocumentation, Location[] diagnosticLocations, string elementName)
+        {
+            var includedElement = completeDocumentation.Nodes().OfType<XElement>().FirstOrDefault(element => element.Name == elementName);
+            if (includedElement == null)
+            {
+                return false;
+            }
+
+            foreach (XNode node in includedElement.Nodes())
+            {
+                var textNode = node as XText;
+                if (textNode == null)
+                {
+                    return false;
+                }
+
+                if (!XmlCommentHelper.IsConsideredEmpty(textNode))
+                {
+                    return CheckIfFirstLetterUppercase(context, diagnosticLocations, elementName, textNode.Value);
+                }
+            }
+
+            return false;
+        }
+
+        private static bool CheckIfFirstLetterUppercase(SyntaxNodeAnalysisContext context, Location[] diagnosticLocations, string elementName, string text)
+        {
+            int index = GetInvalidFirstLetterIndex(text);
+            if (index == -1)
+            {
+                return false;
+            }
+
+            Dictionary<string, string> properties = new Dictionary<string, string>();
+            properties.Add("nofix", string.Empty);
+
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, diagnosticLocations.First(), properties.ToImmutableDictionary(), elementName));
+            return true;
+        }
+
+        private static int GetInvalidFirstLetterIndex(string text)
+        {
+            for (int i = 0; i < text.Length; i++)
+            {
+                if (char.IsWhiteSpace(text[i]))
+                {
+                    continue;
+                }
+
+                if (!char.IsUpper(text[i]))
+                {
+                    return i;
+                }
+
+                break;
+            }
+
+            return -1;
         }
     }
 }


### PR DESCRIPTION
This pull requests implements SA1628 and adds a CodeFixProvider for SA1628 and this will resolve #148. This is my first attempt to write an Analyzer and a CodeFixProvider so please let me know if I can make some improvements. I am not sure if my solution for skipping the CodeFixProvider when something is found inside an "include" is correct but I could not find a better solution. Once this merge request has been reviewed and merged I will start to work on implementing SA1629.

Fixes #148