### PR TITLE
Fixed issue with properties that have an accessibility restriction.

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1513UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1513UnitTests.cs
@@ -826,6 +826,93 @@ public class TestClass
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verifies that setters with an accessibility restriction should not report a warning.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestSetterWithAccessibilityRestrictionAsync()
+        {
+            var testCode = @"
+public class TestClass
+{
+    public int TestProtected
+    {
+        get
+        {
+            return 1;
+        }
+        protected set
+        {
+        }
+    }
+
+    public int TestInternal
+    {
+        get
+        {
+            return 1;
+        }
+        internal set
+        {
+        }
+    }
+
+    public int TestPrivate
+    {
+        get
+        {
+            return 1;
+        }
+        private set
+        {
+        }
+    }
+
+    public int this[int i]
+    {
+        get
+        {
+            return 1;
+        }
+        protected set
+        {
+        }
+    }
+}
+
+public class TestClass2
+{
+    public int this[int i]
+    {
+        get
+        {
+            return 1;
+        }
+        internal set
+        {
+        }
+    }
+}
+
+public class TestClass3
+{
+    public int this[int i]
+    {
+        get
+        {
+            return 1;
+        }
+        private set
+        {
+        }
+    }
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
         /// <inheritdoc/>
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1516UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1516UnitTests.cs
@@ -543,6 +543,189 @@ public class TestClass
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verifies that setters with an accessibility restriction will report a warning.
+        /// This is a regression for #2269
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestSetterWithAccessibilityRestrictionAsync()
+        {
+            var testCode = @"
+public class TestClass
+{
+    public int TestProtected
+    {
+        get
+        {
+            return 1;
+        }
+        protected set
+        {
+        }
+    }
+
+    public int TestInternal
+    {
+        get
+        {
+            return 1;
+        }
+        internal set
+        {
+        }
+    }
+
+    public int TestPrivate
+    {
+        get
+        {
+            return 1;
+        }
+        private set
+        {
+        }
+    }
+
+    public int this[int i]
+    {
+        get
+        {
+            return 1;
+        }
+        protected set
+        {
+        }
+    }
+}
+
+public class TestClass2
+{
+    public int this[int i]
+    {
+        get
+        {
+            return 1;
+        }
+        internal set
+        {
+        }
+    }
+}
+
+public class TestClass3
+{
+    public int this[int i]
+    {
+        get
+        {
+            return 1;
+        }
+        private set
+        {
+        }
+    }
+}
+";
+
+            var fixedTestCode = @"
+public class TestClass
+{
+    public int TestProtected
+    {
+        get
+        {
+            return 1;
+        }
+
+        protected set
+        {
+        }
+    }
+
+    public int TestInternal
+    {
+        get
+        {
+            return 1;
+        }
+
+        internal set
+        {
+        }
+    }
+
+    public int TestPrivate
+    {
+        get
+        {
+            return 1;
+        }
+
+        private set
+        {
+        }
+    }
+
+    public int this[int i]
+    {
+        get
+        {
+            return 1;
+        }
+
+        protected set
+        {
+        }
+    }
+}
+
+public class TestClass2
+{
+    public int this[int i]
+    {
+        get
+        {
+            return 1;
+        }
+
+        internal set
+        {
+        }
+    }
+}
+
+public class TestClass3
+{
+    public int this[int i]
+    {
+        get
+        {
+            return 1;
+        }
+
+        private set
+        {
+        }
+    }
+}
+";
+
+            var expected = new[]
+            {
+                this.CSharpDiagnostic().WithLocation(10, 1),
+                this.CSharpDiagnostic().WithLocation(21, 1),
+                this.CSharpDiagnostic().WithLocation(32, 1),
+                this.CSharpDiagnostic().WithLocation(43, 1),
+                this.CSharpDiagnostic().WithLocation(57, 1),
+                this.CSharpDiagnostic().WithLocation(71, 1),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {
             yield return new SA1516ElementsMustBeSeparatedByBlankLine();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513ClosingBraceMustBeFollowedByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513ClosingBraceMustBeFollowedByBlankLine.cs
@@ -277,6 +277,15 @@ namespace StyleCop.Analyzers.LayoutRules
                         return;
                     }
 
+                    if ((nextToken.IsKind(SyntaxKind.PrivateKeyword)
+                        || nextToken.IsKind(SyntaxKind.ProtectedKeyword)
+                        || nextToken.IsKind(SyntaxKind.InternalKeyword))
+                        && (nextToken.Parent is AccessorDeclarationSyntax))
+                    {
+                        // the close brace is followed by an accessor with an accessibility restriction.
+                        return;
+                    }
+
                     var parenthesizedExpressionSyntax = nextToken.Parent as ParenthesizedExpressionSyntax;
                     if (parenthesizedExpressionSyntax?.CloseParenToken == nextToken)
                     {


### PR DESCRIPTION
This patch fixes an issue where SA1513 would not report a diagnostic for this:
```C#
public int TestProtected
{
    get
    {
        return 1;
    }
    set
    {
    }
}
```
But would report one for a property that has an accessibility restriction:
```C#
public int TestProtected
{
    get
    {
        return 1;
    }
    protected set
    {
    }
}
```

This patch resolves that issue.