### PR TITLE
Updated SA1612 to retrieve parameter name from a declaration by accessing Identifier.ValueText instead of Identifier.Text

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1612UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1612UnitTests.cs
@@ -22,9 +22,9 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         {
             get
             {
-                yield return new[] { "    public ClassName Method(string foo, string bar) { return null; }" };
-                yield return new[] { "    public delegate ClassName Method(string foo, string bar);" };
-                yield return new[] { "    public ClassName this[string foo, string bar] { get { return null; } set { } }" };
+                yield return new[] { "    public ClassName Method(string foo, string bar, string @new) { return null; }" };
+                yield return new[] { "    public delegate ClassName Method(string foo, string bar, string @new);" };
+                yield return new[] { "    public ClassName this[string foo, string bar, string @new] { get { return null; } set { } }" };
             }
         }
 
@@ -75,6 +75,7 @@ public class ClassName
     /// </summary>
     ///<param name=""foo"">Test</param>
     ///<param name=""bar"">Test</param>
+    ///<param name=""new"">Test</param>
 $$
 }";
             await this.VerifyCSharpDiagnosticAsync(testCode.Replace("$$", declaration), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
@@ -95,6 +96,7 @@ public class ClassName
     /// </summary>
     ///<param name=""boo"">Test</param>
     ///<param name=""far"">Test</param>
+    ///<param name=""foe"">Test</param>
 $$
 }";
 
@@ -102,6 +104,7 @@ $$
             {
                 this.CSharpDiagnostic().WithLocation(10, 21).WithArguments("boo"),
                 this.CSharpDiagnostic().WithLocation(11, 21).WithArguments("far"),
+                this.CSharpDiagnostic().WithLocation(12, 21).WithArguments("foe"),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode.Replace("$$", declaration), expected, CancellationToken.None).ConfigureAwait(false);
@@ -124,6 +127,7 @@ public class ClassName
     ///<param/>
     ///<param name="""">Test</param>
     ///<param name=""    "">Test</param>
+    ///<param name=""  "">Test</param>
 $$
 }";
             await this.VerifyCSharpDiagnosticAsync(testCode.Replace("$$", declaration), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
@@ -143,6 +147,7 @@ public class ClassName
     /// Foo
     /// </summary>
     /// <param name=""bar"">Param 2</param>
+    /// <param name=""new"">Param 3</param>
     /// <param name=""foo"">Param 1</param>
     $$
 }";
@@ -153,7 +158,8 @@ public class ClassName
             var expected = new[]
             {
                 diagnostic.WithLocation(10, 22).WithArguments("bar", 2),
-                diagnostic.WithLocation(11, 22).WithArguments("foo", 1),
+                diagnostic.WithLocation(11, 22).WithArguments("new", 3),
+                diagnostic.WithLocation(12, 22).WithArguments("foo", 1),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode.Replace("$$", p), expected, CancellationToken.None).ConfigureAwait(false);
@@ -174,14 +180,15 @@ public class ClassName
     /// </summary>
     /// <param name=""foo"">Param 1</param>
     /// <param name=""bar"">Param 2</param>
-    /// <param name=""bar"">Param 3</param>
+    /// <param name=""new"">Param 3</param>
+    /// <param name=""bar"">Param 4</param>
     $$
 }";
 
             var diagnostic = this.CSharpDiagnostic()
                 .WithMessageFormat("The parameter documentation for '{0}' should be at position {1}.");
 
-            var expected = diagnostic.WithLocation(12, 22).WithArguments("bar", 2);
+            var expected = diagnostic.WithLocation(13, 22).WithArguments("bar", 2);
 
             await this.VerifyCSharpDiagnosticAsync(testCode.Replace("$$", p), expected, CancellationToken.None).ConfigureAwait(false);
         }
@@ -227,7 +234,7 @@ public class ClassName
 public class ClassName
 {
     /// <include file='WithParamDocumentation.xml' path='/ClassName/Method/*' />
-    public ClassName Method(string foo, string bar) { return null; }
+    public ClassName Method(string foo, string bar, string @new) { return null; }
 }";
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
@@ -242,13 +249,14 @@ public class ClassName
 public class ClassName
 {
     /// <include file='WithInvalidParamDocumentation.xml' path='/ClassName/Method/*' />
-    public ClassName Method(string foo, string bar) { return null; }
+    public ClassName Method(string foo, string bar, string @new) { return null; }
 }";
 
             var expected = new[]
             {
                 this.CSharpDiagnostic().WithLocation(8, 22).WithArguments("boo"),
                 this.CSharpDiagnostic().WithLocation(8, 22).WithArguments("far"),
+                this.CSharpDiagnostic().WithLocation(8, 22).WithArguments("foe"),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -264,7 +272,7 @@ public class ClassName
 public class ClassName
 {
     /// <include file='WithSA1613ParamDocumentation.xml' path='/ClassName/Method/*' />
-    public ClassName Method(string foo, string bar) { return null; }
+    public ClassName Method(string foo, string bar, string @new) { return null; }
 }";
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
@@ -279,7 +287,7 @@ public class ClassName
 public class ClassName
 {
     /// <include file='WithParamDocumentation.xml' path='/ClassName/Method/*' />
-    public ClassName Method(string bar, string foo) { return null; }
+    public ClassName Method(string bar, string @new, string foo) { return null; }
 }";
 
             var diagnostic = this.CSharpDiagnostic()
@@ -287,8 +295,9 @@ public class ClassName
 
             var expected = new[]
             {
-                diagnostic.WithLocation(8, 22).WithArguments("foo", 2),
+                diagnostic.WithLocation(8, 22).WithArguments("foo", 3),
                 diagnostic.WithLocation(8, 22).WithArguments("bar", 1),
+                diagnostic.WithLocation(8, 22).WithArguments("new", 2),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -304,7 +313,7 @@ public class ClassName
 public class ClassName
 {
     /// <include file='WithTooManyParamDocumentation.xml' path='/ClassName/Method/*' />
-    public ClassName Method(string foo, string bar) { return null; }
+    public ClassName Method(string foo, string bar, string @new) { return null; }
 }";
 
             var diagnostic = this.CSharpDiagnostic()
@@ -325,7 +334,7 @@ public class ClassName
 public class ClassName
 {
     /// <include file='WithInheritedDocumentation.xml' path='/ClassName/Method/*' />
-    public ClassName Method(string foo, string bar) { return null; }
+    public ClassName Method(string foo, string bar, string @new) { return null; }
 }";
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
@@ -354,6 +363,7 @@ public class ClassName
         </summary>
         <param name=""foo"">Param 1</param>
         <param name=""bar"">Param 2</param>
+        <param name=""new"">Param 3</param>
     </Method>
 </ClassName>
 ";
@@ -367,6 +377,7 @@ public class ClassName
         </summary>
         <param name=""boo"">Param 1</param>
         <param name=""far"">Param 2</param>
+        <param name=""foe"">Param 3</param>
     </Method>
 </ClassName>
 ";
@@ -382,6 +393,7 @@ public class ClassName
         <param/>
         <param name="""">Test</param>
         <param name=""    "">Test</param>
+        <param name=""  "">Test</param>
     </Method>
 </ClassName>
 ";
@@ -395,7 +407,8 @@ public class ClassName
         </summary>
         <param name=""foo"">Param 1</param>
         <param name=""bar"">Param 2</param>
-        <param name=""bar"">Param 3</param>
+        <param name=""new"">Param 3</param>
+        <param name=""bar"">Param 4</param>
     </Method>
 </ClassName>
 ";

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1612ElementParameterDocumentationMustMatchElementParameters.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1612ElementParameterDocumentationMustMatchElementParameters.cs
@@ -92,7 +92,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                     return;
                 }
 
-                var parentParameter = parentParameters.FirstOrDefault(s => s.Identifier.Text == nameAttributeText);
+                var parentParameter = parentParameters.FirstOrDefault(s => s.Identifier.ValueText == nameAttributeText);
                 if (parentParameter == null)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(MissingParameterDescriptor, location ?? identifierLocation, nameAttributeText));
@@ -150,7 +150,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                     return;
                 }
 
-                var parentParameter = parentParameters.FirstOrDefault(s => s.Identifier.Text == nameAttributeText);
+                var parentParameter = parentParameters.FirstOrDefault(s => s.Identifier.ValueText == nameAttributeText);
                 if (parentParameter == null)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(MissingParameterDescriptor, identifierLocation, nameAttributeText));


### PR DESCRIPTION
Fixes #2280.
