### PR TITLE
Remove source browser from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,3 @@ See [Contributing](CONTRIBUTING.md)
 ## Current status
 
 An up-to-date list of which StyleCop rules are implemented and which have code fixes can be found [here](https://stylecop.pdelvo.com/).
-
-## Source browser
-
-The up-to-date source code can be browsed [here](https://source.pdelvo.com/).


### PR DESCRIPTION
Unfortunately I will downgrade to a smaller V-Server so I don't have a windows server anymore. The source browser does not work on it so I have to discontinue it.