### PR TITLE
All changes made for format string component and alignment component

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/NumberSignSpacingTestBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/NumberSignSpacingTestBase.cs
@@ -424,40 +424,25 @@ namespace StyleCop.Analyzers.Test.SpacingRules
             await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
         [WorkItem(2289, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2289")]
-        public async Task TestSpaceBeforeUnaryOperatorInInterpolationAlignmentClauseAsync()
+        public async Task TestSpaceBeforeUnaryOperatorInInterpolationAlignmentClauseAsync(string spacing)
         {
-            string testFormat = @"namespace Namespace
+            string test = $@"namespace Namespace
 {{
     class Type
     {{
         void Foo()
         {{
-            string msg = $""{{5,{0}}}"";
+            string msg = $""{{5,{spacing}{this.Sign}3}}"";
         }}
     }}
 }}
 ";
 
-            // in all cases the final output should be the following
-            string fixedTest = @"namespace Namespace
-{
-    class Type
-    {
-        void Foo()
-        {
-            string msg = $""{5, " + this.Sign + @"3}"";
-        }
-    }
-}
-";
-
-            await this.VerifyCSharpDiagnosticAsync(fixedTest, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-
-            string test = string.Format(testFormat, " " + this.Sign + "3");
             await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpFixAsync(test, fixedTest, numberOfFixAllIterations: 0, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -489,18 +474,17 @@ namespace StyleCop.Analyzers.Test.SpacingRules
 }
 ";
 
-            await this.VerifyCSharpDiagnosticAsync(fixedTest, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-
             string test = string.Format(testFormat, this.Sign + "3");
             await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpFixAsync(test, fixedTest, numberOfFixAllIterations: 0, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, this.Sign + " 3");
-            var expected = new[]
-                               {
-                                   this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 31),
-                               };
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 31),
+            };
+
             await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTest, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
@@ -533,19 +517,17 @@ namespace StyleCop.Analyzers.Test.SpacingRules
 }
 ";
 
-            await this.VerifyCSharpDiagnosticAsync(fixedTest, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-
             string test = string.Format(testFormat, " " + this.Sign + "3");
             await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            await this.VerifyCSharpFixAsync(test, fixedTest, numberOfFixAllIterations: 0, cancellationToken: CancellationToken.None).ConfigureAwait(false);
 
             test = string.Format(testFormat, " " + this.Sign + " 3");
-            var expected =
-                new[]
-                    {
-                        this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 32),
-                    };
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 32),
+            };
+
             await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTest, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/NumberSignSpacingTestBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/NumberSignSpacingTestBase.cs
@@ -424,6 +424,131 @@ namespace StyleCop.Analyzers.Test.SpacingRules
             await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
+        [Fact]
+        [WorkItem(2289, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2289")]
+        public async Task TestSpaceBeforeUnaryOperatorInInterpolationAlignmentClauseAsync()
+        {
+            string testFormat = @"namespace Namespace
+{{
+    class Type
+    {{
+        void Foo()
+        {{
+            string msg = $""{{5,{0}}}"";
+        }}
+    }}
+}}
+";
+
+            // in all cases the final output should be the following
+            string fixedTest = @"namespace Namespace
+{
+    class Type
+    {
+        void Foo()
+        {
+            string msg = $""{5, " + this.Sign + @"3}"";
+        }
+    }
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedTest, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+
+            string test = string.Format(testFormat, " " + this.Sign + "3");
+            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, numberOfFixAllIterations: 0, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(2289, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2289")]
+        public async Task TestSpaceAfterUnaryOperatorInInterpolationAlignmentClauseAsync()
+        {
+            string testFormat = @"namespace Namespace
+{{
+    class Type
+    {{
+        void Foo()
+        {{
+            string msg = $""{{5,{0}}}"";
+        }}
+    }}
+}}
+";
+
+            // in all cases the final output should be the following
+            string fixedTest = @"namespace Namespace
+{
+    class Type
+    {
+        void Foo()
+        {
+            string msg = $""{5," + this.Sign + @"3}"";
+        }
+    }
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedTest, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+
+            string test = string.Format(testFormat, this.Sign + "3");
+            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, numberOfFixAllIterations: 0, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+
+            test = string.Format(testFormat, this.Sign + " 3");
+            var expected = new[]
+                               {
+                                   this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 31),
+                               };
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(2289, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2289")]
+        public async Task TestSpaceBeforeAndAfterUnaryOperatorInInterpolationAlignmentClauseAsync()
+        {
+            string testFormat = @"namespace Namespace
+{{
+    class Type
+    {{
+        void Foo()
+        {{
+            string msg = $""{{5,{0}}}"";
+        }}
+    }}
+}}
+";
+
+            // in all cases the final output should be the following
+            string fixedTest = @"namespace Namespace
+{
+    class Type
+    {
+        void Foo()
+        {
+            string msg = $""{5, " + this.Sign + @"3}"";
+        }
+    }
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(fixedTest, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+
+            string test = string.Format(testFormat, " " + this.Sign + "3");
+            await this.VerifyCSharpDiagnosticAsync(test, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, numberOfFixAllIterations: 0, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+
+            test = string.Format(testFormat, " " + this.Sign + " 3");
+            var expected =
+                new[]
+                    {
+                        this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 32),
+                    };
+            await this.VerifyCSharpDiagnosticAsync(test, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(test, fixedTest, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
         protected override abstract CodeFixProvider GetCSharpCodeFixProvider();
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
@@ -191,6 +191,24 @@ namespace StyleCop.Analyzers.Test.SpacingRules
         }
 
         [Fact]
+        [WorkItem(2289, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2289")]
+        public async Task TestSpaceBeforeAndAfterCommaWhenPartOfInterpolationAlignmentClauseAsync()
+        {
+            string statement = @"var x = new[] { 1, 2, 3, 4, 5, 6, 7 };
+            var t = $""{x[2] , 3}"";";
+            string fixedStatement = @"var x = new[] { 1, 2, 3, 4, 5, 6, 7 };
+            var t = $""{x[2],3}"";";
+
+            DiagnosticResult[] expected =
+                {
+                    this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(8, 29),
+                    this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(8, 29),
+                };
+
+            await this.TestCommaInStatementOrDeclAsync(statement, expected, fixedStatement).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestSpaceOnlyBeforeCommaAsync()
         {
             string spaceOnlyBeforeComma = @"f(a ,b);";

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
@@ -209,6 +209,40 @@ namespace StyleCop.Analyzers.Test.SpacingRules
         }
 
         [Fact]
+        [WorkItem(2289, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2289")]
+        public async Task TestSpaceAfterCommaWithMinusWhenPartOfInterpolationAlignmentClauseAsync()
+        {
+            string statement = @"var x = new[] { 1, 2, 3, 4, 5, 6, 7 };
+            var t = $""{x[2], -3}"";";
+            string fixedStatement = @"var x = new[] { 1, 2, 3, 4, 5, 6, 7 };
+            var t = $""{x[2],-3}"";";
+
+            DiagnosticResult[] expected =
+                {
+                    this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(8, 28),
+                };
+
+            await this.TestCommaInStatementOrDeclAsync(statement, expected, fixedStatement).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(2289, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2289")]
+        public async Task TestSpaceAfterCommaWithPlusWhenPartOfInterpolationAlignmentClauseAsync()
+        {
+            string statement = @"var x = new[] { 1, 2, 3, 4, 5, 6, 7 };
+            var t = $""{x[2], +3}"";";
+            string fixedStatement = @"var x = new[] { 1, 2, 3, 4, 5, 6, 7 };
+            var t = $""{x[2],+3}"";";
+
+            DiagnosticResult[] expected =
+                {
+                    this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(8, 28),
+                };
+
+            await this.TestCommaInStatementOrDeclAsync(statement, expected, fixedStatement).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestSpaceOnlyBeforeCommaAsync()
         {
             string spaceOnlyBeforeComma = @"f(a ,b);";

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.SpacingRules;
@@ -159,6 +158,34 @@ namespace StyleCop.Analyzers.Test.SpacingRules
             string fixedStatement = @"int[,,] myArray;";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 19);
+
+            await this.TestCommaInStatementOrDeclAsync(statement, expected, fixedStatement).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(2289, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2289")]
+        public async Task TestSpaceBeforeCommaWhenPartOfInterpolationAlignmentClauseAsync()
+        {
+            string statement = @"var x = new[] { 1, 2, 3, 4, 5, 6, 7 };
+            var t = $""{x[2] ,3}"";";
+            string fixedStatement = @"var x = new[] { 1, 2, 3, 4, 5, 6, 7 };
+            var t = $""{x[2],3}"";";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(8, 29);
+
+            await this.TestCommaInStatementOrDeclAsync(statement, expected, fixedStatement).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(2289, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2289")]
+        public async Task TestSpaceAfterCommaWhenPartOfInterpolationAlignmentClauseAsync()
+        {
+            string statement = @"var x = new[] { 1, 2, 3, 4, 5, 6, 7 };
+            var t = $""{x[2], 3}"";";
+            string fixedStatement = @"var x = new[] { 1, 2, 3, 4, 5, 6, 7 };
+            var t = $""{x[2],3}"";";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(8, 28);
 
             await this.TestCommaInStatementOrDeclAsync(statement, expected, fixedStatement).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1011UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1011UnitTests.cs
@@ -349,6 +349,24 @@ class ClassName
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        [Fact]
+        [WorkItem(2289, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2289")]
+        public async Task TestCommaCanFollowSquareBracketWhenPartOfInterpolationFormatClauseAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    void Method()
+    {
+        var x = new[] { 1, 2, 3, 4, 5, 6, 7 };
+        var t = $""{ x[2],3}"";
+    }
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
         /// <inheritdoc/>
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1011UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1011UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.SpacingRules;
@@ -325,6 +324,24 @@ class ClassName
             int*[] xx = new[] { p };
             return xx[0]->ToString(""n2"");
         }
+    }
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(2289, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2289")]
+        public async Task TestColonCanFollowSquareBracketWhenPartOfInterpolationFormatClauseAsync()
+        {
+            string testCode = @"
+class ClassName
+{
+    void Method()
+    {
+        var x = new[] { 1, 2, 3, 4, 5, 6, 7 };
+        var t = $""{ x[2]:C}"";
     }
 }
 ";

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1024UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1024UnitTests.cs
@@ -37,6 +37,9 @@ public class Foo<T> : object where T : IFormattable
             case 2:
             case 3:
                 return value;
+            case 4:
+                return (int)Convert.ToDouble($""{3:N}"");
+                return (int)Convert.ToDouble($""{3: N}"");
             default:
                 goto _label;
         }
@@ -70,6 +73,9 @@ public class Foo<T> : object where T/* test */ : IFormattable
             case 2:
             case 3:
                 return value;
+            case 4:
+                return (int)Convert.ToDouble($""{3:N}"");
+                return (int)Convert.ToDouble($""{3: N}"");
             default:
                 goto _label;
         }
@@ -111,6 +117,9 @@ base()
             case 2:
             case 3:
                 return value;
+            case 4:
+                return (int)Convert.ToDouble($""{3:N}"");
+                return (int)Convert.ToDouble($""{3: N}"");
             default:
                 goto _label;
         }
@@ -147,6 +156,9 @@ public class Foo<T> :object where T :IFormattable
             case 2:
             case 3:
                 return value;
+            case 4:
+                return (int)Convert.ToDouble($""{3:N}"");
+                return (int)Convert.ToDouble($""{3: N}"");
             default:
                 goto _label;
         }
@@ -193,6 +205,9 @@ public class Foo<T>: object where T: IFormattable
             case 2:
             case 3:
                 return value;
+            case 4:
+                return (int)Convert.ToDouble($""{3:N}"");
+                return (int)Convert.ToDouble($""{3: N}"");
             default:
                 goto _label;
         }
@@ -239,6 +254,9 @@ public class Foo<T> : object where T : IFormattable
             case 2:
             case 3 :
                 return value;
+            case 4:
+                return (int)Convert.ToDouble($""{3 :N}"");
+                return (int)Convert.ToDouble($""{3 : N}"");
             default :
                 goto _label;
         }
@@ -250,7 +268,9 @@ public class Foo<T> : object where T : IFormattable
                 this.CSharpDiagnostic().WithLocation(10, 19).WithArguments(" not", "preceded", string.Empty),
                 this.CSharpDiagnostic().WithLocation(15, 12).WithArguments(" not", "preceded", string.Empty),
                 this.CSharpDiagnostic().WithLocation(19, 20).WithArguments(" not", "preceded", string.Empty),
-                this.CSharpDiagnostic().WithLocation(21, 21).WithArguments(" not", "preceded", string.Empty),
+                this.CSharpDiagnostic().WithLocation(22, 51).WithArguments(" not", "preceded", string.Empty),
+                this.CSharpDiagnostic().WithLocation(23, 51).WithArguments(" not", "preceded", string.Empty),
+                this.CSharpDiagnostic().WithLocation(24, 21).WithArguments(" not", "preceded", string.Empty),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -284,6 +304,9 @@ public class Foo<T>:object where T:IFormattable
             case 2:
             case 3:
                 return value;
+            case 4:
+                return (int)Convert.ToDouble($""{3:N}"");
+                return (int)Convert.ToDouble($""{3: N}"");
             default:
                 goto _label;
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CommasMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CommasMustBeSpacedCorrectly.cs
@@ -16,8 +16,9 @@ namespace StyleCop.Analyzers.SpacingRules
     /// <remarks>
     /// <para>A violation of this rule occurs when the spacing around a comma is incorrect.</para>
     ///
-    /// <para>A comma should always be followed by a single space, unless it is the last character on the line, and a
-    /// comma should never be preceded by any whitespace, unless it is the first character on the line.</para>
+    /// <para>A comma should always be followed by a single space, unless it is the last character on the line
+    /// or it is part of an alignment component, and a comma should never be preceded by any whitespace,
+    /// unless it is the first character on the line.</para>
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal class SA1001CommasMustBeSpacedCorrectly : DiagnosticAnalyzer
@@ -75,6 +76,9 @@ namespace StyleCop.Analyzers.SpacingRules
 
             // check for a following space
             bool missingFollowingSpace = true;
+
+            // check for things like $"{x,5}"
+            var shouldNotHaveFollowingSpace = token.Parent.IsKind(SyntaxKind.InterpolationAlignmentClause);
             if (token.HasTrailingTrivia)
             {
                 if (token.TrailingTrivia.First().IsKind(SyntaxKind.WhitespaceTrivia))
@@ -102,10 +106,16 @@ namespace StyleCop.Analyzers.SpacingRules
                 context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), TokenSpacingProperties.RemovePrecedingPreserveLayout, " not", "preceded"));
             }
 
-            if (missingFollowingSpace)
+            if (missingFollowingSpace && !shouldNotHaveFollowingSpace)
             {
                 // comma should{} be {followed} by whitespace
                 context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), TokenSpacingProperties.InsertFollowing, string.Empty, "followed"));
+            }
+
+            if (!missingFollowingSpace && shouldNotHaveFollowingSpace)
+            {
+                // comma should{ not} be {followed} by whitespace
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), TokenSpacingProperties.RemoveFollowing, " not", "followed"));
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CommasMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1001CommasMustBeSpacedCorrectly.cs
@@ -16,8 +16,8 @@ namespace StyleCop.Analyzers.SpacingRules
     /// <remarks>
     /// <para>A violation of this rule occurs when the spacing around a comma is incorrect.</para>
     ///
-    /// <para>A comma should always be followed by a single space, unless it is the last character on the line
-    /// or it is part of an alignment component, and a comma should never be preceded by any whitespace,
+    /// <para>A comma should always be followed by a single space, unless it is the last character on the line or it is
+    /// part of a string interpolation alignment component, and a comma should never be preceded by any whitespace,
     /// unless it is the first character on the line.</para>
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011ClosingSquareBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011ClosingSquareBracketsMustBeSpacedCorrectly.cs
@@ -4,7 +4,6 @@
 namespace StyleCop.Analyzers.SpacingRules
 {
     using System;
-    using System.Collections.Generic;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
@@ -22,8 +21,9 @@ namespace StyleCop.Analyzers.SpacingRules
     /// line.</para>
     ///
     /// <para>A closing square bracket should be followed by whitespace, unless it is the last character on the line, it
-    /// is followed by a closing bracket or an opening parenthesis, it is followed by a comma or semicolon, or it is
-    /// followed by certain types of operator symbols.</para>
+    /// is followed by a closing bracket or an opening parenthesis, it is followed by a comma or semicolon, it is
+    /// followed by a alignment component or format string component, or it is followed by certain types of operator
+    /// symbols.</para>
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal class SA1011ClosingSquareBracketsMustBeSpacedCorrectly : DiagnosticAnalyzer
@@ -122,6 +122,11 @@ namespace StyleCop.Analyzers.SpacingRules
 
                 case SyntaxKind.CloseBraceToken:
                     precedesSpecialCharacter = nextToken.Parent is InterpolationSyntax;
+                    break;
+
+                case SyntaxKind.ColonToken:
+                    precedesSpecialCharacter = nextToken.Parent.IsKind(SyntaxKind.InterpolationFormatClause);
+                    suppressFollowingSpaceError = false;
                     break;
 
                 default:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011ClosingSquareBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011ClosingSquareBracketsMustBeSpacedCorrectly.cs
@@ -22,8 +22,8 @@ namespace StyleCop.Analyzers.SpacingRules
     ///
     /// <para>A closing square bracket should be followed by whitespace, unless it is the last character on the line, it
     /// is followed by a closing bracket or an opening parenthesis, it is followed by a comma or semicolon, it is
-    /// followed by a alignment component or format string component, or it is followed by certain types of operator
-    /// symbols.</para>
+    /// followed by a string interpolation alignment component or string interpolation formatting component, or it is
+    /// followed by certain types of operator symbols.</para>
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal class SA1011ClosingSquareBracketsMustBeSpacedCorrectly : DiagnosticAnalyzer

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021NegativeSignsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021NegativeSignsMustBeSpacedCorrectly.cs
@@ -17,7 +17,8 @@ namespace StyleCop.Analyzers.SpacingRules
     /// <para>A violation of this rule occurs when the spacing around a negative sign is not correct.</para>
     ///
     /// <para>A negative sign should always be preceded by a single space, unless it comes after an opening square
-    /// bracket, a parenthesis, or is the first character on the line.</para>
+    /// bracket, a parenthesis, is the first character on the line, or is part of a string interpolation alignment
+    /// component.</para>
     ///
     /// <para>A negative sign should never be followed by whitespace, and should never be the last character on a
     /// line.</para>
@@ -81,6 +82,14 @@ namespace StyleCop.Analyzers.SpacingRules
                 return;
             }
 
+            var isInInterpolationAlignmentClause = token.Parent.Parent.IsKind(SyntaxKind.InterpolationAlignmentClause);
+            if (isInInterpolationAlignmentClause && !token.IsFollowedByWhitespace())
+            {
+                // SA1001 is already handling the case like: line.Append($"{testResult.DisplayName, -75}");
+                // Where the extra space before the minus sign is undesirable.
+                return;
+            }
+
             bool precededBySpace = true;
             bool firstInLine = token.IsFirstInLine();
             bool followsSpecialCharacter = false;
@@ -99,7 +108,7 @@ namespace StyleCop.Analyzers.SpacingRules
                     || precedingToken.IsKind(SyntaxKind.CloseParenToken);
             }
 
-            if (!firstInLine)
+            if (!firstInLine && !isInInterpolationAlignmentClause)
             {
                 if (!followsSpecialCharacter && !precededBySpace)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022PositiveSignsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022PositiveSignsMustBeSpacedCorrectly.cs
@@ -17,7 +17,8 @@ namespace StyleCop.Analyzers.SpacingRules
     /// <para>A violation of this rule occurs when the spacing around a positive sign is not correct.</para>
     ///
     /// <para>A positive sign should always be preceded by a single space, unless it comes after an opening square
-    /// bracket, a parenthesis, or is the first character on the line.</para>
+    /// bracket, a parenthesis, is the first character on the line, or is part of a string interpolation alignment
+    /// component.</para>
     ///
     /// <para>A positive sign should never be followed by whitespace, and should never be the last character on a
     /// line.</para>
@@ -81,6 +82,14 @@ namespace StyleCop.Analyzers.SpacingRules
                 return;
             }
 
+            var isInInterpolationAlignmentClause = token.Parent.Parent.IsKind(SyntaxKind.InterpolationAlignmentClause);
+            if (isInInterpolationAlignmentClause && !token.IsFollowedByWhitespace())
+            {
+                // SA1001 is already handling the case like: line.Append($"{testResult.DisplayName, +75}");
+                // Where the extra space before the plus sign is undesirable.
+                return;
+            }
+
             bool precededBySpace = true;
             bool firstInLine = token.IsFirstInLine();
             bool followsSpecialCharacter = false;
@@ -99,7 +108,7 @@ namespace StyleCop.Analyzers.SpacingRules
                     || precedingToken.IsKind(SyntaxKind.CloseParenToken);
             }
 
-            if (!firstInLine)
+            if (!firstInLine && !isInInterpolationAlignmentClause)
             {
                 if (!followsSpecialCharacter && !precededBySpace)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1024ColonsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1024ColonsMustBeSpacedCorrectly.cs
@@ -42,6 +42,13 @@ namespace StyleCop.Analyzers.SpacingRules
     /// }
     /// </code>
     ///
+    /// <para>A colon that appears as part of format string component should not have leading whitespace characters. For
+    /// example:</para>
+    ///
+    /// <code language="cs">
+    /// var s = $"{x:N}";
+    /// </code>
+    ///
     /// <para>Finally, when a colon is used within a conditional statement, it should always contain a single space on
     /// either side, unless the colon is the first or last character on the line. For example:</para>
     ///
@@ -99,6 +106,7 @@ namespace StyleCop.Analyzers.SpacingRules
             }
 
             bool requireBefore;
+            var checkRequireAfter = true;
             switch (token.Parent.Kind())
             {
             case SyntaxKind.BaseList:
@@ -116,6 +124,11 @@ namespace StyleCop.Analyzers.SpacingRules
             // NameColon is not explicitly listed in the description of this warning, but the behavior is inferred
             case SyntaxKind.NameColon:
                 requireBefore = false;
+                break;
+
+            case SyntaxKind.InterpolationFormatClause:
+                requireBefore = false;
+                checkRequireAfter = false;
                 break;
 
             default:
@@ -155,7 +168,7 @@ namespace StyleCop.Analyzers.SpacingRules
                 context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), properties, requireBefore ? string.Empty : " not", "preceded", string.Empty));
             }
 
-            if (missingFollowingSpace)
+            if (missingFollowingSpace && checkRequireAfter)
             {
                 // colon should{} be {followed}{} by a space
                 context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), TokenSpacingProperties.InsertFollowing, string.Empty, "followed", string.Empty));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1024ColonsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1024ColonsMustBeSpacedCorrectly.cs
@@ -42,8 +42,8 @@ namespace StyleCop.Analyzers.SpacingRules
     /// }
     /// </code>
     ///
-    /// <para>A colon that appears as part of format string component should not have leading whitespace characters. For
-    /// example:</para>
+    /// <para>A colon that appears as part of a string interpolation formatting component should not have leading
+    /// whitespace characters. For example:</para>
     ///
     /// <code language="cs">
     /// var s = $"{x:N}";

--- a/documentation/SA1001.md
+++ b/documentation/SA1001.md
@@ -27,7 +27,7 @@ A comma should be followed by a single space, except in the following cases.
 
 * A comma may appear at the end of a line
 * A comma should not be followed by a space when used in an open generic type in a `typeof` expression
-* A comma is part of an alignment component. For example:`$"{x,3}"`
+* A comma is part of a string interpolation alignment component. For example:`$"{x,3}"`
 
 A comma should never be preceded by a space or appear as the first token on a line.
 

--- a/documentation/SA1001.md
+++ b/documentation/SA1001.md
@@ -27,6 +27,7 @@ A comma should be followed by a single space, except in the following cases.
 
 * A comma may appear at the end of a line
 * A comma should not be followed by a space when used in an open generic type in a `typeof` expression
+* A comma is part of an alignment component. For example:`$"{x,3}"`
 
 A comma should never be preceded by a space or appear as the first token on a line.
 

--- a/documentation/SA1011.md
+++ b/documentation/SA1011.md
@@ -29,7 +29,8 @@ A closing square bracket should be followed by whitespace unless:
 * It is the last character on the line
 * It is followed by a closing bracket or an opening parenthesis
 * It is followed by a comma or semicolon
-* It is followed by a alignment component or format string component. For example: `$"{x[i],3}"` or `$"{x[i]:C}"`
+* It is followed by a string interpolation alignment component. For example: `$"{x[i]:C}"`
+* It is followed by a string interpolation formatting component. For example: `$"{x[i],3}"`
 * It is followed by certain types of operator symbols.
 
 ## How to fix violations

--- a/documentation/SA1011.md
+++ b/documentation/SA1011.md
@@ -25,7 +25,12 @@ A violation of this rule occurs when the spacing around a closing square bracket
 
 A closing square bracket should never be preceded by whitespace, unless it is the first character on the line.
 
-A closing square bracket should be followed by whitespace, unless it is the last character on the line, it is followed by a closing bracket or an opening parenthesis, it is followed by a comma or semicolon, or it is followed by certain types of operator symbols.
+A closing square bracket should be followed by whitespace unless:
+* It is the last character on the line
+* It is followed by a closing bracket or an opening parenthesis
+* It is followed by a comma or semicolon
+* It is followed by a alignment component or format string component. For example: `$"{x[i],3}"` or `$"{x[i]:C}"`
+* It is followed by certain types of operator symbols.
 
 ## How to fix violations
 

--- a/documentation/SA1021.md
+++ b/documentation/SA1021.md
@@ -23,7 +23,7 @@ A negative sign within a C# element is not spaced correctly.
 
 A violation of this rule occurs when the spacing around a negative sign is not correct.
 
-A negative sign should always be preceded by a single space, unless it comes after an opening square bracket, a parenthesis, or is the first character on the line.
+A negative sign should always be preceded by a single space, unless it comes after an opening square bracket, a parenthesis, is the first character on the line, or is part of a string interpolation alignment component.
 
 A negative sign should never be followed by whitespace, and should never be the last character on a line.
 

--- a/documentation/SA1022.md
+++ b/documentation/SA1022.md
@@ -23,7 +23,7 @@ A positive sign within a C# element is not spaced correctly.
 
 A violation of this rule occurs when the spacing around a positive sign is not correct.
 
-A positive sign should always be preceded by a single space, unless it comes after an opening square bracket, a parenthesis, or is the first character on the line.
+A positive sign should always be preceded by a single space, unless it comes after an opening square bracket, a parenthesis, is the first character on the line, or is part of a string interpolation alignment component.
 
 A positive sign should never be followed by whitespace, and should never be the last character on a line.
 

--- a/documentation/SA1024.md
+++ b/documentation/SA1024.md
@@ -45,7 +45,7 @@ switch (x)
 }
 ```
 
-A colon that appears as part of format string component should not have leading whitespace characters. For example:
+A colon that appears as part of a string interpolation formatting component should not have leading whitespace characters. For example:
 
 ```csharp
 var s = $"{x:N}";

--- a/documentation/SA1024.md
+++ b/documentation/SA1024.md
@@ -45,6 +45,12 @@ switch (x)
 }
 ```
 
+A colon that appears as part of format string component should not have leading whitespace characters. For example:
+
+```csharp
+var s = $"{x:N}";
+```
+
 Finally, when a colon is used within a conditional statement, it should always contain a single space on either side, unless the colon is the first or last character on the line. For example:
 
 ```csharp


### PR DESCRIPTION
Fixes #2289 

**SA1001**:
Allow 
```csharp
$"{x,3}"
```
Disallow
```csharp
$"{x, 3}"
$"{x ,3}"
```
**SA1011**:
Allow 
```csharp
$"{x[n],3}"
$"{x[n]:N}"
```

**SA1024**:
Disallow 
```csharp
$"{x :N}"
```

Still allowed
```csharp
$"{x: N}"
```