### PR TITLE
#2308 - SA1008 triggered by typle return types on a method - fixed

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1008UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1008UnitTests.cs
@@ -2032,6 +2032,90 @@ class ClassName
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verifies that spacing for public tuple return type is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact(Skip = "Tuples currently require System.ValueTuple nuget package to be installed")]
+        public async Task TestNoFalsePositiveOnPublicTupleReturnAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public (string primary, string alternate) CalculateMetaphone(string word)
+        {
+        }
+    }
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing for internal tuple return type is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact(Skip = "Tuples currently require System.ValueTuple nuget package to be installed")]
+        public async Task TestNoFalsePositiveOnInternalTupleReturnAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    internal class TestClass
+    {
+        public (string primary, string alternate) CalculateMetaphone(string word)
+        {
+        }
+    }
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing for private tuple return type is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact(Skip = "Tuples currently require System.ValueTuple nuget package to be installed")]
+        public async Task TestNoFalsePositiveOnPrivateTupleReturnAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    private class TestClass
+    {
+        public (string primary, string alternate) CalculateMetaphone(string word)
+        {
+        }
+    }
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing for protected tuple return type is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact(Skip = "Tuples currently require System.ValueTuple nuget package to be installed")]
+        public async Task TestNoFalsePositiveProtectedOnTupleReturnAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    protected class TestClass
+    {
+        public (string primary, string alternate) CalculateMetaphone(string word)
+        {
+        }
+    }
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
         /// <inheritdoc/>
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
@@ -134,7 +134,11 @@ namespace StyleCop.Analyzers.SpacingRules
             case SyntaxKind.WhereKeyword:
             case SyntaxKind.WhileKeyword:
             case SyntaxKind.YieldKeyword:
-                precededByKeyword = true;
+            case SyntaxKind.PublicKeyword:
+            case SyntaxKind.PrivateKeyword:
+            case SyntaxKind.InternalKeyword:
+            case SyntaxKind.ProtectedKeyword:
+                    precededByKeyword = true;
                 break;
 
             default:


### PR DESCRIPTION
#2308 - SA1008 triggered by typle return types on a method (c# version 7) - Fixed

Note: unit tests created but wont work without System.ValueTuple nuget package so set to Skip atm..
