### PR TITLE
Add build artifacts to AppVeyor output

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,3 +17,6 @@ test_script:
 # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
 cache:
   - packages -> **\packages.config
+artifacts:
+- path: 'StyleCop.Analyzers\**\*.vsix'
+- path: 'StyleCop.Analyzers\**\*.nupkg'


### PR DESCRIPTION
This improves the ability of developers to test the build output during the review process for proposed changes.