### PR TITLE
Fix SA1308CodeFixProvider creating empty identifier and add regression test

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/NamingRules/SA1308CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/NamingRules/SA1308CodeFixProvider.cs
@@ -42,18 +42,12 @@ namespace StyleCop.Analyzers.NamingRules
             {
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
 
-                // The variable name is the full suffix. In this case we cannot generate a valid variable name and thus will not offer a code fix.
-                if (token.ValueText.Length <= 2)
-                {
-                    continue;
-                }
-
-                var numberOfCharsToRemove = 2;
+                var numberOfCharsToRemove = 0;
 
                 // If a variable contains multiple prefixes that would result in this diagnostic,
                 // we detect that and remove all of the bad prefixes such that after
                 // the fix is applied there are no more violations of this rule.
-                for (int i = 2; i < token.ValueText.Length; i += 2)
+                for (int i = 0; i < token.ValueText.Length; i += 2)
                 {
                     if (string.Compare("m_", 0, token.ValueText, i, 2, StringComparison.Ordinal) == 0
                         || string.Compare("s_", 0, token.ValueText, i, 2, StringComparison.Ordinal) == 0
@@ -66,16 +60,24 @@ namespace StyleCop.Analyzers.NamingRules
                     break;
                 }
 
-                if (!string.IsNullOrEmpty(token.ValueText))
+                if (numberOfCharsToRemove == 0)
                 {
-                    var newName = token.ValueText.Substring(numberOfCharsToRemove);
-                    context.RegisterCodeFix(
-                        CodeAction.Create(
-                            string.Format(NamingResources.RenameToCodeFix, newName),
-                            cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken),
-                            nameof(SA1308CodeFixProvider)),
-                        diagnostic);
+                    continue;
                 }
+
+                // The prefix is the full variable name. In this case we cannot generate a valid variable name and thus will not offer a code fix.
+                if (token.ValueText.Length == numberOfCharsToRemove)
+                {
+                    continue;
+                }
+
+                var newName = token.ValueText.Substring(numberOfCharsToRemove);
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        string.Format(NamingResources.RenameToCodeFix, newName),
+                        cancellationToken => RenameHelper.RenameSymbolAsync(document, root, token, newName, cancellationToken),
+                        nameof(SA1308CodeFixProvider)),
+                    diagnostic);
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/NamingRules/SA1308CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/NamingRules/SA1308CodeFixProvider.cs
@@ -60,11 +60,6 @@ namespace StyleCop.Analyzers.NamingRules
                     break;
                 }
 
-                if (numberOfCharsToRemove == 0)
-                {
-                    continue;
-                }
-
                 // The prefix is the full variable name. In this case we cannot generate a valid variable name and thus will not offer a code fix.
                 if (token.ValueText.Length == numberOfCharsToRemove)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1308UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1308UnitTests.cs
@@ -87,6 +87,7 @@ string m_bar = ""baz"";
         /// <summary>
         /// This is a regression test for DotNetAnalyzers/StyleCopAnalyzers#627.
         /// </summary>
+        /// <param name="prefix">The prefix to repeat in the variable name.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         /// <seealso href="https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/627">#627: Code Fixes For Naming
         /// Rules SA1308 and SA1309 Do Not Always Fix The Name Entirely</seealso>
@@ -99,9 +100,10 @@ string m_bar = ""baz"";
     private string {prefix}{prefix}bar = ""baz"";
 }}";
 
+            string diagnosticPrefix = prefix.Replace("\\u005F", "_");
             DiagnosticResult expected =
                 this.CSharpDiagnostic()
-                .WithArguments($"{prefix}{prefix}bar", prefix)
+                .WithArguments($"{prefix}{prefix}bar", diagnosticPrefix)
                 .WithLocation(3, 20);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -125,6 +127,7 @@ string m_bar = ""baz"";
                 .WithLocation(3, 20);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
             // A code fix is not offered as removing the prefixes would create an empty identifier.
             await this.VerifyCSharpFixAsync(testCode, testCode).ConfigureAwait(false);
         }
@@ -132,6 +135,8 @@ string m_bar = ""baz"";
         /// <summary>
         /// This is a regression test for DotNetAnalyzers/StyleCopAnalyzers#627.
         /// </summary>
+        /// <param name="prefixes">The prefixes to prepend to the variable name.</param>
+        /// <param name="diagnosticPrefix">The prefix that should be reported in the diagnostic.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         /// <seealso href="https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/627">#627: Code Fixes For Naming
         /// Rules SA1308 and SA1309 Do Not Always Fix The Name Entirely</seealso>
@@ -146,7 +151,7 @@ string m_bar = ""baz"";
 
             DiagnosticResult expected =
                 this.CSharpDiagnostic()
-                .WithArguments($"{prefixes}bar", firstPrefix)
+                .WithArguments($"{prefixes}bar", diagnosticPrefix)
                 .WithLocation(3, 20);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
@@ -166,12 +171,13 @@ string m_bar = ""baz"";
 
             DiagnosticResult expected =
                 this.CSharpDiagnostic()
-                .WithArguments(prefixes, firstPrefix)
+                .WithArguments(prefixes, diagnosticPrefix)
                 .WithLocation(3, 20);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
             // A code fix is not offered as removing the prefixes would create an empty identifier.
-            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, testCode).ConfigureAwait(false);
         }
 
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1308UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1308UnitTests.cs
@@ -14,7 +14,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
 
     public class SA1308UnitTests : CodeFixVerifier
     {
-        private const string UnderscoreEscapeSequence = @"\\u005F";
+        private const string UnderscoreEscapeSequence = @"\u005F";
 
         private readonly string[] modifiers = new[] { "public", "private", "protected", "public readonly", "internal readonly", "public static", "private static" };
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1308UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1308UnitTests.cs
@@ -16,6 +16,22 @@ namespace StyleCop.Analyzers.Test.NamingRules
     {
         private readonly string[] modifiers = new[] { "public", "private", "protected", "public readonly", "internal readonly", "public static", "private static" };
 
+        public static IEnumerable<object[]> PrefixesData()
+        {
+            yield return new object[] { "m_" };
+            yield return new object[] { "s_" };
+            yield return new object[] { "t_" };
+            yield return new object[] { "m\\u005F" };
+            yield return new object[] { "s\\u005F" };
+            yield return new object[] { "t\\u005F" };
+        }
+
+        public static IEnumerable<object[]> MultipleDistinctPrefixesData()
+        {
+            yield return new object[] { "m_t_s_", "m_" };
+            yield return new object[] { "s\\u005Fm\\u005Ft\\u005F", "s_" };
+        }
+
         [Fact]
         public async Task TestFieldStartingWithPrefixesToTriggerDiagnosticAsync()
         {
@@ -74,23 +90,43 @@ string m_bar = ""baz"";
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         /// <seealso href="https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/627">#627: Code Fixes For Naming
         /// Rules SA1308 and SA1309 Do Not Always Fix The Name Entirely</seealso>
-        [Fact]
-        public async Task TestFixingMultipleIdenticalPrefixesAsync()
+        [Theory]
+        [MemberData(nameof(PrefixesData))]
+        public async Task TestFixingMultipleIdenticalPrefixesAsync(string prefix)
         {
-            var testCode = @"public class Foo
-{
-    private string m_m_bar = ""baz"";
-}";
+            var testCode = $@"public class Foo
+{{
+    private string {prefix}{prefix}bar = ""baz"";
+}}";
 
             DiagnosticResult expected =
                 this.CSharpDiagnostic()
-                .WithArguments("m_m_bar", "m_")
+                .WithArguments($"{prefix}{prefix}bar", prefix)
                 .WithLocation(3, 20);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
-            var fixedCode = testCode.Replace("m_", string.Empty);
+            var fixedCode = testCode.Replace(prefix, string.Empty);
             await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(PrefixesData))]
+        public async Task TestMultipleIdenticalPrefixesOnlyAsync(string prefix)
+        {
+            var testCode = $@"public class Foo
+{{
+    private string {prefix}{prefix} = ""baz"";
+}}";
+
+            DiagnosticResult expected =
+                this.CSharpDiagnostic()
+                .WithArguments($"{prefix}{prefix}", prefix)
+                .WithLocation(3, 20);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            // A code fix is not offered as removing the prefixes would create an empty identifier.
+            await this.VerifyCSharpFixAsync(testCode, testCode).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -99,25 +135,42 @@ string m_bar = ""baz"";
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         /// <seealso href="https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/627">#627: Code Fixes For Naming
         /// Rules SA1308 and SA1309 Do Not Always Fix The Name Entirely</seealso>
-        [Fact]
-        public async Task TestFixingMultipleIndependentPrefixesAsync()
+        [Theory]
+        [MemberData(nameof(MultipleDistinctPrefixesData))]
+        public async Task TestFixingMultipleDistinctPrefixesAsync(string prefixes, string diagnosticPrefix)
         {
-            var testCode = @"public class Foo
-{
-    private string m_t_s_bar = ""baz"";
-}";
+            var testCode = $@"public class Foo
+{{
+    private string {prefixes}bar = ""baz"";
+}}";
 
             DiagnosticResult expected =
                 this.CSharpDiagnostic()
-                .WithArguments("m_t_s_bar", "m_")
+                .WithArguments($"{prefixes}bar", firstPrefix)
                 .WithLocation(3, 20);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
 
-            var fixedCode = testCode.Replace("m_", string.Empty);
-            fixedCode = fixedCode.Replace("s_", string.Empty);
-            fixedCode = fixedCode.Replace("t_", string.Empty);
+            var fixedCode = testCode.Replace(prefixes, string.Empty);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
 
+        [Theory]
+        [MemberData(nameof(MultipleDistinctPrefixesData))]
+        public async Task TestMultipleDistinctPrefixesOnlyAsync(string prefixes, string diagnosticPrefix)
+        {
+            var testCode = $@"public class Foo
+{{
+    private string {prefixes} = ""baz"";
+}}";
+
+            DiagnosticResult expected =
+                this.CSharpDiagnostic()
+                .WithArguments(prefixes, firstPrefix)
+                .WithLocation(3, 20);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            // A code fix is not offered as removing the prefixes would create an empty identifier.
             await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
Had to close #2337 because I submitted from the wrong branch. Sorry about that.

`SA1308CodeFixProvider` has a branch to prevent it from creating an empty identifier if the variable name consists solely of the offending prefix. However, if it consists only of multiple prefixes, e.g. `m_s_t_`, then it will try to rename the variable to the empty string.

This PR changes the logic to be more flexible, and adds regression tests. It also converts some existing tests for that analyzer to use `Theory` instead of `Fact`.