### PR TITLE
Update SA1101.md

### DIFF
--- a/documentation/SA1101.md
+++ b/documentation/SA1101.md
@@ -23,7 +23,7 @@ A call to an instance member of the local class or a base class is not prefixed 
 
 A violation of this rule occurs whenever the code contains a call to an instance member of the local class or a base class which is not prefixed with 'this.'. An exception to this rule occurs when there is a local override of a base class member, and the code intends to call the base class member directly, bypassing the local override. In this case the call can be prefixed with 'base.' rather than 'this.'.
 
-By default, StyleCop disallows the use of underscores or *m_* to mark local class fields, in favor of the 'this.' prefix. The advantage of using 'this.' is that it applies equally to all element types including methods, properties, etc., and not just fields, making all calls to class members instantly recognizable, regardless of which editor is being used to view the code. Another advantage is that it creates a quick, recognizable differentiation between instance members and static members, which are not be prefixed.
+By default, StyleCop disallows the use of underscores or *m_* to mark local class fields, in favor of the 'this.' prefix. The advantage of using 'this.' is that it applies equally to all element types including methods, properties, etc., and not just fields, making all calls to class members instantly recognizable, regardless of which editor is being used to view the code. Another advantage is that it creates a quick, recognizable differentiation between instance members and static members, which are not prefixed.
 
 A final advantage of using the 'this.' prefix is that typing *this.* will cause Visual Studio to show the IntelliSense popup, making it quick and easy for the developer to choose the class member to call.
 


### PR DESCRIPTION
Removed the word "be" on line 26. Alternatively, this could be changed to "to be".