### PR TITLE
Update spacing rules for C# 7

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1000CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1000CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using StyleCop.Analyzers.Test.SpacingRules;
+
+    public class SA1000CSharp7UnitTests : SA1000UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1000CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1000CSharp7UnitTests.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using StyleCop.Analyzers.Test.SpacingRules;
     using TestHelper;
@@ -70,6 +71,60 @@ ref @Int32 Call(ref @Int32 p)
             };
 
             await this.TestKeywordStatementAsync(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing for tuple expressions is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        /// <seealso cref="SA1008CSharp7UnitTests.TestTupleExpressionsAsync"/>
+        [Fact]
+        public async Task TestReturnTupleExpressionsAsync()
+        {
+            var testCode = @"using System.Collections.Generic;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            // Returns (leading spaces after keyword checked in SA1000, not SA1008)
+            (int, int) LocalFunction1() { return( 1, 2); }
+            (int, int) LocalFunction2() { return(1, 2); }
+            (int, int) LocalFunction3() { return ( 1, 2); }
+        }
+    }
+}
+";
+
+            var fixedCode = @"using System.Collections.Generic;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            // Returns (leading spaces after keyword checked in SA1000, not SA1008)
+            (int, int) LocalFunction1() { return ( 1, 2); }
+            (int, int) LocalFunction2() { return (1, 2); }
+            (int, int) LocalFunction3() { return ( 1, 2); }
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostics =
+            {
+                // Returns
+                this.CSharpDiagnostic().WithArguments("return", string.Empty, "followed").WithLocation(10, 43),
+                this.CSharpDiagnostic().WithArguments("return", string.Empty, "followed").WithLocation(11, 43),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostics, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1000CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1000CSharp7UnitTests.cs
@@ -3,11 +3,7 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
-    using System;
-    using System.Linq;
-    using System.Reflection;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis;
     using StyleCop.Analyzers.Test.SpacingRules;
     using TestHelper;
     using Xunit;
@@ -74,15 +70,6 @@ ref @Int32 Call(ref @Int32 p)
             };
 
             await this.TestKeywordStatementAsync(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
-        }
-
-        protected override Solution CreateSolution(ProjectId projectId, string language)
-        {
-            Solution solution = base.CreateSolution(projectId, language);
-            Assembly systemRuntime = AppDomain.CurrentDomain.GetAssemblies().Single(x => x.GetName().Name == "System.Runtime");
-            return solution
-                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(systemRuntime.Location))
-                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ValueTuple).Assembly.Location));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1001CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1001CSharp7UnitTests.cs
@@ -55,6 +55,41 @@ public class Foo
         }
 
         /// <summary>
+        /// Verifies spacing around a <c>}</c> character in tuple expressions.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        /// <seealso cref="SA1009CSharp7UnitTests.TestSpacingAroundClosingBraceInTupleExpressionsAsync"/>
+        /// <seealso cref="SA1013CSharp7UnitTests.TestSpacingAroundClosingBraceInTupleExpressionsAsync"/>
+        [Fact]
+        public async Task TestSpacingAroundClosingBraceInTupleExpressionsAsync()
+        {
+            const string testCode = @"using System;
+
+public class Foo
+{
+    public void TestMethod()
+    {
+        var values = (new[] { 3} , new[] { 3} );
+    }
+}";
+            const string fixedCode = @"using System;
+
+public class Foo
+{
+    public void TestMethod()
+    {
+        var values = (new[] { 3}, new[] { 3} );
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 34).WithArguments(" not", "preceded");
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Verifies spacing around a <c>&gt;</c> character in tuple types.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1001CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1001CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using StyleCop.Analyzers.Test.SpacingRules;
+
+    public class SA1001CSharp7UnitTests : SA1001UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1001CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1001CSharp7UnitTests.cs
@@ -3,12 +3,8 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
-    using System;
-    using System.Linq;
-    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis;
     using StyleCop.Analyzers.Test.SpacingRules;
     using TestHelper;
     using Xunit;
@@ -91,15 +87,6 @@ public class Foo
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
-        }
-
-        protected override Solution CreateSolution(ProjectId projectId, string language)
-        {
-            Solution solution = base.CreateSolution(projectId, language);
-            Assembly systemRuntime = AppDomain.CurrentDomain.GetAssemblies().Single(x => x.GetName().Name == "System.Runtime");
-            return solution
-                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(systemRuntime.Location))
-                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ValueTuple).Assembly.Location));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1001CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1001CSharp7UnitTests.cs
@@ -3,9 +3,68 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
     using StyleCop.Analyzers.Test.SpacingRules;
+    using TestHelper;
+    using Xunit;
 
     public class SA1001CSharp7UnitTests : SA1001UnitTests
     {
+        /// <summary>
+        /// Verifies spacing around a <c>]</c> character in tuple types and expressions.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        /// <seealso cref="SA1009CSharp7UnitTests.TestBracketsInTupleTypesNotFollowedBySpaceAsync"/>
+        /// <seealso cref="SA1011CSharp7UnitTests.TestBracketsInTupleTypesNotFollowedBySpaceAsync"/>
+        [Fact]
+        public async Task TestBracketsInTupleTypesNotFollowedBySpaceAsync()
+        {
+            const string testCode = @"using System;
+
+public class Foo
+{
+    public (int[] , int[] ) TestMethod((int[] , int[] ) a)
+    {
+        (int[] , int[] ) ints = (new int[][] { new[] { 3 } }[0] , new int[][] { new[] { 3 } }[0] );
+        return ints;
+    }
+}";
+            const string fixedCode = @"using System;
+
+public class Foo
+{
+    public (int[], int[] ) TestMethod((int[], int[] ) a)
+    {
+        (int[], int[] ) ints = (new int[][] { new[] { 3 } }[0], new int[][] { new[] { 3 } }[0] );
+        return ints;
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(5, 19).WithArguments(" not", "preceded"),
+                this.CSharpDiagnostic().WithLocation(5, 47).WithArguments(" not", "preceded"),
+                this.CSharpDiagnostic().WithLocation(7, 16).WithArguments(" not", "preceded"),
+                this.CSharpDiagnostic().WithLocation(7, 65).WithArguments(" not", "preceded"),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected override Solution CreateSolution(ProjectId projectId, string language)
+        {
+            Solution solution = base.CreateSolution(projectId, language);
+            Assembly systemRuntime = AppDomain.CurrentDomain.GetAssemblies().Single(x => x.GetName().Name == "System.Runtime");
+            return solution
+                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(systemRuntime.Location))
+                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ValueTuple).Assembly.Location));
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1001CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1001CSharp7UnitTests.cs
@@ -58,6 +58,41 @@ public class Foo
             await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verifies spacing around a <c>&gt;</c> character in tuple types.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        /// <seealso cref="SA1009CSharp7UnitTests.TestClosingGenericBracketsInTupleTypesNotFollowedBySpaceAsync"/>
+        /// <seealso cref="SA1015CSharp7UnitTests.TestClosingGenericBracketsInTupleTypesNotPrecededBySpaceAsync"/>
+        [Fact]
+        public async Task TestClosingGenericBracketsInTupleTypesNotFollowedBySpaceAsync()
+        {
+            const string testCode = @"using System;
+
+public class Foo
+{
+    public void TestMethod()
+    {
+        (Func<int > , Func<int > ) value = (null, null);
+    }
+}";
+            const string fixedCode = @"using System;
+
+public class Foo
+{
+    public void TestMethod()
+    {
+        (Func<int >, Func<int > ) value = (null, null);
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 21).WithArguments(" not", "preceded");
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
         protected override Solution CreateSolution(ProjectId projectId, string language)
         {
             Solution solution = base.CreateSolution(projectId, language);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1002CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1002CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1002CSharp7UnitTests : SA1002UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1003CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1003CSharp7UnitTests.cs
@@ -33,6 +33,10 @@ namespace N1
         public event EventHandler E { add=>e += value; remove=>e -= value; } // Event accessors
         public int Answer { get=>42; set=>x = 2; } // Property accessors
         public int this[int index] { get=>42; set=>x = value; } // Indexer accessors
+        public void Method()
+        {
+            int LocalFunction()=>42; // Local functions
+        }
     }
 }
 ";
@@ -49,6 +53,10 @@ namespace N1
         public event EventHandler E { add => e += value; remove => e -= value; } // Event accessors
         public int Answer { get => 42; set => x = 2; } // Property accessors
         public int this[int index] { get => 42; set => x = value; } // Indexer accessors
+        public void Method()
+        {
+            int LocalFunction() => 42; // Local functions
+        }
     }
 }
 ";
@@ -74,6 +82,9 @@ namespace N1
                 this.CSharpDiagnostic(DescriptorFollowedByWhitespace).WithLocation(13, 41).WithArguments("=>"),
                 this.CSharpDiagnostic(DescriptorPrecededByWhitespace).WithLocation(13, 50).WithArguments("=>"),
                 this.CSharpDiagnostic(DescriptorFollowedByWhitespace).WithLocation(13, 50).WithArguments("=>"),
+
+                this.CSharpDiagnostic(DescriptorPrecededByWhitespace).WithLocation(16, 32).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorFollowedByWhitespace).WithLocation(16, 32).WithArguments("=>"),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1003CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1003CSharp7UnitTests.cs
@@ -3,9 +3,81 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using Test.SpacingRules;
+    using TestHelper;
+    using Xunit;
+
+    using static StyleCop.Analyzers.SpacingRules.SA1003SymbolsMustBeSpacedCorrectly;
 
     public class SA1003CSharp7UnitTests : SA1003UnitTests
     {
+        /// <summary>
+        /// Verifies that the additional expression-bodied members supported in C# 7 trigger diagnostics as expected.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestCSharp7ExpressionBodiedMembersAsync()
+        {
+            var testCode = @"using System;
+namespace N1
+{
+    public class C1
+    {
+        private int x;
+        private EventHandler e;
+
+        public C1()=>x = 1; // Constructors
+        ~C1()=>x = 0; // Finalizers
+        public event EventHandler E { add=>e += value; remove=>e -= value; } // Event accessors
+        public int Answer { get=>42; set=>x = 2; } // Property accessors
+        public int this[int index] { get=>42; set=>x = value; } // Indexer accessors
+    }
+}
+";
+            var fixedTestCode = @"using System;
+namespace N1
+{
+    public class C1
+    {
+        private int x;
+        private EventHandler e;
+
+        public C1() => x = 1; // Constructors
+        ~C1() => x = 0; // Finalizers
+        public event EventHandler E { add => e += value; remove => e -= value; } // Event accessors
+        public int Answer { get => 42; set => x = 2; } // Property accessors
+        public int this[int index] { get => 42; set => x = value; } // Indexer accessors
+    }
+}
+";
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic(DescriptorPrecededByWhitespace).WithLocation(9, 20).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorFollowedByWhitespace).WithLocation(9, 20).WithArguments("=>"),
+
+                this.CSharpDiagnostic(DescriptorPrecededByWhitespace).WithLocation(10, 14).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorFollowedByWhitespace).WithLocation(10, 14).WithArguments("=>"),
+
+                this.CSharpDiagnostic(DescriptorPrecededByWhitespace).WithLocation(11, 42).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorFollowedByWhitespace).WithLocation(11, 42).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorPrecededByWhitespace).WithLocation(11, 62).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorFollowedByWhitespace).WithLocation(11, 62).WithArguments("=>"),
+
+                this.CSharpDiagnostic(DescriptorPrecededByWhitespace).WithLocation(12, 32).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorFollowedByWhitespace).WithLocation(12, 32).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorPrecededByWhitespace).WithLocation(12, 41).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorFollowedByWhitespace).WithLocation(12, 41).WithArguments("=>"),
+
+                this.CSharpDiagnostic(DescriptorPrecededByWhitespace).WithLocation(13, 41).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorFollowedByWhitespace).WithLocation(13, 41).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorPrecededByWhitespace).WithLocation(13, 50).WithArguments("=>"),
+                this.CSharpDiagnostic(DescriptorFollowedByWhitespace).WithLocation(13, 50).WithArguments("=>"),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1003CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1003CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1003CSharp7UnitTests : SA1003UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1004CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1004CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1004CSharp7UnitTests : SA1004UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1005CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1005CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1005CSharp7UnitTests : SA1005UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1006CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1006CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1006CSharp7UnitTests : SA1006UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1007CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1007CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1007CSharp7UnitTests : SA1007UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
@@ -14,6 +14,648 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     public class SA1008CSharp7UnitTests : SA1008UnitTests
     {
         /// <summary>
+        /// Verifies that spacing around tuple type casts is handled properly.
+        /// </summary>
+        /// <remarks>
+        /// <para>Tuple type casts must be parenthesized, so there are only a limited number of special cases that need
+        /// to be added after the ones in <see cref="SA1008UnitTests.TestTypeCastSpacingAsync"/>.</para>
+        /// </remarks>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestTupleTypeCastSpacingAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var test1 = ( ( int, int))(3, 3);
+            var test2 = ( (int, int))(3, 3);
+            var test3 = (( int, int))(3, 3);
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var test1 = ((int, int))(3, 3);
+            var test2 = ((int, int))(3, 3);
+            var test3 = ((int, int))(3, 3);
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostic =
+            {
+                // test1
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(7, 25),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(7, 27),
+
+                // test2
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(8, 25),
+
+                // test3
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(9, 26),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing around tuple types in parameters is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        /// <seealso cref="SA1008UnitTests.TestParameterListsAsync"/>
+        [Fact]
+        public async Task TestTupleParameterTypeAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public int TestMethod1( ( int, int) arg) => 0;
+        public int TestMethod2( (int, int) arg) => 0;
+        public int TestMethod3(( int, int) arg) => 0;
+
+        public int TestMethod4((int, int) arg1,( int, int) arg2) => 0;
+        public int TestMethod5((int, int) arg1,(int, int) arg2) => 0;
+        public int TestMethod6((int, int) arg1, ( int, int) arg2) => 0;
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public int TestMethod1((int, int) arg) => 0;
+        public int TestMethod2((int, int) arg) => 0;
+        public int TestMethod3((int, int) arg) => 0;
+
+        public int TestMethod4((int, int) arg1, (int, int) arg2) => 0;
+        public int TestMethod5((int, int) arg1, (int, int) arg2) => 0;
+        public int TestMethod6((int, int) arg1, (int, int) arg2) => 0;
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostic =
+            {
+                // TestMethod1
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(5, 31),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(5, 33),
+
+                // TestMethod2
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(6, 31),
+
+                // TestMethod3
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(7, 32),
+
+                // TestMethod4
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(9, 48),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(9, 48),
+
+                // TestMethod5
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(10, 48),
+
+                // TestMethod6
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(11, 49),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, numberOfFixAllIterations: 2).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing around tuple return types is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestTupleReturnTypeAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public( int, int) TestMethod1() => default( ( int, int));
+        public(int, int) TestMethod2() => default( (int, int));
+        public ( int, int) TestMethod3() => default(( int, int));
+
+        public ( ( int, int), int) TestMethod4() => default(( ( int, int), int));
+        public ( (int, int), int) TestMethod5() => default(( (int, int), int));
+        public (( int, int), int) TestMethod6() => default((( int, int), int));
+
+        public (int,( int, int)) TestMethod7() => default((int,( int, int)));
+        public (int,(int, int)) TestMethod8() => default((int,(int, int)));
+        public (int, ( int, int)) TestMethod9() => default((int, ( int, int)));
+
+        public( int x, int y) TestMethod10() => default( ( int x, int y));
+        public(int x, int y) TestMethod11() => default( (int x, int y));
+        public ( int x, int y) TestMethod12() => default(( int x, int y));
+
+        public ( ( int x, int y), int z) TestMethod13() => default(( ( int x, int y), int z));
+        public ( (int x, int y), int z) TestMethod14() => default(( (int x, int y), int z));
+        public (( int x, int y), int z) TestMethod15() => default((( int x, int y), int z));
+
+        public (int x,( int y, int z)) TestMethod16() => default((int x,( int y, int z)));
+        public (int x,(int y, int z)) TestMethod17() => default((int x,(int y, int z)));
+        public (int x, ( int y, int z)) TestMethod18() => default((int x, ( int y, int z)));
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public (int, int) TestMethod1() => default((int, int));
+        public (int, int) TestMethod2() => default((int, int));
+        public (int, int) TestMethod3() => default((int, int));
+
+        public ((int, int), int) TestMethod4() => default(((int, int), int));
+        public ((int, int), int) TestMethod5() => default(((int, int), int));
+        public ((int, int), int) TestMethod6() => default(((int, int), int));
+
+        public (int, (int, int)) TestMethod7() => default((int, (int, int)));
+        public (int, (int, int)) TestMethod8() => default((int, (int, int)));
+        public (int, (int, int)) TestMethod9() => default((int, (int, int)));
+
+        public (int x, int y) TestMethod10() => default((int x, int y));
+        public (int x, int y) TestMethod11() => default((int x, int y));
+        public (int x, int y) TestMethod12() => default((int x, int y));
+
+        public ((int x, int y), int z) TestMethod13() => default(((int x, int y), int z));
+        public ((int x, int y), int z) TestMethod14() => default(((int x, int y), int z));
+        public ((int x, int y), int z) TestMethod15() => default(((int x, int y), int z));
+
+        public (int x, (int y, int z)) TestMethod16() => default((int x, (int y, int z)));
+        public (int x, (int y, int z)) TestMethod17() => default((int x, (int y, int z)));
+        public (int x, (int y, int z)) TestMethod18() => default((int x, (int y, int z)));
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostic =
+            {
+                // TestMethod1, TestMethod2, TestMethod3
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(5, 15),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(5, 15),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(5, 51),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(5, 53),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(6, 15),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(6, 50),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(7, 16),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(7, 53),
+
+                // TestMethod4, TestMethod5, TestMethod6
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(9, 16),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(9, 18),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(9, 61),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(9, 63),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(10, 16),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(10, 60),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(11, 17),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(11, 61),
+
+                // TestMethod7, TestMethod8, TestMethod9
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(13, 21),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(13, 21),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(13, 64),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(13, 64),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(14, 21),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(14, 63),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(15, 22),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(15, 66),
+
+                // TestMethod10, TestMethod11, TestMethod12
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(17, 15),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(17, 15),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(17, 56),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(17, 58),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(18, 15),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(18, 55),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(19, 16),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(19, 58),
+
+                // TestMethod13, TestMethod14, TestMethod15
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(21, 16),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(21, 18),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(21, 68),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(21, 70),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(22, 16),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(22, 67),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(23, 17),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(23, 68),
+
+                // TestMethod16, TestMethod17, TestMethod18
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(25, 23),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(25, 23),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(25, 73),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(25, 73),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(26, 23),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(26, 72),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(27, 24),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(27, 75),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, numberOfFixAllIterations: 2).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing for tuple expressions is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        /// <seealso cref="SA1000CSharp7UnitTests.TestReturnTupleExpressionsAsync"/>
+        [Fact]
+        public async Task TestTupleExpressionsAsync()
+        {
+            var testCode = @"using System.Collections.Generic;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        private static Dictionary<(int, int), (int, int)> dictionary;
+
+        public void TestMethod()
+        {
+            // Top level
+            var v1 =( 1, 2);
+            var v2 =(1, 2);
+            var v3 = ( 1, 2);
+
+            // Nested first element
+            var v4 = ( ( 1, 3), 2);
+            var v5 = ( (1, 3), 2);
+            var v6 = (( 1, 3), 2);
+
+            // Nested after first element
+            var v7 = (1,( 2, 3));
+            var v8 = (1,(2, 3));
+            var v9 = (1, ( 2, 3));
+
+            // Top level, name inside
+            var v10 =( x: 1, 2);
+            var v11 =(x: 1, 2);
+            var v12 = ( x: 1, 2);
+
+            // Nested first element, name inside
+            var v13 = ( ( x: 1, 3), 2);
+            var v14 = ( (x: 1, 3), 2);
+            var v15 = (( x: 1, 3), 2);
+
+            // Nested after first element, name inside
+            var v16 = (1,( x: 2, 3));
+            var v17 = (1,(x: 2, 3));
+            var v18 = (1, ( x: 2, 3));
+
+            // Nested first element, name outside
+            var v19 = (x:( 1, 3), 2);
+            var v20 = (x:(1, 3), 2);
+            var v21 = (x: ( 1, 3), 2);
+
+            // Nested after first element, name outside
+            var v22 = (1, x:( 2, 3));
+            var v23 = (1, x:(2, 3));
+            var v24 = (1, x: ( 2, 3));
+
+            // Indexer
+            var v25 = dictionary[ ( 1, 2)];
+            var v26 = dictionary[ (1, 2)];
+            var v27 = dictionary[( 1, 2)];
+            var v28 = dictionary[key:( 1, 2)];
+            var v29 = dictionary[key:(1, 2)];
+            var v30 = dictionary[key: ( 1, 2)];
+
+            // First argument
+            dictionary.Add( ( 1, 2), (1, 2));
+            dictionary.Add( (1, 2), (1, 2));
+            dictionary.Add(( 1, 2), (1, 2));
+            dictionary.Add(key:( 1, 2), value: (1, 2));
+            dictionary.Add(key:(1, 2), value: (1, 2));
+            dictionary.Add(key: ( 1, 2), value: (1, 2));
+
+            // Second argument
+            dictionary.Add((1, 2),( 1, 2));
+            dictionary.Add((1, 2),(1, 2));
+            dictionary.Add((1, 2), ( 1, 2));
+            dictionary.Add(key: (1, 2), value:( 1, 2));
+            dictionary.Add(key: (1, 2), value:(1, 2));
+            dictionary.Add(key: (1, 2), value: ( 1, 2));
+
+            // Returns (leading spaces after keyword checked in SA1000, not SA1008)
+            (int, int) LocalFunction1() { return( 1, 2); }
+            (int, int) LocalFunction2() { return(1, 2); }
+            (int, int) LocalFunction3() { return ( 1, 2); }
+            (int, int) LocalFunction4() =>( 1, 2);
+            (int, int) LocalFunction5() =>(1, 2);
+            (int, int) LocalFunction6() => ( 1, 2);
+        }
+    }
+}
+";
+
+            var fixedCode = @"using System.Collections.Generic;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        private static Dictionary<(int, int), (int, int)> dictionary;
+
+        public void TestMethod()
+        {
+            // Top level
+            var v1 = (1, 2);
+            var v2 = (1, 2);
+            var v3 = (1, 2);
+
+            // Nested first element
+            var v4 = ((1, 3), 2);
+            var v5 = ((1, 3), 2);
+            var v6 = ((1, 3), 2);
+
+            // Nested after first element
+            var v7 = (1, (2, 3));
+            var v8 = (1, (2, 3));
+            var v9 = (1, (2, 3));
+
+            // Top level, name inside
+            var v10 = (x: 1, 2);
+            var v11 = (x: 1, 2);
+            var v12 = (x: 1, 2);
+
+            // Nested first element, name inside
+            var v13 = ((x: 1, 3), 2);
+            var v14 = ((x: 1, 3), 2);
+            var v15 = ((x: 1, 3), 2);
+
+            // Nested after first element, name inside
+            var v16 = (1, (x: 2, 3));
+            var v17 = (1, (x: 2, 3));
+            var v18 = (1, (x: 2, 3));
+
+            // Nested first element, name outside
+            var v19 = (x: (1, 3), 2);
+            var v20 = (x: (1, 3), 2);
+            var v21 = (x: (1, 3), 2);
+
+            // Nested after first element, name outside
+            var v22 = (1, x: (2, 3));
+            var v23 = (1, x: (2, 3));
+            var v24 = (1, x: (2, 3));
+
+            // Indexer
+            var v25 = dictionary[(1, 2)];
+            var v26 = dictionary[(1, 2)];
+            var v27 = dictionary[(1, 2)];
+            var v28 = dictionary[key: (1, 2)];
+            var v29 = dictionary[key: (1, 2)];
+            var v30 = dictionary[key: (1, 2)];
+
+            // First argument
+            dictionary.Add((1, 2), (1, 2));
+            dictionary.Add((1, 2), (1, 2));
+            dictionary.Add((1, 2), (1, 2));
+            dictionary.Add(key: (1, 2), value: (1, 2));
+            dictionary.Add(key: (1, 2), value: (1, 2));
+            dictionary.Add(key: (1, 2), value: (1, 2));
+
+            // Second argument
+            dictionary.Add((1, 2), (1, 2));
+            dictionary.Add((1, 2), (1, 2));
+            dictionary.Add((1, 2), (1, 2));
+            dictionary.Add(key: (1, 2), value: (1, 2));
+            dictionary.Add(key: (1, 2), value: (1, 2));
+            dictionary.Add(key: (1, 2), value: (1, 2));
+
+            // Returns (leading spaces after keyword checked in SA1000, not SA1008)
+            (int, int) LocalFunction1() { return(1, 2); }
+            (int, int) LocalFunction2() { return(1, 2); }
+            (int, int) LocalFunction3() { return (1, 2); }
+            (int, int) LocalFunction4() => (1, 2);
+            (int, int) LocalFunction5() => (1, 2);
+            (int, int) LocalFunction6() => (1, 2);
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostics =
+            {
+                // v1, v2, v3
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(12, 21),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(12, 21),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(13, 21),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(14, 22),
+
+                // v4, v5, v6
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(17, 22),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(17, 24),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(18, 22),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(19, 23),
+
+                // v7, v8, v9
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(22, 25),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(22, 25),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(23, 25),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(24, 26),
+
+                // v10, v11, v12
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(27, 22),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(27, 22),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(28, 22),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(29, 23),
+
+                // v13, v14, v15
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(32, 23),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(32, 25),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(33, 23),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(34, 24),
+
+                // v16, v17, v18
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(37, 26),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(37, 26),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(38, 26),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(39, 27),
+
+                // v19, v20, v21
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(42, 26),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(42, 26),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(43, 26),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(44, 27),
+
+                // v22, v23, v24
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(47, 29),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(47, 29),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(48, 29),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(49, 30),
+
+                // v25, v26, v27
+                this.CSharpDiagnostic(DescriptorNotPreceded).WithLocation(52, 35),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(52, 35),
+                this.CSharpDiagnostic(DescriptorNotPreceded).WithLocation(53, 35),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(54, 34),
+
+                // v28, v29, v30
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(55, 38),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(55, 38),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(56, 38),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(57, 39),
+
+                // First argument
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(60, 27),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(60, 29),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(61, 27),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(62, 28),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(63, 32),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(63, 32),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(64, 32),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(65, 33),
+
+                // Second argument
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(68, 35),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(68, 35),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(69, 35),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(70, 36),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(71, 47),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(71, 47),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(72, 47),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(73, 48),
+
+                // Returns
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(76, 49),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(78, 50),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(79, 43),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(79, 43),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(80, 43),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(81, 44),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostics, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, numberOfFixAllIterations: 2).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing for tuple types used as generic arguments is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestTupleTypesAsGenericArgumentsAsync()
+        {
+            var testCode = @"using System;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        static Func< ( int, int), (int, int)> Function1;
+        static Func< (int, int), (int, int)> Function2;
+        static Func<( int, int), (int, int)> Function3;
+
+        static Func<(int, int),( int, int)> Function4;
+        static Func<(int, int),(int, int)> Function5;
+        static Func<(int, int), ( int, int)> Function6;
+    }
+}
+";
+
+            var fixedCode = @"using System;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        static Func<(int, int), (int, int)> Function1;
+        static Func<(int, int), (int, int)> Function2;
+        static Func<(int, int), (int, int)> Function3;
+
+        static Func<(int, int), (int, int)> Function4;
+        static Func<(int, int), (int, int)> Function5;
+        static Func<(int, int), (int, int)> Function6;
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostics =
+            {
+                this.CSharpDiagnostic(DescriptorNotPreceded).WithLocation(7, 22),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(7, 22),
+                this.CSharpDiagnostic(DescriptorNotPreceded).WithLocation(8, 22),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(9, 21),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(11, 32),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(11, 32),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(12, 32),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(13, 33),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostics, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, numberOfFixAllIterations: 2).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing for tuple variable declarations is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestTupleVariablesAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var( x1, y1) = (1, 2);
+            var(x2, y2) = (1, 2);
+            var ( x3, y3) = (1, 2);
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var (x1, y1) = (1, 2);
+            var (x2, y2) = (1, 2);
+            var (x3, y3) = (1, 2);
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostics =
+            {
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(7, 16),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(7, 16),
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(8, 16),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(9, 17),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostics, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, numberOfFixAllIterations: 2).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Verifies that spacing for <c>ref</c> expressions is handled properly.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
@@ -3,9 +3,62 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
-    using Test.SpacingRules;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using StyleCop.Analyzers.Test.SpacingRules;
+    using TestHelper;
+    using Xunit;
+
+    using static StyleCop.Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly;
 
     public class SA1008CSharp7UnitTests : SA1008UnitTests
     {
+        /// <summary>
+        /// Verifies that spacing for <c>ref</c> expressions is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestRefExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    using System.Threading.Tasks;
+
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            int test = 1;
+            ref int t = ref( test);
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    using System.Threading.Tasks;
+
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            int test = 1;
+            ref int t = ref (test);
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostics =
+            {
+                this.CSharpDiagnostic(DescriptorPreceded).WithLocation(10, 28),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(10, 28),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostics, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, numberOfFixAllIterations: 2).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1008CSharp7UnitTests : SA1008UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1009CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1009CSharp7UnitTests.cs
@@ -55,6 +55,41 @@ public class Foo
         }
 
         /// <summary>
+        /// Verifies spacing around a <c>}</c> character in tuple expressions.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        /// <seealso cref="SA1001CSharp7UnitTests.TestSpacingAroundClosingBraceInTupleExpressionsAsync"/>
+        /// <seealso cref="SA1013CSharp7UnitTests.TestSpacingAroundClosingBraceInTupleExpressionsAsync"/>
+        [Fact]
+        public async Task TestSpacingAroundClosingBraceInTupleExpressionsAsync()
+        {
+            const string testCode = @"using System;
+
+public class Foo
+{
+    public void TestMethod()
+    {
+        var values = (new[] { 3} , new[] { 3} );
+    }
+}";
+            const string fixedCode = @"using System;
+
+public class Foo
+{
+    public void TestMethod()
+    {
+        var values = (new[] { 3} , new[] { 3});
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 47).WithArguments(" not", "preceded");
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Verifies spacing around a <c>&gt;</c> character in tuple types.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1009CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1009CSharp7UnitTests.cs
@@ -58,6 +58,41 @@ public class Foo
             await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verifies spacing around a <c>&gt;</c> character in tuple types.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        /// <seealso cref="SA1001CSharp7UnitTests.TestClosingGenericBracketsInTupleTypesNotFollowedBySpaceAsync"/>
+        /// <seealso cref="SA1015CSharp7UnitTests.TestClosingGenericBracketsInTupleTypesNotPrecededBySpaceAsync"/>
+        [Fact]
+        public async Task TestClosingGenericBracketsInTupleTypesNotFollowedBySpaceAsync()
+        {
+            const string testCode = @"using System;
+
+public class Foo
+{
+    public void TestMethod()
+    {
+        (Func<int > , Func<int > ) value = (null, null);
+    }
+}";
+            const string fixedCode = @"using System;
+
+public class Foo
+{
+    public void TestMethod()
+    {
+        (Func<int > , Func<int >) value = (null, null);
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 34).WithArguments(" not", "preceded");
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
         protected override Solution CreateSolution(ProjectId projectId, string language)
         {
             Solution solution = base.CreateSolution(projectId, language);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1009CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1009CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1009CSharp7UnitTests : SA1009UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1009CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1009CSharp7UnitTests.cs
@@ -3,12 +3,8 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
-    using System;
-    using System.Linq;
-    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis;
     using StyleCop.Analyzers.Test.SpacingRules;
     using TestHelper;
     using Xunit;
@@ -91,15 +87,6 @@ public class Foo
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
-        }
-
-        protected override Solution CreateSolution(ProjectId projectId, string language)
-        {
-            Solution solution = base.CreateSolution(projectId, language);
-            Assembly systemRuntime = AppDomain.CurrentDomain.GetAssemblies().Single(x => x.GetName().Name == "System.Runtime");
-            return solution
-                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(systemRuntime.Location))
-                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ValueTuple).Assembly.Location));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1009CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1009CSharp7UnitTests.cs
@@ -3,9 +3,68 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
-    using Test.SpacingRules;
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using StyleCop.Analyzers.Test.SpacingRules;
+    using TestHelper;
+    using Xunit;
 
     public class SA1009CSharp7UnitTests : SA1009UnitTests
     {
+        /// <summary>
+        /// Verifies spacing around a <c>]</c> character in tuple types and expressions.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        /// <seealso cref="SA1001CSharp7UnitTests.TestBracketsInTupleTypesNotFollowedBySpaceAsync"/>
+        /// <seealso cref="SA1011CSharp7UnitTests.TestBracketsInTupleTypesNotFollowedBySpaceAsync"/>
+        [Fact]
+        public async Task TestBracketsInTupleTypesNotFollowedBySpaceAsync()
+        {
+            const string testCode = @"using System;
+
+public class Foo
+{
+    public (int[] , int[] ) TestMethod((int[] , int[] ) a)
+    {
+        (int[] , int[] ) ints = (new int[][] { new[] { 3 } }[0] , new int[][] { new[] { 3 } }[0] );
+        return ints;
+    }
+}";
+            const string fixedCode = @"using System;
+
+public class Foo
+{
+    public (int[] , int[]) TestMethod((int[] , int[]) a)
+    {
+        (int[] , int[]) ints = (new int[][] { new[] { 3 } }[0] , new int[][] { new[] { 3 } }[0]);
+        return ints;
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(5, 27).WithArguments(" not", "preceded"),
+                this.CSharpDiagnostic().WithLocation(5, 55).WithArguments(" not", "preceded"),
+                this.CSharpDiagnostic().WithLocation(7, 24).WithArguments(" not", "preceded"),
+                this.CSharpDiagnostic().WithLocation(7, 98).WithArguments(" not", "preceded"),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected override Solution CreateSolution(ProjectId projectId, string language)
+        {
+            Solution solution = base.CreateSolution(projectId, language);
+            Assembly systemRuntime = AppDomain.CurrentDomain.GetAssemblies().Single(x => x.GetName().Name == "System.Runtime");
+            return solution
+                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(systemRuntime.Location))
+                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ValueTuple).Assembly.Location));
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1009CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1009CSharp7UnitTests.cs
@@ -123,5 +123,779 @@ public class Foo
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Verifies that spacing around tuple type casts is handled properly.
+        /// </summary>
+        /// <remarks>
+        /// <para>Tuple type casts must be parenthesized, so there are only a limited number of special cases that need
+        /// to be added after the ones in <see cref="SA1009UnitTests.TestSpaceInCastAsync"/>.</para>
+        /// </remarks>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestTupleTypeCastSpacingAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var test1 = ((int, int ) )(3, 3);
+            var test2 = ((int, int ))(3, 3);
+            var test3 = ((int, int) )(3, 3);
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var test1 = ((int, int))(3, 3);
+            var test2 = ((int, int))(3, 3);
+            var test3 = ((int, int))(3, 3);
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostic =
+            {
+                // test1
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 36),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 36),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 38),
+
+                // test2
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(8, 36),
+
+                // test3
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(9, 35),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(9, 37),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing around tuple types in parameters is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestTupleParameterTypeAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public int TestMethod1((int, int )arg) => 0;
+        public int TestMethod2((int, int ) arg) => 0;
+        public int TestMethod3((int, int)arg) => 0;
+
+        public int TestMethod4((int, int) arg1, (int, int )arg2) => 0;
+        public int TestMethod5((int, int) arg1, (int, int ) arg2) => 0;
+        public int TestMethod6((int, int) arg1, (int, int)arg2) => 0;
+
+        public int TestMethod7((int, int[] )arg1) => 0;
+        public int TestMethod8((int, int[] ) arg1) => 0;
+        public int TestMethod9((int, int[])arg1) => 0;
+
+        public int TestMethod10((int, int ) [] arg1) => 0;
+        public int TestMethod11((int, int )[] arg1) => 0;
+        public int TestMethod12((int, int) [] arg1) => 0;
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public int TestMethod1((int, int) arg) => 0;
+        public int TestMethod2((int, int) arg) => 0;
+        public int TestMethod3((int, int) arg) => 0;
+
+        public int TestMethod4((int, int) arg1, (int, int) arg2) => 0;
+        public int TestMethod5((int, int) arg1, (int, int) arg2) => 0;
+        public int TestMethod6((int, int) arg1, (int, int) arg2) => 0;
+
+        public int TestMethod7((int, int[]) arg1) => 0;
+        public int TestMethod8((int, int[]) arg1) => 0;
+        public int TestMethod9((int, int[]) arg1) => 0;
+
+        public int TestMethod10((int, int)[] arg1) => 0;
+        public int TestMethod11((int, int)[] arg1) => 0;
+        public int TestMethod12((int, int)[] arg1) => 0;
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostic =
+            {
+                // TestMethod1, TestMethod2, TestMethod3
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(5, 42),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(5, 42),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(6, 42),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(7, 41),
+
+                // TestMethod4, TestMethod5, TestMethod6
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(9, 59),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(9, 59),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(10, 59),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(11, 58),
+
+                // TestMethod7, TestMethod8, TestMethod9
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(13, 44),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(13, 44),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(14, 44),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(15, 43),
+
+                // TestMethod10, TestMethod11, TestMethod12
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(17, 43),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(17, 43),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(18, 43),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(19, 42),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing around tuple return types is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestTupleReturnTypeAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public (int, int )TestMethod1() => default((int, int ) );
+        public (int, int ) TestMethod2() => default((int, int ));
+        public (int, int)TestMethod3() => default((int, int) );
+
+        public ((int, int ) , int) TestMethod4() => default(((int, int ) , int));
+        public ((int, int ), int) TestMethod5() => default(((int, int ), int));
+        public ((int, int) , int) TestMethod6() => default(((int, int) , int));
+
+        public (int, (int, int ) ) TestMethod7() => default((int, (int, int ) ));
+        public (int, (int, int )) TestMethod8() => default((int, (int, int )));
+        public (int, (int, int) ) TestMethod9() => default((int, (int, int) ));
+
+        public (int x, int y )TestMethod10() => default((int x, int y ) );
+        public (int x, int y ) TestMethod11() => default((int x, int y ));
+        public (int x, int y)TestMethod12() => default((int x, int y) );
+
+        public ((int x, int y ) , int z) TestMethod13() => default(((int x, int y ) , int z));
+        public ((int x, int y ), int z) TestMethod14() => default(((int x, int y ), int z));
+        public ((int x, int y) , int z) TestMethod15() => default(((int x, int y) , int z));
+
+        public (int x, (int y, int z ) ) TestMethod16() => default((int x, (int y, int z ) ));
+        public (int x, (int y, int z )) TestMethod17() => default((int x, (int y, int z )));
+        public (int x, (int y, int z) ) TestMethod18() => default((int x, (int y, int z) ));
+
+        public ((int, int )x, int y) TestMethod19() => default(((int, int )x, int y));
+        public ((int, int ) x, int y) TestMethod20() => default(((int, int ) x, int y));
+        public ((int, int)x, int y) TestMethod21() => default(((int, int)x, int y));
+
+        public (int x, (int, int )y) TestMethod22() => default((int x, (int, int )y));
+        public (int x, (int, int ) y) TestMethod23() => default((int x, (int, int ) y));
+        public (int x, (int, int)y) TestMethod24() => default((int x, (int, int)y));
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public (int, int) TestMethod1() => default((int, int));
+        public (int, int) TestMethod2() => default((int, int));
+        public (int, int) TestMethod3() => default((int, int));
+
+        public ((int, int), int) TestMethod4() => default(((int, int), int));
+        public ((int, int), int) TestMethod5() => default(((int, int), int));
+        public ((int, int), int) TestMethod6() => default(((int, int), int));
+
+        public (int, (int, int)) TestMethod7() => default((int, (int, int)));
+        public (int, (int, int)) TestMethod8() => default((int, (int, int)));
+        public (int, (int, int)) TestMethod9() => default((int, (int, int)));
+
+        public (int x, int y) TestMethod10() => default((int x, int y));
+        public (int x, int y) TestMethod11() => default((int x, int y));
+        public (int x, int y) TestMethod12() => default((int x, int y));
+
+        public ((int x, int y), int z) TestMethod13() => default(((int x, int y), int z));
+        public ((int x, int y), int z) TestMethod14() => default(((int x, int y), int z));
+        public ((int x, int y), int z) TestMethod15() => default(((int x, int y), int z));
+
+        public (int x, (int y, int z)) TestMethod16() => default((int x, (int y, int z)));
+        public (int x, (int y, int z)) TestMethod17() => default((int x, (int y, int z)));
+        public (int x, (int y, int z)) TestMethod18() => default((int x, (int y, int z)));
+
+        public ((int, int) x, int y) TestMethod19() => default(((int, int) x, int y));
+        public ((int, int) x, int y) TestMethod20() => default(((int, int) x, int y));
+        public ((int, int) x, int y) TestMethod21() => default(((int, int) x, int y));
+
+        public (int x, (int, int) y) TestMethod22() => default((int x, (int, int) y));
+        public (int x, (int, int) y) TestMethod23() => default((int x, (int, int) y));
+        public (int x, (int, int) y) TestMethod24() => default((int x, (int, int) y));
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostic =
+            {
+                // TestMethod1, TestMethod2, TestMethod3
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(5, 26),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(5, 26),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(5, 62),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(5, 62),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(5, 64),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(6, 26),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(6, 63),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(7, 25),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 60),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 62),
+
+                // TestMethod4, TestMethod5, TestMethod6
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(9, 27),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(9, 27),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(9, 72),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(9, 72),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(10, 27),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(10, 71),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(11, 26),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(11, 70),
+
+                // TestMethod7, TestMethod8, TestMethod9
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(13, 32),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(13, 32),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(13, 34),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(13, 77),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(13, 77),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(13, 79),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(14, 32),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(14, 76),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(15, 31),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(15, 33),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(15, 75),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(15, 77),
+
+                // TestMethod10, TestMethod11, TestMethod12
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(17, 30),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(17, 30),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(17, 71),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(17, 71),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(17, 73),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(18, 30),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(18, 72),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(19, 29),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(19, 69),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(19, 71),
+
+                // TestMethod13, TestMethod14, TestMethod15
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(21, 31),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(21, 31),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(21, 83),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(21, 83),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(22, 31),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(22, 82),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(23, 30),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(23, 81),
+
+                // TestMethod16, TestMethod17, TestMethod18
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(25, 38),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(25, 38),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(25, 40),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(25, 90),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(25, 90),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(25, 92),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(26, 38),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(26, 89),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(27, 37),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(27, 39),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(27, 88),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(27, 90),
+
+                // TestMethod19, TestMethod20, TestMethod21
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(29, 27),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(29, 27),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(29, 75),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(29, 75),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(30, 27),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(30, 76),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(31, 26),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(31, 73),
+
+                // TestMethod22, TestMethod23, TestMethod24
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(33, 34),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(33, 34),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(33, 82),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(33, 82),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(34, 34),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(34, 83),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(35, 33),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(35, 80),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostic, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing for tuple expressions is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestTupleExpressionsAsync()
+        {
+            var testCode = @"using System.Collections.Generic;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        private static Dictionary<(int, int), (int, int)> dictionary;
+
+        public void TestMethod()
+        {
+            // Top level
+            var v1 = (1, 2 ) ;
+            var v2 = (1, 2 );
+            var v3 = (1, 2) ;
+
+            // Nested first element
+            var v4 = ((1, 3 ) , 2);
+            var v5 = ((1, 3 ), 2);
+            var v6 = ((1, 3) , 2);
+
+            // Nested after first element
+            var v7 = (1, (2, 3 ) );
+            var v8 = (1, (2, 3 ));
+            var v9 = (1, (2, 3) );
+
+            // Top level, name inside
+            var v10 = (1, x: 2 ) ;
+            var v11 = (1, x: 2 );
+            var v12 = (1, x: 2) ;
+
+            // Nested first element, name inside
+            var v13 = ((1, x: 3 ) , 2);
+            var v14 = ((1, x: 3 ), 2);
+            var v15 = ((1, x: 3) , 2);
+
+            // Nested after first element, name inside
+            var v16 = (1, (2, x: 3 ) );
+            var v17 = (1, (2, x: 3 ));
+            var v18 = (1, (2, x: 3) );
+
+            // Nested first element, name outside
+            var v19 = (x: (1, 3 ) , 2);
+            var v20 = (x: (1, 3 ), 2);
+            var v21 = (x: (1, 3) , 2);
+
+            // Nested after first element, name outside
+            var v22 = (1, x: (2, 3 ) );
+            var v23 = (1, x: (2, 3 ));
+            var v24 = (1, x: (2, 3) );
+
+            // Indexer
+            var v25 = dictionary[(1, 2 ) ];
+            var v26 = dictionary[(1, 2 )];
+            var v27 = dictionary[(1, 2) ];
+            var v28 = dictionary[key: (1, 2 ) ];
+            var v29 = dictionary[key: (1, 2 )];
+            var v30 = dictionary[key: (1, 2) ];
+
+            // First argument
+            dictionary.Add((1, 2 ) , (1, 2));
+            dictionary.Add((1, 2 ), (1, 2));
+            dictionary.Add((1, 2) , (1, 2));
+            dictionary.Add(key: (1, 2 ) , value: (1, 2));
+            dictionary.Add(key: (1, 2 ), value: (1, 2));
+            dictionary.Add(key: (1, 2) , value: (1, 2));
+
+            // Second argument
+            dictionary.Add((1, 2), (1, 2 ) );
+            dictionary.Add((1, 2), (1, 2 ));
+            dictionary.Add((1, 2), (1, 2) );
+            dictionary.Add(key: (1, 2), value: (1, 2 ) );
+            dictionary.Add(key: (1, 2), value: (1, 2 ));
+            dictionary.Add(key: (1, 2), value: (1, 2) );
+
+            // Returns
+            (int, int) LocalFunction1() { return (1, 2 ) ; }
+            (int, int) LocalFunction2() { return (1, 2 ); }
+            (int, int) LocalFunction3() { return (1, 2) ; }
+            (int, int) LocalFunction4() => (1, 2 ) ;
+            (int, int) LocalFunction5() => (1, 2 );
+            (int, int) LocalFunction6() => (1, 2) ;
+        }
+    }
+}
+";
+
+            var fixedCode = @"using System.Collections.Generic;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        private static Dictionary<(int, int), (int, int)> dictionary;
+
+        public void TestMethod()
+        {
+            // Top level
+            var v1 = (1, 2);
+            var v2 = (1, 2);
+            var v3 = (1, 2);
+
+            // Nested first element
+            var v4 = ((1, 3), 2);
+            var v5 = ((1, 3), 2);
+            var v6 = ((1, 3), 2);
+
+            // Nested after first element
+            var v7 = (1, (2, 3));
+            var v8 = (1, (2, 3));
+            var v9 = (1, (2, 3));
+
+            // Top level, name inside
+            var v10 = (1, x: 2);
+            var v11 = (1, x: 2);
+            var v12 = (1, x: 2);
+
+            // Nested first element, name inside
+            var v13 = ((1, x: 3), 2);
+            var v14 = ((1, x: 3), 2);
+            var v15 = ((1, x: 3), 2);
+
+            // Nested after first element, name inside
+            var v16 = (1, (2, x: 3));
+            var v17 = (1, (2, x: 3));
+            var v18 = (1, (2, x: 3));
+
+            // Nested first element, name outside
+            var v19 = (x: (1, 3), 2);
+            var v20 = (x: (1, 3), 2);
+            var v21 = (x: (1, 3), 2);
+
+            // Nested after first element, name outside
+            var v22 = (1, x: (2, 3));
+            var v23 = (1, x: (2, 3));
+            var v24 = (1, x: (2, 3));
+
+            // Indexer
+            var v25 = dictionary[(1, 2)];
+            var v26 = dictionary[(1, 2)];
+            var v27 = dictionary[(1, 2)];
+            var v28 = dictionary[key: (1, 2)];
+            var v29 = dictionary[key: (1, 2)];
+            var v30 = dictionary[key: (1, 2)];
+
+            // First argument
+            dictionary.Add((1, 2), (1, 2));
+            dictionary.Add((1, 2), (1, 2));
+            dictionary.Add((1, 2), (1, 2));
+            dictionary.Add(key: (1, 2), value: (1, 2));
+            dictionary.Add(key: (1, 2), value: (1, 2));
+            dictionary.Add(key: (1, 2), value: (1, 2));
+
+            // Second argument
+            dictionary.Add((1, 2), (1, 2));
+            dictionary.Add((1, 2), (1, 2));
+            dictionary.Add((1, 2), (1, 2));
+            dictionary.Add(key: (1, 2), value: (1, 2));
+            dictionary.Add(key: (1, 2), value: (1, 2));
+            dictionary.Add(key: (1, 2), value: (1, 2));
+
+            // Returns
+            (int, int) LocalFunction1() { return (1, 2); }
+            (int, int) LocalFunction2() { return (1, 2); }
+            (int, int) LocalFunction3() { return (1, 2); }
+            (int, int) LocalFunction4() => (1, 2);
+            (int, int) LocalFunction5() => (1, 2);
+            (int, int) LocalFunction6() => (1, 2);
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostics =
+            {
+                // v1, v2, v3
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(12, 28),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(12, 28),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(13, 28),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(14, 27),
+
+                // v4, v5, v6
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(17, 29),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(17, 29),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(18, 29),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(19, 28),
+
+                // v7, v8, v9
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(22, 32),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(22, 32),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(22, 34),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(23, 32),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(24, 31),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(24, 33),
+
+                // v10, v11, v12
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(27, 32),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(27, 32),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(28, 32),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(29, 31),
+
+                // v13, v14, v15
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(32, 33),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(32, 33),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(33, 33),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(34, 32),
+
+                // v16, v17, v18
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(37, 36),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(37, 36),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(37, 38),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(38, 36),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(39, 35),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(39, 37),
+
+                // v19, v20, v21
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(42, 33),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(42, 33),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(43, 33),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(44, 32),
+
+                // v22, v23, v24
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(47, 36),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(47, 36),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(47, 38),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(48, 36),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(49, 35),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(49, 37),
+
+                // v25, v26, v27
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(52, 40),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(52, 40),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(53, 40),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(54, 39),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(55, 45),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(55, 45),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(56, 45),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(57, 44),
+
+                // First argument
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(60, 34),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(60, 34),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(61, 34),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(62, 33),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(63, 39),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(63, 39),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(64, 39),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(65, 38),
+
+                // Second argument
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(68, 42),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(68, 42),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(68, 44),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(69, 42),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(70, 41),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(70, 43),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(71, 54),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(71, 54),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(71, 56),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(72, 54),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(73, 53),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(73, 55),
+
+                // Returns
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(76, 56),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(76, 56),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(77, 56),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(78, 55),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(79, 50),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(79, 50),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(80, 50),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(81, 49),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostics, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing for tuple types used as generic arguments is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestTupleTypesAsGenericArgumentsAsync()
+        {
+            var testCode = @"using System;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        static Func<(int, int ) , (int, int)> Function1;
+        static Func<(int, int ), (int, int)> Function2;
+        static Func<(int, int) , (int, int)> Function3;
+
+        static Func<(int, int), (int, int ) > Function4;
+        static Func<(int, int), (int, int )> Function5;
+        static Func<(int, int), (int, int) > Function6;
+    }
+}
+";
+
+            var fixedCode = @"using System;
+
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        static Func<(int, int), (int, int)> Function1;
+        static Func<(int, int), (int, int)> Function2;
+        static Func<(int, int), (int, int)> Function3;
+
+        static Func<(int, int), (int, int)> Function4;
+        static Func<(int, int), (int, int)> Function5;
+        static Func<(int, int), (int, int)> Function6;
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostics =
+            {
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 31),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(7, 31),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(8, 31),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(9, 30),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(11, 43),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(11, 43),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(12, 43),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(13, 42),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostics, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing for tuple variable declarations is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestTupleVariablesAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var (x1, y1 )= (1, 2);
+            var (x2, y2 ) = (1, 2);
+            var (x3, y3)= (1, 2);
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var (x1, y1) = (1, 2);
+            var (x2, y2) = (1, 2);
+            var (x3, y3) = (1, 2);
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostics =
+            {
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(7, 25),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(7, 25),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(8, 25),
+                this.CSharpDiagnostic().WithArguments(string.Empty, "followed").WithLocation(9, 24),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostics, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing for <c>ref</c> expressions is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestRefExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    using System.Threading.Tasks;
+
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            int test = 1;
+            ref int t1 = ref (test ) ;
+            ref int t2 = ref (test );
+            ref int t3 = ref (test) ;
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    using System.Threading.Tasks;
+
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            int test = 1;
+            ref int t1 = ref (test);
+            ref int t2 = ref (test);
+            ref int t3 = ref (test);
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostics =
+            {
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(10, 36),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(10, 36),
+                this.CSharpDiagnostic().WithArguments(" not", "preceded").WithLocation(11, 36),
+                this.CSharpDiagnostic().WithArguments(" not", "followed").WithLocation(12, 35),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostics, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1010CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1010CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1010CSharp7UnitTests : SA1010UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1011CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1011CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1011CSharp7UnitTests : SA1011UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1011CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1011CSharp7UnitTests.cs
@@ -3,9 +3,50 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
-    using Test.SpacingRules;
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using StyleCop.Analyzers.Test.SpacingRules;
+    using TestHelper;
+    using Xunit;
 
     public class SA1011CSharp7UnitTests : SA1011UnitTests
     {
+        /// <summary>
+        /// Verifies spacing around a <c>]</c> character in tuple types and expressions.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        /// <seealso cref="SA1001CSharp7UnitTests.TestBracketsInTupleTypesNotFollowedBySpaceAsync"/>
+        /// <seealso cref="SA1009CSharp7UnitTests.TestBracketsInTupleTypesNotFollowedBySpaceAsync"/>
+        [Fact]
+        public async Task TestBracketsInTupleTypesNotFollowedBySpaceAsync()
+        {
+            // No diagnostics reported because the offending tokens are followed by comma (SA1001) or a closing
+            // parenthesis (SA1009)
+            const string testCode = @"using System;
+
+public class Foo
+{
+    public (int[] , int[] ) TestMethod((int[] , int[] ) a)
+    {
+        (int[] , int[] ) ints = (new int[][] { new[] { 3 } }[0] , new int[][] { new[] { 3 } }[0] );
+        return ints;
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected override Solution CreateSolution(ProjectId projectId, string language)
+        {
+            Solution solution = base.CreateSolution(projectId, language);
+            Assembly systemRuntime = AppDomain.CurrentDomain.GetAssemblies().Single(x => x.GetName().Name == "System.Runtime");
+            return solution
+                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(systemRuntime.Location))
+                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ValueTuple).Assembly.Location));
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1011CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1011CSharp7UnitTests.cs
@@ -3,14 +3,9 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
-    using System;
-    using System.Linq;
-    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis;
     using StyleCop.Analyzers.Test.SpacingRules;
-    using TestHelper;
     using Xunit;
 
     public class SA1011CSharp7UnitTests : SA1011UnitTests
@@ -38,15 +33,6 @@ public class Foo
 }";
 
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        protected override Solution CreateSolution(ProjectId projectId, string language)
-        {
-            Solution solution = base.CreateSolution(projectId, language);
-            Assembly systemRuntime = AppDomain.CurrentDomain.GetAssemblies().Single(x => x.GetName().Name == "System.Runtime");
-            return solution
-                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(systemRuntime.Location))
-                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ValueTuple).Assembly.Location));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1012CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1012CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1012CSharp7UnitTests : SA1012UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1013CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1013CSharp7UnitTests.cs
@@ -3,9 +3,51 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
-    using Test.SpacingRules;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using StyleCop.Analyzers.Test.SpacingRules;
+    using TestHelper;
+    using Xunit;
 
     public class SA1013CSharp7UnitTests : SA1013UnitTests
     {
+        /// <summary>
+        /// Verifies spacing around a <c>}</c> character in tuple expressions.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        /// <seealso cref="SA1001CSharp7UnitTests.TestSpacingAroundClosingBraceInTupleExpressionsAsync"/>
+        /// <seealso cref="SA1009CSharp7UnitTests.TestSpacingAroundClosingBraceInTupleExpressionsAsync"/>
+        [Fact]
+        public async Task TestSpacingAroundClosingBraceInTupleExpressionsAsync()
+        {
+            const string testCode = @"using System;
+
+public class Foo
+{
+    public void TestMethod()
+    {
+        var values = (new[] { 3} , new[] { 3} );
+    }
+}";
+            const string fixedCode = @"using System;
+
+public class Foo
+{
+    public void TestMethod()
+    {
+        var values = (new[] { 3 } , new[] { 3 } );
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(7, 32).WithArguments(string.Empty, "preceded"),
+                this.CSharpDiagnostic().WithLocation(7, 45).WithArguments(string.Empty, "preceded"),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1013CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1013CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1013CSharp7UnitTests : SA1013UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1014CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1014CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1014CSharp7UnitTests : SA1014UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1015CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1015CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1015CSharp7UnitTests : SA1015UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1015CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1015CSharp7UnitTests.cs
@@ -3,12 +3,8 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
-    using System;
-    using System.Linq;
-    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis;
     using StyleCop.Analyzers.Test.SpacingRules;
     using TestHelper;
     using Xunit;
@@ -53,15 +49,6 @@ public class Foo
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
-        }
-
-        protected override Solution CreateSolution(ProjectId projectId, string language)
-        {
-            Solution solution = base.CreateSolution(projectId, language);
-            Assembly systemRuntime = AppDomain.CurrentDomain.GetAssemblies().Single(x => x.GetName().Name == "System.Runtime");
-            return solution
-                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(systemRuntime.Location))
-                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ValueTuple).Assembly.Location));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1015CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1015CSharp7UnitTests.cs
@@ -3,9 +3,65 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
-    using Test.SpacingRules;
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using StyleCop.Analyzers.Test.SpacingRules;
+    using TestHelper;
+    using Xunit;
 
     public class SA1015CSharp7UnitTests : SA1015UnitTests
     {
+        /// <summary>
+        /// Verifies spacing around a <c>&gt;</c> character in tuple types.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        /// <seealso cref="SA1001CSharp7UnitTests.TestClosingGenericBracketsInTupleTypesNotFollowedBySpaceAsync"/>
+        /// <seealso cref="SA1009CSharp7UnitTests.TestClosingGenericBracketsInTupleTypesNotFollowedBySpaceAsync"/>
+        [Fact]
+        public async Task TestClosingGenericBracketsInTupleTypesNotPrecededBySpaceAsync()
+        {
+            const string testCode = @"using System;
+
+public class Foo
+{
+    public void TestMethod()
+    {
+        (Func<int > , Func<int > ) value = (null, null);
+    }
+}";
+            const string fixedCode = @"using System;
+
+public class Foo
+{
+    public void TestMethod()
+    {
+        (Func<int>, Func<int> ) value = (null, null);
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(7, 19).WithArguments(" not", "preceded"),
+                this.CSharpDiagnostic().WithLocation(7, 19).WithArguments(" not", "followed"),
+                this.CSharpDiagnostic().WithLocation(7, 32).WithArguments(" not", "preceded"),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected override Solution CreateSolution(ProjectId projectId, string language)
+        {
+            Solution solution = base.CreateSolution(projectId, language);
+            Assembly systemRuntime = AppDomain.CurrentDomain.GetAssemblies().Single(x => x.GetName().Name == "System.Runtime");
+            return solution
+                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(systemRuntime.Location))
+                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ValueTuple).Assembly.Location));
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1016CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1016CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1016CSharp7UnitTests : SA1016UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1017CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1017CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1017CSharp7UnitTests : SA1017UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1018CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1018CSharp7UnitTests.cs
@@ -3,9 +3,118 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
-    using Test.SpacingRules;
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using StyleCop.Analyzers.Test.SpacingRules;
+    using TestHelper;
+    using Xunit;
 
     public class SA1018CSharp7UnitTests : SA1018UnitTests
     {
+        /// <summary>
+        /// Verifies that nullable tuple types with different kinds of spacing will report.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestNullableTupleTypeSpacingAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            (int, int) ? v1;
+            (int, int) /* test */ ? v2;
+            (int, int)
+? v3;
+            (int, int)
+/* test */
+? v4;
+            (int, int)
+// test
+? v5;
+
+            (int, int)
+#if TEST
+? v6a;
+#else
+? v6b;
+#endif
+        }
+    }
+}
+";
+
+            var fixedTestCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            (int, int)? v1;
+            (int, int)/* test */? v2;
+            (int, int)? v3;
+            (int, int)/* test */? v4;
+            (int, int)
+// test
+? v5;
+
+            (int, int)
+#if TEST
+? v6a;
+#else
+? v6b;
+#endif
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expectedResults =
+            {
+                // v1
+                this.CSharpDiagnostic().WithLocation(7, 24),
+
+                // v2
+                this.CSharpDiagnostic().WithLocation(8, 35),
+
+                // v3
+                this.CSharpDiagnostic().WithLocation(10, 1),
+
+                // v4
+                this.CSharpDiagnostic().WithLocation(13, 1),
+
+                // v5
+                this.CSharpDiagnostic().WithLocation(16, 1),
+
+                // v6
+                this.CSharpDiagnostic().WithLocation(22, 1),
+            };
+
+            // The fixed test code will have diagnostics, because not all cases can be code fixed automatically.
+            DiagnosticResult[] fixedExpectedResults =
+            {
+                this.CSharpDiagnostic().WithLocation(13, 1),
+                this.CSharpDiagnostic().WithLocation(19, 1),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, fixedExpectedResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode, numberOfFixAllIterations: 2, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected override Solution CreateSolution(ProjectId projectId, string language)
+        {
+            Solution solution = base.CreateSolution(projectId, language);
+            Assembly systemRuntime = AppDomain.CurrentDomain.GetAssemblies().Single(x => x.GetName().Name == "System.Runtime");
+            return solution
+                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(systemRuntime.Location))
+                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ValueTuple).Assembly.Location));
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1018CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1018CSharp7UnitTests.cs
@@ -3,12 +3,8 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
-    using System;
-    using System.Linq;
-    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis;
     using StyleCop.Analyzers.Test.SpacingRules;
     using TestHelper;
     using Xunit;
@@ -106,15 +102,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
             await this.VerifyCSharpDiagnosticAsync(testCode, expectedResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedTestCode, fixedExpectedResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(testCode, fixedTestCode, numberOfFixAllIterations: 2, cancellationToken: CancellationToken.None).ConfigureAwait(false);
-        }
-
-        protected override Solution CreateSolution(ProjectId projectId, string language)
-        {
-            Solution solution = base.CreateSolution(projectId, language);
-            Assembly systemRuntime = AppDomain.CurrentDomain.GetAssemblies().Single(x => x.GetName().Name == "System.Runtime");
-            return solution
-                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(systemRuntime.Location))
-                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ValueTuple).Assembly.Location));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1018CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1018CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1018CSharp7UnitTests : SA1018UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1019CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1019CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1019CSharp7UnitTests : SA1019UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1020CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1020CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1020CSharp7UnitTests : SA1020UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1021CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1021CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1021CSharp7UnitTests : SA1021UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1022CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1022CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1022CSharp7UnitTests : SA1022UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1023CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1023CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1023CSharp7UnitTests : SA1023UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1024CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1024CSharp7UnitTests.cs
@@ -3,9 +3,64 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
-    using Test.SpacingRules;
+    using System;
+    using System.Linq;
+    using System.Reflection;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using StyleCop.Analyzers.Test.SpacingRules;
+    using TestHelper;
+    using Xunit;
 
     public class SA1024CSharp7UnitTests : SA1024UnitTests
     {
+        /// <summary>
+        /// Verifies spacing around a <c>:</c> character in tuple expressions.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestSpacingAroundColonInTupleExpressionsAsync()
+        {
+            const string testCode = @"using System;
+
+public class Foo
+{
+    public void TestMethod()
+    {
+        var values = (x :3, y :4);
+    }
+}";
+            const string fixedCode = @"using System;
+
+public class Foo
+{
+    public void TestMethod()
+    {
+        var values = (x: 3, y: 4);
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(7, 25).WithArguments(" not", "preceded", string.Empty),
+                this.CSharpDiagnostic().WithLocation(7, 25).WithArguments(string.Empty, "followed", string.Empty),
+                this.CSharpDiagnostic().WithLocation(7, 31).WithArguments(" not", "preceded", string.Empty),
+                this.CSharpDiagnostic().WithLocation(7, 31).WithArguments(string.Empty, "followed", string.Empty),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected override Solution CreateSolution(ProjectId projectId, string language)
+        {
+            Solution solution = base.CreateSolution(projectId, language);
+            Assembly systemRuntime = AppDomain.CurrentDomain.GetAssemblies().Single(x => x.GetName().Name == "System.Runtime");
+            return solution
+                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(systemRuntime.Location))
+                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ValueTuple).Assembly.Location));
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1024CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1024CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1024CSharp7UnitTests : SA1024UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1024CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1024CSharp7UnitTests.cs
@@ -3,12 +3,8 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
-    using System;
-    using System.Linq;
-    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis;
     using StyleCop.Analyzers.Test.SpacingRules;
     using TestHelper;
     using Xunit;
@@ -52,15 +48,6 @@ public class Foo
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(testCode, fixedCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
-        }
-
-        protected override Solution CreateSolution(ProjectId projectId, string language)
-        {
-            Solution solution = base.CreateSolution(projectId, language);
-            Assembly systemRuntime = AppDomain.CurrentDomain.GetAssemblies().Single(x => x.GetName().Name == "System.Runtime");
-            return solution
-                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(systemRuntime.Location))
-                .AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(ValueTuple).Assembly.Location));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1025CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1025CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1025CSharp7UnitTests : SA1025UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1026CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1026CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1026CSharp7UnitTests : SA1026UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1027AlternateIndentationCSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1027AlternateIndentationCSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1027AlternateIndentationCSharp7UnitTests : SA1027AlternateIndentationUnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1027CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1027CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1027CSharp7UnitTests : SA1027UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1027UseTabsCSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1027UseTabsCSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1027UseTabsCSharp7UnitTests : SA1027UseTabsUnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1028CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1028CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
+{
+    using Test.SpacingRules;
+
+    public class SA1028CSharp7UnitTests : SA1028UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/StyleCop.Analyzers.Test.CSharp7.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/StyleCop.Analyzers.Test.CSharp7.csproj
@@ -209,6 +209,37 @@
     <Compile Include="Lightup\SyntaxWrapperTests.cs" />
     <Compile Include="Lightup\VariableDesignationSyntaxWrapperTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SpacingRules\SA1000CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1001CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1002CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1003CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1004CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1005CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1006CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1007CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1008CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1009CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1010CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1011CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1012CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1013CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1014CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1015CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1016CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1017CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1018CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1019CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1020CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1021CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1022CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1023CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1024CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1025CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1026CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1027AlternateIndentationCSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1027CSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1027UseTabsCSharp7UnitTests.cs" />
+    <Compile Include="SpacingRules\SA1028CSharp7UnitTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\build\keys\TestingKey.snk">

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -125,6 +125,16 @@ namespace TestHelper
                 .AddMetadataReference(projectId, MetadataReferences.CSharpSymbolsReference)
                 .AddMetadataReference(projectId, MetadataReferences.CodeAnalysisReference);
 
+            if (MetadataReferences.SystemRuntimeReference != null)
+            {
+                solution = solution.AddMetadataReference(projectId, MetadataReferences.SystemRuntimeReference);
+            }
+
+            if (MetadataReferences.SystemValueTupleReference != null)
+            {
+                solution = solution.AddMetadataReference(projectId, MetadataReferences.SystemValueTupleReference);
+            }
+
             solution.Workspace.Options =
                 solution.Workspace.Options
                 .WithChangedOption(FormattingOptions.IndentationSize, language, this.IndentationSize)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/MetadataReferences.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/MetadataReferences.cs
@@ -3,8 +3,10 @@
 
 namespace StyleCop.Analyzers.Test.Helpers
 {
+    using System;
     using System.Collections.Immutable;
     using System.Linq;
+    using System.Reflection;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
 
@@ -18,5 +20,23 @@ namespace StyleCop.Analyzers.Test.Helpers
         internal static readonly MetadataReference SystemCoreReference = MetadataReference.CreateFromFile(typeof(Enumerable).Assembly.Location);
         internal static readonly MetadataReference CSharpSymbolsReference = MetadataReference.CreateFromFile(typeof(CSharpCompilation).Assembly.Location);
         internal static readonly MetadataReference CodeAnalysisReference = MetadataReference.CreateFromFile(typeof(Compilation).Assembly.Location);
+
+        internal static readonly MetadataReference SystemRuntimeReference;
+        internal static readonly MetadataReference SystemValueTupleReference;
+
+        static MetadataReferences()
+        {
+            Assembly systemRuntime = AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(x => x.GetName().Name == "System.Runtime");
+            if (systemRuntime != null)
+            {
+                SystemRuntimeReference = MetadataReference.CreateFromFile(systemRuntime.Location);
+            }
+
+            Assembly systemValueTuple = AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(x => x.GetName().Name == "System.ValueTuple");
+            if (systemValueTuple != null)
+            {
+                SystemValueTupleReference = MetadataReference.CreateFromFile(systemValueTuple.Location);
+            }
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1000UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1000UnitTests.cs
@@ -838,6 +838,20 @@ default:
         }
 
         [Fact]
+        public async Task TestVarKeywordAsync()
+        {
+            string statementWithoutSpace = @"var@x = ""test"";";
+
+            string statementWithSpace = @"var @x = ""test"";";
+
+            await this.TestKeywordStatementAsync(statementWithSpace, EmptyDiagnosticResults, statementWithSpace).ConfigureAwait(false);
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("var", string.Empty, "followed").WithLocation(12, 13);
+
+            await this.TestKeywordStatementAsync(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestMissingSelectTokenAsync()
         {
             string testCode = @"
@@ -900,12 +914,12 @@ class ClassName
             return new TokenSpacingCodeFixProvider();
         }
 
-        private Task TestKeywordStatementAsync(string statement, DiagnosticResult expected, string fixedStatement, string returnType = "void", bool asyncMethod = false)
+        protected Task TestKeywordStatementAsync(string statement, DiagnosticResult expected, string fixedStatement, string returnType = "void", bool asyncMethod = false)
         {
             return this.TestKeywordStatementAsync(statement, new[] { expected }, fixedStatement, returnType, asyncMethod);
         }
 
-        private async Task TestKeywordStatementAsync(string statement, DiagnosticResult[] expected, string fixedStatement, string returnType = "void", bool asyncMethod = false)
+        protected async Task TestKeywordStatementAsync(string statement, DiagnosticResult[] expected, string fixedStatement, string returnType = "void", bool asyncMethod = false)
         {
             string testCodeFormat = @"
 using System;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1003UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1003UnitTests.cs
@@ -801,7 +801,7 @@ public class Foo : Exception
         }
 
         /// <summary>
-        /// Verifies that unary plus expression will not trigger any diagnostics.
+        /// Verifies that the <c>=&gt;</c> operator for expression-bodied members triggers diagnostics as expected.
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TypeSyntaxHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TypeSyntaxHelper.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Helpers
+{
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using StyleCop.Analyzers.Lightup;
+
+    internal static class TypeSyntaxHelper
+    {
+        public static bool IsReturnType(this TypeSyntax syntax)
+        {
+            switch (syntax.Parent.Kind())
+            {
+            case SyntaxKind.MethodDeclaration:
+                return ((MethodDeclarationSyntax)syntax.Parent).ReturnType == syntax;
+
+            case SyntaxKind.OperatorDeclaration:
+                return ((OperatorDeclarationSyntax)syntax.Parent).ReturnType == syntax;
+
+            case SyntaxKind.ConversionOperatorDeclaration:
+                return ((ConversionOperatorDeclarationSyntax)syntax.Parent).Type == syntax;
+
+            case SyntaxKind.PropertyDeclaration:
+            case SyntaxKind.IndexerDeclaration:
+            case SyntaxKind.EventDeclaration:
+                return ((BasePropertyDeclarationSyntax)syntax.Parent).Type == syntax;
+
+            case SyntaxKind.VariableDeclaration:
+                return ((VariableDeclarationSyntax)syntax.Parent).Type == syntax;
+
+            case SyntaxKindEx.LocalFunctionStatement:
+                return ((LocalFunctionStatementSyntaxWrapper)syntax.Parent).ReturnType == syntax;
+
+            default:
+                return false;
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
@@ -104,7 +104,6 @@ namespace StyleCop.Analyzers.SpacingRules
                 case SyntaxKind.StackAllocKeyword:
                 case SyntaxKind.SwitchKeyword:
                 case SyntaxKind.UsingKeyword:
-                case SyntaxKind.TypeVarKeyword:
                 case SyntaxKind.WhereKeyword:
                 case SyntaxKind.WhileKeyword:
                 case SyntaxKind.YieldKeyword:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
@@ -46,6 +46,13 @@ namespace StyleCop.Analyzers.SpacingRules
 
         private static readonly Action<SyntaxTreeAnalysisContext> SyntaxTreeAction = HandleSyntaxTree;
         private static readonly Action<SyntaxNodeAnalysisContext> InvocationExpressionAction = HandleInvocationExpression;
+        private static readonly ReportDiagnosticCallback<SyntaxTreeAnalysisContext> ReportSyntaxTreeDiagnostic =
+            (ref SyntaxTreeAnalysisContext context, Diagnostic diagnostic) => context.ReportDiagnostic(diagnostic);
+
+        private static readonly ReportDiagnosticCallback<SyntaxNodeAnalysisContext> ReportSyntaxNodeDiagnostic =
+            (ref SyntaxNodeAnalysisContext context, Diagnostic diagnostic) => context.ReportDiagnostic(diagnostic);
+
+        private delegate void ReportDiagnosticCallback<TContext>(ref TContext context, Diagnostic diagnostic);
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
@@ -93,18 +100,18 @@ namespace StyleCop.Analyzers.SpacingRules
                 case SyntaxKind.WhereKeyword:
                 case SyntaxKind.WhileKeyword:
                 case SyntaxKind.YieldKeyword:
-                    HandleRequiredSpaceToken(context, token);
+                    HandleRequiredSpaceToken(ref context, token);
                     break;
 
                 case SyntaxKind.CheckedKeyword:
                 case SyntaxKind.UncheckedKeyword:
                     if (token.GetNextToken().IsKind(SyntaxKind.OpenBraceToken))
                     {
-                        HandleRequiredSpaceToken(context, token);
+                        HandleRequiredSpaceToken(ref context, token);
                     }
                     else
                     {
-                        HandleDisallowedSpaceToken(context, token);
+                        HandleDisallowedSpaceToken(ref context, token);
                     }
 
                     break;
@@ -113,19 +120,19 @@ namespace StyleCop.Analyzers.SpacingRules
                 case SyntaxKind.NameOfKeyword:
                 case SyntaxKind.SizeOfKeyword:
                 case SyntaxKind.TypeOfKeyword:
-                    HandleDisallowedSpaceToken(context, token);
+                    HandleDisallowedSpaceToken(ref context, token);
                     break;
 
                 case SyntaxKind.NewKeyword:
-                    HandleNewKeywordToken(context, token);
+                    HandleNewKeywordToken(ref context, token);
                     break;
 
                 case SyntaxKind.ReturnKeyword:
-                    HandleReturnKeywordToken(context, token);
+                    HandleReturnKeywordToken(ref context, token);
                     break;
 
                 case SyntaxKind.ThrowKeyword:
-                    HandleThrowKeywordToken(context, token);
+                    HandleThrowKeywordToken(ref context, token);
                     break;
 
                 default:
@@ -157,11 +164,14 @@ namespace StyleCop.Analyzers.SpacingRules
             if (constantValue.HasValue && !string.IsNullOrEmpty(constantValue.Value as string))
             {
                 // this is a nameof expression
-                HandleDisallowedSpaceToken(context, identifierNameSyntax.Identifier);
+                HandleDisallowedSpaceToken(ref context, identifierNameSyntax.Identifier);
             }
         }
 
-        private static void HandleRequiredSpaceToken(SyntaxTreeAnalysisContext context, SyntaxToken token)
+        private static void HandleRequiredSpaceToken(ref SyntaxTreeAnalysisContext context, SyntaxToken token)
+            => HandleRequiredSpaceToken(ReportSyntaxTreeDiagnostic, ref context, token);
+
+        private static void HandleRequiredSpaceToken<TContext>(ReportDiagnosticCallback<TContext> reportDiagnostic, ref TContext context, SyntaxToken token)
         {
             if (token.IsMissing)
             {
@@ -181,10 +191,16 @@ namespace StyleCop.Analyzers.SpacingRules
                 }
             }
 
-            context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), TokenSpacingProperties.InsertFollowing, token.Text, string.Empty));
+            reportDiagnostic(ref context, Diagnostic.Create(Descriptor, token.GetLocation(), TokenSpacingProperties.InsertFollowing, token.Text, string.Empty));
         }
 
-        private static void HandleDisallowedSpaceToken(SyntaxTreeAnalysisContext context, SyntaxToken token)
+        private static void HandleDisallowedSpaceToken(ref SyntaxTreeAnalysisContext context, SyntaxToken token)
+            => HandleDisallowedSpaceToken(ReportSyntaxTreeDiagnostic, ref context, token);
+
+        private static void HandleDisallowedSpaceToken(ref SyntaxNodeAnalysisContext context, SyntaxToken token)
+            => HandleDisallowedSpaceToken(ReportSyntaxNodeDiagnostic, ref context, token);
+
+        private static void HandleDisallowedSpaceToken<TContext>(ReportDiagnosticCallback<TContext> reportDiagnostic, ref TContext context, SyntaxToken token)
         {
             if (token.IsMissing || !token.HasTrailingTrivia)
             {
@@ -196,25 +212,10 @@ namespace StyleCop.Analyzers.SpacingRules
                 return;
             }
 
-            context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), TokenSpacingProperties.RemoveFollowing, token.Text, " not"));
+            reportDiagnostic(ref context, Diagnostic.Create(Descriptor, token.GetLocation(), TokenSpacingProperties.RemoveFollowing, token.Text, " not"));
         }
 
-        private static void HandleDisallowedSpaceToken(SyntaxNodeAnalysisContext context, SyntaxToken token)
-        {
-            if (token.IsMissing || !token.HasTrailingTrivia)
-            {
-                return;
-            }
-
-            if (!token.TrailingTrivia.First().IsKind(SyntaxKind.WhitespaceTrivia))
-            {
-                return;
-            }
-
-            context.ReportDiagnostic(Diagnostic.Create(Descriptor, token.GetLocation(), TokenSpacingProperties.RemoveFollowing, token.Text, " not"));
-        }
-
-        private static void HandleNewKeywordToken(SyntaxTreeAnalysisContext context, SyntaxToken token)
+        private static void HandleNewKeywordToken(ref SyntaxTreeAnalysisContext context, SyntaxToken token)
         {
             if (token.IsMissing)
             {
@@ -231,15 +232,15 @@ namespace StyleCop.Analyzers.SpacingRules
                     return;
                 }
 
-                HandleDisallowedSpaceToken(context, token);
+                HandleDisallowedSpaceToken(ref context, token);
                 return;
             }
 
             // otherwise treat as required
-            HandleRequiredSpaceToken(context, token);
+            HandleRequiredSpaceToken(ref context, token);
         }
 
-        private static void HandleReturnKeywordToken(SyntaxTreeAnalysisContext context, SyntaxToken token)
+        private static void HandleReturnKeywordToken(ref SyntaxTreeAnalysisContext context, SyntaxToken token)
         {
             if (token.IsMissing)
             {
@@ -253,15 +254,15 @@ namespace StyleCop.Analyzers.SpacingRules
             SyntaxToken nextToken = token.GetNextToken();
             if (nextToken.IsKind(SyntaxKind.SemicolonToken) || nextToken.IsKind(SyntaxKind.ColonToken))
             {
-                HandleDisallowedSpaceToken(context, token);
+                HandleDisallowedSpaceToken(ref context, token);
                 return;
             }
 
             // otherwise treat as required
-            HandleRequiredSpaceToken(context, token);
+            HandleRequiredSpaceToken(ref context, token);
         }
 
-        private static void HandleThrowKeywordToken(SyntaxTreeAnalysisContext context, SyntaxToken token)
+        private static void HandleThrowKeywordToken(ref SyntaxTreeAnalysisContext context, SyntaxToken token)
         {
             if (token.IsMissing)
             {
@@ -274,12 +275,12 @@ namespace StyleCop.Analyzers.SpacingRules
             SyntaxToken nextToken = token.GetNextToken();
             if (nextToken.IsKind(SyntaxKind.SemicolonToken))
             {
-                HandleDisallowedSpaceToken(context, token);
+                HandleDisallowedSpaceToken(ref context, token);
                 return;
             }
 
             // otherwise treat as required
-            HandleRequiredSpaceToken(context, token);
+            HandleRequiredSpaceToken(ref context, token);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
@@ -19,9 +19,10 @@ namespace StyleCop.Analyzers.SpacingRules
     /// <para>The following C# keywords must always be followed by a single space: <strong>catch</strong>,
     /// <strong>fixed</strong>, <strong>for</strong>, <strong>foreach</strong>, <strong>from</strong>,
     /// <strong>group</strong>, <strong>if</strong>, <strong>in</strong>, <strong>into</strong>, <strong>join</strong>,
-    /// <strong>let</strong>, <strong>lock</strong>, <strong>orderby</strong>, <strong>return</strong>,
-    /// <strong>select</strong>, <strong>stackalloc</strong>, <strong>switch</strong>, <strong>throw</strong>,
-    /// <strong>using</strong>, <strong>where</strong>, <strong>while</strong>, <strong>yield</strong>.</para>
+    /// <strong>let</strong>, <strong>lock</strong>, <strong>orderby</strong>, <strong>out</strong>,
+    /// <strong>ref</strong>, <strong>return</strong>, <strong>select</strong>, <strong>stackalloc</strong>,
+    /// <strong>switch</strong>, <strong>throw</strong>, <strong>using</strong>, <strong>var</strong>,
+    /// <strong>where</strong>, <strong>while</strong>, <strong>yield</strong>.</para>
     ///
     /// <para>The following keywords must not be followed by any space: <strong>checked</strong>,
     /// <strong>default</strong>, <strong>sizeof</strong>, <strong>typeof</strong>, <strong>unchecked</strong>.</para>
@@ -46,6 +47,7 @@ namespace StyleCop.Analyzers.SpacingRules
 
         private static readonly Action<SyntaxTreeAnalysisContext> SyntaxTreeAction = HandleSyntaxTree;
         private static readonly Action<SyntaxNodeAnalysisContext> InvocationExpressionAction = HandleInvocationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> IdentifierNameAction = HandleIdentifierName;
         private static readonly ReportDiagnosticCallback<SyntaxTreeAnalysisContext> ReportSyntaxTreeDiagnostic =
             (ref SyntaxTreeAnalysisContext context, Diagnostic diagnostic) => context.ReportDiagnostic(diagnostic);
 
@@ -69,6 +71,9 @@ namespace StyleCop.Analyzers.SpacingRules
 
             // handle nameof (which appears as an invocation expression??)
             context.RegisterSyntaxNodeAction(InvocationExpressionAction, SyntaxKind.InvocationExpression);
+
+            // handle var (which appears as an identifier name??)
+            context.RegisterSyntaxNodeAction(IdentifierNameAction, SyntaxKind.IdentifierName);
         }
 
         private static void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
@@ -93,10 +98,13 @@ namespace StyleCop.Analyzers.SpacingRules
                 case SyntaxKind.LetKeyword:
                 case SyntaxKind.LockKeyword:
                 case SyntaxKind.OrderByKeyword:
+                case SyntaxKind.OutKeyword:
+                case SyntaxKind.RefKeyword:
                 case SyntaxKind.SelectKeyword:
                 case SyntaxKind.StackAllocKeyword:
                 case SyntaxKind.SwitchKeyword:
                 case SyntaxKind.UsingKeyword:
+                case SyntaxKind.TypeVarKeyword:
                 case SyntaxKind.WhereKeyword:
                 case SyntaxKind.WhileKeyword:
                 case SyntaxKind.YieldKeyword:
@@ -168,8 +176,20 @@ namespace StyleCop.Analyzers.SpacingRules
             }
         }
 
+        private static void HandleIdentifierName(SyntaxNodeAnalysisContext context)
+        {
+            IdentifierNameSyntax identifierNameSyntax = (IdentifierNameSyntax)context.Node;
+            if (identifierNameSyntax.IsVar)
+            {
+                HandleRequiredSpaceToken(ref context, identifierNameSyntax.Identifier);
+            }
+        }
+
         private static void HandleRequiredSpaceToken(ref SyntaxTreeAnalysisContext context, SyntaxToken token)
             => HandleRequiredSpaceToken(ReportSyntaxTreeDiagnostic, ref context, token);
+
+        private static void HandleRequiredSpaceToken(ref SyntaxNodeAnalysisContext context, SyntaxToken token)
+            => HandleRequiredSpaceToken(ReportSyntaxNodeDiagnostic, ref context, token);
 
         private static void HandleRequiredSpaceToken<TContext>(ReportDiagnosticCallback<TContext> reportDiagnostic, ref TContext context, SyntaxToken token)
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003SymbolsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003SymbolsMustBeSpacedCorrectly.cs
@@ -128,11 +128,7 @@ namespace StyleCop.Analyzers.SpacingRules
         private static readonly Action<SyntaxNodeAnalysisContext> CastExpressionAction = HandleCastExpression;
         private static readonly Action<SyntaxNodeAnalysisContext> EqualsValueClauseAction = HandleEqualsValueClause;
         private static readonly Action<SyntaxNodeAnalysisContext> LambdaExpressionAction = HandleLambdaExpression;
-        private static readonly Action<SyntaxNodeAnalysisContext> PropertyDeclarationAction = HandlePropertyDeclaration;
-        private static readonly Action<SyntaxNodeAnalysisContext> MethodDeclarationAction = HandleMethodDeclaration;
-        private static readonly Action<SyntaxNodeAnalysisContext> OperatorDeclarationAction = HandleOperatorDeclaration;
-        private static readonly Action<SyntaxNodeAnalysisContext> ConversionOperatorDeclarationAction = HandleConversionOperatorDeclaration;
-        private static readonly Action<SyntaxNodeAnalysisContext> IndexerDeclarationAction = HandleIndexerDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext> ArrowExpressionClauseAction = HandleArrowExpressionClause;
 
         /// <summary>
         /// Gets the descriptor for prefix unary expression that may not be followed by a comment.
@@ -208,11 +204,7 @@ namespace StyleCop.Analyzers.SpacingRules
             context.RegisterSyntaxNodeAction(CastExpressionAction, SyntaxKind.CastExpression);
             context.RegisterSyntaxNodeAction(EqualsValueClauseAction, SyntaxKind.EqualsValueClause);
             context.RegisterSyntaxNodeAction(LambdaExpressionAction, SyntaxKinds.LambdaExpression);
-            context.RegisterSyntaxNodeAction(PropertyDeclarationAction, SyntaxKind.PropertyDeclaration);
-            context.RegisterSyntaxNodeAction(IndexerDeclarationAction, SyntaxKind.IndexerDeclaration);
-            context.RegisterSyntaxNodeAction(MethodDeclarationAction, SyntaxKind.MethodDeclaration);
-            context.RegisterSyntaxNodeAction(OperatorDeclarationAction, SyntaxKind.OperatorDeclaration);
-            context.RegisterSyntaxNodeAction(ConversionOperatorDeclarationAction, SyntaxKind.ConversionOperatorDeclaration);
+            context.RegisterSyntaxNodeAction(ArrowExpressionClauseAction, SyntaxKind.ArrowExpressionClause);
         }
 
         private static void HandleConstructorDeclaration(SyntaxNodeAnalysisContext context)
@@ -350,42 +342,10 @@ namespace StyleCop.Analyzers.SpacingRules
             CheckToken(context, lambdaExpression.ArrowToken, true, true, true);
         }
 
-        private static void HandlePropertyDeclaration(SyntaxNodeAnalysisContext context)
+        private static void HandleArrowExpressionClause(SyntaxNodeAnalysisContext context)
         {
-            var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
-            HandleArrowExpressionClause(context, propertyDeclaration.ExpressionBody);
-        }
-
-        private static void HandleIndexerDeclaration(SyntaxNodeAnalysisContext context)
-        {
-            var indexerDeclaration = (IndexerDeclarationSyntax)context.Node;
-            HandleArrowExpressionClause(context, indexerDeclaration.ExpressionBody);
-        }
-
-        private static void HandleMethodDeclaration(SyntaxNodeAnalysisContext context)
-        {
-            var methodDeclaration = (MethodDeclarationSyntax)context.Node;
-            HandleArrowExpressionClause(context, methodDeclaration.ExpressionBody);
-        }
-
-        private static void HandleOperatorDeclaration(SyntaxNodeAnalysisContext context)
-        {
-            var operatorDeclaration = (OperatorDeclarationSyntax)context.Node;
-            HandleArrowExpressionClause(context, operatorDeclaration.ExpressionBody);
-        }
-
-        private static void HandleConversionOperatorDeclaration(SyntaxNodeAnalysisContext context)
-        {
-            var conversionOperatorDeclaration = (ConversionOperatorDeclarationSyntax)context.Node;
-            HandleArrowExpressionClause(context, conversionOperatorDeclaration.ExpressionBody);
-        }
-
-        private static void HandleArrowExpressionClause(SyntaxNodeAnalysisContext context, ArrowExpressionClauseSyntax arrowExpressionClause)
-        {
-            if (arrowExpressionClause != null)
-            {
-                CheckToken(context, arrowExpressionClause.ArrowToken, true, true, true);
-            }
+            ArrowExpressionClauseSyntax arrowExpressionClause = (ArrowExpressionClauseSyntax)context.Node;
+            CheckToken(context, arrowExpressionClause.ArrowToken, true, true, true);
         }
 
         private static void CheckToken(SyntaxNodeAnalysisContext context, SyntaxToken token, bool withLeadingWhitespace, bool allowAtEndOfLine, bool withTrailingWhitespace, string tokenText = null)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
@@ -11,6 +11,7 @@ namespace StyleCop.Analyzers.SpacingRules
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.Helpers;
+    using StyleCop.Analyzers.Lightup;
 
     /// <summary>
     /// An opening parenthesis within a C# statement is not spaced correctly.
@@ -201,7 +202,12 @@ namespace StyleCop.Analyzers.SpacingRules
                 haveLeadingSpace = false;
                 break;
 
+            case SyntaxKindEx.ParenthesizedVariableDesignation:
+                haveLeadingSpace = true;
+                break;
+
             case SyntaxKind.ParenthesizedExpression:
+            case SyntaxKindEx.TupleExpression:
                 if (prevToken.Parent.IsKind(SyntaxKind.Interpolation))
                 {
                     haveLeadingSpace = false;
@@ -227,6 +233,13 @@ namespace StyleCop.Analyzers.SpacingRules
             case SyntaxKind.ParameterList:
                 var partOfLambdaExpression = token.Parent.Parent.IsKind(SyntaxKind.ParenthesizedLambdaExpression);
                 haveLeadingSpace = partOfLambdaExpression;
+                break;
+
+            case SyntaxKindEx.TupleType:
+                // Comma covers tuple types in parameters and nested within other tuple types.
+                // Return types are handled by a helper.
+                haveLeadingSpace = prevToken.IsKind(SyntaxKind.CommaToken)
+                    || ((TypeSyntax)token.Parent).IsReturnType();
                 break;
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
@@ -94,6 +94,7 @@ namespace StyleCop.Analyzers.SpacingRules
             case SyntaxKind.SemicolonToken:
             case SyntaxKind.CommaToken:
             case SyntaxKind.DoubleQuoteToken:
+            case SyntaxKind.GreaterThanToken:
                 precedesStickyCharacter = true;
                 break;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/StyleCop.Analyzers.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Helpers\SyntaxTreeHelpers.cs" />
     <Compile Include="Helpers\TokenHelper.cs" />
     <Compile Include="Helpers\TriviaHelper.cs" />
+    <Compile Include="Helpers\TypeSyntaxHelper.cs" />
     <Compile Include="Helpers\UsingDirectiveSyntaxHelpers.cs" />
     <Compile Include="Helpers\UsingGroup.cs" />
     <Compile Include="Helpers\XmlCommentHelper.cs" />

--- a/documentation/SA1000.md
+++ b/documentation/SA1000.md
@@ -24,8 +24,8 @@ The spacing around a C# keyword is incorrect.
 A violation of this rule occurs when the spacing around a keyword is incorrect.
 
 The following C# keywords must always be followed by a single space: `await`, `case`, `catch`, `fixed`, `for`,
-`foreach`, `from`, `group`, `if`, `in`, `into`, `join`, `let`, `lock`, `orderby`, `return`, `select`, `stackalloc`,
-`switch`, `using`, `where`, `while`, `yield`.
+`foreach`, `from`, `group`, `if`, `in`, `into`, `join`, `let`, `lock`, `orderby`, `out`, `ref`, `return`, `select`,
+`stackalloc`, `switch`, `using`, `var`, `where`, `while`, `yield`.
 
 The following keywords must not be followed by any space: `checked`, `default`, `sizeof`, `typeof`, `unchecked`.
 


### PR DESCRIPTION
Fixes #2267 
Fixes #2308

* [x] Run all existing spacing tests with Roslyn 1.3 and Roslyn 2.0
* [x] SA1000
  * [x] `out` keyword for `out` variables
  * [x] `ref` keyword for ref locals and expressions
  * [x] `var` keyword
* [x] SA1001
* [x] SA1002
* [x] SA1003
  * [x] Arrow expression clause `=>`
* [x] SA1004
* [x] SA1005
* [x] SA1006
* [x] SA1007
* [x] SA1008
  * [x] Tuple types
  * [x] Tuple expressions
  * [x] `ref` expressions
* [x] SA1009
  * [x] Tuple types
  * [x] Tuple expressions
* [x] SA1010
* [x] SA1011
  * [x] `]` before a comma in a tuple type `(int[], int)`
* [x] SA1012
* [x] SA1013
  * [x] `}` before a comma in tuple expression `(new[] { 3 }, 3)`
* [x] SA1014
* [x] SA1015
  * [x] `>` before a comma or closing parenthesis in tuple type `(Func<int>, Func<int>)`
* [x] SA1016
* [x] SA1017
* [x] SA1018
  * [x] Nullable tuple type, e.g. `(int, int)?`
* [x] SA1019
* [x] SA1020
* [x] SA1021
* [x] SA1022
* [x] SA1023
* [x] SA1024
  * [x] Tuple expressions, e.g. `(x: 3, y: 4)`
* [x] SA1025
* [x] SA1026
* [x] SA1027
* [x] SA1028
