### PR TITLE
Update special rules tests for C# 7

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpecialRules/SA0001CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpecialRules/SA0001CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpecialRules
+{
+    using StyleCop.Analyzers.Test.SpecialRules;
+
+    public class SA0001CSharp7UnitTests : SA0001UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpecialRules/SA0002CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpecialRules/SA0002CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.SpecialRules
+{
+    using StyleCop.Analyzers.Test.SpecialRules;
+
+    public class SA0002CSharp7UnitTests : SA0002UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/StyleCop.Analyzers.Test.CSharp7.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/StyleCop.Analyzers.Test.CSharp7.csproj
@@ -340,6 +340,8 @@
     <Compile Include="SpacingRules\SA1027CSharp7UnitTests.cs" />
     <Compile Include="SpacingRules\SA1027UseTabsCSharp7UnitTests.cs" />
     <Compile Include="SpacingRules\SA1028CSharp7UnitTests.cs" />
+    <Compile Include="SpecialRules\SA0001CSharp7UnitTests.cs" />
+    <Compile Include="SpecialRules\SA0002CSharp7UnitTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\build\keys\TestingKey.snk">


### PR DESCRIPTION
Run all existing special tests with Roslyn 1.3 and Roslyn 2.0