### PR TITLE
Fix spacing rules for new arrays of a tuple type

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1000CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1000CSharp7UnitTests.cs
@@ -126,5 +126,99 @@ namespace TestNamespace
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Verifies that spacing for <c>new</c> expressions for an array of a tuple type is handled correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        /// <seealso cref="SA1008CSharp7UnitTests.TestNewTupleArrayAsync"/>
+        [Fact]
+        public async Task TestNewTupleArrayAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var x = new( int, int)[0];
+            var y = new(int, int)[0];
+            var z = new ( int, int)[0];
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var x = new ( int, int)[0];
+            var y = new (int, int)[0];
+            var z = new ( int, int)[0];
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostics =
+            {
+                this.CSharpDiagnostic().WithArguments("new", string.Empty, "followed").WithLocation(7, 21),
+                this.CSharpDiagnostic().WithArguments("new", string.Empty, "followed").WithLocation(8, 21),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostics, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing for <c>foreach</c> expressions using tuple deconstruction is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        /// <seealso cref="SA1008CSharp7UnitTests.TestForEachVariableStatementAsync"/>
+        [Fact]
+        public async Task TestForEachVariableStatementAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            foreach( var (x, y) in new (int, int)[0]) { }
+            foreach(var (x, y) in new (int, int)[0]) { }
+            foreach ( var (x, y) in new (int, int)[0]) { }
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            foreach ( var (x, y) in new (int, int)[0]) { }
+            foreach (var (x, y) in new (int, int)[0]) { }
+            foreach ( var (x, y) in new (int, int)[0]) { }
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostics =
+            {
+                this.CSharpDiagnostic().WithArguments("foreach", string.Empty, "followed").WithLocation(7, 13),
+                this.CSharpDiagnostic().WithArguments("foreach", string.Empty, "followed").WithLocation(8, 13),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostics, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
@@ -702,5 +702,99 @@ namespace TestNamespace
             await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(testCode, fixedCode, numberOfFixAllIterations: 2).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Verifies that spacing for <c>new</c> expressions for an array of a tuple type is handled correctly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        /// <seealso cref="SA1000CSharp7UnitTests.TestNewTupleArrayAsync"/>
+        [Fact]
+        public async Task TestNewTupleArrayAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var x = new( int, int)[0];
+            var y = new(int, int)[0];
+            var z = new ( int, int)[0];
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            var x = new(int, int)[0];
+            var y = new(int, int)[0];
+            var z = new (int, int)[0];
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostics =
+            {
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(7, 24),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(9, 25),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostics, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that spacing for <c>foreach</c> expressions using tuple deconstruction is handled properly.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        /// <seealso cref="SA1000CSharp7UnitTests.TestForEachVariableStatementAsync"/>
+        [Fact]
+        public async Task TestForEachVariableStatementAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            foreach( var (x, y) in new (int, int)[0]) { }
+            foreach(var (x, y) in new (int, int)[0]) { }
+            foreach ( var (x, y) in new (int, int)[0]) { }
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod()
+        {
+            foreach(var (x, y) in new (int, int)[0]) { }
+            foreach(var (x, y) in new (int, int)[0]) { }
+            foreach (var (x, y) in new (int, int)[0]) { }
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostics =
+            {
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(7, 20),
+                this.CSharpDiagnostic(DescriptorNotFollowed).WithLocation(9, 21),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expectedDiagnostics, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedCode).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
@@ -241,22 +241,39 @@ namespace StyleCop.Analyzers.SpacingRules
                 return;
             }
 
-            // if the next token is [ or (, then treat as disallowed
+            bool needSpace;
             SyntaxToken nextToken = token.GetNextToken();
-            if (nextToken.IsKind(SyntaxKind.OpenBracketToken) || nextToken.IsKind(SyntaxKind.OpenParenToken))
+            switch (nextToken.Kind())
             {
+            case SyntaxKind.OpenBracketToken:
                 if (token.Parent.IsKind(SyntaxKind.ImplicitArrayCreationExpression))
                 {
                     // This is handled by SA1026
                     return;
                 }
 
-                HandleDisallowedSpaceToken(ref context, token);
-                return;
+                // Disallowed, but can we hit this??
+                needSpace = false;
+                break;
+
+            case SyntaxKind.OpenParenToken:
+                // Disallowed for new() constraint, but otherwise allowed for tuple types
+                needSpace = !token.Parent.IsKind(SyntaxKind.ConstructorConstraint);
+                break;
+
+            default:
+                needSpace = true;
+                break;
             }
 
-            // otherwise treat as required
-            HandleRequiredSpaceToken(ref context, token);
+            if (!needSpace)
+            {
+                HandleDisallowedSpaceToken(ref context, token);
+            }
+            else
+            {
+                HandleRequiredSpaceToken(ref context, token);
+            }
         }
 
         private static void HandleReturnKeywordToken(ref SyntaxTreeAnalysisContext context, SyntaxToken token)


### PR DESCRIPTION
Previously SA1000 was firing on the `new` keyword in the following:

```csharp
var x = new (int, int)[0];
```

:memo: Prior to C# 7, the only time `(` could follow `new` was in the following. We assumed this in the original implementation, so the new C# 7 syntax threw us off.

```csharp
class Class<T>
  where T : new()
{
}
```