### PR TITLE
Initial round of testing for LightJson

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -166,8 +166,8 @@ namespace TestHelper
                 }
                 else
                 {
-                    JsonObject indentationObject = JsonReader.Parse(indentationSettings);
-                    JsonObject settingsObject = JsonReader.Parse(settings);
+                    JsonObject indentationObject = JsonReader.Parse(indentationSettings).AsJsonObject;
+                    JsonObject settingsObject = JsonReader.Parse(settings).AsJsonObject;
                     JsonObject mergedSettings = MergeJsonObjects(settingsObject, indentationObject);
                     using (var writer = new JsonWriter(pretty: true))
                     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/JsonArrayTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/JsonArrayTests.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.LightJson
+{
+    using System;
+    using global::LightJson;
+    using Xunit;
+    using IEnumerable = System.Collections.IEnumerable;
+
+    public class JsonArrayTests
+    {
+        [Fact]
+        public void TestConstructor()
+        {
+            var obj = new JsonArray();
+            Assert.Equal(0, obj.Count);
+
+            var obj1 = new JsonArray(1, "test1");
+            Assert.Equal(2, obj1.Count);
+            Assert.Equal(1, obj1[0].AsInteger);
+            Assert.Equal("test1", obj1[1].AsString);
+
+            var obj2 = new JsonArray { 1, "test2" };
+            Assert.Equal(2, obj2.Count);
+            Assert.Equal(1, obj2[0].AsInteger);
+            Assert.Equal("test2", obj2[1].AsString);
+
+            Assert.Throws<ArgumentNullException>("values", () => new JsonArray(default(JsonValue[])));
+        }
+
+        [Fact]
+        public void TestIndexer()
+        {
+            var obj = new JsonArray(1);
+            Assert.Equal(1, obj.Count);
+            Assert.Equal(1, obj[0].AsInteger);
+            Assert.Equal(JsonValue.Null, obj[1]);
+            Assert.Equal(JsonValue.Null, obj[-1]);
+
+            obj[0] = 2;
+            Assert.Equal(2, obj[0].AsInteger);
+
+            Assert.ThrowsAny<ArgumentOutOfRangeException>(() => obj[-1] = 0);
+            Assert.ThrowsAny<ArgumentException>(() => obj[1] = 0);
+        }
+
+        [Fact]
+        public void TestInsert()
+        {
+            var obj = new JsonArray(1);
+            Assert.Equal(1, obj.Count);
+            Assert.Equal(1, obj[0].AsInteger);
+
+            // Insert at end
+            Assert.Same(obj, obj.Insert(obj.Count, 2));
+            Assert.Equal(2, obj.Count);
+            Assert.Equal(1, obj[0].AsInteger);
+            Assert.Equal(2, obj[1].AsInteger);
+
+            // Insert at beginning
+            Assert.Same(obj, obj.Insert(0, 0));
+            Assert.Equal(3, obj.Count);
+            Assert.Equal(0, obj[0].AsInteger);
+            Assert.Equal(1, obj[1].AsInteger);
+            Assert.Equal(2, obj[2].AsInteger);
+
+            Assert.ThrowsAny<ArgumentOutOfRangeException>(() => obj.Insert(-1, 0));
+            Assert.ThrowsAny<ArgumentException>(() => obj.Insert(obj.Count + 1, 0));
+        }
+
+        [Fact]
+        public void TestRemove()
+        {
+            var obj = new JsonArray(0, 1, 2);
+            Assert.Equal(3, obj.Count);
+
+            Assert.ThrowsAny<ArgumentOutOfRangeException>(() => obj.Remove(-1));
+            Assert.ThrowsAny<ArgumentException>(() => obj.Remove(obj.Count));
+
+            Assert.Same(obj, obj.Remove(1));
+            Assert.Equal(2, obj.Count);
+            Assert.Equal(0, obj[0].AsInteger);
+            Assert.Equal(2, obj[1].AsInteger);
+        }
+
+        [Fact]
+        public void TestClear()
+        {
+            var obj = new JsonArray(0, 1, 2);
+            Assert.Equal(3, obj.Count);
+
+            Assert.Same(obj, obj.Clear());
+            Assert.Equal(0, obj.Count);
+
+            Assert.Same(obj, obj.Clear());
+            Assert.Equal(0, obj.Count);
+        }
+
+        [Fact]
+        public void TestContains()
+        {
+            var obj = new JsonArray("a", "b", "c");
+            Assert.True(obj.Contains("b"));
+            obj.Remove(1);
+            Assert.False(obj.Contains("b"));
+
+            Assert.False(obj.Contains(JsonValue.Null));
+        }
+
+        [Fact]
+        public void TestIndexOf()
+        {
+            var obj = new JsonArray("a", "b", "c");
+            Assert.Equal(1, obj.IndexOf("b"));
+            Assert.Equal(2, obj.IndexOf("c"));
+            obj.Remove(1);
+            Assert.Equal(-1, obj.IndexOf("b"));
+            Assert.Equal(1, obj.IndexOf("c"));
+
+            Assert.Equal(-1, obj.IndexOf(JsonValue.Null));
+        }
+
+        [Fact]
+        public void TestEnumerators()
+        {
+            var obj = new JsonArray("a", "b", "c");
+
+            using (var genericEnumerator = obj.GetEnumerator())
+            {
+                var legacyEnumerator = ((IEnumerable)obj).GetEnumerator();
+                for (int i = 0; i < obj.Count; i++)
+                {
+                    Assert.True(genericEnumerator.MoveNext());
+                    Assert.True(legacyEnumerator.MoveNext());
+                    Assert.Equal(obj[i], genericEnumerator.Current);
+                    Assert.Equal(obj[i], legacyEnumerator.Current);
+                    Assert.Equal(genericEnumerator.Current, legacyEnumerator.Current);
+                }
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/JsonObjectTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/JsonObjectTests.cs
@@ -1,0 +1,112 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.LightJson
+{
+    using System;
+    using System.Collections.Generic;
+    using global::LightJson;
+    using Xunit;
+    using IEnumerable = System.Collections.IEnumerable;
+
+    public class JsonObjectTests
+    {
+        [Fact]
+        public void TestCount()
+        {
+            var obj = new JsonObject();
+            Assert.Equal(0, obj.Count);
+
+            obj["x"] = "value";
+            Assert.Equal(1, obj.Count);
+
+            obj["y"] = "value";
+            Assert.Equal(2, obj.Count);
+
+            obj["x"] = "value2";
+            Assert.Equal(2, obj.Count);
+
+            Assert.True(obj.Remove("x"));
+            Assert.Equal(1, obj.Count);
+
+            Assert.False(obj.Remove("x"));
+            Assert.Equal(1, obj.Count);
+
+            obj["z"] = "value3";
+            Assert.Equal(2, obj.Count);
+
+            Assert.Same(obj, obj.Clear());
+            Assert.Equal(0, obj.Count);
+        }
+
+        [Fact]
+        public void TestAdd()
+        {
+            var obj = new JsonObject();
+            Assert.Equal(JsonValue.Null, obj["x"]);
+            Assert.False(obj.ContainsKey("x"));
+
+            Assert.Same(obj, obj.Add("x"));
+            Assert.Equal(JsonValue.Null, obj["x"]);
+            Assert.True(obj.ContainsKey("x"));
+        }
+
+        [Fact]
+        public void TestEnumerator()
+        {
+            var obj = new JsonObject();
+            obj["x"] = "x1";
+            obj["y"] = "y1";
+
+            foreach (var value in obj)
+            {
+                Assert.Equal(typeof(KeyValuePair<string, JsonValue>), StaticType(value));
+                Assert.Equal(value.Value, obj[value.Key]);
+            }
+
+            IEnumerable<JsonValue> genericEnumerable = obj;
+            foreach (var value in genericEnumerable)
+            {
+                Assert.True(obj.Contains(value));
+            }
+
+            IEnumerable legacyEnumerable = obj;
+            foreach (var value in legacyEnumerable)
+            {
+                Assert.IsType<KeyValuePair<string, JsonValue>>(value);
+                Assert.True(obj.Contains(((KeyValuePair<string, JsonValue>)value).Value));
+            }
+        }
+
+        [Fact]
+        public void TestRename()
+        {
+            var obj = new JsonObject { ["x"] = "value1", ["y"] = "value2" };
+            Assert.Equal(2, obj.Count);
+
+            var value = obj["x"].AsString;
+            Assert.False(obj.ContainsKey("z"));
+            Assert.Same(obj, obj.Rename("x", "z"));
+            Assert.Same(value, obj["z"].AsString);
+            Assert.False(obj.ContainsKey("x"));
+            Assert.Equal(2, obj.Count);
+
+            // Renaming can overwrite a value
+            Assert.Same(obj, obj.Rename("z", "y"));
+            Assert.Same(value, obj["y"].AsString);
+            Assert.Equal(1, obj.Count);
+
+            // Renaming to the same name does nothing
+            Assert.Same(obj, obj.Rename("y", "y"));
+            Assert.Same(value, obj["y"].AsString);
+            Assert.Equal(1, obj.Count);
+
+            // Renaming a non-existent element is not a problem, and does not overwrite the target
+            Assert.Same(obj, obj.Rename("bogus", "y"));
+            Assert.Equal(1, obj.Count);
+            Assert.Same(value, obj["y"].AsString);
+        }
+
+        private static Type StaticType<T>(T value) => typeof(T);
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/JsonReaderTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/JsonReaderTests.cs
@@ -1,0 +1,28 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.LightJson
+{
+    using global::LightJson;
+    using global::LightJson.Serialization;
+    using Xunit;
+
+    public class JsonReaderTests
+    {
+        [Fact]
+        public void TestKeyMatchesPreviousValue()
+        {
+            var jsonObject = JsonValue.Parse("{ \"x\": \"value\", \"value\": \"value\" }");
+            Assert.NotNull(jsonObject);
+            Assert.Equal("value", jsonObject["x"].AsString);
+            Assert.Equal("value", jsonObject["value"].AsString);
+            Assert.Equal(jsonObject["x"], jsonObject["value"]);
+        }
+
+        [Fact]
+        public void TestDuplicateKeys()
+        {
+            Assert.ThrowsAny<JsonParseException>(() => JsonValue.Parse("{ \"x\": \"value\", \"x\": \"value\" }"));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/JsonValueTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/JsonValueTests.cs
@@ -1,0 +1,334 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.LightJson
+{
+    using System;
+    using global::LightJson;
+    using global::LightJson.Serialization;
+    using Xunit;
+
+    public class JsonValueTests
+    {
+        [Fact]
+        public void TestJsonValueConstructors()
+        {
+            // JsonValue(bool?)
+            Assert.True(new JsonValue(true).IsBoolean);
+            Assert.True(new JsonValue(true).AsBoolean);
+            Assert.True(new JsonValue(false).IsBoolean);
+            Assert.False(new JsonValue(false).AsBoolean);
+            Assert.True(new JsonValue(default(bool?)).IsNull);
+            Assert.False(new JsonValue(default(bool?)).IsBoolean);
+            Assert.False(new JsonValue(default(bool?)).AsBoolean);
+
+            // JsonValue(double?)
+            Assert.True(new JsonValue(1.0).IsNumber);
+            Assert.Equal(1.0, new JsonValue(1.0).AsNumber);
+            Assert.True(new JsonValue(default(double?)).IsNull);
+            Assert.False(new JsonValue(default(double?)).IsNumber);
+            Assert.Equal(0.0, new JsonValue(default(double?)).AsNumber);
+
+            // JsonValue(string)
+            Assert.True(new JsonValue(string.Empty).IsString);
+            Assert.True(new JsonValue("text").IsString);
+            Assert.Equal("text", new JsonValue("text").AsString);
+            Assert.True(new JsonValue(default(string)).IsNull);
+            Assert.False(new JsonValue(default(string)).IsString);
+            Assert.Null(new JsonValue(default(string)).AsString);
+
+            // JsonValue(JsonObject)
+            Assert.True(new JsonValue(new JsonObject()).IsJsonObject);
+            Assert.IsType<JsonObject>(new JsonValue(new JsonObject()).AsJsonObject);
+            Assert.True(new JsonValue(default(JsonObject)).IsNull);
+            Assert.False(new JsonValue(default(JsonObject)).IsJsonObject);
+            Assert.Null(new JsonValue(default(JsonObject)).AsJsonObject);
+
+            // JsonValue(JsonArray)
+            Assert.True(new JsonValue(new JsonArray()).IsJsonArray);
+            Assert.IsType<JsonArray>(new JsonValue(new JsonArray()).AsJsonArray);
+            Assert.True(new JsonValue(default(JsonArray)).IsNull);
+            Assert.False(new JsonValue(default(JsonArray)).IsJsonArray);
+            Assert.Null(new JsonValue(default(JsonArray)).AsJsonArray);
+        }
+
+        [Fact]
+        public void TestIsInteger()
+        {
+            Assert.False(new JsonValue(false).IsInteger);
+            Assert.True(new JsonValue(1.0).IsInteger);
+            Assert.False(new JsonValue(1.1).IsInteger);
+            Assert.False(new JsonValue(double.PositiveInfinity).IsInteger);
+        }
+
+        [Fact]
+        public void TestIsDateTime()
+        {
+            Assert.False(new JsonValue(false).IsDateTime);
+            Assert.False(new JsonValue("Some text").IsDateTime);
+            Assert.True(new JsonValue(DateTime.Now.ToString("o")).IsDateTime);
+        }
+
+        [Fact]
+        public void TestAsBoolean()
+        {
+            Assert.False(new JsonValue(false).AsBoolean);
+            Assert.False(new JsonValue(0.0).AsBoolean);
+            Assert.False(new JsonValue(string.Empty).AsBoolean);
+            Assert.False(new JsonValue(default(JsonObject)).AsBoolean);
+
+            Assert.True(new JsonValue(true).AsBoolean);
+            Assert.True(new JsonValue(1.0).AsBoolean);
+            Assert.True(new JsonValue("text").AsBoolean);
+            Assert.True(new JsonValue(new JsonObject()).AsBoolean);
+            Assert.True(new JsonValue(new JsonArray()).AsBoolean);
+        }
+
+        [Fact]
+        public void TestAsInteger()
+        {
+            Assert.Equal(int.MaxValue, new JsonValue(uint.MaxValue).AsInteger);
+            Assert.Equal(int.MinValue, new JsonValue(long.MinValue).AsInteger);
+            Assert.Equal(0, new JsonValue(0.5).AsInteger);
+            Assert.Equal(1, new JsonValue(1).AsInteger);
+        }
+
+        [Fact]
+        public void TestAsNumber()
+        {
+            Assert.Equal(0.0, new JsonValue(false).AsNumber);
+            Assert.Equal(1.0, new JsonValue(true).AsNumber);
+            Assert.Equal(1.0, new JsonValue(1.0).AsNumber);
+            Assert.Equal(1.0, new JsonValue("1.0").AsNumber);
+            Assert.Equal(0, new JsonValue("text").AsNumber);
+            Assert.Equal(0.0, new JsonValue(new JsonObject()).AsNumber);
+            Assert.Equal(0.0, new JsonValue(default(JsonObject)).AsNumber);
+            Assert.Equal(0.0, new JsonValue(new JsonArray()).AsNumber);
+        }
+
+        [Fact]
+        public void TestAsString()
+        {
+            Assert.Equal("false", new JsonValue(false).AsString);
+            Assert.Equal("true", new JsonValue(true).AsString);
+            Assert.Equal("1", new JsonValue(1.0).AsString);
+            Assert.Equal("text", new JsonValue("text").AsString);
+            Assert.Null(new JsonValue(new JsonObject()).AsString);
+            Assert.Null(new JsonValue(default(JsonObject)).AsString);
+            Assert.Null(new JsonValue(new JsonArray()).AsString);
+        }
+
+        [Fact]
+        public void TestAsJsonObject()
+        {
+            Assert.Null(new JsonValue(false).AsJsonObject);
+            Assert.IsType<JsonObject>(new JsonValue(new JsonObject()).AsJsonObject);
+            Assert.Null(new JsonValue(default(JsonObject)).AsJsonObject);
+        }
+
+        [Fact]
+        public void TestAsJsonArray()
+        {
+            Assert.Null(new JsonValue(false).AsJsonArray);
+            Assert.IsType<JsonArray>(new JsonValue(new JsonArray()).AsJsonArray);
+            Assert.Null(new JsonValue(default(JsonArray)).AsJsonArray);
+        }
+
+        [Fact]
+        public void TestAsDateTime()
+        {
+            Assert.Null(new JsonValue(false).AsDateTime);
+            Assert.Null(new JsonValue("Some text").AsDateTime);
+
+            var now = new DateTime(2016, 1, 20, 5, 12, 33, DateTimeKind.Local);
+            Assert.Equal(now, new JsonValue(now.ToString("o")).AsDateTime);
+        }
+
+        [Fact]
+        public void TestAsObject()
+        {
+            Assert.Equal(0.0, new JsonValue(false).AsObject);
+            Assert.Equal(1.0, new JsonValue(true).AsObject);
+            Assert.Equal(1.0, new JsonValue(1.0).AsObject);
+            Assert.Equal("1.0", new JsonValue("1.0").AsObject);
+            Assert.IsType<JsonObject>(new JsonValue(new JsonObject()).AsObject);
+            Assert.IsType<JsonArray>(new JsonValue(new JsonArray()).AsObject);
+            Assert.Null(new JsonValue(default(JsonObject)).AsObject);
+        }
+
+        [Fact]
+        public void TestStringIndexer()
+        {
+            Assert.ThrowsAny<InvalidOperationException>(() => new JsonValue(false)["key"]);
+            Assert.ThrowsAny<InvalidOperationException>(() => new JsonValue(false)[null]);
+            Assert.ThrowsAny<InvalidOperationException>(() => new JsonValue(false) { ["key"] = "value" });
+
+            Assert.Equal(JsonValue.Null, new JsonValue(new JsonObject())["key"]);
+            var value = new JsonValue(new JsonObject()) { ["key"] = "value" };
+            Assert.Equal("value", value["key"].AsString);
+            Assert.ThrowsAny<ArgumentNullException>(() => new JsonValue(new JsonObject())[null]);
+        }
+
+        [Fact]
+        public void TestIntegerIndexer()
+        {
+            Assert.ThrowsAny<InvalidOperationException>(() => new JsonValue(false)[0]);
+            Assert.ThrowsAny<InvalidOperationException>(() => new JsonValue(false)[-1]);
+            Assert.ThrowsAny<InvalidOperationException>(() => new JsonValue(false) { [0] = "value" });
+
+            Assert.Equal(JsonValue.Null, new JsonValue(new JsonArray())[0]);
+            Assert.Equal(JsonValue.Null, new JsonValue(new JsonArray())[-1]);
+
+            var value = new JsonValue(new JsonArray() { "initial" });
+            Assert.Equal("initial", value[0].AsString);
+            value[0] = "value";
+            Assert.Equal("value", value[0].AsString);
+        }
+
+        [Fact]
+        public void TestConversionOperators()
+        {
+            // (JsonValue)(DateTime?)
+            DateTime time = DateTime.Now;
+            Assert.NotNull((JsonValue)time);
+            Assert.Equal(time.ToString("o"), ((JsonValue)time).AsString);
+            Assert.Equal(JsonValue.Null, (JsonValue)default(DateTime?));
+
+            // (int)(JsonValue)
+            Assert.Equal(0, (int)new JsonValue(uint.MaxValue));
+            Assert.Equal(0, (int)new JsonValue(long.MinValue));
+            Assert.Equal(0, (int)new JsonValue(2.5));
+            Assert.Equal(1, (int)new JsonValue(1));
+
+            // (int?)(JsonValue)
+            Assert.Equal(0, (int?)new JsonValue(uint.MaxValue));
+            Assert.Equal(0, (int?)new JsonValue(long.MinValue));
+            Assert.Equal(0, (int?)new JsonValue(2.5));
+            Assert.Equal(1, (int?)new JsonValue(1));
+            Assert.Null((int?)JsonValue.Null);
+            Assert.Null((int?)new JsonValue(default(JsonObject)));
+
+            // (bool)(JsonValue)
+            Assert.False((bool)new JsonValue(false));
+            Assert.False((bool)new JsonValue(0.0));
+            Assert.False((bool)new JsonValue(string.Empty));
+            Assert.False((bool)new JsonValue(default(JsonObject)));
+
+            Assert.True((bool)new JsonValue(true));
+            Assert.False((bool)new JsonValue(1.0));
+            Assert.False((bool)new JsonValue("text"));
+            Assert.False((bool)new JsonValue(new JsonObject()));
+            Assert.False((bool)new JsonValue(new JsonArray()));
+
+            // (bool?)(JsonValue)
+            Assert.False((bool?)new JsonValue(false));
+            Assert.False((bool?)new JsonValue(0.0));
+            Assert.False((bool?)new JsonValue(string.Empty));
+
+            Assert.True((bool?)new JsonValue(true));
+            Assert.False((bool?)new JsonValue(1.0));
+            Assert.False((bool?)new JsonValue("text"));
+            Assert.False((bool?)new JsonValue(new JsonObject()));
+            Assert.False((bool?)new JsonValue(new JsonArray()));
+
+            Assert.Null((bool?)JsonValue.Null);
+            Assert.Null((bool?)new JsonValue(default(JsonObject)));
+
+            // (double)(JsonValue)
+            Assert.Equal(double.NaN, (double)new JsonValue(false));
+            Assert.Equal(double.NaN, (double)new JsonValue(true));
+            Assert.Equal(1.0, (double)new JsonValue(1.0));
+            Assert.Equal(double.NaN, (double)new JsonValue("1.0"));
+            Assert.Equal(double.NaN, (double)new JsonValue(new JsonObject()));
+            Assert.Equal(double.NaN, (double)new JsonValue(new JsonArray()));
+            Assert.Equal(double.NaN, (double)JsonValue.Null);
+            Assert.Equal(double.NaN, (double)new JsonValue(default(JsonObject)));
+
+            // (double?)(JsonValue)
+            Assert.Equal(double.NaN, (double?)new JsonValue(false));
+            Assert.Equal(double.NaN, (double?)new JsonValue(true));
+            Assert.Equal(1.0, (double?)new JsonValue(1.0));
+            Assert.Equal(double.NaN, (double?)new JsonValue("1.0"));
+            Assert.Equal(double.NaN, (double?)new JsonValue(new JsonObject()));
+            Assert.Equal(double.NaN, (double?)new JsonValue(new JsonArray()));
+            Assert.Null((double?)JsonValue.Null);
+            Assert.Null((double?)new JsonValue(default(JsonObject)));
+
+            // (string)(JsonValue)
+            Assert.Null((string)new JsonValue(false));
+            Assert.Null((string)new JsonValue(true));
+            Assert.Null((string)new JsonValue(1.0));
+            Assert.Equal("text", (string)new JsonValue("text"));
+            Assert.Null((string)new JsonValue(new JsonObject()));
+            Assert.Null((string)new JsonValue(default(JsonObject)));
+            Assert.Null((string)new JsonValue(new JsonArray()));
+
+            // (JsonObject)(JsonValue)
+            Assert.Null((JsonObject)new JsonValue(false));
+            Assert.IsType<JsonObject>((JsonObject)new JsonValue(new JsonObject()));
+            Assert.Null((JsonObject)new JsonValue(default(JsonObject)));
+
+            // (JsonArray)(JsonValue)
+            Assert.Null((JsonArray)new JsonValue(false));
+            Assert.IsType<JsonArray>((JsonArray)new JsonValue(new JsonArray()));
+            Assert.Null((JsonArray)new JsonValue(default(JsonArray)));
+
+            // (DateTime)(JsonValue)
+            Assert.Equal(DateTime.MinValue, (DateTime)new JsonValue(false));
+            Assert.Equal(DateTime.MinValue, (DateTime)new JsonValue("Some text"));
+
+            var now = new DateTime(2016, 1, 20, 5, 12, 33, DateTimeKind.Local);
+            Assert.Equal(now, (DateTime)new JsonValue(now.ToString("o")));
+
+            // (DateTime?)(JsonValue)
+            Assert.Null((DateTime?)new JsonValue(false));
+            Assert.Null((DateTime?)new JsonValue("Some text"));
+            Assert.Equal(now, (DateTime?)new JsonValue(now.ToString("o")));
+        }
+
+        [Fact]
+        public void TestOpInequality()
+        {
+            Assert.False(JsonValue.Null != default(JsonValue));
+            Assert.True(new JsonValue(true) != new JsonValue(0));
+        }
+
+        [Fact]
+        public void TestEquals()
+        {
+            Assert.True(JsonValue.Null.Equals(null));
+            Assert.True(JsonValue.Null.Equals(JsonValue.Null));
+            Assert.True(JsonValue.Null.Equals(default(JsonValue)));
+
+            Assert.True(new JsonValue(true).Equals(new JsonValue(true)));
+            Assert.False(new JsonValue(true).Equals(new JsonValue(false)));
+
+            Assert.False(JsonValue.Null.Equals(1));
+            Assert.False(JsonValue.Null.Equals(new Exception()));
+        }
+
+        [Fact]
+        public void TestGetHashCode()
+        {
+            Assert.Equal(JsonValue.Null.GetHashCode(), default(JsonValue).GetHashCode());
+            Assert.Equal(new JsonValue(1).GetHashCode(), new JsonValue(1).GetHashCode());
+            Assert.Equal(new JsonValue("text").GetHashCode(), new JsonValue(new string("text".ToCharArray())).GetHashCode());
+        }
+
+        [Fact]
+        public void TestParse()
+        {
+            Assert.True(JsonValue.Parse("true").IsBoolean);
+            Assert.True(JsonValue.Parse("1").IsInteger);
+            Assert.True(JsonValue.Parse("1.0").IsInteger);
+            Assert.True(JsonValue.Parse("1.0").IsNumber);
+            Assert.True(JsonValue.Parse("\"text\"").IsString);
+            Assert.True(JsonValue.Parse("null").IsNull);
+            Assert.True(JsonValue.Parse("{}").IsJsonObject);
+            Assert.True(JsonValue.Parse("[]").IsJsonArray);
+
+            Assert.ThrowsAny<JsonParseException>(() => JsonValue.Parse(string.Empty));
+            Assert.ThrowsAny<JsonParseException>(() => JsonValue.Parse("{"));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/Serialization/JsonParseExceptionTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/Serialization/JsonParseExceptionTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.LightJson.Serialization
+{
+    using global::LightJson.Serialization;
+    using Xunit;
+
+    public class JsonParseExceptionTests
+    {
+        [Fact]
+        public void TestDefaultConstructor()
+        {
+            var ex = new JsonParseException();
+            Assert.Equal(JsonParseException.ErrorType.Unknown, ex.Type);
+            Assert.False(string.IsNullOrEmpty(ex.Message));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/Serialization/JsonReaderTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/Serialization/JsonReaderTests.cs
@@ -3,6 +3,8 @@
 
 namespace StyleCop.Analyzers.Test.LightJson.Serialization
 {
+    using System;
+    using System.IO;
     using global::LightJson;
     using global::LightJson.Serialization;
     using Xunit;
@@ -23,6 +25,71 @@ namespace StyleCop.Analyzers.Test.LightJson.Serialization
         public void TestDuplicateKeys()
         {
             Assert.ThrowsAny<JsonParseException>(() => JsonValue.Parse("{ \"x\": \"value\", \"x\": \"value\" }"));
+        }
+
+        [Fact]
+        public void TestParse()
+        {
+            Assert.Equal("true", JsonReader.Parse("true").AsString);
+
+            using (var reader = new StringReader("true"))
+            {
+                Assert.Equal("true", JsonReader.Parse(reader).AsString);
+            }
+
+            Assert.Throws<ArgumentNullException>("source", () => JsonReader.Parse(default(string)));
+            Assert.Throws<ArgumentNullException>("reader", () => JsonReader.Parse(default(TextReader)));
+        }
+
+        [Fact]
+        public void TestNumbers()
+        {
+            Assert.Equal(0, JsonReader.Parse("0").AsInteger);
+            Assert.Equal(0, JsonReader.Parse("-0").AsInteger);
+            Assert.Equal(-1, JsonReader.Parse("-1").AsInteger);
+            Assert.Equal(-1.0, JsonReader.Parse("-1.0").AsNumber);
+            Assert.Equal(-1e1, JsonReader.Parse("-1e1").AsNumber);
+            Assert.Equal(-1E1, JsonReader.Parse("-1E1").AsNumber);
+            Assert.Equal(-1E+1, JsonReader.Parse("-1E+1").AsNumber);
+            Assert.Equal(-10E-1, JsonReader.Parse("-10E-1").AsNumber);
+        }
+
+        [Fact]
+        public void TestEscapeSequences()
+        {
+            Assert.Equal("\"", JsonReader.Parse("\"\\\"\"").AsString);
+            Assert.Equal("\\", JsonReader.Parse("\"\\\\\"").AsString);
+            Assert.Equal("/", JsonReader.Parse("\"\\/\"").AsString);
+            Assert.Equal("\b", JsonReader.Parse("\"\\b\"").AsString);
+            Assert.Equal("\f", JsonReader.Parse("\"\\f\"").AsString);
+            Assert.Equal("\n", JsonReader.Parse("\"\\n\"").AsString);
+            Assert.Equal("\r", JsonReader.Parse("\"\\r\"").AsString);
+            Assert.Equal("\t", JsonReader.Parse("\"\\t\"").AsString);
+            Assert.Equal("\u0123\u4567\u89AB\uCDEF", JsonReader.Parse("\"\\u0123\\u4567\\u89AB\\uCDEF\"").AsString);
+
+            var ex = Assert.Throws<JsonParseException>(() => JsonReader.Parse("\"\\x\""));
+            Assert.Equal(JsonParseException.ErrorType.InvalidOrUnexpectedCharacter, ex.Type);
+            Assert.Equal(0, ex.Position.Line);
+            Assert.Equal(2, ex.Position.Column);
+
+            ex = Assert.Throws<JsonParseException>(() => JsonReader.Parse("\"\\u11GA\""));
+            Assert.Equal(JsonParseException.ErrorType.InvalidOrUnexpectedCharacter, ex.Type);
+            Assert.Equal(0, ex.Position.Line);
+            Assert.Equal(5, ex.Position.Column);
+
+            ex = Assert.Throws<JsonParseException>(() => JsonReader.Parse("\"\r\""));
+            Assert.Equal(JsonParseException.ErrorType.InvalidOrUnexpectedCharacter, ex.Type);
+            Assert.Equal(0, ex.Position.Line);
+            Assert.Equal(1, ex.Position.Column);
+        }
+
+        [Fact]
+        public void TestArrayMissingComma()
+        {
+            var ex = Assert.ThrowsAny<JsonParseException>(() => JsonReader.Parse("[ 1 2 ]"));
+            Assert.Equal(JsonParseException.ErrorType.InvalidOrUnexpectedCharacter, ex.Type);
+            Assert.Equal(0, ex.Position.Line);
+            Assert.Equal(4, ex.Position.Column);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/Serialization/JsonReaderTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/Serialization/JsonReaderTests.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-namespace StyleCop.Analyzers.Test.LightJson
+namespace StyleCop.Analyzers.Test.LightJson.Serialization
 {
     using global::LightJson;
     using global::LightJson.Serialization;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/Serialization/JsonSerializationExceptionTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/Serialization/JsonSerializationExceptionTests.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.LightJson.Serialization
+{
+    using global::LightJson.Serialization;
+    using Xunit;
+
+    public class JsonSerializationExceptionTests
+    {
+        [Fact]
+        public void TestDefaultConstructor()
+        {
+            var ex = new JsonSerializationException();
+            Assert.Equal(JsonSerializationException.ErrorType.Unknown, ex.Type);
+            Assert.False(string.IsNullOrEmpty(ex.Message));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/Serialization/JsonWriterTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/Serialization/JsonWriterTests.cs
@@ -1,0 +1,214 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.LightJson.Serialization
+{
+    using System;
+    using global::LightJson;
+    using global::LightJson.Serialization;
+    using Xunit;
+
+    public class JsonWriterTests
+    {
+        [Fact]
+        public void TestConstructor()
+        {
+            var writer = new JsonWriter();
+            var writerNotPretty = new JsonWriter(pretty: false);
+            var writerPretty = new JsonWriter(pretty: true);
+
+            Assert.True(string.IsNullOrEmpty(writer.IndentString));
+            Assert.True(string.IsNullOrEmpty(writer.SpacingString));
+            Assert.True(string.IsNullOrEmpty(writer.NewLineString));
+            Assert.False(writer.SortObjects);
+
+            Assert.Equal(writer.IndentString, writerNotPretty.IndentString);
+            Assert.Equal(writer.SpacingString, writerNotPretty.SpacingString);
+            Assert.Equal(writer.NewLineString, writerNotPretty.NewLineString);
+            Assert.Equal(writer.SortObjects, writerNotPretty.SortObjects);
+
+            Assert.Equal("\t", writerPretty.IndentString);
+            Assert.Equal(" ", writerPretty.SpacingString);
+            Assert.Equal("\n", writerPretty.NewLineString);
+            Assert.False(writerPretty.SortObjects);
+        }
+
+        [Fact]
+        public void TestSimpleSerialization()
+        {
+            var writer = new JsonWriter();
+            Assert.Equal("null", writer.Serialize(JsonValue.Null));
+            Assert.Equal("true", writer.Serialize(true));
+            Assert.Equal("1.5", writer.Serialize(1.5));
+            Assert.Equal("1", writer.Serialize(1));
+            Assert.Equal("\"text\"", writer.Serialize("text"));
+            Assert.Equal("{}", writer.Serialize(new JsonObject()));
+            Assert.Equal("[]", writer.Serialize(new JsonArray()));
+        }
+
+        [Fact]
+        public void TestCircularReference()
+        {
+            var obj = new JsonObject();
+            obj["x"] = obj;
+
+            var writer = new JsonWriter();
+            var ex = Assert.ThrowsAny<JsonSerializationException>(() => writer.Serialize(obj));
+            Assert.Equal(JsonSerializationException.ErrorType.CircularReference, ex.Type);
+        }
+
+        [Fact]
+        public void TestEscapeSequences()
+        {
+            var writer = new JsonWriter();
+            Assert.Equal("\"\\\"\"", writer.Serialize("\""));
+            Assert.Equal("\"\\\\\"", writer.Serialize("\\"));
+            Assert.Equal("\"\\/\"", writer.Serialize("/"));
+            Assert.Equal("\"\\b\"", writer.Serialize("\b"));
+            Assert.Equal("\"\\f\"", writer.Serialize("\f"));
+            Assert.Equal("\"\\n\"", writer.Serialize("\n"));
+            Assert.Equal("\"\\r\"", writer.Serialize("\r"));
+            Assert.Equal("\"\\t\"", writer.Serialize("\t"));
+
+            // The result is not converted to an escape sequence
+            Assert.Equal("\"\u0123\u4567\u89AB\uCDEF\"", writer.Serialize("\u0123\u4567\u89AB\uCDEF"));
+        }
+
+        [Fact]
+        public void TestWriteObject()
+        {
+            var obj = new JsonObject
+            {
+                ["a"] = "valueA",
+                ["b"] = new JsonObject
+                {
+                    ["x"] = 0,
+                    ["y"] = JsonValue.Null,
+                    ["z"] = new JsonObject(),
+                },
+                ["c"] = 3,
+            };
+
+            var writer = new JsonWriter { SortObjects = true };
+            Assert.Equal("{\"a\":\"valueA\",\"b\":{\"x\":0,\"y\":null,\"z\":{}},\"c\":3}", writer.Serialize(obj));
+        }
+
+        [Theory]
+        [InlineData("\t", " ", "\n")]
+        [InlineData("  ", "", "\r\n")]
+        public void TestWriteObjectPretty(string indent, string space, string newline)
+        {
+            var obj = new JsonObject
+            {
+                ["a"] = "valueA",
+                ["b"] = new JsonObject
+                {
+                    ["x"] = 0,
+                    ["y"] = JsonValue.Null,
+                    ["z"] = new JsonObject(),
+                },
+                ["c"] = 3,
+            };
+
+            var writer = new JsonWriter
+            {
+                IndentString = indent,
+                SpacingString = space,
+                NewLineString = newline,
+                SortObjects = true,
+            };
+
+            var expected =
+                $"{{{newline}"
+                + $"{indent}\"a\":{space}\"valueA\",{newline}"
+                + $"{indent}\"b\":{space}{{{newline}"
+                + $"{indent}{indent}\"x\":{space}0,{newline}"
+                + $"{indent}{indent}\"y\":{space}null,{newline}"
+                + $"{indent}{indent}\"z\":{space}{{{newline}"
+                + $"{indent}{indent}}}{newline}"
+                + $"{indent}}},{newline}"
+                + $"{indent}\"c\":{space}3{newline}"
+                + $"}}";
+            Assert.Equal(expected, writer.Serialize(obj));
+        }
+
+        [Fact]
+        public void TestWriteArray()
+        {
+            var obj = new JsonArray
+            {
+                "valueA",
+                new JsonArray
+                {
+                    0,
+                    JsonValue.Null,
+                    new JsonArray(),
+                },
+                3,
+            };
+
+            var writer = new JsonWriter { SortObjects = true };
+            Assert.Equal("[\"valueA\",[0,null,[]],3]", writer.Serialize(obj));
+        }
+
+        [Theory]
+        [InlineData("\t", "\n")]
+        [InlineData("  ", "\r\n")]
+        public void TestWriteArrayPretty(string indent, string newline)
+        {
+            var obj = new JsonArray
+            {
+                "valueA",
+                new JsonArray
+                {
+                    0,
+                    JsonValue.Null,
+                    new JsonArray(),
+                },
+                3,
+            };
+
+            var writer = new JsonWriter
+            {
+                IndentString = indent,
+                NewLineString = newline,
+                SortObjects = true,
+            };
+
+            var expected =
+                $"[{newline}"
+                + $"{indent}\"valueA\",{newline}"
+                + $"{indent}[{newline}"
+                + $"{indent}{indent}0,{newline}"
+                + $"{indent}{indent}null,{newline}"
+                + $"{indent}{indent}[{newline}"
+                + $"{indent}{indent}]{newline}"
+                + $"{indent}],{newline}"
+                + $"{indent}3{newline}"
+                + $"]";
+            Assert.Equal(expected, writer.Serialize(obj));
+        }
+
+        [Fact]
+        public void TestDispose()
+        {
+            var writer = new JsonWriter();
+            writer.Dispose();
+            writer.Dispose(); // Disposing multiple times is allowed
+
+            writer = new JsonWriter();
+            writer.Serialize(1);
+            writer.Dispose();
+            writer.Dispose();
+        }
+
+        [Fact]
+        public void TestUnsortedEnumerator()
+        {
+            // Use an object with only one possible ordering for this test
+            var obj = new JsonObject { ["x"] = 3 };
+            var writer = new JsonWriter { SortObjects = false };
+            Assert.Equal("{\"x\":3}", writer.Serialize(obj));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/Serialization/TextScannerTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/Serialization/TextScannerTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.LightJson.Serialization
+{
+    using global::LightJson;
+    using global::LightJson.Serialization;
+    using Xunit;
+
+    public class TextScannerTests
+    {
+        [Fact]
+        public void TestUnexpectedLookahead()
+        {
+            JsonParseException ex;
+
+            ex = Assert.ThrowsAny<JsonParseException>(() => JsonValue.Parse("trUe"));
+            Assert.Equal(JsonParseException.ErrorType.InvalidOrUnexpectedCharacter, ex.Type);
+            Assert.Equal(0, ex.Position.Line);
+            Assert.Equal(2, ex.Position.Column);
+
+            ex = Assert.ThrowsAny<JsonParseException>(() => JsonValue.Parse("tr"));
+            Assert.Equal(JsonParseException.ErrorType.IncompleteMessage, ex.Type);
+            Assert.Equal(0, ex.Position.Line);
+            Assert.Equal(2, ex.Position.Column);
+        }
+
+        [Fact]
+        public void TestIncompleteComment()
+        {
+            var ex = Assert.ThrowsAny<JsonParseException>(() => JsonValue.Parse("{ /1 }"));
+            Assert.Equal(JsonParseException.ErrorType.InvalidOrUnexpectedCharacter, ex.Type);
+            Assert.Contains("'1'", ex.Message);
+            Assert.Equal(0, ex.Position.Line);
+            Assert.Equal(3, ex.Position.Column);
+
+            ex = Assert.ThrowsAny<JsonParseException>(() => JsonValue.Parse("{ // ignored text }"));
+            Assert.Equal(JsonParseException.ErrorType.IncompleteMessage, ex.Type);
+
+            ex = Assert.ThrowsAny<JsonParseException>(() => JsonValue.Parse("{ /* ignored text }"));
+            Assert.Equal(JsonParseException.ErrorType.IncompleteMessage, ex.Type);
+        }
+
+        [Fact]
+        public void TestBlockCommentTermination()
+        {
+            var obj = JsonValue.Parse("{ /* * / */ }");
+            Assert.Equal(JsonValueType.Object, obj.Type);
+            Assert.Equal(0, obj.AsJsonObject.Count);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -235,6 +235,7 @@
     <Compile Include="LayoutRules\SA1518UnitTests.cs" />
     <Compile Include="LayoutRules\SA1519UnitTests.cs" />
     <Compile Include="LayoutRules\SA1520UnitTests.cs" />
+    <Compile Include="LightJson\JsonValueTests.cs" />
     <Compile Include="Lightup\AccessorDeclarationSyntaxExtensionsTests.cs" />
     <Compile Include="Lightup\AutoWrapSeparatedSyntaxListTests.cs" />
     <Compile Include="Lightup\BaseMethodDeclarationSyntaxExtensionsTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -235,6 +235,7 @@
     <Compile Include="LayoutRules\SA1518UnitTests.cs" />
     <Compile Include="LayoutRules\SA1519UnitTests.cs" />
     <Compile Include="LayoutRules\SA1520UnitTests.cs" />
+    <Compile Include="LightJson\JsonObjectTests.cs" />
     <Compile Include="LightJson\JsonReaderTests.cs" />
     <Compile Include="LightJson\JsonValueTests.cs" />
     <Compile Include="Lightup\AccessorDeclarationSyntaxExtensionsTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -237,8 +237,8 @@
     <Compile Include="LayoutRules\SA1520UnitTests.cs" />
     <Compile Include="LightJson\JsonArrayTests.cs" />
     <Compile Include="LightJson\JsonObjectTests.cs" />
-    <Compile Include="LightJson\JsonReaderTests.cs" />
     <Compile Include="LightJson\JsonValueTests.cs" />
+    <Compile Include="LightJson\Serialization\JsonReaderTests.cs" />
     <Compile Include="LightJson\Serialization\TextScannerTests.cs" />
     <Compile Include="Lightup\AccessorDeclarationSyntaxExtensionsTests.cs" />
     <Compile Include="Lightup\AutoWrapSeparatedSyntaxListTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -239,6 +239,7 @@
     <Compile Include="LightJson\JsonObjectTests.cs" />
     <Compile Include="LightJson\JsonValueTests.cs" />
     <Compile Include="LightJson\Serialization\JsonReaderTests.cs" />
+    <Compile Include="LightJson\Serialization\JsonWriterTests.cs" />
     <Compile Include="LightJson\Serialization\TextScannerTests.cs" />
     <Compile Include="Lightup\AccessorDeclarationSyntaxExtensionsTests.cs" />
     <Compile Include="Lightup\AutoWrapSeparatedSyntaxListTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -238,7 +238,9 @@
     <Compile Include="LightJson\JsonArrayTests.cs" />
     <Compile Include="LightJson\JsonObjectTests.cs" />
     <Compile Include="LightJson\JsonValueTests.cs" />
+    <Compile Include="LightJson\Serialization\JsonParseExceptionTests.cs" />
     <Compile Include="LightJson\Serialization\JsonReaderTests.cs" />
+    <Compile Include="LightJson\Serialization\JsonSerializationExceptionTests.cs" />
     <Compile Include="LightJson\Serialization\JsonWriterTests.cs" />
     <Compile Include="LightJson\Serialization\TextScannerTests.cs" />
     <Compile Include="Lightup\AccessorDeclarationSyntaxExtensionsTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -235,6 +235,7 @@
     <Compile Include="LayoutRules\SA1518UnitTests.cs" />
     <Compile Include="LayoutRules\SA1519UnitTests.cs" />
     <Compile Include="LayoutRules\SA1520UnitTests.cs" />
+    <Compile Include="LightJson\JsonReaderTests.cs" />
     <Compile Include="LightJson\JsonValueTests.cs" />
     <Compile Include="Lightup\AccessorDeclarationSyntaxExtensionsTests.cs" />
     <Compile Include="Lightup\AutoWrapSeparatedSyntaxListTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -239,6 +239,7 @@
     <Compile Include="LightJson\JsonObjectTests.cs" />
     <Compile Include="LightJson\JsonReaderTests.cs" />
     <Compile Include="LightJson\JsonValueTests.cs" />
+    <Compile Include="LightJson\Serialization\TextScannerTests.cs" />
     <Compile Include="Lightup\AccessorDeclarationSyntaxExtensionsTests.cs" />
     <Compile Include="Lightup\AutoWrapSeparatedSyntaxListTests.cs" />
     <Compile Include="Lightup\BaseMethodDeclarationSyntaxExtensionsTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -235,6 +235,7 @@
     <Compile Include="LayoutRules\SA1518UnitTests.cs" />
     <Compile Include="LayoutRules\SA1519UnitTests.cs" />
     <Compile Include="LayoutRules\SA1520UnitTests.cs" />
+    <Compile Include="LightJson\JsonArrayTests.cs" />
     <Compile Include="LightJson\JsonObjectTests.cs" />
     <Compile Include="LightJson\JsonReaderTests.cs" />
     <Compile Include="LightJson\JsonValueTests.cs" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/JsonArray.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/JsonArray.cs
@@ -3,8 +3,10 @@
 
 namespace LightJson
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
     /// Represents an ordered collection of JsonValues.
@@ -30,6 +32,11 @@ namespace LightJson
         public JsonArray(params JsonValue[] values)
             : this()
         {
+            if (values == null)
+            {
+                throw new ArgumentNullException(nameof(values));
+            }
+
             foreach (var value in values)
             {
                 this.items.Add(value);
@@ -157,6 +164,7 @@ namespace LightJson
             return this.GetEnumerator();
         }
 
+        [ExcludeFromCodeCoverage]
         private class JsonArrayDebugView
         {
             private JsonArray jsonArray;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/JsonObject.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/JsonObject.cs
@@ -5,6 +5,7 @@ namespace LightJson
 {
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
     /// Represents a key-value pair collection of JsonValue objects.
@@ -121,6 +122,12 @@ namespace LightJson
         /// <returns>Returns this JsonObject.</returns>
         public JsonObject Rename(string oldKey, string newKey)
         {
+            if (oldKey == newKey)
+            {
+                // Renaming to the same name just does nothing
+                return this;
+            }
+
             JsonValue value;
 
             if (this.properties.TryGetValue(oldKey, out value))
@@ -179,6 +186,7 @@ namespace LightJson
             return this.GetEnumerator();
         }
 
+        [ExcludeFromCodeCoverage]
         private class JsonObjectDebugView
         {
             private JsonObject jsonObject;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/JsonValue.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/JsonValue.cs
@@ -583,7 +583,7 @@ namespace LightJson
         /// Converts the given JsonValue into an Int.
         /// </summary>
         /// <param name="jsonValue">The JsonValue to be converted.</param>
-        public static implicit operator int(JsonValue jsonValue)
+        public static explicit operator int(JsonValue jsonValue)
         {
             if (jsonValue.IsInteger)
             {
@@ -603,7 +603,7 @@ namespace LightJson
         /// Throws System.InvalidCastException when the inner value type of the
         /// JsonValue is not the desired type of the conversion.
         /// </exception>
-        public static implicit operator int?(JsonValue jsonValue)
+        public static explicit operator int?(JsonValue jsonValue)
         {
             if (jsonValue.IsNull)
             {
@@ -619,7 +619,7 @@ namespace LightJson
         /// Converts the given JsonValue into a Bool.
         /// </summary>
         /// <param name="jsonValue">The JsonValue to be converted.</param>
-        public static implicit operator bool(JsonValue jsonValue)
+        public static explicit operator bool(JsonValue jsonValue)
         {
             if (jsonValue.IsBoolean)
             {
@@ -639,7 +639,7 @@ namespace LightJson
         /// Throws System.InvalidCastException when the inner value type of the
         /// JsonValue is not the desired type of the conversion.
         /// </exception>
-        public static implicit operator bool?(JsonValue jsonValue)
+        public static explicit operator bool?(JsonValue jsonValue)
         {
             if (jsonValue.IsNull)
             {
@@ -655,7 +655,7 @@ namespace LightJson
         /// Converts the given JsonValue into a Double.
         /// </summary>
         /// <param name="jsonValue">The JsonValue to be converted.</param>
-        public static implicit operator double(JsonValue jsonValue)
+        public static explicit operator double(JsonValue jsonValue)
         {
             if (jsonValue.IsNumber)
             {
@@ -675,7 +675,7 @@ namespace LightJson
         /// Throws System.InvalidCastException when the inner value type of the
         /// JsonValue is not the desired type of the conversion.
         /// </exception>
-        public static implicit operator double?(JsonValue jsonValue)
+        public static explicit operator double?(JsonValue jsonValue)
         {
             if (jsonValue.IsNull)
             {
@@ -691,7 +691,7 @@ namespace LightJson
         /// Converts the given JsonValue into a String.
         /// </summary>
         /// <param name="jsonValue">The JsonValue to be converted.</param>
-        public static implicit operator string(JsonValue jsonValue)
+        public static explicit operator string(JsonValue jsonValue)
         {
             if (jsonValue.IsString || jsonValue.IsNull)
             {
@@ -707,7 +707,7 @@ namespace LightJson
         /// Converts the given JsonValue into a JsonObject.
         /// </summary>
         /// <param name="jsonValue">The JsonValue to be converted.</param>
-        public static implicit operator JsonObject(JsonValue jsonValue)
+        public static explicit operator JsonObject(JsonValue jsonValue)
         {
             if (jsonValue.IsJsonObject || jsonValue.IsNull)
             {
@@ -723,7 +723,7 @@ namespace LightJson
         /// Converts the given JsonValue into a JsonArray.
         /// </summary>
         /// <param name="jsonValue">The JsonValue to be converted.</param>
-        public static implicit operator JsonArray(JsonValue jsonValue)
+        public static explicit operator JsonArray(JsonValue jsonValue)
         {
             if (jsonValue.IsJsonArray || jsonValue.IsNull)
             {
@@ -739,7 +739,7 @@ namespace LightJson
         /// Converts the given JsonValue into a DateTime.
         /// </summary>
         /// <param name="jsonValue">The JsonValue to be converted.</param>
-        public static implicit operator DateTime(JsonValue jsonValue)
+        public static explicit operator DateTime(JsonValue jsonValue)
         {
             var dateTime = jsonValue.AsDateTime;
 
@@ -757,7 +757,7 @@ namespace LightJson
         /// Converts the given JsonValue into a nullable DateTime.
         /// </summary>
         /// <param name="jsonValue">The JsonValue to be converted.</param>
-        public static implicit operator DateTime?(JsonValue jsonValue)
+        public static explicit operator DateTime?(JsonValue jsonValue)
         {
             if (jsonValue.IsDateTime || jsonValue.IsNull)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/JsonValue.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/JsonValue.cs
@@ -4,7 +4,9 @@
 namespace LightJson
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using LightJson.Serialization;
 
     /// <summary>
@@ -191,16 +193,8 @@ namespace LightJson
                     return false;
                 }
 
-                try
-                {
-                    var value = this.value;
-
-                    return ((int)value) == value;
-                }
-                catch (OverflowException)
-                {
-                    return false;
-                }
+                var value = this.value;
+                return unchecked((int)value) == value;
             }
         }
 
@@ -810,11 +804,15 @@ namespace LightJson
         /// <inheritdoc/>
         public override bool Equals(object obj)
         {
-            var jsonValue = obj as JsonValue?;
-
-            if (jsonValue == null)
+            if (obj == null)
             {
                 return this.IsNull;
+            }
+
+            var jsonValue = obj as JsonValue?;
+            if (jsonValue == null)
+            {
+                return false;
             }
             else
             {
@@ -833,10 +831,11 @@ namespace LightJson
             {
                 return this.Type.GetHashCode()
                     ^ this.value.GetHashCode()
-                    ^ this.reference.GetHashCode();
+                    ^ EqualityComparer<object>.Default.GetHashCode(this.reference);
             }
         }
 
+        [ExcludeFromCodeCoverage]
         private class JsonValueDebugView
         {
             private JsonValue jsonValue;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/Serialization/JsonReader.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/Serialization/JsonReader.cs
@@ -30,7 +30,7 @@ namespace LightJson.Serialization
         {
             if (reader == null)
             {
-                throw new ArgumentNullException("reader");
+                throw new ArgumentNullException(nameof(reader));
             }
 
             return new JsonReader(reader).Parse();
@@ -45,12 +45,12 @@ namespace LightJson.Serialization
         {
             if (source == null)
             {
-                throw new ArgumentNullException("source");
+                throw new ArgumentNullException(nameof(source));
             }
 
             using (var reader = new StringReader(source))
             {
-                return new JsonReader(reader).Parse();
+                return Parse(reader);
             }
         }
 
@@ -112,14 +112,9 @@ namespace LightJson.Serialization
                     this.scanner.Assert("true");
                     return true;
 
-                case 'f':
+                default:
                     this.scanner.Assert("false");
                     return false;
-
-                default:
-                    throw new JsonParseException(
-                        ErrorType.InvalidOrUnexpectedCharacter,
-                        this.scanner.Position);
             }
         }
 
@@ -191,10 +186,12 @@ namespace LightJson.Serialization
 
             while (true)
             {
+                var errorPosition = this.scanner.Position;
                 var c = this.scanner.Read();
 
                 if (c == '\\')
                 {
+                    errorPosition = this.scanner.Position;
                     c = this.scanner.Read();
 
                     switch (char.ToLower(c))
@@ -225,7 +222,7 @@ namespace LightJson.Serialization
                         default:
                             throw new JsonParseException(
                                 ErrorType.InvalidOrUnexpectedCharacter,
-                                this.scanner.Position);
+                                errorPosition);
                     }
                 }
                 else if (c == '"')
@@ -238,7 +235,7 @@ namespace LightJson.Serialization
                     {
                         throw new JsonParseException(
                             ErrorType.InvalidOrUnexpectedCharacter,
-                            this.scanner.Position);
+                            errorPosition);
                     }
                     else
                     {
@@ -252,6 +249,7 @@ namespace LightJson.Serialization
 
         private int ReadHexDigit()
         {
+            var errorPosition = this.scanner.Position;
             switch (char.ToUpper(this.scanner.Read()))
             {
                 case '0':
@@ -305,7 +303,7 @@ namespace LightJson.Serialization
                 default:
                     throw new JsonParseException(
                         ErrorType.InvalidOrUnexpectedCharacter,
-                        this.scanner.Position);
+                        errorPosition);
             }
         }
 
@@ -342,13 +340,14 @@ namespace LightJson.Serialization
                 {
                     this.scanner.SkipWhitespace();
 
+                    var errorPosition = this.scanner.Position;
                     var key = this.ReadJsonKey();
 
                     if (jsonObject.ContainsKey(key))
                     {
                         throw new JsonParseException(
                             ErrorType.DuplicateObjectKeys,
-                            this.scanner.Position);
+                            errorPosition);
                     }
 
                     this.scanner.SkipWhitespace();
@@ -363,6 +362,7 @@ namespace LightJson.Serialization
 
                     this.scanner.SkipWhitespace();
 
+                    errorPosition = this.scanner.Position;
                     var next = this.scanner.Read();
                     if (next == ',')
                     {
@@ -386,7 +386,7 @@ namespace LightJson.Serialization
                     {
                         throw new JsonParseException(
                             ErrorType.InvalidOrUnexpectedCharacter,
-                            this.scanner.Position);
+                            errorPosition);
                     }
                 }
             }
@@ -421,6 +421,7 @@ namespace LightJson.Serialization
 
                     this.scanner.SkipWhitespace();
 
+                    var errorPosition = this.scanner.Position;
                     var next = this.scanner.Read();
                     if (next == ',')
                     {
@@ -444,7 +445,7 @@ namespace LightJson.Serialization
                     {
                         throw new JsonParseException(
                             ErrorType.InvalidOrUnexpectedCharacter,
-                            this.scanner.Position);
+                            errorPosition);
                     }
                 }
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/Serialization/JsonReader.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/Serialization/JsonReader.cs
@@ -344,7 +344,7 @@ namespace LightJson.Serialization
 
                     var key = this.ReadJsonKey();
 
-                    if (jsonObject.Contains(key))
+                    if (jsonObject.ContainsKey(key))
                     {
                         throw new JsonParseException(
                             ErrorType.DuplicateObjectKeys,

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/Serialization/JsonReader.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/Serialization/JsonReader.cs
@@ -125,8 +125,14 @@ namespace LightJson.Serialization
 
         private void ReadDigits(StringBuilder builder)
         {
-            while (char.IsNumber(this.scanner.Peek()))
+            while (true)
             {
+                int next = this.scanner.Peek(throwAtEndOfFile: false);
+                if (next == -1 || !char.IsNumber((char)next))
+                {
+                    return;
+                }
+
                 builder.Append(this.scanner.Read());
             }
         }
@@ -149,13 +155,13 @@ namespace LightJson.Serialization
                 this.ReadDigits(builder);
             }
 
-            if (this.scanner.Peek() == '.')
+            if (this.scanner.Peek(throwAtEndOfFile: false) == '.')
             {
                 builder.Append(this.scanner.Read());
                 this.ReadDigits(builder);
             }
 
-            if (char.ToLower(this.scanner.Peek()) == 'e')
+            if (this.scanner.Peek(throwAtEndOfFile: false) == 'e' || this.scanner.Peek(throwAtEndOfFile: false) == 'E')
             {
                 builder.Append(this.scanner.Read());
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/Serialization/JsonWriter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/Serialization/JsonWriter.cs
@@ -5,6 +5,7 @@ namespace LightJson.Serialization
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Globalization;
     using System.IO;
     using ErrorType = JsonSerializationException.ErrorType;
@@ -146,20 +147,10 @@ namespace LightJson.Serialization
                 this.writer.Write(((double)value).ToString(CultureInfo.InvariantCulture));
                 break;
 
-            case JsonValueType.String:
+            default:
+                Debug.Assert(value.Type == JsonValueType.String, "value.Type == JsonValueType.String");
                 this.WriteEncodedString((string)value);
                 break;
-
-            case JsonValueType.Object:
-                this.writer.Write(string.Format("JsonObject[{0}]", value.AsJsonObject.Count));
-                break;
-
-            case JsonValueType.Array:
-                this.writer.Write(string.Format("JsonArray[{0}]", value.AsJsonArray.Count));
-                break;
-
-            default:
-                throw new InvalidOperationException("Invalid value type.");
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/Serialization/JsonWriter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/Serialization/JsonWriter.cs
@@ -255,6 +255,12 @@ namespace LightJson.Serialization
 
         private void Render(JsonValue value)
         {
+            if (this.isNewLine)
+            {
+                this.isNewLine = false;
+                this.WriteIndentation();
+            }
+
             switch (value.Type)
             {
             case JsonValueType.Null:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/Serialization/JsonWriter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/Serialization/JsonWriter.cs
@@ -136,15 +136,15 @@ namespace LightJson.Serialization
             switch (value.Type)
             {
             case JsonValueType.Null:
-                this.writer.Write("null");
+                this.Write("null");
                 break;
 
             case JsonValueType.Boolean:
-                this.writer.Write(value.AsString);
+                this.Write(value.AsString);
                 break;
 
             case JsonValueType.Number:
-                this.writer.Write(((double)value).ToString(CultureInfo.InvariantCulture));
+                this.Write(((double)value).ToString(CultureInfo.InvariantCulture));
                 break;
 
             default:
@@ -246,12 +246,6 @@ namespace LightJson.Serialization
 
         private void Render(JsonValue value)
         {
-            if (this.isNewLine)
-            {
-                this.isNewLine = false;
-                this.WriteIndentation();
-            }
-
             switch (value.Type)
             {
             case JsonValueType.Null:

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/Serialization/TextScanner.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/Serialization/TextScanner.cs
@@ -40,10 +40,20 @@ namespace LightJson.Serialization
         /// </summary>
         /// <returns>The next character in the stream.</returns>
         public char Peek()
+            => (char)this.Peek(throwAtEndOfFile: true);
+
+        /// <summary>
+        /// Reads the next character in the stream without changing the current position.
+        /// </summary>
+        /// <param name="throwAtEndOfFile"><see langword="true"/> to throw an exception if the end of the file is
+        /// reached; otherwise, <see langword="false"/>.</param>
+        /// <returns>The next character in the stream, or -1 if the end of the file is reached with
+        /// <paramref name="throwAtEndOfFile"/> set to <see langword="false"/>.</returns>
+        public int Peek(bool throwAtEndOfFile)
         {
             var next = this.reader.Peek();
 
-            if (next == -1)
+            if (next == -1 && throwAtEndOfFile)
             {
                 throw new JsonParseException(
                     ErrorType.IncompleteMessage,
@@ -51,7 +61,7 @@ namespace LightJson.Serialization
             }
             else
             {
-                return (char)next;
+                return next;
             }
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/Serialization/TextScanner.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/Serialization/TextScanner.cs
@@ -110,7 +110,7 @@ namespace LightJson.Serialization
                 }
                 else if (next == '/')
                 {
-                    this.SkipCommentOrInvalidSlash();
+                    this.SkipComment();
                     continue;
                 }
                 else
@@ -127,12 +127,13 @@ namespace LightJson.Serialization
         /// <param name="next">The expected character.</param>
         public void Assert(char next)
         {
+            var errorPosition = this.position;
             if (this.Read() != next)
             {
                 throw new JsonParseException(
                     string.Format("Parser expected '{0}'", next),
                     ErrorType.InvalidOrUnexpectedCharacter,
-                    this.position);
+                    errorPosition);
             }
         }
 
@@ -149,9 +150,9 @@ namespace LightJson.Serialization
             }
         }
 
-        private void SkipCommentOrInvalidSlash()
+        private void SkipComment()
         {
-            // First character is the a slash
+            // First character is the first slash
             this.Read();
             switch (this.Peek())
             {
@@ -164,7 +165,10 @@ namespace LightJson.Serialization
                 return;
 
             default:
-                return;
+                throw new JsonParseException(
+                    string.Format("Parser expected '{0}'", this.Peek()),
+                    ErrorType.InvalidOrUnexpectedCharacter,
+                    this.position);
             }
         }
 


### PR DESCRIPTION
* Remove unnecessary exception handler in `IsInteger`
* Fix `JsonValue.GetHashCode()` exception for number and boolean types
* Fix multiple failures to parse a number with `JsonValue.Parse`
* Fix `JsonValue.Equals` handling of unrelated non-null types
* Fix bug where JSON value can't match an earlier key
* Fix bug where renaming an object property to the same name would remove the property
* Fix exception thrown for `new JsonArray((JsonValue[])null)`
* Fix error handling edge cases in `JsonReader` and `TextScanner`