### PR TITLE
Ignore spacing around a default literal expression

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/SyntaxKindEx.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/SyntaxKindEx.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Lightup
     {
         public const SyntaxKind UnderscoreToken = (SyntaxKind)8491;
         public const SyntaxKind IsPatternExpression = (SyntaxKind)8657;
+        public const SyntaxKind DefaultLiteralExpression = (SyntaxKind)8755;
         public const SyntaxKind LocalFunctionStatement = (SyntaxKind)8830;
         public const SyntaxKind TupleType = (SyntaxKind)8924;
         public const SyntaxKind TupleElement = (SyntaxKind)8925;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.SpacingRules
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Lightup;
 
     /// <summary>
     /// The spacing around a C# keyword is incorrect.
@@ -124,6 +125,15 @@ namespace StyleCop.Analyzers.SpacingRules
                     break;
 
                 case SyntaxKind.DefaultKeyword:
+                    if (token.Parent.IsKind(SyntaxKindEx.DefaultLiteralExpression))
+                    {
+                        // Ignore spacing around a default literal expression for now
+                        break;
+                    }
+
+                    HandleDisallowedSpaceToken(ref context, token);
+                    break;
+
                 case SyntaxKind.NameOfKeyword:
                 case SyntaxKind.SizeOfKeyword:
                 case SyntaxKind.TypeOfKeyword:


### PR DESCRIPTION
Full support for C# 7.1 will be added when it is finally released, but this change offers a clean workaround for #2420 in the interim.