### PR TITLE
Add a test for SA0002 when deserialization throws JsonParseException

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpecialRules/SA0002UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpecialRules/SA0002UnitTests.cs
@@ -79,6 +79,26 @@ namespace NamespaceName { }
         }
 
         [Fact]
+        public async Task TestInvalidSettingSyntaxAsync()
+        {
+            // Missing the ':' between "companyName" and "name"
+            this.settings = @"
+{
+  ""settings"": {
+    ""documentationRules"": {
+      ""companyName"" ""name""
+    }
+  }
+}
+";
+
+            // This diagnostic is reported without a location
+            DiagnosticResult expected = this.CSharpDiagnostic();
+
+            await this.VerifyCSharpDiagnosticAsync(TestCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestEmptySettingsAsync()
         {
             // The test infrastructure will not add a settings file to the compilation if GetSettings returns null or an empty string.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpecialRules/SA0002UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpecialRules/SA0002UnitTests.cs
@@ -68,7 +68,7 @@ namespace NamespaceName { }
         }
 
         [Fact]
-        public async Task TestInvalidSettingValueAsync()
+        public async Task TestInvalidSettingStringValueAsync()
         {
             this.settings = @"
 {
@@ -76,6 +76,156 @@ namespace NamespaceName { }
     ""documentationRules"": {
       ""companyName"": 3
     }
+  }
+}
+";
+
+            // This diagnostic is reported without a location
+            DiagnosticResult expected = this.CSharpDiagnostic();
+
+            await this.VerifyCSharpDiagnosticAsync(TestCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInvalidSettingStringArrayElementValueAsync()
+        {
+            this.settings = @"
+{
+  ""settings"": {
+    ""namingRules"": {
+      ""allowedHungarianPrefixes"": [ 3 ]
+    }
+  }
+}
+";
+
+            // This diagnostic is reported without a location
+            DiagnosticResult expected = this.CSharpDiagnostic();
+
+            await this.VerifyCSharpDiagnosticAsync(TestCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInvalidSettingBooleanValueAsync()
+        {
+            this.settings = @"
+{
+  ""settings"": {
+    ""documentationRules"": {
+      ""xmlHeader"": 3
+    }
+  }
+}
+";
+
+            // This diagnostic is reported without a location
+            DiagnosticResult expected = this.CSharpDiagnostic();
+
+            await this.VerifyCSharpDiagnosticAsync(TestCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInvalidSettingIntegerValueAsync()
+        {
+            this.settings = @"
+{
+  ""settings"": {
+    ""indentation"": {
+      ""tabSize"": ""3""
+    }
+  }
+}
+";
+
+            // This diagnostic is reported without a location
+            DiagnosticResult expected = this.CSharpDiagnostic();
+
+            await this.VerifyCSharpDiagnosticAsync(TestCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInvalidSettingEnumValueNotStringAsync()
+        {
+            this.settings = @"
+{
+  ""settings"": {
+    ""documentationRules"": {
+      ""fileNamingConvention"": 3
+    }
+  }
+}
+";
+
+            // This diagnostic is reported without a location
+            DiagnosticResult expected = this.CSharpDiagnostic();
+
+            await this.VerifyCSharpDiagnosticAsync(TestCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInvalidSettingArrayElementEnumValueNotStringAsync()
+        {
+            this.settings = @"
+{
+  ""settings"": {
+    ""maintainabilityRules"": {
+      ""topLevelTypes"": [ 3 ]
+    }
+  }
+}
+";
+
+            // This diagnostic is reported without a location
+            DiagnosticResult expected = this.CSharpDiagnostic();
+
+            await this.VerifyCSharpDiagnosticAsync(TestCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInvalidSettingArrayElementEnumValueNotRecognizedAsync()
+        {
+            this.settings = @"
+{
+  ""settings"": {
+    ""maintainabilityRules"": {
+      ""topLevelTypes"": [ ""Some incorrect value"" ]
+    }
+  }
+}
+";
+
+            // This diagnostic is reported without a location
+            DiagnosticResult expected = this.CSharpDiagnostic();
+
+            await this.VerifyCSharpDiagnosticAsync(TestCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInvalidSettingArrayAsync()
+        {
+            this.settings = @"
+{
+  ""settings"": {
+    ""namingRules"": {
+      ""allowedHungarianPrefixes"": ""ah""
+    }
+  }
+}
+";
+
+            // This diagnostic is reported without a location
+            DiagnosticResult expected = this.CSharpDiagnostic();
+
+            await this.VerifyCSharpDiagnosticAsync(TestCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInvalidSettingObjectAsync()
+        {
+            this.settings = @"
+{
+  ""settings"": {
+    ""namingRules"": true
   }
 }
 ";

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -64,7 +64,9 @@
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.2.1\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System" />
+    <Reference Include="System">
+      <Aliases>global,system</Aliases>
+    </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
       <Private>True</Private>


### PR DESCRIPTION
Previously we were testing for cases where `InvalidSettingsException` was thrown, but not for the case where the JSON syntax was invalid, or when some other unrelated exception was thrown. This commit adds tests covering additional cases.

