### PR TITLE
Add initial object pools tests

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/HelperTests/ObjectPools/ObjectPoolTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/HelperTests/ObjectPools/ObjectPoolTests.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.HelperTests.ObjectPools
+{
+    using System;
+    using Analyzers.Helpers.ObjectPools;
+    using Xunit;
+
+    public class ObjectPoolTests
+    {
+        [Fact]
+        public void TestDefaultConstructor()
+        {
+            Func<object> factory = () => new object();
+            var pool = new ObjectPool<object>(factory);
+            Assert.IsType<object>(pool.Allocate());
+        }
+
+        [Fact]
+        public void TestAllocateFree()
+        {
+            Func<object> factory = () => new object();
+            var pool = new ObjectPool<object>(factory);
+
+            // Covers the case where no item is in the pool
+            Assert.IsType<object>(pool.Allocate());
+
+            // Covers the case where the item is the first in the pool
+            var obj = new object();
+            pool.Free(obj);
+            Assert.Same(obj, pool.Allocate());
+
+            // Covers the case where the item is not the first in the pool
+            var obj2 = new object();
+            pool.Free(obj);
+            pool.Free(obj2);
+            Assert.Same(obj, pool.Allocate());
+            Assert.Same(obj2, pool.Allocate());
+
+            // Covers the case (in AllocateSlow and FreeSlow) where the item is not the first or second in the pool
+            var obj3 = new object();
+            pool.Free(obj);
+            pool.Free(obj2);
+            pool.Free(obj3);
+            Assert.Same(obj, pool.Allocate());
+            Assert.Same(obj2, pool.Allocate());
+            Assert.Same(obj3, pool.Allocate());
+        }
+
+        [Fact]
+        public void TestObjectCanBeDropped()
+        {
+            Func<object> factory = () => new object();
+            var pool = new ObjectPool<object>(factory, 1);
+
+            var obj = new object();
+            pool.Free(obj);
+            var obj2 = new object();
+            pool.Free(obj2);
+
+            Assert.Same(obj, pool.Allocate());
+            Assert.NotSame(obj2, pool.Allocate());
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/HelperTests/ObjectPools/SharedPoolsTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/HelperTests/ObjectPools/SharedPoolsTests.cs
@@ -1,0 +1,221 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.HelperTests.ObjectPools
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using StyleCop.Analyzers.Helpers.ObjectPools;
+    using Xunit;
+
+    public class SharedPoolsTests
+    {
+        [Fact]
+        public void TestBigDefault()
+        {
+            var listPool = SharedPools.BigDefault<List<int>>();
+            Assert.IsAssignableFrom<ObjectPool<List<int>>>(listPool);
+
+            var stackPool = SharedPools.BigDefault<Stack<int>>();
+            Assert.IsAssignableFrom<ObjectPool<Stack<int>>>(stackPool);
+
+            Assert.NotSame(listPool, stackPool);
+        }
+
+        [Fact]
+        public void TestDefault()
+        {
+            var listPool = SharedPools.BigDefault<List<int>>();
+            Assert.IsAssignableFrom<ObjectPool<List<int>>>(listPool);
+
+            var stackPool = SharedPools.BigDefault<Stack<int>>();
+            Assert.IsAssignableFrom<ObjectPool<Stack<int>>>(stackPool);
+
+            Assert.NotSame(listPool, stackPool);
+        }
+
+        [Fact]
+        public void TestStringBuilderPool()
+        {
+            StringBuilder builder = null;
+            using (var obj = SharedPools.Default<StringBuilder>().GetPooledObject())
+            {
+                Assert.NotNull(obj.Object);
+                Assert.True(obj.Object.Length == 0);
+
+                obj.Object.Append("testing");
+
+                // Keep a copy to verify its length is reset
+                builder = obj.Object;
+                Assert.NotEqual(0, builder.Length);
+            }
+
+            Assert.Equal(0, builder.Length);
+        }
+
+        [Fact]
+        public void TestStackPool()
+        {
+            Stack<int> collection = null;
+            using (var obj = SharedPools.Default<Stack<int>>().GetPooledObject())
+            {
+                Assert.NotNull(obj.Object);
+                Assert.True(obj.Object.Count == 0);
+
+                obj.Object.Push(1);
+
+                // Keep a copy to verify its length is reset
+                collection = obj.Object;
+                Assert.NotEqual(0, collection.Count);
+            }
+
+            Assert.Equal(0, collection.Count);
+        }
+
+        [Fact]
+        public void TestQueuePool()
+        {
+            Queue<int> collection = null;
+            using (var obj = SharedPools.Default<Queue<int>>().GetPooledObject())
+            {
+                Assert.NotNull(obj.Object);
+                Assert.True(obj.Object.Count == 0);
+
+                obj.Object.Enqueue(1);
+
+                // Keep a copy to verify its length is reset
+                collection = obj.Object;
+                Assert.NotEqual(0, collection.Count);
+            }
+
+            Assert.Equal(0, collection.Count);
+        }
+
+        [Fact]
+        public void TestHashSetPool()
+        {
+            HashSet<int> collection = null;
+            using (var obj = SharedPools.Default<HashSet<int>>().GetPooledObject())
+            {
+                Assert.NotNull(obj.Object);
+                Assert.True(obj.Object.Count == 0);
+
+                obj.Object.Add(1);
+
+                // Keep a copy to verify its length is reset
+                collection = obj.Object;
+                Assert.NotEqual(0, collection.Count);
+            }
+
+            Assert.Equal(0, collection.Count);
+        }
+
+        [Fact]
+        public void TestDictionaryPool()
+        {
+            Dictionary<int, int> collection = null;
+            using (var obj = SharedPools.Default<Dictionary<int, int>>().GetPooledObject())
+            {
+                Assert.NotNull(obj.Object);
+                Assert.True(obj.Object.Count == 0);
+
+                obj.Object.Add(1, 1);
+
+                // Keep a copy to verify its length is reset
+                collection = obj.Object;
+                Assert.NotEqual(0, collection.Count);
+            }
+
+            Assert.Equal(0, collection.Count);
+        }
+
+        [Fact]
+        public void TestListPool()
+        {
+            List<int> collection = null;
+            using (var obj = SharedPools.Default<List<int>>().GetPooledObject())
+            {
+                Assert.NotNull(obj.Object);
+                Assert.True(obj.Object.Count == 0);
+
+                obj.Object.Add(1);
+
+                // Keep a copy to verify its length is reset
+                collection = obj.Object;
+                Assert.NotEqual(0, collection.Count);
+            }
+
+            Assert.Equal(0, collection.Count);
+        }
+
+        [Fact]
+        public void TestExceptionPool()
+        {
+            using (var obj = SharedPools.Default<Exception>().GetPooledObject())
+            {
+                Assert.NotNull(obj.Object);
+            }
+        }
+
+        [Fact]
+        public void TestClearAndFreeNull()
+        {
+            SharedPools.Default<StringBuilder>().ClearAndFree(null);
+            SharedPools.Default<HashSet<int>>().ClearAndFree(null);
+            SharedPools.Default<Stack<int>>().ClearAndFree(null);
+            SharedPools.Default<Queue<int>>().ClearAndFree(null);
+            SharedPools.Default<Dictionary<int, int>>().ClearAndFree(null);
+            SharedPools.Default<List<int>>().ClearAndFree(null);
+        }
+
+        [Fact]
+        public void TestClearAndFreeLarge()
+        {
+            // StringBuilder
+            var builder = new StringBuilder("text", 1024);
+            SharedPools.Default<StringBuilder>().ClearAndFree(builder);
+            Assert.Equal(0, builder.Length);
+            Assert.True(builder.Capacity < 1024);
+
+            // HashSet<int>
+            var set = new HashSet<int>(Enumerable.Range(0, 1024));
+            SharedPools.Default<HashSet<int>>().ClearAndFree(set);
+            Assert.Equal(0, set.Count);
+
+            // Stack<int>
+            var stack = new Stack<int>(Enumerable.Range(0, 1024));
+            SharedPools.Default<Stack<int>>().ClearAndFree(stack);
+            Assert.Equal(0, stack.Count);
+
+            // Queue<int>
+            var queue = new Queue<int>(Enumerable.Range(0, 1024));
+            SharedPools.Default<Queue<int>>().ClearAndFree(queue);
+            Assert.Equal(0, queue.Count);
+
+            // Dictionary<int, int> **This one doesn't go back in the pool!**
+            var dictionary = Enumerable.Range(0, 1024).ToDictionary(i => i);
+            SharedPools.Default<Dictionary<int, int>>().ClearAndFree(dictionary);
+            Assert.Equal(1024, dictionary.Count);
+
+            // List<int>
+            var list = new List<int>(Enumerable.Range(0, 1024));
+            Assert.True(list.Capacity >= 1024);
+            SharedPools.Default<List<int>>().ClearAndFree(list);
+            Assert.Equal(0, list.Count);
+            Assert.True(list.Capacity < 1024);
+        }
+
+        [Fact]
+        public void TestPooledObjectHandlesNullAllocation()
+        {
+            Func<ObjectPool<object>, object> allocator = pool => null;
+            Action<ObjectPool<object>, object> releaser = (pool, obj) => { };
+            using (var obj = new PooledObject<object>(SharedPools.Default<object>(), allocator, releaser))
+            {
+                Assert.Null(obj.Object);
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -180,6 +180,8 @@
     <Compile Include="Helpers\UseCultureAttribute.cs" />
     <Compile Include="HelperTests\AccessLevelHelperTests.cs" />
     <Compile Include="HelperTests\IndentationHelperTests.cs" />
+    <Compile Include="HelperTests\ObjectPools\ObjectPoolTests.cs" />
+    <Compile Include="HelperTests\ObjectPools\SharedPoolsTests.cs" />
     <Compile Include="HelperTests\RequiresTests.cs" />
     <Compile Include="HelperTests\TokenHelperTests.cs" />
     <Compile Include="HelperTests\TriviaHelperTests.cs" />


### PR DESCRIPTION
This should provide consistent coverage of object pooling code that tends to come in and out of coverage reports. The one remaining uncovered branch is a race condition that we can't guarantee will be covered.