### PR TITLE
Relax documentation requirements according to the current settings

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.DocumentationRules;
     using TestHelper;
@@ -17,6 +16,8 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     /// </summary>
     public class SA1600UnitTests : DiagnosticVerifier
     {
+        private string currentTestSettings;
+
         [Theory]
         [InlineData("public string TestMember;", 15)]
         [InlineData("public string TestMember { get; set; }", 15)]
@@ -189,11 +190,83 @@ using System;
             await this.TestFieldDeclarationDocumentationAsync("internal", true, false).ConfigureAwait(false);
             await this.TestFieldDeclarationDocumentationAsync("protected internal", true, false).ConfigureAwait(false);
             await this.TestFieldDeclarationDocumentationAsync("public", true, false).ConfigureAwait(false);
+
+            // Re-test with the 'documentPrivateElements' setting enabled (doesn't impact fields)
+            this.currentTestSettings = @"
+{
+  ""settings"": {
+    ""documentationRules"": {
+      ""documentPrivateElements"": true
+    }
+  }
+}
+";
+
+            await this.TestFieldDeclarationDocumentationAsync(string.Empty, false, false).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("private", false, false).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("protected", true, false).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("internal", true, false).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("protected internal", true, false).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("public", true, false).ConfigureAwait(false);
+
+            // Re-test with the 'documentPrivateFields' setting enabled (does impact fields)
+            this.currentTestSettings = @"
+{
+  ""settings"": {
+    ""documentationRules"": {
+      ""documentPrivateFields"": true
+    }
+  }
+}
+";
+
+            await this.TestFieldDeclarationDocumentationAsync(string.Empty, true, false).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("private", true, false).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("protected", true, false).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("internal", true, false).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("protected internal", true, false).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("public", true, false).ConfigureAwait(false);
         }
 
         [Fact]
         public async Task TestFieldWithDocumentationAsync()
         {
+            await this.TestFieldDeclarationDocumentationAsync(string.Empty, false, true).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("private", false, true).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("protected", false, true).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("internal", false, true).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("protected internal", false, true).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("public", false, true).ConfigureAwait(false);
+
+            // Re-test with the 'documentPrivateElements' setting enabled (doesn't impact fields)
+            this.currentTestSettings = @"
+{
+  ""settings"": {
+    ""documentationRules"": {
+      ""documentPrivateElements"": true
+    }
+  }
+}
+";
+
+            await this.TestFieldDeclarationDocumentationAsync(string.Empty, false, true).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("private", false, true).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("protected", false, true).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("internal", false, true).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("protected internal", false, true).ConfigureAwait(false);
+            await this.TestFieldDeclarationDocumentationAsync("public", false, true).ConfigureAwait(false);
+
+            // Re-test with the 'documentPrivateFields' setting enabled (does impact fields)
+            this.currentTestSettings = @"
+{
+  ""settings"": {
+    ""documentationRules"": {
+      ""documentPrivateFields"": true
+    }
+  }
+}
+";
+
             await this.TestFieldDeclarationDocumentationAsync(string.Empty, false, true).ConfigureAwait(false);
             await this.TestFieldDeclarationDocumentationAsync("private", false, true).ConfigureAwait(false);
             await this.TestFieldDeclarationDocumentationAsync("protected", false, true).ConfigureAwait(false);
@@ -428,6 +501,11 @@ public class OuterClass
 }";
 
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected override string GetSettings()
+        {
+            return this.currentTestSettings ?? base.GetSettings();
         }
 
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
@@ -27,6 +27,8 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
 }
 ";
 
+        private string currentTestSettings = TestSettings;
+
         [Theory]
         [InlineData("class")]
         [InlineData("struct")]
@@ -58,6 +60,20 @@ TypeName
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(3, 1);
 
             await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeKeyword), expected, CancellationToken.None).ConfigureAwait(false);
+
+            // The same situation is allowed if 'documentExposedElements' and 'documentInterfaces' is false
+            string interfaceSettingName = typeKeyword == "interface" ? "documentInterfaces" : "ignoredProperty";
+            this.currentTestSettings = $@"
+{{
+  ""settings"": {{
+    ""documentationRules"": {{
+      ""documentExposedElements"": false,
+      ""{interfaceSettingName}"": false
+    }}
+  }}
+}}
+";
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeKeyword), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
@@ -78,6 +94,20 @@ TypeName
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(6, 1);
 
             await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeKeyword), expected, CancellationToken.None).ConfigureAwait(false);
+
+            // The same situation is allowed if 'documentExposedElements' and 'documentInterfaces' is false
+            string interfaceSettingName = typeKeyword == "interface" ? "documentInterfaces" : "ignoredProperty";
+            this.currentTestSettings = $@"
+{{
+  ""settings"": {{
+    ""documentationRules"": {{
+      ""documentExposedElements"": false,
+      ""{interfaceSettingName}"": false
+    }}
+  }}
+}}
+";
+            await this.VerifyCSharpDiagnosticAsync(string.Format(testCode, typeKeyword), EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -112,6 +142,10 @@ public partial class TypeName
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(7, 18);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            // The same situation is allowed if 'documentPrivateElements' is false (the default)
+            this.currentTestSettings = null;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -132,12 +166,16 @@ public partial class TypeName
             DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(10, 18);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+
+            // The same situation is allowed if 'documentPrivateElements' is false (the default)
+            this.currentTestSettings = null;
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <inheritdoc/>
         protected override string GetSettings()
         {
-            return TestSettings;
+            return this.currentTestSettings ?? base.GetSettings();
         }
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1602UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1602UnitTests.cs
@@ -48,6 +48,21 @@ enum TypeName
         }
 
         [Fact]
+        public async Task TestNestedPrivateEnumWithoutDocumentationAsync()
+        {
+            var testCode = @"
+class ClassName
+{
+    private enum TypeName
+    {
+        Bar
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestEnumWithEmptyDocumentationAsync()
         {
             var testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1604UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1604UnitTests.cs
@@ -208,6 +208,28 @@ public class ClassName
         }
 
         [Fact]
+        [WorkItem(2443, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2443")]
+        public async Task TestPrivateMethodWithoutSummaryAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+internal class ClassName
+{
+    ///
+    private void Test1() { }
+
+    /**
+     *
+     */
+    private void Test2() { }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestPartialMethodWithoutDocumentationAsync()
         {
             var testCode = @"
@@ -663,10 +685,10 @@ public class ClassName
 public class ClassName
 {
     ///
-    event System.Action Foo { add { } remove { } }
+    public event System.Action Foo { add { } remove { } }
 }";
 
-            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 25);
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(8, 32);
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1605UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1605UnitTests.cs
@@ -18,6 +18,18 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     /// </summary>
     public class SA1605UnitTests : DiagnosticVerifier
     {
+        private const string TestSettings = @"
+{
+  ""settings"": {
+    ""documentationRules"": {
+      ""documentPrivateElements"": true
+    }
+  }
+}
+";
+
+        private string currentTestSettings = TestSettings;
+
         [Theory]
         [InlineData("class")]
         [InlineData("struct")]
@@ -225,6 +237,32 @@ public partial class ClassName
         }
 
         [Fact]
+        [WorkItem(2450, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2450")]
+        public async Task TestIncludedNotRequiredDocumentationWithoutSummaryAsync()
+        {
+            var testCode = @"
+/// <include file='ClassWithoutSummary.xml' path='/ClassName/*'/>
+public partial class ClassName
+{
+    ///
+    public void Test() { }
+}";
+
+            // The situation is allowed if 'documentExposedElements' false
+            this.currentTestSettings = @"
+{
+  ""settings"": {
+    ""documentationRules"": {
+      ""documentExposedElements"": false
+    }
+  }
+}
+";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestIncludedDocumentationWithInheritdocAsync()
         {
             var testCode = @"
@@ -305,6 +343,11 @@ public partial class ClassName
             project = base.ApplyCompilationOptions(project);
             project = project.WithCompilationOptions(project.CompilationOptions.WithXmlReferenceResolver(resolver));
             return project;
+        }
+
+        protected override string GetSettings()
+        {
+            return this.currentTestSettings ?? base.GetSettings();
         }
 
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1605UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1605UnitTests.cs
@@ -347,7 +347,8 @@ public partial class ClassName
 
         protected override string GetSettings()
         {
-            return this.currentTestSettings ?? base.GetSettings();
+            Assert.NotNull(this.currentTestSettings);
+            return this.currentTestSettings;
         }
 
         protected override IEnumerable<DiagnosticAnalyzer> GetCSharpDiagnosticAnalyzers()

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1609UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1609UnitTests.cs
@@ -354,6 +354,31 @@ public class ClassName : ITestInterface
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        [Fact]
+        [WorkItem(2451, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2451")]
+        public async Task TestPropertyWithoutDocumentationRequirementAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <include file='PropertyWithoutValue.xml' path='/ClassName/Property/*'/>
+    private int Property
+    {
+        get;
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    private ClassName PropertyWithSummary { get; set; }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
         protected override Project ApplyCompilationOptions(Project project)
         {
             var resolver = new TestXmlReferenceResolver();

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1611UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1611UnitTests.cs
@@ -23,6 +23,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             get
             {
                 // These method names are chosen so that the position of the parameters are always the same. This makes testing easier
+                yield return new object[] { "         ClassName(string param1, string param2, string param3) { }" };
                 yield return new object[] { "void Foooooooooooo(string param1, string param2, string param3) { }" };
                 yield return new object[] { "delegate void Fooo(string param1, string param2, string param3);" };
                 yield return new object[] { "System.String this[string param1, string param2, string param3] { get { return param1; } }" };
@@ -168,6 +169,20 @@ internal class ClassName
      *
      */
     private void Test2(int arg) { }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(2444, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2444")]
+        public async Task TestPrivateMethodMissingParametersInIncludedDocumentationAsync()
+        {
+            var testCode = @"
+internal class ClassName
+{
+    /// <include file='MissingElementDocumentation.xml' path='/TestClass/TestMethod/*' />
+    private void TestMethod(string param1, string param2, string param3) { }
 }";
 
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1611UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1611UnitTests.cs
@@ -154,6 +154,25 @@ public class ClassName
             await this.VerifyCSharpDiagnosticAsync(testCode.Replace("##", p), expected, CancellationToken.None).ConfigureAwait(false);
         }
 
+        [Fact]
+        [WorkItem(2444, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2444")]
+        public async Task TestPrivateMethodMissingParametersAsync()
+        {
+            var testCode = @"
+internal class ClassName
+{
+    ///
+    private void Test1(int arg) { }
+
+    /**
+     *
+     */
+    private void Test2(int arg) { }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Verifies that valid operator declarations will not produce diagnostics.
         /// </summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1615UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1615UnitTests.cs
@@ -330,6 +330,25 @@ class Class1
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        [Fact]
+        [WorkItem(2445, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2445")]
+        public async Task TestPrivateMethodMissingReturnsAsync()
+        {
+            var testCode = @"
+internal class ClassName
+{
+    ///
+    private int Test1(int arg) { throw new System.NotImplementedException(); }
+
+    /**
+     *
+     */
+    private int Test2(int arg) { throw new System.NotImplementedException(); }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
         /// <inheritdoc/>
         protected override Project ApplyCompilationOptions(Project project)
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1618UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1618UnitTests.cs
@@ -395,6 +395,25 @@ public class TestClass
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        [Fact]
+        [WorkItem(2446, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2446")]
+        public async Task TestPrivateMethodMissingGenericParametersAsync()
+        {
+            var testCode = @"
+internal class ClassName
+{
+    ///
+    private void Test1<T>(int arg) { }
+
+    /**
+     *
+     */
+    private void Test2<T>(int arg) { }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
         protected override Project ApplyCompilationOptions(Project project)
         {
             var resolver = new TestXmlReferenceResolver();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/ElementDocumentationSummaryBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/ElementDocumentationSummaryBase.cs
@@ -63,6 +63,8 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// Analyzes the top-level <c>&lt;summary&gt;</c> element of a documentation comment.
         /// </summary>
         /// <param name="context">The current analysis context.</param>
+        /// <param name="needsComment"><see langword="true"/> if the current documentation settings indicate that the
+        /// element should be documented; otherwise, <see langword="false"/>.</param>
         /// <param name="documentation">The documentation syntax associated with the element.</param>
         /// <param name="syntax">The <see cref="XmlElementSyntax"/> or <see cref="XmlEmptyElementSyntax"/> of the node
         /// to examine.</param>
@@ -71,7 +73,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// element, this value will be <see langword="null"/>, even if the XML documentation comment also included an
         /// <c>&lt;include&gt;</c> element.</param>
         /// <param name="diagnosticLocations">The location(s) where diagnostics, if any, should be reported.</param>
-        protected abstract void HandleXmlElement(SyntaxNodeAnalysisContext context, DocumentationCommentTriviaSyntax documentation, XmlNodeSyntax syntax, XElement completeDocumentation, params Location[] diagnosticLocations);
+        protected abstract void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, DocumentationCommentTriviaSyntax documentation, XmlNodeSyntax syntax, XElement completeDocumentation, params Location[] diagnosticLocations);
 
         private void HandleTypeDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
@@ -87,7 +89,10 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
-            this.HandleDeclaration(context, node, node.Identifier.GetLocation());
+            Accessibility declaredAccessibility = node.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
+            Accessibility effectiveAccessibility = node.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
+            bool needsComment = SA1600ElementsMustBeDocumented.NeedsComment(settings.DocumentationRules, node.Kind(), node.Parent.Kind(), declaredAccessibility, effectiveAccessibility);
+            this.HandleDeclaration(context, needsComment, node, node.Identifier.GetLocation());
         }
 
         private void HandleDelegateDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
@@ -98,7 +103,10 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
-            this.HandleDeclaration(context, node, node.Identifier.GetLocation());
+            Accessibility declaredAccessibility = node.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
+            Accessibility effectiveAccessibility = node.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
+            bool needsComment = SA1600ElementsMustBeDocumented.NeedsComment(settings.DocumentationRules, node.Kind(), node.Parent.Kind(), declaredAccessibility, effectiveAccessibility);
+            this.HandleDeclaration(context, needsComment, node, node.Identifier.GetLocation());
         }
 
         private void HandleMethodDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
@@ -115,7 +123,10 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
-            this.HandleDeclaration(context, node, node.Identifier.GetLocation());
+            Accessibility declaredAccessibility = node.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
+            Accessibility effectiveAccessibility = node.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
+            bool needsComment = SA1600ElementsMustBeDocumented.NeedsComment(settings.DocumentationRules, node.Kind(), node.Parent.Kind(), declaredAccessibility, effectiveAccessibility);
+            this.HandleDeclaration(context, needsComment, node, node.Identifier.GetLocation());
         }
 
         private void HandleConstructorDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
@@ -126,7 +137,10 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
-            this.HandleDeclaration(context, node, node.Identifier.GetLocation());
+            Accessibility declaredAccessibility = node.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
+            Accessibility effectiveAccessibility = node.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
+            bool needsComment = SA1600ElementsMustBeDocumented.NeedsComment(settings.DocumentationRules, node.Kind(), node.Parent.Kind(), declaredAccessibility, effectiveAccessibility);
+            this.HandleDeclaration(context, needsComment, node, node.Identifier.GetLocation());
         }
 
         private void HandleDestructorDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
@@ -137,7 +151,10 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
-            this.HandleDeclaration(context, node, node.Identifier.GetLocation());
+            Accessibility declaredAccessibility = node.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
+            Accessibility effectiveAccessibility = node.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
+            bool needsComment = SA1600ElementsMustBeDocumented.NeedsComment(settings.DocumentationRules, node.Kind(), node.Parent.Kind(), declaredAccessibility, effectiveAccessibility);
+            this.HandleDeclaration(context, needsComment, node, node.Identifier.GetLocation());
         }
 
         private void HandlePropertyDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
@@ -148,7 +165,10 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
-            this.HandleDeclaration(context, node, node.Identifier.GetLocation());
+            Accessibility declaredAccessibility = node.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
+            Accessibility effectiveAccessibility = node.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
+            bool needsComment = SA1600ElementsMustBeDocumented.NeedsComment(settings.DocumentationRules, node.Kind(), node.Parent.Kind(), declaredAccessibility, effectiveAccessibility);
+            this.HandleDeclaration(context, needsComment, node, node.Identifier.GetLocation());
         }
 
         private void HandleIndexerDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
@@ -159,7 +179,10 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
-            this.HandleDeclaration(context, node, node.ThisKeyword.GetLocation());
+            Accessibility declaredAccessibility = node.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
+            Accessibility effectiveAccessibility = node.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
+            bool needsComment = SA1600ElementsMustBeDocumented.NeedsComment(settings.DocumentationRules, node.Kind(), node.Parent.Kind(), declaredAccessibility, effectiveAccessibility);
+            this.HandleDeclaration(context, needsComment, node, node.ThisKeyword.GetLocation());
         }
 
         private void HandleFieldDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
@@ -188,7 +211,10 @@ namespace StyleCop.Analyzers.DocumentationRules
             // int i,;
             Array.Resize(ref locations, insertionIndex);
 
-            this.HandleDeclaration(context, node, locations);
+            Accessibility declaredAccessibility = node.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
+            Accessibility effectiveAccessibility = node.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
+            bool needsComment = SA1600ElementsMustBeDocumented.NeedsComment(settings.DocumentationRules, node.Kind(), node.Parent.Kind(), declaredAccessibility, effectiveAccessibility);
+            this.HandleDeclaration(context, needsComment, node, locations);
         }
 
         private void HandleEventDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
@@ -199,10 +225,13 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
-            this.HandleDeclaration(context, node, node.Identifier.GetLocation());
+            Accessibility declaredAccessibility = node.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
+            Accessibility effectiveAccessibility = node.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
+            bool needsComment = SA1600ElementsMustBeDocumented.NeedsComment(settings.DocumentationRules, node.Kind(), node.Parent.Kind(), declaredAccessibility, effectiveAccessibility);
+            this.HandleDeclaration(context, needsComment, node, node.Identifier.GetLocation());
         }
 
-        private void HandleDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings, SyntaxNode node, params Location[] locations)
+        private void HandleDeclaration(SyntaxNodeAnalysisContext context, bool needsComment, SyntaxNode node, params Location[] locations)
         {
             var documentation = node.GetDocumentationCommentTriviaSyntax();
             if (documentation == null)
@@ -229,7 +258,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                 }
             }
 
-            this.HandleXmlElement(context, documentation, relevantXmlElement, completeDocumentation, locations);
+            this.HandleXmlElement(context, needsComment, documentation, relevantXmlElement, completeDocumentation, locations);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/ElementDocumentationSummaryBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/ElementDocumentationSummaryBase.cs
@@ -4,7 +4,6 @@
 namespace StyleCop.Analyzers.DocumentationRules
 {
     using System;
-    using System.Collections.Immutable;
     using System.Linq;
     using System.Xml.Linq;
     using Microsoft.CodeAnalysis;
@@ -12,6 +11,7 @@ namespace StyleCop.Analyzers.DocumentationRules
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.Helpers;
+    using StyleCop.Analyzers.Settings.ObjectModel;
 
     /// <summary>
     /// This is the base class for analyzers which examine the <c>&lt;summary&gt;</c> text of a documentation comment.
@@ -19,15 +19,15 @@ namespace StyleCop.Analyzers.DocumentationRules
     internal abstract class ElementDocumentationSummaryBase : DiagnosticAnalyzer
     {
         private readonly Action<CompilationStartAnalysisContext> compilationStartAction;
-        private readonly Action<SyntaxNodeAnalysisContext> typeDeclarationAction;
-        private readonly Action<SyntaxNodeAnalysisContext> methodDeclarationAction;
-        private readonly Action<SyntaxNodeAnalysisContext> constructorDeclarationAction;
-        private readonly Action<SyntaxNodeAnalysisContext> destructorDeclarationAction;
-        private readonly Action<SyntaxNodeAnalysisContext> propertyDeclarationAction;
-        private readonly Action<SyntaxNodeAnalysisContext> indexerDeclarationAction;
-        private readonly Action<SyntaxNodeAnalysisContext> fieldDeclarationAction;
-        private readonly Action<SyntaxNodeAnalysisContext> delegateDeclarationAction;
-        private readonly Action<SyntaxNodeAnalysisContext> eventDeclarationAction;
+        private readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> typeDeclarationAction;
+        private readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> methodDeclarationAction;
+        private readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> constructorDeclarationAction;
+        private readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> destructorDeclarationAction;
+        private readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> propertyDeclarationAction;
+        private readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> indexerDeclarationAction;
+        private readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> fieldDeclarationAction;
+        private readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> delegateDeclarationAction;
+        private readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> eventDeclarationAction;
 
         protected ElementDocumentationSummaryBase()
         {
@@ -73,7 +73,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// <param name="diagnosticLocations">The location(s) where diagnostics, if any, should be reported.</param>
         protected abstract void HandleXmlElement(SyntaxNodeAnalysisContext context, DocumentationCommentTriviaSyntax documentation, XmlNodeSyntax syntax, XElement completeDocumentation, params Location[] diagnosticLocations);
 
-        private void HandleTypeDeclaration(SyntaxNodeAnalysisContext context)
+        private void HandleTypeDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var node = (BaseTypeDeclarationSyntax)context.Node;
             if (node.Identifier.IsMissing)
@@ -90,7 +90,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             this.HandleDeclaration(context, node, node.Identifier.GetLocation());
         }
 
-        private void HandleDelegateDeclaration(SyntaxNodeAnalysisContext context)
+        private void HandleDelegateDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var node = (DelegateDeclarationSyntax)context.Node;
             if (node.Identifier.IsMissing)
@@ -101,7 +101,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             this.HandleDeclaration(context, node, node.Identifier.GetLocation());
         }
 
-        private void HandleMethodDeclaration(SyntaxNodeAnalysisContext context)
+        private void HandleMethodDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var node = (MethodDeclarationSyntax)context.Node;
             if (node.Identifier.IsMissing)
@@ -118,7 +118,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             this.HandleDeclaration(context, node, node.Identifier.GetLocation());
         }
 
-        private void HandleConstructorDeclaration(SyntaxNodeAnalysisContext context)
+        private void HandleConstructorDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var node = (ConstructorDeclarationSyntax)context.Node;
             if (node.Identifier.IsMissing)
@@ -129,7 +129,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             this.HandleDeclaration(context, node, node.Identifier.GetLocation());
         }
 
-        private void HandleDestructorDeclaration(SyntaxNodeAnalysisContext context)
+        private void HandleDestructorDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var node = (DestructorDeclarationSyntax)context.Node;
             if (node.Identifier.IsMissing)
@@ -140,7 +140,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             this.HandleDeclaration(context, node, node.Identifier.GetLocation());
         }
 
-        private void HandlePropertyDeclaration(SyntaxNodeAnalysisContext context)
+        private void HandlePropertyDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var node = (PropertyDeclarationSyntax)context.Node;
             if (node.Identifier.IsMissing)
@@ -151,7 +151,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             this.HandleDeclaration(context, node, node.Identifier.GetLocation());
         }
 
-        private void HandleIndexerDeclaration(SyntaxNodeAnalysisContext context)
+        private void HandleIndexerDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var node = (IndexerDeclarationSyntax)context.Node;
             if (node.ThisKeyword.IsMissing)
@@ -162,7 +162,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             this.HandleDeclaration(context, node, node.ThisKeyword.GetLocation());
         }
 
-        private void HandleFieldDeclaration(SyntaxNodeAnalysisContext context)
+        private void HandleFieldDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var node = (BaseFieldDeclarationSyntax)context.Node;
             if (node.Declaration == null)
@@ -191,7 +191,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             this.HandleDeclaration(context, node, locations);
         }
 
-        private void HandleEventDeclaration(SyntaxNodeAnalysisContext context)
+        private void HandleEventDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var node = (EventDeclarationSyntax)context.Node;
             if (node.Identifier.IsMissing)
@@ -202,7 +202,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             this.HandleDeclaration(context, node, node.Identifier.GetLocation());
         }
 
-        private void HandleDeclaration(SyntaxNodeAnalysisContext context, SyntaxNode node, params Location[] locations)
+        private void HandleDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings, SyntaxNode node, params Location[] locations)
         {
             var documentation = node.GetDocumentationCommentTriviaSyntax();
             if (documentation == null)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
@@ -57,7 +57,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         protected override string XmlTagToHandle => XmlCommentHelper.SummaryXmlTag;
 
         /// <inheritdoc/>
-        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, XmlNodeSyntax syntax, XElement completeDocumentation, Location diagnosticLocation)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, XmlNodeSyntax syntax, XElement completeDocumentation, Location diagnosticLocation)
         {
             var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
             var propertyType = context.SemanticModel.GetTypeInfo(propertyDeclaration.Type);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1601PartialElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1601PartialElementsMustBeDocumented.cs
@@ -119,7 +119,7 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                 Accessibility declaredAccessibility = declaration.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
                 Accessibility effectiveAccessibility = declaration.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
-                if (NeedsComment(settings.DocumentationRules, declaration.Kind(), declaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility))
+                if (SA1600ElementsMustBeDocumented.NeedsComment(settings.DocumentationRules, declaration.Kind(), declaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility))
                 {
                     if (!XmlCommentHelper.HasDocumentation(declaration))
                     {
@@ -143,47 +143,12 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                 Accessibility declaredAccessibility = declaration.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
                 Accessibility effectiveAccessibility = declaration.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
-                if (NeedsComment(settings.DocumentationRules, declaration.Kind(), declaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility))
+                if (SA1600ElementsMustBeDocumented.NeedsComment(settings.DocumentationRules, declaration.Kind(), declaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility))
                 {
                     if (!XmlCommentHelper.HasDocumentation(declaration))
                     {
                         context.ReportDiagnostic(Diagnostic.Create(Descriptor, declaration.Identifier.GetLocation()));
                     }
-                }
-            }
-
-            private static bool NeedsComment(DocumentationSettings documentationSettings, SyntaxKind syntaxKind, SyntaxKind parentSyntaxKind, Accessibility declaredAccessibility, Accessibility effectiveAccessibility)
-            {
-                if (documentationSettings.DocumentInterfaces
-                    && (syntaxKind == SyntaxKind.InterfaceDeclaration || parentSyntaxKind == SyntaxKind.InterfaceDeclaration))
-                {
-                    // DocumentInterfaces => all interfaces must be documented
-                    return true;
-                }
-
-                if (documentationSettings.DocumentPrivateElements)
-                {
-                    // DocumentPrivateMembers => everything except declared private fields must be documented
-                    return true;
-                }
-
-                switch (effectiveAccessibility)
-                {
-                case Accessibility.Public:
-                case Accessibility.Protected:
-                case Accessibility.ProtectedOrInternal:
-                    // These items are part of the exposed API surface => document if configured
-                    return documentationSettings.DocumentExposedElements;
-
-                case Accessibility.ProtectedAndInternal:
-                case Accessibility.Internal:
-                    // These items are part of the internal API surface => document if configured
-                    return documentationSettings.DocumentInternalElements;
-
-                case Accessibility.NotApplicable:
-                case Accessibility.Private:
-                default:
-                    return false;
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1602EnumerationItemsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1602EnumerationItemsMustBeDocumented.cs
@@ -79,47 +79,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                 EnumMemberDeclarationSyntax declaration = (EnumMemberDeclarationSyntax)context.Node;
                 Accessibility declaredAccessibility = declaration.GetDeclaredAccessibility();
                 Accessibility effectiveAccessibility = declaration.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
-                if (NeedsComment(settings.DocumentationRules, declaration.Kind(), declaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility))
+                if (SA1600ElementsMustBeDocumented.NeedsComment(settings.DocumentationRules, declaration.Kind(), declaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility))
                 {
                     if (!XmlCommentHelper.HasDocumentation(declaration))
                     {
                         context.ReportDiagnostic(Diagnostic.Create(Descriptor, declaration.Identifier.GetLocation()));
                     }
-                }
-            }
-
-            private static bool NeedsComment(DocumentationSettings documentationSettings, SyntaxKind syntaxKind, SyntaxKind parentSyntaxKind, Accessibility declaredAccessibility, Accessibility effectiveAccessibility)
-            {
-                if (documentationSettings.DocumentInterfaces
-                    && (syntaxKind == SyntaxKind.InterfaceDeclaration || parentSyntaxKind == SyntaxKind.InterfaceDeclaration))
-                {
-                    // DocumentInterfaces => all interfaces must be documented
-                    return true;
-                }
-
-                if (documentationSettings.DocumentPrivateElements)
-                {
-                    // DocumentPrivateMembers => everything except declared private fields must be documented
-                    return true;
-                }
-
-                switch (effectiveAccessibility)
-                {
-                case Accessibility.Public:
-                case Accessibility.Protected:
-                case Accessibility.ProtectedOrInternal:
-                    // These items are part of the exposed API surface => document if configured
-                    return documentationSettings.DocumentExposedElements;
-
-                case Accessibility.ProtectedAndInternal:
-                case Accessibility.Internal:
-                    // These items are part of the internal API surface => document if configured
-                    return documentationSettings.DocumentInternalElements;
-
-                case Accessibility.NotApplicable:
-                case Accessibility.Private:
-                default:
-                    return false;
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1604ElementDocumentationMustHaveSummary.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1604ElementDocumentationMustHaveSummary.cs
@@ -6,10 +6,11 @@ namespace StyleCop.Analyzers.DocumentationRules
     using System.Collections.Immutable;
     using System.Linq;
     using System.Xml.Linq;
-    using Helpers;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
+    using StyleCop.Analyzers.Settings.ObjectModel;
 
     /// <summary>
     /// The XML header documentation for a C# element is missing a <c>&lt;summary&gt;</c> tag.
@@ -43,8 +44,14 @@ namespace StyleCop.Analyzers.DocumentationRules
             ImmutableArray.Create(Descriptor);
 
         /// <inheritdoc/>
-        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, DocumentationCommentTriviaSyntax documentation, XmlNodeSyntax syntax, XElement completeDocumentation, Location[] diagnosticLocations)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, DocumentationCommentTriviaSyntax documentation, XmlNodeSyntax syntax, XElement completeDocumentation, Location[] diagnosticLocations)
         {
+            if (!needsComment)
+            {
+                // A missing summary is allowed for this element.
+                return;
+            }
+
             if (completeDocumentation != null)
             {
                 // We are working with an <include> element

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1605PartialElementDocumentationMustHaveSummary.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1605PartialElementDocumentationMustHaveSummary.cs
@@ -88,8 +88,14 @@ namespace StyleCop.Analyzers.DocumentationRules
             ImmutableArray.Create(Descriptor);
 
         /// <inheritdoc/>
-        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, XmlNodeSyntax syntax, XElement completeDocumentation, Location[] diagnosticLocations)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, XmlNodeSyntax syntax, XElement completeDocumentation, Location[] diagnosticLocations)
         {
+            if (!needsComment)
+            {
+                // A missing summary is allowed for this element.
+                return;
+            }
+
             if (completeDocumentation != null)
             {
                 var hasSummaryTag = completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.SummaryXmlTag);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1606ElementDocumentationMustHaveSummaryText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1606ElementDocumentationMustHaveSummaryText.cs
@@ -45,7 +45,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             ImmutableArray.Create(Descriptor);
 
         /// <inheritdoc/>
-        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, DocumentationCommentTriviaSyntax documentation, XmlNodeSyntax syntax, XElement completeDocumentation, Location[] diagnosticLocations)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, DocumentationCommentTriviaSyntax documentation, XmlNodeSyntax syntax, XElement completeDocumentation, Location[] diagnosticLocations)
         {
             if (syntax == null)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1607PartialElementDocumentationMustHaveSummaryText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1607PartialElementDocumentationMustHaveSummaryText.cs
@@ -89,7 +89,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             ImmutableArray.Create(Descriptor);
 
         /// <inheritdoc/>
-        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, XmlNodeSyntax syntax, XElement completeDocumentation, Location[] diagnosticLocations)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, XmlNodeSyntax syntax, XElement completeDocumentation, Location[] diagnosticLocations)
         {
             if (completeDocumentation != null)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1608ElementDocumentationMustNotHaveDefaultSummary.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1608ElementDocumentationMustNotHaveDefaultSummary.cs
@@ -59,7 +59,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             ImmutableArray.Create(Descriptor);
 
         /// <inheritdoc/>
-        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, IEnumerable<XmlNodeSyntax> syntaxList, params Location[] diagnosticLocations)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, IEnumerable<XmlNodeSyntax> syntaxList, params Location[] diagnosticLocations)
         {
             foreach (var syntax in syntaxList)
             {
@@ -79,7 +79,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         }
 
         /// <inheritdoc/>
-        protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, XElement completeDocumentation, params Location[] diagnosticLocations)
+        protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, bool needsComment, XElement completeDocumentation, params Location[] diagnosticLocations)
         {
             // We are working with an <include> element
             var includedSummaryElement = completeDocumentation.Nodes().OfType<XElement>().FirstOrDefault(element => element.Name == XmlCommentHelper.SummaryXmlTag);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1609PropertyDocumentationMustHaveValue.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1609PropertyDocumentationMustHaveValue.cs
@@ -49,8 +49,14 @@ namespace StyleCop.Analyzers.DocumentationRules
         protected override string XmlTagToHandle => XmlCommentHelper.ValueXmlTag;
 
         /// <inheritdoc/>
-        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, XmlNodeSyntax syntax, XElement completeDocumentation, Location diagnosticLocation)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, XmlNodeSyntax syntax, XElement completeDocumentation, Location diagnosticLocation)
         {
+            if (!needsComment)
+            {
+                // A missing 'value' documentation is allowed for this element.
+                return;
+            }
+
             var properties = ImmutableDictionary.Create<string, string>();
 
             if (completeDocumentation != null)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1610PropertyDocumentationMustHaveValueText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1610PropertyDocumentationMustHaveValueText.cs
@@ -49,7 +49,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         protected override string XmlTagToHandle => XmlCommentHelper.ValueXmlTag;
 
         /// <inheritdoc/>
-        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, XmlNodeSyntax syntax, XElement completeDocumentation, Location diagnosticLocation)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, XmlNodeSyntax syntax, XElement completeDocumentation, Location diagnosticLocation)
         {
             var properties = ImmutableDictionary.Create<string, string>();
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1611ElementParametersMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1611ElementParametersMustBeDocumented.cs
@@ -51,8 +51,14 @@ namespace StyleCop.Analyzers.DocumentationRules
             ImmutableArray.Create(Descriptor);
 
         /// <inheritdoc/>
-        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, IEnumerable<XmlNodeSyntax> syntaxList, params Location[] diagnosticLocations)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, IEnumerable<XmlNodeSyntax> syntaxList, params Location[] diagnosticLocations)
         {
+            if (!needsComment)
+            {
+                // Omitting documentation for a parameter is allowed for this element.
+                return;
+            }
+
             var node = context.Node;
             var parameterList = GetParameters(node);
             if (parameterList == null)
@@ -69,8 +75,14 @@ namespace StyleCop.Analyzers.DocumentationRules
         }
 
         /// <inheritdoc/>
-        protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, XElement completeDocumentation, params Location[] diagnosticLocations)
+        protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, bool needsComment, XElement completeDocumentation, params Location[] diagnosticLocations)
         {
+            if (!needsComment)
+            {
+                // Omitting documentation for a parameter is allowed for this element.
+                return;
+            }
+
             var node = context.Node;
             var parameterList = GetParameters(node);
             if (parameterList == null)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1612ElementParameterDocumentationMustMatchElementParameters.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1612ElementParameterDocumentationMustMatchElementParameters.cs
@@ -57,7 +57,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             ImmutableArray.Create(MissingParameterDescriptor);
 
         /// <inheritdoc/>
-        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, IEnumerable<XmlNodeSyntax> syntaxList, params Location[] diagnosticLocations)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, IEnumerable<XmlNodeSyntax> syntaxList, params Location[] diagnosticLocations)
         {
             var node = context.Node;
             var identifier = GetIdentifier(node);
@@ -112,7 +112,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         }
 
         /// <inheritdoc/>
-        protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, XElement completeDocumentation, params Location[] diagnosticLocations)
+        protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, bool needsComment, XElement completeDocumentation, params Location[] diagnosticLocations)
         {
             var node = context.Node;
             var identifier = GetIdentifier(node);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1612ElementParameterDocumentationMustMatchElementParameters.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1612ElementParameterDocumentationMustMatchElementParameters.cs
@@ -68,7 +68,6 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
-            var identifierLocation = identifier.Value.GetLocation();
             var parameterList = GetParameters(node)?.ToImmutableArray();
 
             bool hasNoParameters = !parameterList?.Any() ?? false;
@@ -84,7 +83,6 @@ namespace StyleCop.Analyzers.DocumentationRules
             {
                 var nameAttributeSyntax = XmlCommentHelper.GetFirstAttributeOrDefault<XmlNameAttributeSyntax>(syntax);
                 var nameAttributeText = nameAttributeSyntax?.Identifier?.Identifier.ValueText;
-                var location = nameAttributeSyntax?.Identifier?.Identifier.GetLocation();
 
                 // Make sure we ignore violations that should be reported by SA1613 instead.
                 if (string.IsNullOrWhiteSpace(nameAttributeText))
@@ -92,10 +90,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                     return;
                 }
 
+                var location = nameAttributeSyntax.Identifier.Identifier.GetLocation();
+
                 var parentParameter = parentParameters.FirstOrDefault(s => s.Identifier.ValueText == nameAttributeText);
                 if (parentParameter == null)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(MissingParameterDescriptor, location ?? identifierLocation, nameAttributeText));
+                    context.ReportDiagnostic(Diagnostic.Create(MissingParameterDescriptor, location, nameAttributeText));
                 }
                 else
                 {
@@ -114,7 +114,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                         context.ReportDiagnostic(
                             Diagnostic.Create(
                                 OrderDescriptor,
-                                location ?? identifierLocation,
+                                location,
                                 nameAttributeText,
                                 parentParameters.IndexOf(parentParameter) + 1));
                     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1612ElementParameterDocumentationMustMatchElementParameters.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1612ElementParameterDocumentationMustMatchElementParameters.cs
@@ -97,14 +97,27 @@ namespace StyleCop.Analyzers.DocumentationRules
                 {
                     context.ReportDiagnostic(Diagnostic.Create(MissingParameterDescriptor, location ?? identifierLocation, nameAttributeText));
                 }
-                else if (parentParameters.Length <= index || parentParameters[index] != parentParameter)
+                else
                 {
-                    context.ReportDiagnostic(
-                        Diagnostic.Create(
-                            OrderDescriptor,
-                            location ?? identifierLocation,
-                            nameAttributeText,
-                            parentParameters.IndexOf(parentParameter) + 1));
+                    if (!needsComment)
+                    {
+                        // Parameter documentation is allowed to be omitted, so skip parameters for which there is no
+                        // documentation.
+                        while (index < parentParameters.Length && parentParameters[index] != parentParameter)
+                        {
+                            index++;
+                        }
+                    }
+
+                    if (parentParameters.Length <= index || parentParameters[index] != parentParameter)
+                    {
+                        context.ReportDiagnostic(
+                            Diagnostic.Create(
+                                OrderDescriptor,
+                                location ?? identifierLocation,
+                                nameAttributeText,
+                                parentParameters.IndexOf(parentParameter) + 1));
+                    }
                 }
 
                 index++;
@@ -155,14 +168,27 @@ namespace StyleCop.Analyzers.DocumentationRules
                 {
                     context.ReportDiagnostic(Diagnostic.Create(MissingParameterDescriptor, identifierLocation, nameAttributeText));
                 }
-                else if (parentParameters.Length <= index || parentParameters[index] != parentParameter)
+                else
                 {
-                    context.ReportDiagnostic(
-                        Diagnostic.Create(
-                            OrderDescriptor,
-                            identifierLocation,
-                            nameAttributeText,
-                            parentParameters.IndexOf(parentParameter) + 1));
+                    if (!needsComment)
+                    {
+                        // Parameter documentation is allowed to be omitted, so skip parameters for which there is no
+                        // documentation.
+                        while (index < parentParameters.Length && parentParameters[index] != parentParameter)
+                        {
+                            index++;
+                        }
+                    }
+
+                    if (parentParameters.Length <= index || parentParameters[index] != parentParameter)
+                    {
+                        context.ReportDiagnostic(
+                            Diagnostic.Create(
+                                OrderDescriptor,
+                                identifierLocation,
+                                nameAttributeText,
+                                parentParameters.IndexOf(parentParameter) + 1));
+                    }
                 }
 
                 index++;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1613ElementParameterDocumentationMustDeclareParameterName.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1613ElementParameterDocumentationMustDeclareParameterName.cs
@@ -56,7 +56,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             ImmutableArray.Create(Descriptor);
 
         /// <inheritdoc/>
-        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, IEnumerable<XmlNodeSyntax> syntaxList, params Location[] diagnosticLocations)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, IEnumerable<XmlNodeSyntax> syntaxList, params Location[] diagnosticLocations)
         {
             foreach (var syntax in syntaxList)
             {
@@ -71,7 +71,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         }
 
         /// <inheritdoc/>
-        protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, XElement completeDocumentation, params Location[] diagnosticLocations)
+        protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, bool needsComment, XElement completeDocumentation, params Location[] diagnosticLocations)
         {
             var xmlParamTags = completeDocumentation.Nodes()
                 .OfType<XElement>()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1614ElementParameterDocumentationMustHaveText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1614ElementParameterDocumentationMustHaveText.cs
@@ -52,7 +52,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             ImmutableArray.Create(Descriptor);
 
         /// <inheritdoc/>
-        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, IEnumerable<XmlNodeSyntax> syntaxList, params Location[] diagnosticLocations)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, IEnumerable<XmlNodeSyntax> syntaxList, params Location[] diagnosticLocations)
         {
             foreach (var syntax in syntaxList)
             {
@@ -66,7 +66,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         }
 
         /// <inheritdoc/>
-        protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, XElement completeDocumentation, params Location[] diagnosticLocations)
+        protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, bool needsComment, XElement completeDocumentation, params Location[] diagnosticLocations)
         {
             var xmlParamTags = completeDocumentation.Nodes()
                 .OfType<XElement>()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1616ElementReturnValueDocumentationMustHaveText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1616ElementReturnValueDocumentationMustHaveText.cs
@@ -51,7 +51,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             ImmutableArray.Create(Descriptor);
 
         /// <inheritdoc/>
-        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, IEnumerable<XmlNodeSyntax> syntaxList, params Location[] diagnosticLocations)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, IEnumerable<XmlNodeSyntax> syntaxList, params Location[] diagnosticLocations)
         {
             foreach (var syntax in syntaxList)
             {
@@ -64,7 +64,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         }
 
         /// <inheritdoc/>
-        protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, XElement completeDocumentation, params Location[] diagnosticLocations)
+        protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, bool needsComment, XElement completeDocumentation, params Location[] diagnosticLocations)
         {
             var returnsNodes = completeDocumentation.Nodes()
                 .OfType<XElement>()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1618GenericTypeParametersMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1618GenericTypeParametersMustBeDocumented.cs
@@ -12,6 +12,7 @@ namespace StyleCop.Analyzers.DocumentationRules
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.Helpers;
+    using StyleCop.Analyzers.Settings.ObjectModel;
 
     /// <summary>
     /// A generic C# element is missing documentation for one or more of its generic type parameters.
@@ -41,9 +42,9 @@ namespace StyleCop.Analyzers.DocumentationRules
         private static readonly DiagnosticDescriptor Descriptor =
             new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.DocumentationRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
-        private static readonly Action<SyntaxNodeAnalysisContext> TypeDeclarationAction = HandleTypeDeclaration;
-        private static readonly Action<SyntaxNodeAnalysisContext> MethodDeclarationAction = HandleMethodDeclaration;
-        private static readonly Action<SyntaxNodeAnalysisContext> DelegateDeclarationAction = HandleDelegateDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> TypeDeclarationAction = HandleTypeDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> MethodDeclarationAction = HandleMethodDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> DelegateDeclarationAction = HandleDelegateDeclaration;
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
@@ -60,7 +61,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             context.RegisterSyntaxNodeAction(DelegateDeclarationAction, SyntaxKind.DelegateDeclaration);
         }
 
-        private static void HandleTypeDeclaration(SyntaxNodeAnalysisContext context)
+        private static void HandleTypeDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             TypeDeclarationSyntax typeDeclaration = (TypeDeclarationSyntax)context.Node;
 
@@ -70,25 +71,40 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
-            HandleMemberDeclaration(context, typeDeclaration, typeDeclaration.TypeParameterList);
+            Accessibility declaredAccessibility = typeDeclaration.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
+            Accessibility effectiveAccessibility = typeDeclaration.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
+            bool needsComment = SA1600ElementsMustBeDocumented.NeedsComment(settings.DocumentationRules, typeDeclaration.Kind(), typeDeclaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility);
+            HandleMemberDeclaration(context, needsComment, typeDeclaration, typeDeclaration.TypeParameterList);
         }
 
-        private static void HandleMethodDeclaration(SyntaxNodeAnalysisContext context)
+        private static void HandleMethodDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             MethodDeclarationSyntax methodDeclaration = (MethodDeclarationSyntax)context.Node;
 
-            HandleMemberDeclaration(context, methodDeclaration, methodDeclaration.TypeParameterList);
+            Accessibility declaredAccessibility = methodDeclaration.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
+            Accessibility effectiveAccessibility = methodDeclaration.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
+            bool needsComment = SA1600ElementsMustBeDocumented.NeedsComment(settings.DocumentationRules, methodDeclaration.Kind(), methodDeclaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility);
+            HandleMemberDeclaration(context, needsComment, methodDeclaration, methodDeclaration.TypeParameterList);
         }
 
-        private static void HandleDelegateDeclaration(SyntaxNodeAnalysisContext context)
+        private static void HandleDelegateDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             DelegateDeclarationSyntax delegateDeclaration = (DelegateDeclarationSyntax)context.Node;
 
-            HandleMemberDeclaration(context, delegateDeclaration, delegateDeclaration.TypeParameterList);
+            Accessibility declaredAccessibility = delegateDeclaration.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
+            Accessibility effectiveAccessibility = delegateDeclaration.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
+            bool needsComment = SA1600ElementsMustBeDocumented.NeedsComment(settings.DocumentationRules, delegateDeclaration.Kind(), delegateDeclaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility);
+            HandleMemberDeclaration(context, needsComment, delegateDeclaration, delegateDeclaration.TypeParameterList);
         }
 
-        private static void HandleMemberDeclaration(SyntaxNodeAnalysisContext context, SyntaxNode node, TypeParameterListSyntax typeParameterList)
+        private static void HandleMemberDeclaration(SyntaxNodeAnalysisContext context, bool needsComment, SyntaxNode node, TypeParameterListSyntax typeParameterList)
         {
+            if (!needsComment)
+            {
+                // Documentation is not required for this element.
+                return;
+            }
+
             if (typeParameterList == null)
             {
                 // The member does not have a type parameter list

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1625ElementDocumentationMustNotBeCopiedAndPasted.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1625ElementDocumentationMustNotBeCopiedAndPasted.cs
@@ -87,7 +87,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             ImmutableArray.Create(Descriptor);
 
         /// <inheritdoc/>
-        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, IEnumerable<XmlNodeSyntax> syntaxList, params Location[] diagnosticLocations)
+        protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, IEnumerable<XmlNodeSyntax> syntaxList, params Location[] diagnosticLocations)
         {
             var objectPool = SharedPools.Default<HashSet<string>>();
             HashSet<string> documentationTexts = objectPool.Allocate();
@@ -119,7 +119,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         }
 
         /// <inheritdoc/>
-        protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, XElement completeDocumentation, params Location[] diagnosticLocations)
+        protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, bool needsComment, XElement completeDocumentation, params Location[] diagnosticLocations)
         {
             var objectPool = SharedPools.Default<HashSet<string>>();
             HashSet<string> documentationTexts = objectPool.Allocate();

--- a/documentation/Configuration.md
+++ b/documentation/Configuration.md
@@ -512,7 +512,7 @@ The following example shows a configuration file which requires developers to do
   "settings": {
     "documentationRules": {
       "documentInterfaces": true,
-      "documentInternalMembers": false
+      "documentInternalElements": false
     }
   }
 }


### PR DESCRIPTION
* Fixes #1731 (incorrect documentation of `documentInternalElements`)
* Fixes #2443 
* Fixes #2444 
* Fixes #2445 
* Fixes #2446
* Fixes #2450 
* Fixes #2451 
* Fixes #2452
* Fixes #2453
