### PR TITLE
Support postfix operator followed by member access

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1003UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1003UnitTests.cs
@@ -194,6 +194,114 @@ v1;
             await this.VerifyCSharpFixAsync(testCode, fixedTestCode, numberOfFixAllIterations: 2, cancellationToken: CancellationToken.None).ConfigureAwait(false);
         }
 
+        [Fact]
+        [WorkItem(2471, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2471")]
+        public async Task TestUnaryMemberAccessAsync()
+        {
+            var testCode = @"public class ClassName
+{
+    public unsafe void MethodName()
+    {
+        int? x = 0;
+        int* y = null;
+
+        x -- .ToString();
+        x --.ToString();
+        x-- .ToString();
+
+        x ++ .ToString();
+        x ++.ToString();
+        x++ .ToString();
+
+        x -- ?.ToString();
+        x --?.ToString();
+        x-- ?.ToString();
+
+        x ++ ?.ToString();
+        x ++?.ToString();
+        x++ ?.ToString();
+
+        y -- ->ToString();
+        y --->ToString();
+        y-- ->ToString();
+
+        y ++ ->ToString();
+        y ++->ToString();
+        y++ ->ToString();
+    }
+}
+";
+            var fixedTestCode = @"public class ClassName
+{
+    public unsafe void MethodName()
+    {
+        int? x = 0;
+        int* y = null;
+
+        x--.ToString();
+        x--.ToString();
+        x--.ToString();
+
+        x++.ToString();
+        x++.ToString();
+        x++.ToString();
+
+        x--?.ToString();
+        x--?.ToString();
+        x--?.ToString();
+
+        x++?.ToString();
+        x++?.ToString();
+        x++?.ToString();
+
+        y--->ToString();
+        y--->ToString();
+        y--->ToString();
+
+        y++->ToString();
+        y++->ToString();
+        y++->ToString();
+    }
+}
+";
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic(DescriptorNotPrecededByWhitespace).WithLocation(8, 11).WithArguments("--"),
+                this.CSharpDiagnostic(DescriptorNotFollowedByWhitespace).WithLocation(8, 11).WithArguments("--"),
+                this.CSharpDiagnostic(DescriptorNotPrecededByWhitespace).WithLocation(9, 11).WithArguments("--"),
+                this.CSharpDiagnostic(DescriptorNotFollowedByWhitespace).WithLocation(10, 10).WithArguments("--"),
+
+                this.CSharpDiagnostic(DescriptorNotPrecededByWhitespace).WithLocation(12, 11).WithArguments("++"),
+                this.CSharpDiagnostic(DescriptorNotFollowedByWhitespace).WithLocation(12, 11).WithArguments("++"),
+                this.CSharpDiagnostic(DescriptorNotPrecededByWhitespace).WithLocation(13, 11).WithArguments("++"),
+                this.CSharpDiagnostic(DescriptorNotFollowedByWhitespace).WithLocation(14, 10).WithArguments("++"),
+
+                this.CSharpDiagnostic(DescriptorNotPrecededByWhitespace).WithLocation(16, 11).WithArguments("--"),
+                this.CSharpDiagnostic(DescriptorNotFollowedByWhitespace).WithLocation(16, 11).WithArguments("--"),
+                this.CSharpDiagnostic(DescriptorNotPrecededByWhitespace).WithLocation(17, 11).WithArguments("--"),
+                this.CSharpDiagnostic(DescriptorNotFollowedByWhitespace).WithLocation(18, 10).WithArguments("--"),
+
+                this.CSharpDiagnostic(DescriptorNotPrecededByWhitespace).WithLocation(20, 11).WithArguments("++"),
+                this.CSharpDiagnostic(DescriptorNotFollowedByWhitespace).WithLocation(20, 11).WithArguments("++"),
+                this.CSharpDiagnostic(DescriptorNotPrecededByWhitespace).WithLocation(21, 11).WithArguments("++"),
+                this.CSharpDiagnostic(DescriptorNotFollowedByWhitespace).WithLocation(22, 10).WithArguments("++"),
+
+                this.CSharpDiagnostic(DescriptorNotPrecededByWhitespace).WithLocation(24, 11).WithArguments("--"),
+                this.CSharpDiagnostic(DescriptorNotFollowedByWhitespace).WithLocation(24, 11).WithArguments("--"),
+                this.CSharpDiagnostic(DescriptorNotPrecededByWhitespace).WithLocation(25, 11).WithArguments("--"),
+                this.CSharpDiagnostic(DescriptorNotFollowedByWhitespace).WithLocation(26, 10).WithArguments("--"),
+
+                this.CSharpDiagnostic(DescriptorNotPrecededByWhitespace).WithLocation(28, 11).WithArguments("++"),
+                this.CSharpDiagnostic(DescriptorNotFollowedByWhitespace).WithLocation(28, 11).WithArguments("++"),
+                this.CSharpDiagnostic(DescriptorNotPrecededByWhitespace).WithLocation(29, 11).WithArguments("++"),
+                this.CSharpDiagnostic(DescriptorNotFollowedByWhitespace).WithLocation(30, 10).WithArguments("++"),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Verifies that valid binary expressions do not produce diagnostics.
         /// </summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1019UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1019UnitTests.cs
@@ -183,6 +183,88 @@ namespace StyleCop.Analyzers.Test.SpacingRules
             await this.VerifyCSharpDiagnosticAsync(template, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        [Fact]
+        [WorkItem(2471, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2471")]
+        public async Task TestUnaryMemberAccessAsync()
+        {
+            var testCode = @"public class ClassName
+{
+    public unsafe void MethodName()
+    {
+        int? x = 0;
+        int* y = null;
+
+        x-- . ToString();
+        x-- .ToString();
+        x--. ToString();
+
+        x++ . ToString();
+        x++ .ToString();
+        x++. ToString();
+
+        x-- ?. ToString();
+        x-- ?.ToString();
+        x--?. ToString();
+
+        x++ ?. ToString();
+        x++ ?.ToString();
+        x++?. ToString();
+    }
+}
+";
+            var fixedTestCode = @"public class ClassName
+{
+    public unsafe void MethodName()
+    {
+        int? x = 0;
+        int* y = null;
+
+        x--.ToString();
+        x--.ToString();
+        x--.ToString();
+
+        x++.ToString();
+        x++.ToString();
+        x++.ToString();
+
+        x--?.ToString();
+        x--?.ToString();
+        x--?.ToString();
+
+        x++?.ToString();
+        x++?.ToString();
+        x++?.ToString();
+    }
+}
+";
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(8, 13).WithArguments(".", "preceded"),
+                this.CSharpDiagnostic().WithLocation(8, 13).WithArguments(".", "followed"),
+                this.CSharpDiagnostic().WithLocation(9, 13).WithArguments(".", "preceded"),
+                this.CSharpDiagnostic().WithLocation(10, 12).WithArguments(".", "followed"),
+
+                this.CSharpDiagnostic().WithLocation(12, 13).WithArguments(".", "preceded"),
+                this.CSharpDiagnostic().WithLocation(12, 13).WithArguments(".", "followed"),
+                this.CSharpDiagnostic().WithLocation(13, 13).WithArguments(".", "preceded"),
+                this.CSharpDiagnostic().WithLocation(14, 12).WithArguments(".", "followed"),
+
+                this.CSharpDiagnostic().WithLocation(16, 13).WithArguments("?", "preceded"),
+                this.CSharpDiagnostic().WithLocation(16, 14).WithArguments(".", "followed"),
+                this.CSharpDiagnostic().WithLocation(17, 13).WithArguments("?", "preceded"),
+                this.CSharpDiagnostic().WithLocation(18, 13).WithArguments(".", "followed"),
+
+                this.CSharpDiagnostic().WithLocation(20, 13).WithArguments("?", "preceded"),
+                this.CSharpDiagnostic().WithLocation(20, 14).WithArguments(".", "followed"),
+                this.CSharpDiagnostic().WithLocation(21, 13).WithArguments("?", "preceded"),
+                this.CSharpDiagnostic().WithLocation(22, 13).WithArguments(".", "followed"),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode, cancellationToken: CancellationToken.None).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Gets the C# analyzers being tested
         /// </summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1019UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1019UnitTests.cs
@@ -209,6 +209,14 @@ namespace StyleCop.Analyzers.Test.SpacingRules
         x++ ?. ToString();
         x++ ?.ToString();
         x++?. ToString();
+
+        y-- -> ToString();
+        y-- ->ToString();
+        y---> ToString();
+
+        y++ -> ToString();
+        y++ ->ToString();
+        y++-> ToString();
     }
 }
 ";
@@ -234,6 +242,14 @@ namespace StyleCop.Analyzers.Test.SpacingRules
         x++?.ToString();
         x++?.ToString();
         x++?.ToString();
+
+        y--->ToString();
+        y--->ToString();
+        y--->ToString();
+
+        y++->ToString();
+        y++->ToString();
+        y++->ToString();
     }
 }
 ";
@@ -258,6 +274,16 @@ namespace StyleCop.Analyzers.Test.SpacingRules
                 this.CSharpDiagnostic().WithLocation(20, 14).WithArguments(".", "followed"),
                 this.CSharpDiagnostic().WithLocation(21, 13).WithArguments("?", "preceded"),
                 this.CSharpDiagnostic().WithLocation(22, 13).WithArguments(".", "followed"),
+
+                this.CSharpDiagnostic().WithLocation(24, 13).WithArguments("->", "preceded"),
+                this.CSharpDiagnostic().WithLocation(24, 13).WithArguments("->", "followed"),
+                this.CSharpDiagnostic().WithLocation(25, 13).WithArguments("->", "preceded"),
+                this.CSharpDiagnostic().WithLocation(26, 12).WithArguments("->", "followed"),
+
+                this.CSharpDiagnostic().WithLocation(28, 13).WithArguments("->", "preceded"),
+                this.CSharpDiagnostic().WithLocation(28, 13).WithArguments("->", "followed"),
+                this.CSharpDiagnostic().WithLocation(29, 13).WithArguments("->", "preceded"),
+                this.CSharpDiagnostic().WithLocation(30, 12).WithArguments("->", "followed"),
             };
 
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003SymbolsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003SymbolsMustBeSpacedCorrectly.cs
@@ -292,11 +292,30 @@ namespace StyleCop.Analyzers.SpacingRules
             var unaryExpression = (PostfixUnaryExpressionSyntax)context.Node;
             var followingToken = unaryExpression.OperatorToken.GetNextToken();
 
-            var mustHaveTrailingWhitespace = !followingToken.IsKind(SyntaxKind.CloseParenToken)
-                && !followingToken.IsKind(SyntaxKind.CloseBracketToken)
-                && !followingToken.IsKind(SyntaxKind.SemicolonToken)
-                && !followingToken.IsKind(SyntaxKind.CommaToken)
-                && !(followingToken.IsKind(SyntaxKind.CloseBraceToken) && (followingToken.Parent is InterpolationSyntax));
+            bool mustHaveTrailingWhitespace;
+            switch (followingToken.Kind())
+            {
+            case SyntaxKind.CloseParenToken:
+            case SyntaxKind.CloseBracketToken:
+            case SyntaxKind.SemicolonToken:
+            case SyntaxKind.CommaToken:
+            case SyntaxKind.DotToken:
+            case SyntaxKind.MinusGreaterThanToken:
+                mustHaveTrailingWhitespace = false;
+                break;
+
+            case SyntaxKind.QuestionToken:
+                mustHaveTrailingWhitespace = !(followingToken.Parent is ConditionalAccessExpressionSyntax);
+                break;
+
+            case SyntaxKind.CloseBraceToken:
+                mustHaveTrailingWhitespace = !(followingToken.Parent is InterpolationSyntax);
+                break;
+
+            default:
+                mustHaveTrailingWhitespace = true;
+                break;
+            }
 
             // If the next token is a close brace token we are in an anonymous object creation or an initialization.
             // Then we allow a new line

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1019MemberAccessSymbolsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1019MemberAccessSymbolsMustBeSpacedCorrectly.cs
@@ -59,6 +59,10 @@ namespace StyleCop.Analyzers.SpacingRules
                     HandleDotToken(context, token);
                     break;
 
+                case SyntaxKind.MinusGreaterThanToken:
+                    HandleMemberAccessSymbol(context, token);
+                    break;
+
                 // This case handles the new ?. and ?[ operators
                 case SyntaxKind.QuestionToken:
                     HandleQuestionToken(context, token);


### PR DESCRIPTION
* Fix behavior of postfix unary operator followed by a member access operator
* Update SA1019 to treat `->` as a member access operator

Fixes #2471