### PR TITLE
Reference ExcludeFromCodeCoverageAttribute using an assembly alias

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpecialRules/SA0002UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpecialRules/SA0002UnitTests.cs
@@ -3,6 +3,8 @@
 
 namespace StyleCop.Analyzers.Test.SpecialRules
 {
+    extern alias system;
+
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
@@ -16,6 +18,8 @@ namespace StyleCop.Analyzers.Test.SpecialRules
     using Microsoft.CodeAnalysis.Text;
     using TestHelper;
     using Xunit;
+
+    using ExcludeFromCodeCoverageAttribute = system::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute;
 
     /// <summary>
     /// Unit tests for <see cref="SA0002InvalidSettingsFile"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -25,4 +25,10 @@
     <ProjectReference Include="..\StyleCop.Analyzers\StyleCop.Analyzers.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Update="System">
+      <Aliases>global,system</Aliases>
+    </Reference>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
# DO NOT MERGE

This pull request exists solely to aid in the reporting of a bug in the new SDK.