### PR TITLE
Support the ref keyword in SA1206

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/OrderingRules/SA1206CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/OrderingRules/SA1206CSharp7UnitTests.cs
@@ -3,9 +3,37 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.OrderingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using StyleCop.Analyzers.Test.OrderingRules;
+    using TestHelper;
+    using Xunit;
 
     public class SA1206CSharp7UnitTests : SA1206UnitTests
     {
+        [Fact(Skip = "The version of the compiler used in these tests does not yet support this feature.")]
+        public async Task TestRefKeywordInStructDeclarationAsync()
+        {
+            var testCode = @"private ref struct BitHelper
+{
+}
+";
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact(Skip = "The version of the compiler used in these tests does not yet support this feature.")]
+        public async Task TestRefKeywordInStructDeclarationWrongOrderAsync()
+        {
+            var testCode = @"ref private struct BitHelper
+{
+}
+";
+
+            DiagnosticResult[] expected = new[]
+            {
+                this.CSharpDiagnostic().WithLocation(1, 13).WithArguments("ref", "private"),
+            };
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/ModifierOrderHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/ModifierOrderHelper.cs
@@ -29,7 +29,7 @@ namespace StyleCop.Analyzers.OrderingRules
             Static,
 
             /// <summary>
-            /// Represents other modifiers i.e partial, virtual, abstract, override, extern, unsafe, new, async, const, sealed, readonly, volatile, fixed
+            /// Represents other modifiers i.e partial, virtual, abstract, override, extern, unsafe, new, async, const, sealed, readonly, volatile, fixed, ref
             /// </summary>
             Other,
         }
@@ -64,6 +64,7 @@ namespace StyleCop.Analyzers.OrderingRules
             case SyntaxKind.ConstKeyword:
             case SyntaxKind.AsyncKeyword:
             case SyntaxKind.PartialKeyword:
+            case SyntaxKind.RefKeyword:
                 result = ModifierType.Other;
                 break;
             }


### PR DESCRIPTION
Fixes #2546.

Note that the tests are disabled right now (and I was not able to test this yet) because there is no released Roslyn version for C# 7.2.