### PR TITLE
Added unit test for issue #2236

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
@@ -970,6 +970,11 @@ public class TestClass
 
         protected override string GetSettings()
         {
+            if (this.settings == null)
+            {
+                return base.GetSettings();
+            }
+
             return this.settings;
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
@@ -20,6 +20,8 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     [UseCulture("en-US")]
     public class SA1642UnitTests : CodeFixVerifier
     {
+        private string settings = null;
+
         [Theory]
         [InlineData("class")]
         [InlineData("struct")]
@@ -861,6 +863,30 @@ public class TestClass
             Assert.Empty(offeredFixes);
         }
 
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [WorkItem(2236, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2236")]
+        public async Task TestDocumentationCultureIsUsedAsync(string typeKind)
+        {
+            this.settings = @"
+{
+  ""settings"": {
+    ""documentationRules"": {
+      ""documentationCulture"": ""en-GB"",
+    }
+  }
+}
+";
+
+            await this.TestConstructorCorrectDocumentationSimpleAsync(
+                typeKind,
+                "public",
+                "Initialises a new instance of the ",
+                " " + typeKind,
+                false).ConfigureAwait(false);
+        }
+
         protected override Project ApplyCompilationOptions(Project project)
         {
             var resolver = new TestXmlReferenceResolver();
@@ -940,6 +966,11 @@ public class TestClass
         protected override CodeFixProvider GetCSharpCodeFixProvider()
         {
             return new SA1642SA1643CodeFixProvider();
+        }
+
+        protected override string GetSettings()
+        {
+            return this.settings;
         }
 
         private async Task TestEmptyConstructorAsync(string typeKind, string modifiers)


### PR DESCRIPTION
This patch adds a unit test for SA1642 that checks if the `documentationCulture` is used. This might not be the most excessive test but I think this proves that #2236 is fixed.