### PR TITLE
Fix Turkish İ problem

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/UseCultureAttribute.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/UseCultureAttribute.cs
@@ -33,6 +33,10 @@ namespace StyleCop.Analyzers.Test.Helpers
 
         private CultureInfo originalUiCulture;
 
+        private CultureInfo originalDefaultCulture;
+
+        private CultureInfo originalDefaultUiCulture;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="UseCultureAttribute"/>
         /// class with a culture.
@@ -85,9 +89,14 @@ namespace StyleCop.Analyzers.Test.Helpers
         {
             this.originalCulture = Thread.CurrentThread.CurrentCulture;
             this.originalUiCulture = Thread.CurrentThread.CurrentUICulture;
+            this.originalDefaultCulture = CultureInfo.DefaultThreadCurrentCulture;
+            this.originalDefaultUiCulture = CultureInfo.DefaultThreadCurrentUICulture;
 
             Thread.CurrentThread.CurrentCulture = this.Culture;
             Thread.CurrentThread.CurrentUICulture = this.UiCulture;
+
+            CultureInfo.DefaultThreadCurrentCulture = this.Culture;
+            CultureInfo.DefaultThreadCurrentUICulture = this.UiCulture;
         }
 
         /// <summary>
@@ -99,6 +108,9 @@ namespace StyleCop.Analyzers.Test.Helpers
         {
             Thread.CurrentThread.CurrentCulture = this.originalCulture;
             Thread.CurrentThread.CurrentUICulture = this.originalUiCulture;
+
+            CultureInfo.DefaultThreadCurrentCulture = this.originalDefaultCulture;
+            CultureInfo.DefaultThreadCurrentUICulture = this.originalDefaultUiCulture;
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
@@ -9,9 +9,11 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.NamingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using TestHelper;
     using Xunit;
 
+    [UseCulture("en-US")]
     public class SA1300UnitTests : CodeFixVerifier
     {
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1312UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1312UnitTests.cs
@@ -9,9 +9,11 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.NamingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using TestHelper;
     using Xunit;
 
+    [UseCulture("en-US")]
     public class SA1312UnitTests : CodeFixVerifier
     {
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
@@ -9,9 +9,11 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.NamingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using TestHelper;
     using Xunit;
 
+    [UseCulture("en-US")]
     public class SA1313UnitTests : CodeFixVerifier
     {
         [Fact]


### PR DESCRIPTION
This PR makes sure tests don't fail on a platform with Turkish-specific globalization settings.

I also had to modify `UseCultureAttribute` class so that the `async` methods are executed with the given culture info.