### PR TITLE
SA1206 C# 7.2 test update

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/OrderingRules/SA1206CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/OrderingRules/SA1206CSharp7UnitTests.cs
@@ -5,35 +5,66 @@ namespace StyleCop.Analyzers.Test.CSharp7.OrderingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
     using StyleCop.Analyzers.Test.OrderingRules;
     using TestHelper;
     using Xunit;
 
     public class SA1206CSharp7UnitTests : SA1206UnitTests
     {
-        [Fact(Skip = "The version of the compiler used in these tests does not yet support this feature.")]
+        [Fact]
         public async Task TestRefKeywordInStructDeclarationAsync()
         {
-            var testCode = @"private ref struct BitHelper
+            var testCode = @"class OuterClass
 {
+    private ref struct BitHelper
+    {
+    }
 }
 ";
             await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact(Skip = "The version of the compiler used in these tests does not yet support this feature.")]
-        public async Task TestRefKeywordInStructDeclarationWrongOrderAsync()
+        [Fact]
+        public async Task TestReadonlyKeywordInStructDeclarationAsync()
         {
-            var testCode = @"ref private struct BitHelper
+            var testCode = @"class OuterClass
 {
+    private readonly struct BitHelper
+    {
+    }
+}
+";
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestReadonlyKeywordInStructDeclarationWrongOrderAsync()
+        {
+            // Note that we don't need a test for ref with the wrong order, because this would be a compile time error
+            var testCode = @"class OuterClass
+{
+    readonly private struct BitHelper
+    {
+    }
 }
 ";
 
             DiagnosticResult[] expected = new[]
             {
-                this.CSharpDiagnostic().WithLocation(1, 13).WithArguments("ref", "private"),
+                this.CSharpDiagnostic().WithLocation(3, 14).WithArguments("private", "readonly"),
             };
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected override Project ApplyCompilationOptions(Project project)
+        {
+            var newProject = base.ApplyCompilationOptions(project);
+
+            var parseOptions = (CSharpParseOptions)newProject.ParseOptions;
+
+            return newProject.WithParseOptions(parseOptions.WithLanguageVersion(LanguageVersion.Latest));
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/StyleCop.Analyzers.Test.CSharp7.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/StyleCop.Analyzers.Test.CSharp7.csproj
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.1.0" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.6.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/app.config
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/app.config
@@ -4,23 +4,23 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces.Desktop" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.1.0.0" newVersion="2.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-2.6.0.0" newVersion="2.6.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />


### PR DESCRIPTION
I updated the test project to use the newest roslyn version and I updated the SA1206 tests appropriately. I had to remove one test I had previously because it tested code that is not valid C# (putting ref before the access modifier is illegal).

I also updated xunit to the current version.

This partially adresses #2578.