### PR TITLE
SA1210 is inconsistent with IDE's Remove and Sort Usings

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/UsingCodeFixProvider.UsingsSorter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/UsingCodeFixProvider.UsingsSorter.cs
@@ -438,7 +438,7 @@ namespace StyleCop.Analyzers.OrderingRules
                 var namespaceTypeName = namespaceSymbol.ToDisplayString(FullNamespaceDisplayFormat);
                 var firstPart = namespaceTypeName.Split('.')[0];
 
-                return string.Equals(SystemUsingDirectiveIdentifier, firstPart, StringComparison.Ordinal);
+                return string.Equals(SystemUsingDirectiveIdentifier, firstPart, StringComparison.Ordinal) || string.Equals(WindowsUsingDirectiveIdentifier, firstPart, StringComparison.Ordinal);
             }
 
             private void ProcessMembers(SyntaxList<MemberDeclarationSyntax> members)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/UsingCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/UsingCodeFixProvider.cs
@@ -26,6 +26,7 @@ namespace StyleCop.Analyzers.OrderingRules
     internal sealed partial class UsingCodeFixProvider : CodeFixProvider
     {
         private const string SystemUsingDirectiveIdentifier = nameof(System);
+        private const string WindowsUsingDirectiveIdentifier = "Windows";
 
         private static readonly List<UsingDirectiveSyntax> EmptyUsingsList = new List<UsingDirectiveSyntax>();
         private static readonly SyntaxAnnotation UsingCodeFixAnnotation = new SyntaxAnnotation(nameof(UsingCodeFixAnnotation));

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1208UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1208UnitTests.cs
@@ -116,6 +116,92 @@ class A
         }
 
         [Fact]
+        public async Task TestWhenSystemAndWindowsUsingDirectivesAreNotOnTopInCompilationAsync()
+        {
+            var usingsInCompilationUnit = new[]
+            {
+                "namespace Windows.Foundation {}",
+                "namespace Xyz {}",
+                "namespace AnotherNamespace {}",
+                @"using Xyz;
+using System;
+using System.IO;
+using AnotherNamespace;
+using Windows.Foundation;
+using System.Threading.Tasks;
+
+class A
+{
+}",
+            };
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation("Test3.cs", 2, 1).WithArguments("System", "Xyz"),
+                this.CSharpDiagnostic().WithLocation("Test3.cs", 3, 1).WithArguments("System.IO", "Xyz"),
+                this.CSharpDiagnostic().WithLocation("Test3.cs", 5, 1).WithArguments("Windows.Foundation", "Xyz"),
+                this.CSharpDiagnostic().WithLocation("Test3.cs", 6, 1).WithArguments("System.Threading.Tasks", "Xyz"),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(usingsInCompilationUnit, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestWhenSystemAndWindowsUsingDirectivesAreNotOnTopInNamespaceAsync()
+        {
+            var usingsInNamespaceDeclaration = new[]
+            {
+                "namespace Windows.Foundation {}",
+                "namespace Namespace {}",
+                "namespace AnotherNamespace {}",
+                @"namespace Test
+{
+    using Namespace;
+    using System.Threading;
+    using System.IO;
+    using Windows.Foundation;
+    using AnotherNamespace;
+
+    class A
+    {
+    }
+}",
+            };
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation("Test3.cs", 4, 5).WithArguments("System.Threading", "Namespace"),
+                this.CSharpDiagnostic().WithLocation("Test3.cs", 5, 5).WithArguments("System.IO", "Namespace"),
+                this.CSharpDiagnostic().WithLocation("Test3.cs", 6, 5).WithArguments("Windows.Foundation", "Namespace"),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(usingsInNamespaceDeclaration, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestWhenWindowsUsingDirectivesAreNotOnTopAsync()
+        {
+            var usingsInCompilationUnit = new[]
+            {
+                "namespace Windows.Foundation {}",
+                "namespace Namespace {}",
+                @"using Namespace;
+using Windows.Foundation;
+
+class A
+{
+}",
+            };
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation("Test2.cs", 2, 1).WithArguments("Windows.Foundation", "Namespace"),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(usingsInCompilationUnit, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestSystemUsingDirectivesInCompilationUnitAndInNamespaceDeclarationAsync()
         {
             var sources = new[]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210UnitTests.cs
@@ -115,6 +115,65 @@ namespace Bar
         }
 
         [Fact]
+        public async Task TestInvalidOrderedUsingDirectivesWithWindowsUsingDirectiveAsync()
+        {
+            var testCode = @"namespace Windows.Foundation {}
+namespace Windows.Foundation.Collections {}
+namespace Foo
+{
+    using Windows.Foundation.Collections;
+    using Windows.Foundation;
+    using System.Threading;
+    using System;
+}
+
+namespace Bar
+{
+    using Foo;
+    using Bar;
+    using Windows.Foundation.Collections;
+    using Windows.Foundation;
+    using System.Threading;
+    using System;
+}";
+
+            var fixedTestCode = @"namespace Windows.Foundation {}
+namespace Windows.Foundation.Collections {}
+namespace Foo
+{
+    using System;
+    using System.Threading;
+    using Windows.Foundation;
+    using Windows.Foundation.Collections;
+}
+
+namespace Bar
+{
+    using System;
+    using System.Threading;
+    using Windows.Foundation;
+    using Windows.Foundation.Collections;
+    using Bar;
+    using Foo;
+}";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(5, 5),
+                this.CSharpDiagnostic().WithLocation(6, 5),
+                this.CSharpDiagnostic().WithLocation(7, 5),
+                this.CSharpDiagnostic().WithLocation(13, 5),
+                this.CSharpDiagnostic().WithLocation(15, 5),
+                this.CSharpDiagnostic().WithLocation(16, 5),
+                this.CSharpDiagnostic().WithLocation(17, 5),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        [Fact]
         [WorkItem(2336, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2336")]
         public async Task TestUsingDirectivesCaseSensitivityAsync()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/UsingDirectiveSyntaxHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/UsingDirectiveSyntaxHelpers.cs
@@ -16,13 +16,20 @@ namespace StyleCop.Analyzers.Helpers
     internal static class UsingDirectiveSyntaxHelpers
     {
         private const string SystemUsingDirectiveIdentifier = nameof(System);
+        private const string WindowsUsingDirectiveIdentifier = "Windows";
 
         /// <summary>
         /// Check if <see cref="UsingDirectiveSyntax"/> is system using directive.
         /// </summary>
         /// <param name="usingDirective">The <see cref="UsingDirectiveSyntax"/> that will be checked.</param>
         /// <returns>Return true if the <see cref="UsingDirectiveSyntax"/>is system using directive, otherwise false.</returns>
-        internal static bool IsSystemUsingDirective(this UsingDirectiveSyntax usingDirective) => string.Equals(SystemUsingDirectiveIdentifier, GetFirstIdentifierInUsingDirective(usingDirective)?.ValueText, StringComparison.Ordinal);
+        internal static bool IsSystemUsingDirective(this UsingDirectiveSyntax usingDirective)
+        {
+            string firstIdentifier = GetFirstIdentifierInUsingDirective(usingDirective)?.ValueText;
+
+            // Visual Studio treats Windows.* namespaces as system namespaces.
+            return string.Equals(SystemUsingDirectiveIdentifier, firstIdentifier, StringComparison.Ordinal) || string.Equals(WindowsUsingDirectiveIdentifier, firstIdentifier, StringComparison.Ordinal);
+        }
 
         /// <summary>
         /// Check if <see cref="UsingDirectiveSyntax"/> is preceded by a preprocessor directive.


### PR DESCRIPTION
Fixes #2587 
SA1208 and SA1210 are inconsistent with the IDE's Remove and Sort Usings when "Place 'System' directives first when sorting usings" settings is enabled for a UWP project. In that scenario, the IDE treats Windows.* namespaces as 'System' usings as well, whereas SA1208 and SA1210 don't.