### PR TITLE
Migrate to portable PDB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ packages/
 *.user
 TestResults/
 OpenCover.Reports/
+OpenCover.Symbols/
 .nuget/NuGet.exe
 build/nuget/
 *.log

--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Codecov" version="1.0.1" />
-  <package id="OpenCover" version="4.6.247-rc" />
+  <package id="OpenCover" version="4.6.519" />
   <package id="ReportGenerator" version="2.3.5.0" targetFramework="net452" />
   <package id="xunit.runner.console" version="2.1.0" targetFramework="net452" />
 </packages>

--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Codecov" version="1.0.1" />
+  <package id="Microsoft.DiaSymReader.Pdb2Pdb" version="1.1.0-beta1-62624-01" />
   <package id="OpenCover" version="4.6.519" />
   <package id="ReportGenerator" version="2.3.5.0" targetFramework="net452" />
   <package id="xunit.runner.console" version="2.1.0" targetFramework="net452" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="symreader-converter" value="https://dotnet.myget.org/F/symreader-converter/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/StyleCop.Analyzers/Directory.Build.props
+++ b/StyleCop.Analyzers/Directory.Build.props
@@ -27,13 +27,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <DebugType>pdbonly</DebugType>
+  <PropertyGroup>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="1.2.1" />
-    <PackageReference Include="xunit" Version="2.3.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0" PrivateAssets="all" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,9 +8,10 @@ build:
   project: StyleCopAnalyzers.sln
   verbosity: minimal
 test_script:
-- .\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"C:\projects\stylecopanalyzers\StyleCop.Analyzers\StyleCop.Analyzers.Test\bin\Debug\net452\StyleCop.Analyzers.Test.dll -noshadow -appveyor" -returntargetcode -filter:"+[StyleCop*]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -excludebyfile:*\*Designer.cs -hideskipped:All -output:.\StyleCopAnalyzers_coverage.xml
-- .\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"C:\projects\stylecopanalyzers\StyleCop.Analyzers\StyleCop.Analyzers.Test.CSharp7\bin\Debug\net46\StyleCop.Analyzers.Test.CSharp7.dll -noshadow -appveyor" -returntargetcode -filter:"+[StyleCop*]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -excludebyfile:*\*Designer.cs -hideskipped:All -mergebyhash -mergeoutput -output:.\StyleCopAnalyzers_coverage.xml
-- .\packages\Codecov.1.0.1\tools\codecov.exe -f "StyleCopAnalyzers_coverage.xml"
+- cd build
+- ps: .\opencover-report.ps1 -Debug -NoBuild -NoReport -AppVeyor
+- cd ..
+- .\packages\Codecov.1.0.1\tools\codecov.exe -f ".\build\OpenCover.Reports\OpenCover.StyleCopAnalyzers.xml"
 cache:
   - packages -> **\packages.config
   - C:\Users\appveyor\.nuget\packages -> appveyor.yml

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,8 @@ build:
   project: StyleCopAnalyzers.sln
   verbosity: minimal
 test_script:
-- .\packages\OpenCover.4.6.247-rc\tools\OpenCover.Console.exe -register:user -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"C:\projects\stylecopanalyzers\StyleCop.Analyzers\StyleCop.Analyzers.Test\bin\Debug\net452\StyleCop.Analyzers.Test.dll -noshadow -appveyor" -returntargetcode -filter:"+[StyleCop*]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -excludebyfile:*\*Designer.cs -hideskipped:All -output:.\StyleCopAnalyzers_coverage.xml
-- .\packages\OpenCover.4.6.247-rc\tools\OpenCover.Console.exe -register:user -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"C:\projects\stylecopanalyzers\StyleCop.Analyzers\StyleCop.Analyzers.Test.CSharp7\bin\Debug\net46\StyleCop.Analyzers.Test.CSharp7.dll -noshadow -appveyor" -returntargetcode -filter:"+[StyleCop*]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -excludebyfile:*\*Designer.cs -hideskipped:All -mergebyhash -mergeoutput -output:.\StyleCopAnalyzers_coverage.xml
+- .\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"C:\projects\stylecopanalyzers\StyleCop.Analyzers\StyleCop.Analyzers.Test\bin\Debug\net452\StyleCop.Analyzers.Test.dll -noshadow -appveyor" -returntargetcode -filter:"+[StyleCop*]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -excludebyfile:*\*Designer.cs -hideskipped:All -output:.\StyleCopAnalyzers_coverage.xml
+- .\packages\OpenCover.4.6.519\tools\OpenCover.Console.exe -register:user -target:"%xunit20%\xunit.console.x86.exe" -targetargs:"C:\projects\stylecopanalyzers\StyleCop.Analyzers\StyleCop.Analyzers.Test.CSharp7\bin\Debug\net46\StyleCop.Analyzers.Test.CSharp7.dll -noshadow -appveyor" -returntargetcode -filter:"+[StyleCop*]*" -excludebyattribute:*.ExcludeFromCodeCoverage* -excludebyfile:*\*Designer.cs -hideskipped:All -mergebyhash -mergeoutput -output:.\StyleCopAnalyzers_coverage.xml
 - .\packages\Codecov.1.0.1\tools\codecov.exe -f "StyleCopAnalyzers_coverage.xml"
 cache:
   - packages -> **\packages.config

--- a/build/opencover-report.ps1
+++ b/build/opencover-report.ps1
@@ -30,7 +30,8 @@ $opencover_console = "$packages_folder\OpenCover.$opencover_version\tools\OpenCo
 $xunit_runner_console = "$packages_folder\xunit.runner.console.$xunitrunner_version\tools\xunit.console.x86.exe"
 $report_generator = "$packages_folder\ReportGenerator.$reportgenerator_version\tools\ReportGenerator.exe"
 $report_folder = '.\OpenCover.Reports'
-$target_dll = "..\StyleCop.Analyzers\StyleCop.Analyzers.Test\bin\$Configuration\StyleCop.Analyzers.Test.dll"
+$target_dll = "..\StyleCop.Analyzers\StyleCop.Analyzers.Test\bin\$Configuration\net452\StyleCop.Analyzers.Test.dll"
+$target_dll_csharp7 = "..\StyleCop.Analyzers\StyleCop.Analyzers.Test.CSharp7\bin\$Configuration\net46\StyleCop.Analyzers.Test.CSharp7.dll"
 
 If (Test-Path $report_folder) {
 	Remove-Item -Recurse -Force $report_folder
@@ -40,7 +41,6 @@ mkdir $report_folder | Out-Null
 
 &$opencover_console `
 	-register:user `
-	-threshold:1 `
 	-returntargetcode `
 	-hideskipped:All `
 	-filter:"+[StyleCop*]*" `
@@ -49,6 +49,18 @@ mkdir $report_folder | Out-Null
 	-output:"$report_folder\OpenCover.StyleCopAnalyzers.xml" `
 	-target:"$xunit_runner_console" `
 	-targetargs:"$target_dll -noshadow"
+
+&$opencover_console `
+	-register:user `
+	-returntargetcode `
+	-hideskipped:All `
+	-filter:"+[StyleCop*]*" `
+	-excludebyattribute:*.ExcludeFromCodeCoverage* `
+	-excludebyfile:*\*Designer.cs `
+	-output:"$report_folder\OpenCover.StyleCopAnalyzers.xml" `
+	-mergebyhash -mergeoutput `
+	-target:"$xunit_runner_console" `
+	-targetargs:"$target_dll_csharp7 -noshadow"
 
 &$report_generator -targetdir:$report_folder -reports:$report_folder\OpenCover.*.xml
 

--- a/build/opencover-report.ps1
+++ b/build/opencover-report.ps1
@@ -29,14 +29,74 @@ $packageConfig = [xml](Get-Content ..\.nuget\packages.config)
 $opencover_version = $packageConfig.SelectSingleNode('/packages/package[@id="OpenCover"]').version
 $reportgenerator_version = $packageConfig.SelectSingleNode('/packages/package[@id="ReportGenerator"]').version
 $xunitrunner_version = $packageConfig.SelectSingleNode('/packages/package[@id="xunit.runner.console"]').version
+$pdb2pdb_version = $packageConfig.SelectSingleNode('/packages/package[@id="Microsoft.DiaSymReader.Pdb2Pdb"]').version
 
 $packages_folder = '..\packages'
 $opencover_console = "$packages_folder\OpenCover.$opencover_version\tools\OpenCover.Console.exe"
 $xunit_runner_console = "$packages_folder\xunit.runner.console.$xunitrunner_version\tools\xunit.console.x86.exe"
 $report_generator = "$packages_folder\ReportGenerator.$reportgenerator_version\tools\ReportGenerator.exe"
+$pdb2pdb = "$packages_folder\Microsoft.DiaSymReader.Pdb2Pdb.$pdb2pdb_version\tools\Pdb2Pdb.exe"
 $report_folder = '.\OpenCover.Reports'
+$symbols_folder = '.\OpenCover.Symbols'
 $target_dll = "..\StyleCop.Analyzers\StyleCop.Analyzers.Test\bin\$Configuration\net452\StyleCop.Analyzers.Test.dll"
 $target_dll_csharp7 = "..\StyleCop.Analyzers\StyleCop.Analyzers.Test.CSharp7\bin\$Configuration\net46\StyleCop.Analyzers.Test.CSharp7.dll"
+
+If (Test-Path $symbols_folder) {
+	Remove-Item -Recurse -Force $symbols_folder
+}
+
+$symbols_folder_csharp6 = Join-Path $symbols_folder 'CSharp6'
+$symbols_folder_csharp7 = Join-Path $symbols_folder 'CSharp7'
+mkdir $symbols_folder | Out-Null
+mkdir $symbols_folder_csharp6 | Out-Null
+mkdir $symbols_folder_csharp7 | Out-Null
+
+function Convert-Coverage-Pdb() {
+	param (
+		[string]$assembly,
+		[string]$outputDir
+	)
+	$sourceDir = [IO.Path]::GetDirectoryName($assembly)
+	$outputName = [IO.Path]::ChangeExtension([IO.Path]::GetFileName($assembly), 'pdb')
+	$sourcePdb = Join-Path $sourceDir $outputName
+	$output = Join-Path $outputDir $outputName
+	if (Test-Path $sourcePdb) {
+		&$pdb2pdb $assembly /out $output
+
+		# Workaround for https://github.com/OpenCover/opencover/issues/800
+		Remove-Item $sourcePdb
+		Copy-Item $assembly $outputDir
+	}
+}
+
+function Extract-Coverage-Pdb() {
+	param (
+		[string]$assembly,
+		[string]$outputDir
+	)
+	$sourceDir = [IO.Path]::GetDirectoryName($assembly)
+	$outputName = [IO.Path]::ChangeExtension([IO.Path]::GetFileName($assembly), 'pdb')
+	$intermediatePdb = Join-Path $sourceDir $outputName
+	$output = Join-Path $outputDir $outputName
+	if (-not (Test-Path $output)) {
+		&$pdb2pdb $assembly /out $intermediatePdb /extract
+		if (Test-Path $intermediatePdb) {
+			&$pdb2pdb $assembly /pdb $intermediatePdb /out $output
+			Remove-Item $intermediatePdb
+
+			# Workaround for https://github.com/OpenCover/opencover/issues/800
+			Copy-Item $assembly $outputDir
+		}
+	}
+}
+
+$target_dir = [IO.Path]::GetDirectoryName($target_dll)
+Get-ChildItem $target_dir -Filter *.dll | Foreach-Object { Convert-Coverage-Pdb -assembly $_.FullName -outputDir $symbols_folder_csharp6 }
+Get-ChildItem $target_dir -Filter *.dll | Foreach-Object { Extract-Coverage-Pdb -assembly $_.FullName -outputDir $symbols_folder_csharp6 }
+
+$target_dir = [IO.Path]::GetDirectoryName($target_dll_csharp7)
+Get-ChildItem $target_dir -Filter *.dll | Foreach-Object { Convert-Coverage-Pdb -assembly $_.FullName -outputDir $symbols_folder_csharp7 }
+Get-ChildItem $target_dir -Filter *.dll | Foreach-Object { Extract-Coverage-Pdb -assembly $_.FullName -outputDir $symbols_folder_csharp7 }
 
 If (Test-Path $report_folder) {
 	Remove-Item -Recurse -Force $report_folder
@@ -55,6 +115,7 @@ If ($AppVeyor) {
 	-filter:"+[StyleCop*]*" `
 	-excludebyattribute:*.ExcludeFromCodeCoverage* `
 	-excludebyfile:*\*Designer.cs `
+	-searchdirs:"$symbols_folder_csharp6" `
 	-output:"$report_folder\OpenCover.StyleCopAnalyzers.xml" `
 	-target:"$xunit_runner_console" `
 	-targetargs:"$target_dll -noshadow $AppVeyorArg"
@@ -71,6 +132,7 @@ If ($AppVeyor -and -not $?) {
 	-filter:"+[StyleCop*]*" `
 	-excludebyattribute:*.ExcludeFromCodeCoverage* `
 	-excludebyfile:*\*Designer.cs `
+	-searchdirs:"$symbols_folder_csharp7" `
 	-output:"$report_folder\OpenCover.StyleCopAnalyzers.xml" `
 	-mergebyhash -mergeoutput `
 	-target:"$xunit_runner_console" `


### PR DESCRIPTION
* Fix the **opencover-report.ps1** script, and use it for AppVeyor builds
* Generate and package portable PDBs, which are much smaller and more easily consumed on other platforms
* Implement a conversion layer so we retain full OpenCover support even though the build is producing portable PDBs