### PR TITLE
support .stylecop.json configuration file name

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Settings/SettingsFileCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Settings/SettingsFileCodeFixProvider.cs
@@ -63,7 +63,7 @@ namespace StyleCop.Analyzers.Settings
             var workspace = project.Solution.Workspace;
 
             // check if the settings file already exists
-            if (project.AdditionalDocuments.Any(IsStyleCopSettingsDocument))
+            if (project.AdditionalDocuments.Any(document => SettingsHelper.IsStyleCopSettingsFile(document.Name)))
             {
                 return SpecializedTasks.CompletedTask;
             }
@@ -92,11 +92,6 @@ namespace StyleCop.Analyzers.Settings
         {
             // Added this to make it explicitly clear that this code fix does not support fix all actions.
             return null;
-        }
-
-        private static bool IsStyleCopSettingsDocument(TextDocument document)
-        {
-            return string.Equals(document.Name, SettingsHelper.SettingsFileName, StringComparison.OrdinalIgnoreCase);
         }
 
         private static Task<Solution> GetTransformedSolutionAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -179,7 +179,7 @@ namespace TestHelper
             if (!string.IsNullOrEmpty(settings))
             {
                 var documentId = DocumentId.CreateNewId(projectId);
-                solution = solution.AddAdditionalDocument(documentId, SettingsHelper.SettingsFileName, settings);
+                solution = solution.AddAdditionalDocument(documentId, this.GetSettingsFileName(), settings);
             }
 
             ParseOptions parseOptions = solution.GetProject(projectId).ParseOptions;
@@ -202,6 +202,15 @@ namespace TestHelper
         protected virtual string GetSettings()
         {
             return null;
+        }
+
+        /// <summary>
+        /// Gets the name of the settings file to use.
+        /// </summary>
+        /// <returns>The name of the settings file to use.</returns>
+        protected virtual string GetSettingsFileName()
+        {
+            return SettingsHelper.SettingsFileName;
         }
 
         protected DiagnosticResult CSharpDiagnostic(string diagnosticId = null)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Settings/SettingsFileCodeFixProviderUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Settings/SettingsFileCodeFixProviderUnitTests.cs
@@ -79,7 +79,7 @@ namespace NamespaceName
         public async Task TestDotPrefixedSettingsFileAlreadyExistsAsync()
         {
             this.createSettingsFile = true;
-            this.settingsFileName = $".{SettingsHelper.SettingsFileName}";
+            this.settingsFileName = SettingsHelper.AltSettingsFileName;
 
             var offeredFixes = await this.GetOfferedCSharpFixesAsync(TestCode).ConfigureAwait(false);
             Assert.Empty(offeredFixes);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Settings/SettingsFileCodeFixProviderUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Settings/SettingsFileCodeFixProviderUnitTests.cs
@@ -26,6 +26,7 @@ namespace NamespaceName
 ";
 
         private bool createSettingsFile;
+        private string settingsFileName = SettingsHelper.SettingsFileName;
 
         /// <summary>
         /// Verifies that a file without a header, but with leading trivia will produce the correct diagnostic message.
@@ -64,6 +65,21 @@ namespace NamespaceName
         public async Task TestSettingsFileAlreadyExistsAsync()
         {
             this.createSettingsFile = true;
+            this.settingsFileName = SettingsHelper.SettingsFileName;
+
+            var offeredFixes = await this.GetOfferedCSharpFixesAsync(TestCode).ConfigureAwait(false);
+            Assert.Empty(offeredFixes);
+        }
+
+        /// <summary>
+        /// Verifies that a code fix will not be offered if the settings file is already present.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestDotPrefixedSettingsFileAlreadyExistsAsync()
+        {
+            this.createSettingsFile = true;
+            this.settingsFileName = $".{SettingsHelper.SettingsFileName}";
 
             var offeredFixes = await this.GetOfferedCSharpFixesAsync(TestCode).ConfigureAwait(false);
             Assert.Empty(offeredFixes);
@@ -78,6 +94,12 @@ namespace NamespaceName
             }
 
             return null;
+        }
+
+        /// <inheritdoc/>
+        protected override string GetSettingsFileName()
+        {
+            return this.settingsFileName;
         }
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Settings/SettingsUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Settings/SettingsUnitTests.cs
@@ -309,6 +309,25 @@ namespace StyleCop.Analyzers.Test.Settings
         }
 
         [Fact]
+        public async Task VerifySettingsFileNameSupportsDotPrefixAsync()
+        {
+            var settings = @"
+{
+  ""settings"": {
+    ""documentationRules"": {
+      ""companyName"": ""TestCompany"",
+    },
+  }
+}
+";
+            var context = await CreateAnalysisContextAsync(settings, ".stylecop.json").ConfigureAwait(false);
+
+            var styleCopSettings = context.GetStyleCopSettings(CancellationToken.None);
+
+            Assert.Equal("TestCompany", styleCopSettings.DocumentationRules.CompanyName);
+        }
+
+        [Fact]
         public async Task VerifyInvalidJsonBehaviorAsync()
         {
             var settings = @"This is not a JSON file.";
@@ -334,7 +353,7 @@ namespace StyleCop.Analyzers.Test.Settings
             Assert.Equal("Copyright (c) PlaceholderCompany. All rights reserved.", styleCopSettings.DocumentationRules.GetCopyrightText("unused"));
         }
 
-        private static async Task<SyntaxTreeAnalysisContext> CreateAnalysisContextAsync(string stylecopJSON)
+        private static async Task<SyntaxTreeAnalysisContext> CreateAnalysisContextAsync(string stylecopJSON, string settingsFileName = SettingsHelper.SettingsFileName)
         {
             var projectId = ProjectId.CreateNewId();
             var documentId = DocumentId.CreateNewId(projectId);
@@ -347,7 +366,7 @@ namespace StyleCop.Analyzers.Test.Settings
             var document = solution.GetDocument(documentId);
             var syntaxTree = await document.GetSyntaxTreeAsync().ConfigureAwait(false);
 
-            var stylecopJSONFile = new AdditionalTextHelper(SettingsHelper.SettingsFileName, stylecopJSON);
+            var stylecopJSONFile = new AdditionalTextHelper(settingsFileName, stylecopJSON);
             var additionalFiles = ImmutableArray.Create<AdditionalText>(stylecopJSONFile);
             var analyzerOptions = new AnalyzerOptions(additionalFiles);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpecialRules/SA0002UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpecialRules/SA0002UnitTests.cs
@@ -278,7 +278,7 @@ namespace NamespaceName { }
             Assert.Null(additionalFiles[0].Path);
             Assert.Null(additionalFiles[0].GetText(CancellationToken.None));
             var context = new CompilationAnalysisContext(compilation: null, options: new AnalyzerOptions(additionalFiles), reportDiagnostic: null, isSupportedDiagnostic: null, cancellationToken: CancellationToken.None);
-            Assert.Throws<NullReferenceException>(() => analysisContext.CompilationAction(context));
+            Assert.Throws<ArgumentNullException>(() => analysisContext.CompilationAction(context));
         }
 
         /// <inheritdoc/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/SettingsHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/SettingsHelper.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers
 {
+    using System;
     using System.Collections.Immutable;
     using System.IO;
     using System.Threading;
@@ -18,6 +19,7 @@ namespace StyleCop.Analyzers
     internal static class SettingsHelper
     {
         internal const string SettingsFileName = "stylecop.json";
+        internal const string AltSettingsFileName = ".stylecop.json";
 
         private static readonly SourceTextValueProvider<StyleCopSettings> SettingsValueProvider =
             new SourceTextValueProvider<StyleCopSettings>(
@@ -73,14 +75,15 @@ namespace StyleCop.Analyzers
         /// <returns><c>true</c> if <paramref name="path"/> points to a StyleCop settings file; otherwise, <c>false</c>.</returns>
         internal static bool IsStyleCopSettingsFile(string path)
         {
-            var fileName = Path.GetFileName(path).ToLowerInvariant();
-
-            if (fileName.StartsWith("."))
+            if (path == null)
             {
-                fileName = fileName.Substring(1);
+                throw new ArgumentNullException(nameof(path));
             }
 
-            return fileName == SettingsFileName;
+            var fileName = Path.GetFileName(path);
+
+            return string.Equals(fileName, SettingsFileName, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(fileName, AltSettingsFileName, StringComparison.OrdinalIgnoreCase);
         }
 
         internal static StyleCopSettings GetStyleCopSettings(this AnalysisContext context, AnalyzerOptions options, CancellationToken cancellationToken)
@@ -90,8 +93,8 @@ namespace StyleCop.Analyzers
 
         internal static StyleCopSettings GetStyleCopSettings(this AnalysisContext context, AnalyzerOptions options, DeserializationFailureBehavior failureBehavior, CancellationToken cancellationToken)
         {
-            string settingsFileName;
-            SourceText text = TryGetStyleCopSettingsText(options, cancellationToken, out settingsFileName);
+            string settingsFilePath;
+            SourceText text = TryGetStyleCopSettingsText(options, cancellationToken, out settingsFilePath);
             if (text == null)
             {
                 return new StyleCopSettings();
@@ -108,7 +111,7 @@ namespace StyleCop.Analyzers
                 return settings;
             }
 
-            return GetStyleCopSettings(settingsFileName, text, failureBehavior);
+            return GetStyleCopSettings(settingsFilePath, text, failureBehavior);
         }
 
         internal static StyleCopSettings GetStyleCopSettings(this CompilationStartAnalysisContext context, AnalyzerOptions options, CancellationToken cancellationToken)
@@ -120,8 +123,8 @@ namespace StyleCop.Analyzers
         internal static StyleCopSettings GetStyleCopSettings(this CompilationStartAnalysisContext context, AnalyzerOptions options, DeserializationFailureBehavior failureBehavior, CancellationToken cancellationToken)
 #pragma warning restore RS1012 // Start action has no registered actions.
         {
-            string settingsFileName;
-            SourceText text = TryGetStyleCopSettingsText(options, cancellationToken, out settingsFileName);
+            string settingsFilePath;
+            SourceText text = TryGetStyleCopSettingsText(options, cancellationToken, out settingsFilePath);
             if (text == null)
             {
                 return new StyleCopSettings();
@@ -138,7 +141,7 @@ namespace StyleCop.Analyzers
                 return settings;
             }
 
-            return GetStyleCopSettings(settingsFileName, text, failureBehavior);
+            return GetStyleCopSettings(settingsFilePath, text, failureBehavior);
         }
 
         private static StyleCopSettings GetStyleCopSettings(string path, SourceText text, DeserializationFailureBehavior failureBehavior)
@@ -178,19 +181,19 @@ namespace StyleCop.Analyzers
             return new StyleCopSettings();
         }
 
-        private static SourceText TryGetStyleCopSettingsText(this AnalyzerOptions options, CancellationToken cancellationToken, out string settingsFileName)
+        private static SourceText TryGetStyleCopSettingsText(this AnalyzerOptions options, CancellationToken cancellationToken, out string settingsFilePath)
         {
             foreach (var additionalFile in options.AdditionalFiles)
             {
                 if (IsStyleCopSettingsFile(additionalFile.Path))
                 {
-                    settingsFileName = additionalFile.Path;
+                    settingsFilePath = additionalFile.Path;
 
                     return additionalFile.GetText(cancellationToken);
                 }
             }
 
-            settingsFileName = null;
+            settingsFilePath = null;
 
             return null;
         }

--- a/documentation/Configuration.md
+++ b/documentation/Configuration.md
@@ -18,6 +18,8 @@ Code analysis rule sets are the standard way to configure most diagnostic analyz
 
 The easiest way to add a **stylecop.json** configuration file to a new project is using a code fix provided by the project. To invoke the code fix, open any file where SA1633 is reported¹ and press Ctrl+. to bring up the Quick Fix menu. From the menu, select **Add StyleCop settings file to the project**.
 
+The dot file naming convention is also supported, which makes it possible to name the configuration file **.stylecop.json**.
+
 ### JSON Schema for IntelliSense
 
 A JSON schema is available for **stylecop.json**. By including a reference in **stylecop.json** to this schema, Visual Studio will offer IntelliSense functionality (code completion, quick info, etc.) while editing this file. The schema may be configured by adding the following top-level property in **stylecop.json**:


### PR DESCRIPTION
This PR adds dot file naming support for the StyleCop configuration file so that stylecop.json and .stylecop.json are supported file names. Just like many other configuration files (.gitignore, .appveyor.yml, .travis.yml, .codecov.yml, .editorconfig, ...) it would be nice if StyleCop would support this kind of configuration file naming convention.