### PR TITLE
Updated SA1118 to allow multi-line anonymous object creation expressions

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1118UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1118UnitTests.cs
@@ -142,6 +142,30 @@ class Foo
         }
 
         [Fact]
+        public async Task TestMethodCallWithTwoParametersSecondSpansMultipleLinesButIsAnonymousObjectCreationExpressionAsync()
+        {
+            var testCode = @"
+class Foo
+{
+    public void FunA(int i, object j)
+    {
+    }
+
+    public void FunB()
+    {
+        FunA(1,
+             new
+             {
+                 Foo = 1,
+                 Bar = 2,
+             });
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestMethodCallWithTwoParametersFirstIsMultilineSecondIsOneLineAsync()
         {
             var testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1118ParameterMustNotSpanMultipleLines.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1118ParameterMustNotSpanMultipleLines.cs
@@ -79,6 +79,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
             SyntaxKind.SimpleLambdaExpression,
             SyntaxKind.InvocationExpression,
             SyntaxKind.ObjectCreationExpression,
+            SyntaxKind.AnonymousObjectCreationExpression,
         };
 
         /// <inheritdoc/>


### PR DESCRIPTION
SA1118 allows multi-line object creation expressions (added in #2217). This change allows multi-line _anonymous_ object creation expressions like:

```
MyMethod(
    "SingleLine",
    new
    {
        Foo = 1,
    });
```

Fixes #2048, #2088.