### PR TITLE
Fix typo in SA1411 rule documentation

### DIFF
--- a/documentation/SA1411.md
+++ b/documentation/SA1411.md
@@ -23,7 +23,7 @@ An attribute declaration does not contain any parameters, yet it still includes 
 
 When an attribute declaration does not contain any parameters, the parenthesis around the parameters are optional.
 
-A violation of this rule occurs when unneccsary parenthesis have been used in an attribute constructor. For example:
+A violation of this rule occurs when unnecessary parenthesis have been used in an attribute constructor. For example:
 
 ```csharp
 [Serializable()]


### PR DESCRIPTION
Fix small typo in `unnecessary` word.