### PR TITLE
Update StyleCopTester

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="dotnet.myget.org roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/StyleCop.Analyzers/StyleCopTester/App.config
+++ b/StyleCop.Analyzers/StyleCopTester/App.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
-<configuration>
-    <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
-    </startup>
-</configuration>

--- a/StyleCop.Analyzers/StyleCopTester/Properties/launchSettings.json
+++ b/StyleCop.Analyzers/StyleCopTester/Properties/launchSettings.json
@@ -5,10 +5,6 @@
       "commandLineArgs": "..\\..\\StyleCopAnalyzers.sln /stats",
       "workingDirectory": "$(MSBuildProjectDirectory)",
       "environmentVariables": {
-        "MSBuildSDKsPath": "$(MSBuildSDKsPath)",
-        "MSBuildExtensionsPath": "$(MSBuildExtensionsPath)",
-        "VisualStudioVersion": "$(VisualStudioVersion)",
-        "VSINSTALLDIR": "$(VSAPPIDDIR)\\..\\..\\"
       }
     },
     "StyleCopAnalyzers.sln /stats /editperf": {
@@ -16,10 +12,6 @@
       "commandLineArgs": "..\\..\\StyleCopAnalyzers.sln /stats /editperf",
       "workingDirectory": "$(MSBuildProjectDirectory)",
       "environmentVariables": {
-        "MSBuildSDKsPath": "$(MSBuildSDKsPath)",
-        "MSBuildExtensionsPath": "$(MSBuildExtensionsPath)",
-        "VisualStudioVersion": "$(VisualStudioVersion)",
-        "VSINSTALLDIR": "$(VSAPPIDDIR)\\..\\..\\"
       }
     }
   }

--- a/StyleCop.Analyzers/StyleCopTester/Properties/launchSettings.json
+++ b/StyleCop.Analyzers/StyleCopTester/Properties/launchSettings.json
@@ -1,8 +1,15 @@
 {
   "profiles": {
     "StyleCopAnalyzers.sln /stats": {
+      "commandName": "Project",
       "commandLineArgs": "..\\..\\StyleCopAnalyzers.sln /stats",
-      "workingDirectory": "$(MSBuildProjectDirectory)"
+      "workingDirectory": "$(MSBuildProjectDirectory)",
+      "environmentVariables": {
+        "MSBuildSDKsPath": "$(MSBuildSDKsPath)",
+        "MSBuildExtensionsPath": "$(MSBuildExtensionsPath)",
+        "VisualStudioVersion": "$(VisualStudioVersion)",
+        "VSINSTALLDIR": "$(VSAPPIDDIR)\\..\\..\\"
+      }
     }
   }
 }

--- a/StyleCop.Analyzers/StyleCopTester/Properties/launchSettings.json
+++ b/StyleCop.Analyzers/StyleCopTester/Properties/launchSettings.json
@@ -10,6 +10,17 @@
         "VisualStudioVersion": "$(VisualStudioVersion)",
         "VSINSTALLDIR": "$(VSAPPIDDIR)\\..\\..\\"
       }
+    },
+    "StyleCopAnalyzers.sln /stats /editperf": {
+      "commandName": "Project",
+      "commandLineArgs": "..\\..\\StyleCopAnalyzers.sln /stats /editperf",
+      "workingDirectory": "$(MSBuildProjectDirectory)",
+      "environmentVariables": {
+        "MSBuildSDKsPath": "$(MSBuildSDKsPath)",
+        "MSBuildExtensionsPath": "$(MSBuildExtensionsPath)",
+        "VisualStudioVersion": "$(VisualStudioVersion)",
+        "VSINSTALLDIR": "$(VSAPPIDDIR)\\..\\..\\"
+      }
     }
   }
 }

--- a/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
+++ b/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
@@ -23,19 +23,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="15.3.409" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.3.409" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.3.409" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="1.2.1" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.0.13" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="	2.9.0-beta4-62830-01" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="	2.9.0-beta4-62830-01" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="	2.9.0-beta4-62830-01" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="	2.9.0-beta4-62830-01" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\StyleCop.Analyzers.CodeFixes\StyleCop.Analyzers.CodeFixes.csproj" />
     <ProjectReference Include="..\StyleCop.Analyzers\StyleCop.Analyzers.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="App.config" />
   </ItemGroup>
 
 </Project>

--- a/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
+++ b/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
@@ -3,7 +3,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net452</TargetFrameworks>
+    <TargetFrameworks>net46</TargetFrameworks>
+
+    <!-- Automatically generate the necessary assembly binding redirects -->
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -20,6 +23,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Build" Version="15.3.409" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.3.409" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="15.3.409" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="1.2.1" />
   </ItemGroup>
 


### PR DESCRIPTION
* Update to Microsoft.CodeAnalysis.Workspaces.MSBuild
    * Fixes support for SDK projects
    * Improves project analysis compatibility
* Support testing edit performance with `/editperf` and `/edititer`