### PR TITLE
Automatically include stylecop.json

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -44,7 +44,7 @@ Describes the configuration options for StyleCop.Analyzers
 
 **[How to enable the configuration](documentation/EnableConfiguration.md)**
 
-Describes how to enable the **stylecop.json** file for usage.
+Describes how to enable the **stylecop.json** file for usage in version 1.1.0 and below of the StyleCop.Analyzers package.
 
 **[Known changes](documentation/KnownChanges.md)**
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/StyleCop.Analyzers.nuspec
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/StyleCop.Analyzers.nuspec
@@ -29,6 +29,9 @@
     <file src="tools\install.ps1" target="tools\" />
     <file src="tools\uninstall.ps1" target="tools\" />
 
+    <!-- Build logic -->
+    <file src="build\**" target="build\" />
+
     <!-- Source code -->
     <file src="..\StyleCop.Analyzers\**\*.cs" exclude="..\StyleCop.Analyzers\obj\**\*.cs" target="src"/>
     <file src="**\*.cs" exclude="obj\**\*.cs;Properties\AssemblyInfo.cs" target="src"/>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/build/MSBuild15.props
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/build/MSBuild15.props
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Condition="Exists('stylecop.json')">
+    <!--
+      If stylecop.json exists in the project directory add it to <AdditionalFiles /> automatically.  The point of
+      this is that the user sees the file in Visual Studio Solution Explorer but they don't understand that they
+      need to add it to the <AdditionalFiles /> item group.
+      
+      1. Legacy project system - Files in the project directory are in an explicit <None /> item.
+      2. New project system - Files in the project directory are implicitly added to the <None /> item through a glob.
+    -->
+    <None Remove="stylecop.json" />
+
+    <AdditionalFiles Include="stylecop.json" Condition=" '@(AdditionalFiles->EndsWith('stylecop.json', System.StringComparison.OrdinalIgnoreCase))' != 'true' " />
+  </ItemGroup>
+
+  <ItemGroup Condition="!Exists('stylecop.json')">
+    <!--
+      If stylecop.json doesn't exist in the project directory, search parent directories for one.  This allows user
+      to simply create a file at the root of their repository and this will automatically include it.
+    -->
+    <AdditionalFiles Include="$([MSBuild]::GetPathOfFileAbove(stylecop.json, $(MSBuildProjectDirectory)..))"
+                     Condition=" '@(AdditionalFiles->EndsWith('stylecop.json', System.StringComparison.OrdinalIgnoreCase))' != 'true' And Exists('$([MSBuild]::GetPathOfFileAbove(stylecop.json, $(MSBuildProjectDirectory)..))')">
+      <!--
+        Show the file as a link as if its in the project directory so users can open it up in Visual Studio easily
+        and they know its affecting each project.
+      -->
+      <Link>stylecop.json</Link>
+    </AdditionalFiles>
+  </ItemGroup>
+</Project>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/build/MSBuildOld.props
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/build/MSBuildOld.props
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    This file is imported by versions of MSBuild older than 15.0 and must use compatible syntax.
+  -->
+
+  <ItemGroup Condition=" Exists('stylecop.json')">
+    <!--
+      If stylecop.json exists in the project directory add it to <AdditionalFiles /> automatically.  The point of
+      this is that the user sees the file in Visual Studio Solution Explorer but they don't understand that they
+      need to add it to the <AdditionalFiles /> item group.
+      
+      In this case, copy it to <AdditionalFiles /> and hide it so it doesn't show up twice and the user doesn't
+      have to do anything.
+    -->
+    <AdditionalFiles Include="stylecop.json">
+      <Visible>False</Visible>
+    </AdditionalFiles>
+  </ItemGroup>
+
+  <ItemGroup Condition=" !Exists('stylecop.json')">
+    <!--
+      If stylecop.json doesn't exist in the project directory, search parent directories for one.  This allows user
+      to simply create a file at the root of their repository and this will automatically include it.
+    -->
+    <AdditionalFiles Include="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory).., stylecop.json))\stylecop.json"
+                     Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory).., stylecop.json))\stylecop.json')">
+      <!--
+        Show the file as a link as if its in the project directory so users can open it up in Visual Studio easily
+        and they know its affecting each project.
+      -->
+      <Link>stylecop.json</Link>
+    </AdditionalFiles>
+  </ItemGroup>
+</Project>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/build/StyleCop.Analyzers.targets
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/build/StyleCop.Analyzers.targets
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<!--
+  Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+  Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--
+    Attempt to automatically include stylecop.json in the <AdditionalFiles /> item group.
+    
+    To disable this functionality, set the MSBuild property "AutoIncludeStyleCopJson" to "false".  Example:
+    
+    <PropertyGroup>
+      <AutoIncludeStyleCopJson>false</AutoIncludeStyleCopJson>
+    </PropertyGroup>
+  -->
+  <ImportGroup Condition=" '$(AutoIncludeStyleCopJson)' != 'false' ">
+    <!--
+      MSBuild 15.0+ has support for newer syntax that will cause project parsing errors so import the
+      appropriate file based on the version of MSBuild being used.
+    -->
+    <Import Project="MSBuild15.props"
+            Condition=" '$(MSBuildAssemblyVersion)' != '' And '$(MSBuildAssemblyVersion)' >= '15.0' " />
+    
+    <Import Project="MSBuildOld.props"
+            Condition=" '$(MSBuildAssemblyVersion)' == '' Or '$(MSBuildAssemblyVersion)' &lt; '15.0' " />
+
+  </ImportGroup>
+</Project>

--- a/build/version.ps1
+++ b/build/version.ps1
@@ -1,1 +1,1 @@
-$Version = "1.1.0-dev"
+$Version = "1.2.0-dev"

--- a/documentation/EnableConfiguration.md
+++ b/documentation/EnableConfiguration.md
@@ -1,8 +1,15 @@
 ﻿# Enabling **stylecop.json**
 
-At this time, the code fix is not able to fully configure the newly-created **stylecop.json** file for use. This is
-tracked in bug report [dotnet/roslyn#4655](https://github.com/dotnet/roslyn/issues/4655). In the mean time, users must
-manually perform the following additional steps after creating the **stylecop.json** file.
+## StyleCop.Analyzers v1.2 and above
+
+If you are using version 1.1.1 or newer, you no longer need to include stylecop.json using the methods below.  It is
+automatically included if it is next to the project or in a directory above the project.  
+
+## StyleCop.Analyzers v1.1 and below
+
+For older versions of the StyleCop.Analyzers package (v1.1.0 and below), the code fix is not able to fully configure the
+ newly-created **stylecop.json** file for use. This is tracked in bug report [dotnet/roslyn#4655](https://github.com/dotnet/roslyn/issues/4655).
+In the mean time, users must manually perform the following additional steps after creating the **stylecop.json** file.
 
 In Visual Studio 2017:
 


### PR DESCRIPTION
For legacy projects and older MSBuild, simply add the item as hidden and it will show up as a None item but still be passed as an AdditionalFiles item

For newer MSBuild, remove stylecop.json from None and add it to AdditionalFiles unless its already been done by the user.

Fixes #2698