### PR TITLE
Update SA1629 to analyze the content of paragraphs

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1629UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1629UnitTests.cs
@@ -644,6 +644,88 @@ public interface ITest
             await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
+        [Fact]
+        [WorkItem(2712, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2712")]
+        public async Task TestExceptionElementsWithStandardFormAsync()
+        {
+            var testCode = @"
+using System;
+public interface ITest
+{
+    /// <exception cref=""ArgumentNullException"">
+    /// <para>If <paramref name=""name""/> is <see langword=""null""/></para>
+    /// <para>-or-</para>
+    /// <para>If <paramref name=""value""/> is <see langword=""null""/></para>
+    /// </exception>
+    void Method(string name, string value);
+}
+";
+
+            var fixedTestCode = @"
+using System;
+public interface ITest
+{
+    /// <exception cref=""ArgumentNullException"">
+    /// <para>If <paramref name=""name""/> is <see langword=""null""/>.</para>
+    /// <para>-or-</para>
+    /// <para>If <paramref name=""value""/> is <see langword=""null""/>.</para>
+    /// </exception>
+    void Method(string name, string value);
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(6, 67),
+                this.CSharpDiagnostic().WithLocation(8, 68),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(2712, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2712")]
+        public async Task TestExceptionElementsWithAlternateFormAsync()
+        {
+            var testCode = @"
+using System;
+public interface ITest
+{
+    /// <exception cref=""ArgumentNullException"">
+    /// <para>If <paramref name=""name""/> is <see langword=""null""/></para>
+    /// -or-
+    /// <para>If <paramref name=""value""/> is <see langword=""null""/></para>
+    /// </exception>
+    void Method(string name, string value);
+}
+";
+
+            var fixedTestCode = @"
+using System;
+public interface ITest
+{
+    /// <exception cref=""ArgumentNullException"">
+    /// <para>If <paramref name=""name""/> is <see langword=""null""/>.</para>
+    /// -or-
+    /// <para>If <paramref name=""value""/> is <see langword=""null""/>.</para>
+    /// </exception>
+    void Method(string name, string value);
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(6, 67),
+                this.CSharpDiagnostic().WithLocation(8, 68),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
         protected override Project ApplyCompilationOptions(Project project)
         {
             var resolver = new TestXmlReferenceResolver();

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1629UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1629UnitTests.cs
@@ -449,6 +449,201 @@ public interface ITest
             await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
         }
 
+        [Fact]
+        public async Task TestMultipleParagraphBlocksAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// <para>Paragraph 1</para>
+/// <para>Paragraph 2</para>
+/// <para>Paragraph 3</para>
+/// </summary>
+public interface ITest
+{
+}
+";
+
+            var fixedTestCode = @"
+/// <summary>
+/// <para>Paragraph 1.</para>
+/// <para>Paragraph 2.</para>
+/// <para>Paragraph 3.</para>
+/// </summary>
+public interface ITest
+{
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(3, 22),
+                this.CSharpDiagnostic().WithLocation(4, 22),
+                this.CSharpDiagnostic().WithLocation(5, 22),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMultipleParagraphInlinesAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Paragraph 1
+/// <para/>
+/// Paragraph 2
+/// <para/>
+/// Paragraph 3
+/// </summary>
+public interface ITest
+{
+}
+";
+
+            var fixedTestCode = @"
+/// <summary>
+/// Paragraph 1.
+/// <para/>
+/// Paragraph 2.
+/// <para/>
+/// Paragraph 3.
+/// </summary>
+public interface ITest
+{
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(3, 16),
+                this.CSharpDiagnostic().WithLocation(5, 16),
+                this.CSharpDiagnostic().WithLocation(7, 16),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMultipleParagraphBlocksAfterFirstAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Paragraph 1
+/// <para>Paragraph 2</para>
+/// <para>Paragraph 3</para>
+/// </summary>
+public interface ITest
+{
+}
+";
+
+            var fixedTestCode = @"
+/// <summary>
+/// Paragraph 1.
+/// <para>Paragraph 2.</para>
+/// <para>Paragraph 3.</para>
+/// </summary>
+public interface ITest
+{
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(3, 16),
+                this.CSharpDiagnostic().WithLocation(4, 22),
+                this.CSharpDiagnostic().WithLocation(5, 22),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMultipleParagraphBlocksAfterFirstInNoteAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Paragraph 0
+/// <note>
+/// Paragraph 1
+/// <para>Paragraph 2</para>
+/// <para>Paragraph 3</para>
+/// </note>
+/// </summary>
+public interface ITest
+{
+}
+";
+
+            var fixedTestCode = @"
+/// <summary>
+/// Paragraph 0.
+/// <note>
+/// Paragraph 1.
+/// <para>Paragraph 2.</para>
+/// <para>Paragraph 3.</para>
+/// </note>
+/// </summary>
+public interface ITest
+{
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(3, 16),
+                this.CSharpDiagnostic().WithLocation(5, 16),
+                this.CSharpDiagnostic().WithLocation(6, 22),
+                this.CSharpDiagnostic().WithLocation(7, 22),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestCodeBetweenParagraphBlocksAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Paragraph 1
+/// <code>Code block</code>
+/// <para>Paragraph 2</para>
+/// </summary>
+public interface ITest
+{
+}
+";
+
+            var fixedTestCode = @"
+/// <summary>
+/// Paragraph 1.
+/// <code>Code block</code>
+/// <para>Paragraph 2.</para>
+/// </summary>
+public interface ITest
+{
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                this.CSharpDiagnostic().WithLocation(3, 16),
+                this.CSharpDiagnostic().WithLocation(5, 22),
+            };
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
         protected override Project ApplyCompilationOptions(Project project)
         {
             var resolver = new TestXmlReferenceResolver();

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1629UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1629UnitTests.cs
@@ -487,6 +487,38 @@ public interface ITest
         }
 
         [Fact]
+        public async Task TestMultipleParagraphBlocksWithColonsAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// <para>Paragraph 1:</para>
+/// <para>Paragraph 2:</para>
+/// <para>Paragraph 3:</para>
+/// </summary>
+public interface ITest
+{
+}
+";
+
+            var fixedTestCode = @"
+/// <summary>
+/// <para>Paragraph 1:</para>
+/// <para>Paragraph 2:</para>
+/// <para>Paragraph 3:.</para>
+/// </summary>
+public interface ITest
+{
+}
+";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithLocation(5, 23);
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpDiagnosticAsync(fixedTestCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await this.VerifyCSharpFixAsync(testCode, fixedTestCode).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestMultipleParagraphInlinesAsync()
         {
             var testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1629DocumentationTextMustEndWithAPeriod.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1629DocumentationTextMustEndWithAPeriod.cs
@@ -120,7 +120,8 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                         if (!string.IsNullOrEmpty(textWithoutTrailingWhitespace))
                         {
-                            if (!textWithoutTrailingWhitespace.EndsWith(".", StringComparison.Ordinal))
+                            if (!textWithoutTrailingWhitespace.EndsWith(".", StringComparison.Ordinal)
+                                && !textWithoutTrailingWhitespace.EndsWith("-or-", StringComparison.Ordinal))
                             {
                                 var location = Location.Create(xmlElement.SyntaxTree, new TextSpan(textToken.SpanStart + textWithoutTrailingWhitespace.Length, 1));
                                 context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1629DocumentationTextMustEndWithAPeriod.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1629DocumentationTextMustEndWithAPeriod.cs
@@ -78,7 +78,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         {
             foreach (var xmlElement in syntaxList.OfType<XmlElementSyntax>())
             {
-                HandleSectionOrBlockXmlElement(context, xmlElement);
+                HandleSectionOrBlockXmlElement(context, xmlElement, startingWithFinalParagraph: true);
             }
         }
 
@@ -101,7 +101,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             }
         }
 
-        private static void HandleSectionOrBlockXmlElement(SyntaxNodeAnalysisContext context, XmlElementSyntax xmlElement)
+        private static void HandleSectionOrBlockXmlElement(SyntaxNodeAnalysisContext context, XmlElementSyntax xmlElement, bool startingWithFinalParagraph)
         {
             if (xmlElement.StartTag?.Name?.LocalName.ValueText == XmlCommentHelper.SeeAlsoXmlTag)
             {
@@ -121,6 +121,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                         if (!string.IsNullOrEmpty(textWithoutTrailingWhitespace))
                         {
                             if (!textWithoutTrailingWhitespace.EndsWith(".", StringComparison.Ordinal)
+                                && (startingWithFinalParagraph || !textWithoutTrailingWhitespace.EndsWith(":", StringComparison.Ordinal))
                                 && !textWithoutTrailingWhitespace.EndsWith("-or-", StringComparison.Ordinal))
                             {
                                 var location = Location.Create(xmlElement.SyntaxTree, new TextSpan(textToken.SpanStart + textWithoutTrailingWhitespace.Length, 1));
@@ -145,7 +146,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                     case XmlCommentHelper.NoteXmlTag:
                     case XmlCommentHelper.ParaXmlTag:
                         // Recursively handle <note> and <para> elements
-                        HandleSectionOrBlockXmlElement(context, childXmlElement);
+                        HandleSectionOrBlockXmlElement(context, childXmlElement, startingWithFinalParagraph);
                         break;
 
                     default:
@@ -155,6 +156,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                     if (childXmlElement.IsBlockElement())
                     {
                         currentParagraphDone = false;
+                        startingWithFinalParagraph = false;
                     }
                 }
                 else if (xmlElement.Content[i] is XmlEmptyElementSyntax emptyElement)
@@ -163,6 +165,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                     if (emptyElement.Name?.LocalName.ValueText == XmlCommentHelper.ParaXmlTag)
                     {
                         currentParagraphDone = false;
+                        startingWithFinalParagraph = false;
                     }
                 }
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1629DocumentationTextMustEndWithAPeriod.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1629DocumentationTextMustEndWithAPeriod.cs
@@ -78,41 +78,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         {
             foreach (var xmlElement in syntaxList.OfType<XmlElementSyntax>())
             {
-                if (xmlElement.StartTag?.Name?.LocalName.ValueText == XmlCommentHelper.SeeAlsoXmlTag)
-                {
-                    continue;
-                }
-
-                var elementDone = false;
-                for (var i = xmlElement.Content.Count - 1; !elementDone && (i >= 0); i--)
-                {
-                    if (xmlElement.Content[i] is XmlTextSyntax contentNode)
-                    {
-                        for (var j = contentNode.TextTokens.Count - 1; !elementDone && (j >= 0); j--)
-                        {
-                            var textToken = contentNode.TextTokens[j];
-                            var textWithoutTrailingWhitespace = textToken.Text.TrimEnd(' ', '\r', '\n');
-
-                            if (!string.IsNullOrEmpty(textWithoutTrailingWhitespace))
-                            {
-                                if (!textWithoutTrailingWhitespace.EndsWith(".", StringComparison.Ordinal))
-                                {
-                                    var location = Location.Create(xmlElement.SyntaxTree, new TextSpan(textToken.SpanStart + textWithoutTrailingWhitespace.Length, 1));
-                                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));
-                                }
-
-                                elementDone = true;
-                            }
-                        }
-                    }
-                    else if (xmlElement.Content[i].IsInlineElement())
-                    {
-                        // Treat empty XML elements as a "word not ending with a period"
-                        var location = Location.Create(xmlElement.SyntaxTree, new TextSpan(xmlElement.Content[i].Span.End, 1));
-                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));
-                        elementDone = true;
-                    }
-                }
+                HandleSectionXmlElement(context, xmlElement);
             }
         }
 
@@ -131,6 +97,45 @@ namespace StyleCop.Analyzers.DocumentationRules
                         // only report a single instance of the diagnostic, as they will all be reported on the same location anyway.
                         break;
                     }
+                }
+            }
+        }
+
+        private static void HandleSectionXmlElement(SyntaxNodeAnalysisContext context, XmlElementSyntax xmlElement)
+        {
+            if (xmlElement.StartTag?.Name?.LocalName.ValueText == XmlCommentHelper.SeeAlsoXmlTag)
+            {
+                return;
+            }
+
+            var elementDone = false;
+            for (var i = xmlElement.Content.Count - 1; !elementDone && (i >= 0); i--)
+            {
+                if (xmlElement.Content[i] is XmlTextSyntax contentNode)
+                {
+                    for (var j = contentNode.TextTokens.Count - 1; !elementDone && (j >= 0); j--)
+                    {
+                        var textToken = contentNode.TextTokens[j];
+                        var textWithoutTrailingWhitespace = textToken.Text.TrimEnd(' ', '\r', '\n');
+
+                        if (!string.IsNullOrEmpty(textWithoutTrailingWhitespace))
+                        {
+                            if (!textWithoutTrailingWhitespace.EndsWith(".", StringComparison.Ordinal))
+                            {
+                                var location = Location.Create(xmlElement.SyntaxTree, new TextSpan(textToken.SpanStart + textWithoutTrailingWhitespace.Length, 1));
+                                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));
+                            }
+
+                            elementDone = true;
+                        }
+                    }
+                }
+                else if (xmlElement.Content[i].IsInlineElement())
+                {
+                    // Treat empty XML elements as a "word not ending with a period"
+                    var location = Location.Create(xmlElement.SyntaxTree, new TextSpan(xmlElement.Content[i].Span.End, 1));
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));
+                    elementDone = true;
                 }
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
@@ -23,6 +23,10 @@ namespace StyleCop.Analyzers.Helpers
         internal const string ValueXmlTag = "value";
         internal const string CXmlTag = "c";
         internal const string SeeXmlTag = "see";
+        internal const string CodeXmlTag = "code";
+        internal const string ListXmlTag = "list";
+        internal const string NoteXmlTag = "note";
+        internal const string ParaXmlTag = "para";
         internal const string SeeAlsoXmlTag = "seealso";
         internal const string ParamXmlTag = "param";
         internal const string ParamRefXmlTag = "paramref";
@@ -284,6 +288,16 @@ namespace StyleCop.Analyzers.Helpers
             return false;
         }
 
+        internal static bool IsBlockElement(this XmlNodeSyntax nodeSyntax)
+        {
+            if (nodeSyntax is XmlElementSyntax elementSyntax)
+            {
+                return IsBlockElement(elementSyntax.StartTag?.Name?.LocalName.ValueText);
+            }
+
+            return false;
+        }
+
         private static bool IsInlineElement(string localName)
         {
             switch (localName)
@@ -292,6 +306,21 @@ namespace StyleCop.Analyzers.Helpers
             case ParamRefXmlTag:
             case SeeXmlTag:
             case TypeParamRefXmlTag:
+                return true;
+
+            default:
+                return false;
+            }
+        }
+
+        private static bool IsBlockElement(string localName)
+        {
+            switch (localName)
+            {
+            case CodeXmlTag:
+            case ListXmlTag:
+            case NoteXmlTag:
+            case ParaXmlTag:
                 return true;
 
             default:


### PR DESCRIPTION
Expands analysis to include `<para>` and `<note>` elements.

Fixes #2712 