### PR TITLE
docs: Add missing slashes to example .props file

### DIFF
--- a/documentation/Configuration.md
+++ b/documentation/Configuration.md
@@ -622,8 +622,8 @@ Example `.props` file:
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CodeAnalysisRuleSetLocation Condition=" '$(NuGetPackageRoot)' != '' ">$(NuGetPackageRoot)acme.stylecop\1.0.0</CodeAnalysisRuleSetLocation>
-    <CodeAnalysisRuleSetLocation Condition=" '$(CodeAnalysisRuleSetLocation)' == '' and '$(SolutionDir)' != '' ">$(SolutionDir)packages\acme.stylecop.1.0.0</CodeAnalysisRuleSetLocation>
+    <CodeAnalysisRuleSetLocation Condition=" '$(NuGetPackageRoot)' != '' ">$(NuGetPackageRoot)\acme.stylecop\1.0.0</CodeAnalysisRuleSetLocation>
+    <CodeAnalysisRuleSetLocation Condition=" '$(CodeAnalysisRuleSetLocation)' == '' and '$(SolutionDir)' != '' ">$(SolutionDir)\packages\acme.stylecop.1.0.0</CodeAnalysisRuleSetLocation>
     <CodeAnalysisRuleSetLocation Condition=" '$(CodeAnalysisRuleSetLocation)' == '' ">$([System.IO.Path]::GetDirectoryName($(MSBuildProjectDirectory)))\packages\acme.stylecop.1.0.0</CodeAnalysisRuleSetLocation>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
Before this change, I would get a "cannot find file" error for some of these files. After the change, the build process finds the files.