### PR TITLE
Allow double underscore as lambda parameter name

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
@@ -401,8 +401,8 @@ public class Test : Testbase
         }
 
         [Fact]
-        [WorkItem(1343, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1343")]
-        public async Task TestLambdaParameterMultipleUnderscoresAsync()
+        [WorkItem(1606, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1606")]
+        public async Task TestLambdaParameterNamedDoubleUnderscoreAsync()
         {
             var testCode = @"public class TypeName
 {
@@ -414,11 +414,49 @@ public class Test : Testbase
     }
 }";
 
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies this diagnostic does not check whether or not a parameter named <c>__</c> is being used.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        [Fact]
+        [WorkItem(1606, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1606")]
+        public async Task TestLambdaParameterNamedDoubleUnderscoreUsageAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        System.Func<int, int> function1 = __ => __;
+        System.Func<int, int> function2 = (__) => __;
+        System.Func<int, int> function3 = delegate(int __) { return __; };
+    }
+}";
+
+            await this.VerifyCSharpDiagnosticAsync(testCode, EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(1343, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1343")]
+        public async Task TestLambdaParameterWithThreeUnderscoresAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        System.Action<int> action1 = ___ => { };
+        System.Action<int> action2 = (___) => { };
+        System.Action<int> action3 = delegate(int ___) { };
+    }
+}";
+
             DiagnosticResult[] expected =
             {
-                this.CSharpDiagnostic().WithArguments("__").WithLocation(5, 38),
-                this.CSharpDiagnostic().WithArguments("__").WithLocation(6, 39),
-                this.CSharpDiagnostic().WithArguments("__").WithLocation(7, 51),
+                this.CSharpDiagnostic().WithArguments("___").WithLocation(5, 38),
+                this.CSharpDiagnostic().WithArguments("___").WithLocation(6, 39),
+                this.CSharpDiagnostic().WithArguments("___").WithLocation(7, 51),
             };
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
             await this.VerifyCSharpFixAsync(testCode, testCode).ConfigureAwait(false);
@@ -436,6 +474,21 @@ public class Test : Testbase
 }";
 
             DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("_").WithLocation(3, 32);
+            await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(1606, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1606")]
+        public async Task TestMethodParameterNamedDoubleUnderscoreAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName(int __)
+    {
+    }
+}";
+
+            DiagnosticResult expected = this.CSharpDiagnostic().WithArguments("__").WithLocation(3, 32);
             await this.VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1313ParameterNamesMustBeginWithLowerCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1313ParameterNamesMustBeginWithLowerCaseLetter.cs
@@ -17,8 +17,8 @@ namespace StyleCop.Analyzers.NamingRules
     /// <remarks>
     /// <para>A violation of this rule occurs when the name of a parameter does not begin with a lower-case letter.</para>
     ///
-    /// <para>An exception to this rule is made for lambda parameters named <c>_</c>. These parameters are often used to
-    /// designate a placeholder parameter which is not actually used in the body of the lambda expression.</para>
+    /// <para>An exception to this rule is made for lambda parameters named <c>_</c> and <c>__</c>. These parameters are
+    /// often used to designate a placeholder parameter which is not actually used in the body of the lambda expression.</para>
     ///
     /// <para>If the parameter name is intended to match the name of an item associated with Win32 or COM, and thus
     /// needs to begin with an upper-case letter, place the parameter within a special <c>NativeMethods</c> class. A
@@ -76,7 +76,7 @@ namespace StyleCop.Analyzers.NamingRules
                 return;
             }
 
-            if (name == "_" && IsInLambda(syntax))
+            if ((name == "_" || name == "__") && IsInLambda(syntax))
             {
                 return;
             }

--- a/documentation/KnownChanges.md
+++ b/documentation/KnownChanges.md
@@ -199,6 +199,10 @@ This rule is disabled by default in StyleCop Analyzers, but can be enabled by us
 :warning: StyleCop Analyzers does not report SA1305 for parameters in overriding methods and methods which implement an
 interface. StyleCop Classic reported SA1305 for all methods.
 
+### SA1313
+
+StyleCop Analyzers allows the single and double underscore (`_` and `__`) as lambda parameter names.
+
 ## Maintainability Rules
 
 There are no known changes at this time.

--- a/documentation/SA1313.md
+++ b/documentation/SA1313.md
@@ -25,7 +25,7 @@ The name of a parameter in C# does not begin with a lower-case letter.
 
 A violation of this rule occurs when the name of a parameter does not begin with a lower-case letter.
 
-An exception to this rule is made for lambda parameters named `_`. These parameters are often used to designate a
+An exception to this rule is made for lambda parameters named `_` and `__`. These parameters are often used to designate a
 placeholder parameter which is not actually used in the body of the lambda expression.
 
 If the parameter name is intended to match the name of an item associated with Win32 or COM, and thus needs to begin


### PR DESCRIPTION
Closes #1606 using https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/1443/commits/58e7be66a6765d77b48ad69f360e2986ae946db1 as prior art.

⚠Tests `SA1100UnitTests.TestIndexerAsync` and `SA1100UnitTests.TestIndexerWithInvokationAsync` were failing immediately after cloning using ReSharper's runner, before any changes were made.