### PR TITLE
Fixed ISymbol equality comparisons

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Status.Generator/SolutionReader.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Status.Generator/SolutionReader.cs
@@ -262,7 +262,7 @@ namespace StyleCop.Analyzers.Status.Generator
 
                 // We use the fact that the only parameter that returns a boolean is the one we are interested in
                 var enabledByDefaultParameter = from argument in initializer.ArgumentList.Arguments
-                                                where model.GetTypeInfo(argument.Expression).Type == this.booleanType
+                                                where Equals(model.GetTypeInfo(argument.Expression).Type, this.booleanType)
                                                 select argument.Expression;
                 var parameter = enabledByDefaultParameter.FirstOrDefault();
                 string parameterString = parameter.ToString();
@@ -296,7 +296,7 @@ namespace StyleCop.Analyzers.Status.Generator
 
             var noCodeFixAttribute = classSymbol
                 .GetAttributes()
-                .SingleOrDefault(x => x.AttributeClass == this.noCodeFixAttributeTypeSymbol);
+                .SingleOrDefault(x => Equals(x.AttributeClass, this.noCodeFixAttributeTypeSymbol));
 
             bool hasCodeFix = noCodeFixAttribute == null;
             if (!hasCodeFix)
@@ -356,7 +356,7 @@ namespace StyleCop.Analyzers.Status.Generator
         {
             while (declaration != null)
             {
-                if (declaration == possibleBaseType)
+                if (declaration.Equals(possibleBaseType))
                 {
                     return true;
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/StandardTextDiagnosticBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/StandardTextDiagnosticBase.cs
@@ -167,7 +167,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             }
 
             INamedTypeSymbol expectedSymbol = semanticModel.GetDeclaredSymbol(constructorDeclarationSyntax.Parent, context.CancellationToken) as INamedTypeSymbol;
-            return actualSymbol.OriginalDefinition == expectedSymbol;
+            return Equals(actualSymbol.OriginalDefinition, expectedSymbol);
         }
 
         private static bool SeeTagIsCorrect(SyntaxNodeAnalysisContext context, XElement classReferencePart, BaseMethodDeclarationSyntax constructorDeclarationSyntax)
@@ -193,7 +193,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             }
 
             INamedTypeSymbol expectedSymbol = semanticModel.GetDeclaredSymbol(constructorDeclarationSyntax.Parent, context.CancellationToken) as INamedTypeSymbol;
-            return actualSymbol.OriginalDefinition == expectedSymbol;
+            return Equals(actualSymbol.OriginalDefinition, expectedSymbol);
         }
 
         private static bool TextPartsMatch(string firstText, string secondText, XmlTextSyntax firstTextPart, XmlTextSyntax secondTextPart)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1404CodeAnalysisSuppressionMustHaveJustification.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1404CodeAnalysisSuppressionMustHaveJustification.cs
@@ -118,7 +118,7 @@ namespace StyleCop.Analyzers.MaintainabilityRules
                         this.suppressMessageAttribute = context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(SuppressMessageAttribute).FullName);
                     }
 
-                    if (symbol.ContainingType == this.suppressMessageAttribute)
+                    if (Equals(symbol.ContainingType, this.suppressMessageAttribute))
                     {
                         foreach (var attributeArgument in attribute.ArgumentList.Arguments)
                         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SystemDiagnosticsDebugDiagnosticBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SystemDiagnosticsDebugDiagnosticBase.cs
@@ -34,7 +34,7 @@ namespace StyleCop.Analyzers.MaintainabilityRules
                 {
                     var debugType = context.SemanticModel.Compilation.GetTypeByMetadataName(typeof(Debug).FullName);
 
-                    if (symbolInfo.ContainingType == debugType
+                    if (Equals(symbolInfo.ContainingType, debugType)
                         && symbolInfo.Name == methodName)
                     {
                         if ((invocationExpressionSyntax.ArgumentList?.Arguments.Count ?? 0) <= parameterIndex)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1313ParameterNamesMustBeginWithLowerCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1313ParameterNamesMustBeginWithLowerCaseLetter.cs
@@ -146,7 +146,7 @@ namespace StyleCop.Analyzers.NamingRules
                 {
                     foreach (var member in implementedInterface.GetMembers(methodSymbol.Name).OfType<IMethodSymbol>())
                     {
-                        if (containingType.FindImplementationForInterfaceMember(member) == methodSymbol)
+                        if (methodSymbol.Equals(containingType.FindImplementationForInterfaceMember(member)))
                         {
                             return member.Parameters[index].Name == syntax.Identifier.ValueText;
                         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists.cs
@@ -112,7 +112,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
             }
 
             var speculativeSymbol = context.SemanticModel.GetSpeculativeSymbolInfo(parent.SpanStart, speculativeExpression, SpeculativeBindingOption.BindAsExpression);
-            if (speculativeSymbol.Symbol != targetSymbol.Symbol)
+            if (!targetSymbol.Symbol.Equals(speculativeSymbol.Symbol))
             {
                 return;
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1130UseLambdaSyntax.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1130UseLambdaSyntax.cs
@@ -117,7 +117,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
                 var invocationExpression = originalInvocationExpression.ReplaceNode(anonymousMethod, lambdaExpression);
                 SymbolInfo newSymbolInfo = semanticModel.GetSpeculativeSymbolInfo(location.SourceSpan.Start, invocationExpression, SpeculativeBindingOption.BindAsExpression);
 
-                if (originalSymbolInfo.Symbol != newSymbolInfo.Symbol)
+                if (!originalSymbolInfo.Symbol.Equals(newSymbolInfo.Symbol))
                 {
                     return false;
                 }


### PR DESCRIPTION
Fixes the broken tests mentioned in https://github.com/DotNetAnalyzers/StyleCopAnalyzers/pull/2758.