### PR TITLE
Clarify that SA1135 was not in StyleCop Classic

### DIFF
--- a/documentation/SA1135.md
+++ b/documentation/SA1135.md
@@ -15,6 +15,8 @@
 </tr>
 </table>
 
+:memo: This rule is new for StyleCop Analyzers, and was not present in StyleCop Classic.
+
 ## Cause
 
 A using directive is not qualified.


### PR DESCRIPTION
Fixes #2782.