### PR TITLE
Adopt Nerdbank.GitVersioning

### DIFF
--- a/StyleCop.Analyzers/Directory.Build.props
+++ b/StyleCop.Analyzers/Directory.Build.props
@@ -7,10 +7,6 @@
     <Company>Tunnel Vision Laboratories, LLC</Company>
     <Copyright>Copyright © Tunnel Vision Laboratories, LLC 2015</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>
-
-    <Version>1.1.0.40</Version>
-    <FileVersion>1.1.0.40</FileVersion>
-    <InformationalVersion>1.1.0-dev</InformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -39,6 +35,10 @@
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <NoWarn>$(NoWarn),1573,1591</NoWarn>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/StyleCop.Analyzers.CodeFixes.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/StyleCop.Analyzers.CodeFixes.csproj
@@ -6,8 +6,14 @@
     <RootNamespace>StyleCop.Analyzers</RootNamespace>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeSymbols>true</IncludeSymbols>
-    <NuspecFile>StyleCop.Analyzers.nuspec</NuspecFile>
-    <NuspecProperties>configuration=$(Configuration);version=$(InformationalVersion)</NuspecProperties>
+
+    <NuspecFile Condition="'$(MetadataPackage)' != 'true'">StyleCop.Analyzers.nuspec</NuspecFile>
+    <NuspecFile Condition="'$(MetadataPackage)' == 'true'">StyleCop.Analyzers.Metadata.nuspec</NuspecFile>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- This package intentionally uses SemVer 2. -->
+    <NoWarn>$(NoWarn),NU5105</NoWarn>
   </PropertyGroup>
 
   <Choose>
@@ -40,5 +46,39 @@
   <ItemGroup>
     <ProjectReference Include="..\StyleCop.Analyzers\StyleCop.Analyzers.csproj" />
   </ItemGroup>
+
+  <Target Name="SetNuspecProperties" AfterTargets="GetBuildVersion">
+    <PropertyGroup>
+      <BaseNuspecId>StyleCop.Analyzers</BaseNuspecId>
+      <ImplementationNuspecId>$(BaseNuspecId)</ImplementationNuspecId>
+      <MetadataNuspecId>$(BaseNuspecId)</MetadataNuspecId>
+
+      <ImplementationNuspecId Condition="'$(PrereleaseVersion)' != ''">$(BaseNuspecId).Unstable</ImplementationNuspecId>
+      <MetadataNuspecId Condition="'$(PrereleaseVersion)' == ''">$(BaseNuspecId).Unstable</MetadataNuspecId>
+
+      <NuspecId Condition="'$(MetadataPackage)' != 'true'">$(ImplementationNuspecId)</NuspecId>
+      <NuspecId Condition="'$(MetadataPackage)' == 'true'">$(MetadataNuspecId)</NuspecId>
+
+      <NuspecUnstableVersion>$(AssemblyVersion)</NuspecUnstableVersion>
+      <NuspecUnstableVersion Condition="'$(PublicRelease)' != 'true'">$(NuspecUnstableVersion)-g$(GitCommitIdShort)</NuspecUnstableVersion>
+      <NuspecStableVersion>$(PackageVersion)</NuspecStableVersion>
+
+      <UnstablePackage Condition="('$(PrereleaseVersion)' != '' AND '$(MetadataPackage)' != 'true') OR ('$(PrereleaseVersion)' == '' AND '$(MetadataPackage)' == 'true')">true</UnstablePackage>
+
+      <NuspecVersion Condition="'$(UnstablePackage)' != 'true'">$(NuspecStableVersion)</NuspecVersion>
+      <NuspecVersion Condition="'$(UnstablePackage)' == 'true'">$(NuspecUnstableVersion)</NuspecVersion>
+
+      <ImplementationNuspecVersion Condition="'$(PrereleaseVersion)' != ''">$(NuspecUnstableVersion)</ImplementationNuspecVersion>
+      <ImplementationNuspecVersion Condition="'$(PrereleaseVersion)' == ''">$(NuspecStableVersion)</ImplementationNuspecVersion>
+
+      <NuspecProperties>id=$(NuspecId);configuration=$(Configuration);GitCommitIdShort=$(GitCommitIdShort);version=$(NuspecVersion);tag=$(NuspecStableVersion);implId=$(ImplementationNuspecId);implVersion=$(ImplementationNuspecVersion)</NuspecProperties>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="PackMetadata" AfterTargets="Pack" Condition="'$(MetadataPackage)' != 'true'">
+    <MSBuild Projects="$(MSBuildProjectFullPath)"
+             Targets="Pack"
+             Properties="MetadataPackage=true;IncludeSymbols=false" />
+  </Target>
 
 </Project>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/StyleCop.Analyzers.Metadata.nuspec
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/StyleCop.Analyzers.Metadata.nuspec
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0"?>
+<package>
+  <metadata minClientVersion="2.7">
+    <id>$id$</id>
+    <version>0.0.0</version>
+    <title>$id$</title>
+    <authors>Sam Harwell et. al.</authors>
+    <owners>Sam Harwell</owners>
+    <licenseUrl>https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/$GitCommitIdShort$/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/DotNetAnalyzers/StyleCopAnalyzers</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>An implementation of StyleCop's rules using Roslyn analyzers and code fixes</description>
+    <releaseNotes>https://github.com/DotNetAnalyzers/StyleCopAnalyzers/releases/$tag$</releaseNotes>
+    <copyright>Copyright 2015 Tunnel Vision Laboratories, LLC</copyright>
+    <tags>StyleCop DotNetAnalyzers Roslyn Diagnostic Analyzer</tags>
+    <developmentDependency>true</developmentDependency>
+    <dependencies>
+      <dependency id="$implId$" version="$implVersion$"/>
+    </dependencies>
+  </metadata>
+  <files>
+
+    <!-- Additional Files -->
+    <file src="..\..\LICENSE" />
+    <file src="..\..\THIRD-PARTY-NOTICES.txt" />
+
+  </files>
+</package>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/StyleCop.Analyzers.nuspec
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/StyleCop.Analyzers.nuspec
@@ -1,21 +1,25 @@
 ﻿<?xml version="1.0"?>
 <package>
   <metadata minClientVersion="2.7">
-    <id>StyleCop.Analyzers</id>
+    <id>$id$</id>
     <version>0.0.0</version>
-    <title>StyleCop.Analyzers</title>
+    <title>$id$</title>
     <authors>Sam Harwell et. al.</authors>
     <owners>Sam Harwell</owners>
-    <licenseUrl>https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/$version$/LICENSE</licenseUrl>
+    <licenseUrl>https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/$GitCommitIdShort$/LICENSE</licenseUrl>
     <projectUrl>https://github.com/DotNetAnalyzers/StyleCopAnalyzers</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>An implementation of StyleCop's rules using Roslyn analyzers and code fixes</description>
-    <releaseNotes>https://github.com/DotNetAnalyzers/StyleCopAnalyzers/releases/$version$</releaseNotes>
-    <copyright>Copyright Sam Harwell 2015</copyright>
+    <releaseNotes>https://github.com/DotNetAnalyzers/StyleCopAnalyzers/releases/$tag$</releaseNotes>
+    <copyright>Copyright 2015 Tunnel Vision Laboratories, LLC</copyright>
     <tags>StyleCop DotNetAnalyzers Roslyn Diagnostic Analyzer</tags>
     <developmentDependency>true</developmentDependency>
   </metadata>
   <files>
+
+    <!-- Additional Files -->
+    <file src="..\..\LICENSE" />
+    <file src="..\..\THIRD-PARTY-NOTICES.txt" />
 
     <!-- Binaries and symbols -->
     <file src="bin\$Configuration$\netstandard1.1\StyleCop.Analyzers.dll" target="analyzers\dotnet\cs" />

--- a/StyleCop.Analyzers/version.json
+++ b/StyleCop.Analyzers/version.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://raw.githubusercontent.com/AArnott/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "1.1.0-beta.{height}",
+  // The build number offset accounts for the delay in adopting Nerdbank.GitVersioning
+  "buildNumberOffset": 40,
+  "assemblyVersion": {
+    "precision": "revision"
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$"
+  ],
+  "nugetPackageVersion": {
+    "semVer": 2
+  },
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,22 +1,38 @@
-version: 1.0.{build}
+version: '{build}'
 image: Visual Studio 2017
 init:
 - git config --global core.autocrlf true
+configuration:
+- Debug
+- Release
 before_build:
 - nuget restore
+skip_tags: true
 build:
   project: StyleCopAnalyzers.sln
   verbosity: minimal
 test_script:
 - cd build
-- ps: .\opencover-report.ps1 -Debug -NoBuild -NoReport -AppVeyor
+- ps: |
+    if ($env:Configuration -eq 'Debug') {
+      .\opencover-report.ps1 -Debug -NoBuild -NoReport -AppVeyor
+      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+      $packageConfig = [xml](Get-Content ..\.nuget\packages.config)
+      $codecov_version = $packageConfig.SelectSingleNode('/packages/package[@id="Codecov"]').version
+      $codecov = "..\packages\Codecov.$codecov_version\tools\codecov.exe"
+      &$codecov -f '..\build\OpenCover.Reports\OpenCover.StyleCopAnalyzers.xml'
+    } else {
+      .\opencover-report.ps1 -NoBuild -NoReport -AppVeyor
+      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
+    }
 - cd ..
-- .\packages\Codecov.1.1.0\tools\codecov.exe -f ".\build\OpenCover.Reports\OpenCover.StyleCopAnalyzers.xml"
-- .\StyleCop.Analyzers\StyleCop.Analyzers.Status.Generator\bin\Debug\net46\StyleCop.Analyzers.Status.Generator.exe .\StyleCopAnalyzers.sln > StyleCop.Analyzers.Status.json
+- .\StyleCop.Analyzers\StyleCop.Analyzers.Status.Generator\bin\%Configuration%\net46\StyleCop.Analyzers.Status.Generator.exe .\StyleCopAnalyzers.sln > StyleCop.Analyzers.Status.json
 cache:
   - packages -> **\packages.config
   - C:\Users\appveyor\.nuget\packages -> appveyor.yml
+
+# 'Release' is hard-coded to ensure VSIX and NuGet artifacts are only published for release configuration builds
 artifacts:
-- path: 'StyleCop.Analyzers\**\*.vsix'
-- path: 'StyleCop.Analyzers\**\*.nupkg'
+- path: 'StyleCop.Analyzers\StyleCop.Analyzers.Vsix\bin\Release\net452\*.vsix'
+- path: 'StyleCop.Analyzers\StyleCop.Analyzers.CodeFixes\bin\Release\*.nupkg'
 - path: 'StyleCop.Analyzers.Status.json'

--- a/docs/index.html
+++ b/docs/index.html
@@ -173,7 +173,7 @@
     </script>
 
     <script type="text/javascript">
-        $.getJSON("https://ci.appveyor.com/api/projects/sharwell/stylecopanalyzers/artifacts/StyleCop.Analyzers.Status.json?branch=master&pr=false&stream=true", function (data) {
+        $.getJSON("https://ci.appveyor.com/api/projects/sharwell/stylecopanalyzers/artifacts/StyleCop.Analyzers.Status.json?branch=master&pr=false&stream=true&job=Configuration:%20Release", function (data) {
             $("#renderedDiagnostics").html($.templates($("#diagnostics").html()).render(data));
             $("#renderedCommitInfo").html($.templates($("#commitInfo").html()).render(data.git));
         });


### PR DESCRIPTION
* Create a new package StyleCop.Analyzers.Unstable which avoids the use
  of prerelease version numbers
* Use SemVer 2 for the prereleases of StyleCop.Analyzers
* Avoid the need to publish builds from dedicated release branches

Implements https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2585#issuecomment-397678483