### PR TITLE
Suppress CS1712 (Type parameter 'type_parameter' has no matching typeparam tag)

### DIFF
--- a/StyleCop.Analyzers/Directory.Build.props
+++ b/StyleCop.Analyzers/Directory.Build.props
@@ -35,9 +35,10 @@
 
       CS1573: Parameter 'parameter' has no matching param tag in the XML comment for 'parameter' (but other parameters do)
       CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+      CS1712: Type parameter 'type_parameter' has no matching typeparam tag in the XML comment on 'type_or_member' (but other type parameters do)
     -->
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
-    <NoWarn>$(NoWarn),1573,1591</NoWarn>
+    <NoWarn>$(NoWarn),1573,1591,1712</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update to follow the current recommendation in SA0001.