### PR TITLE
Fix that SA1130 crashes on an overload resolution failure

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1130UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1130UnitTests.cs
@@ -380,5 +380,29 @@ namespace StyleCopDemo
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
+
+        [Fact]
+        public async Task TestOverloadResolutionFailureAsync()
+        {
+            var testCode = @"
+using System;
+using System.Linq.Expressions;
+public class TypeName
+{
+    public void Test(string argument)
+    {
+
+    }
+
+    public void Test()
+    {
+        Test(delegate { });
+    }
+}";
+
+            var expected = DiagnosticResult.CompilerError("CS1660").WithLocation(13, 14);
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1130UseLambdaSyntax.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1130UseLambdaSyntax.cs
@@ -99,6 +99,13 @@ namespace StyleCop.Analyzers.ReadabilityRules
             if (originalInvocationExpression != null)
             {
                 SymbolInfo originalSymbolInfo = semanticModel.GetSymbolInfo(originalInvocationExpression);
+
+                if (originalSymbolInfo.Symbol == null)
+                {
+                    // The most likely cause for this is an overload resolution failure.
+                    return false;
+                }
+
                 Location location = originalInvocationExpression.GetLocation();
 
                 var argumentIndex = argumentListSyntax.Arguments.IndexOf(argumentSyntax);


### PR DESCRIPTION
This was found using the Tester on the monodevelop source.