### PR TITLE
Fix that SA1130 crashes on params

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1130UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1130UnitTests.cs
@@ -380,5 +380,47 @@ namespace StyleCopDemo
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
+
+        [Fact]
+        public async Task TestParamsAsync()
+        {
+            var testCode = @"
+using System;
+public class TypeName
+{
+    public void Test(params Action[] argument)
+    {
+
+    }
+
+    public void Test()
+    {
+        Test(delegate { }, delegate { });
+    }
+}";
+
+            string fixedCode = @"
+using System;
+public class TypeName
+{
+    public void Test(params Action[] argument)
+    {
+
+    }
+
+    public void Test()
+    {
+        Test(() => { }, () => { });
+    }
+}";
+
+            var expected = new[]
+            {
+                Diagnostic().WithLocation(12, 14),
+                Diagnostic().WithLocation(12, 28),
+            };
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1130UseLambdaSyntax.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1130UseLambdaSyntax.cs
@@ -55,7 +55,25 @@ namespace StyleCop.Analyzers.ReadabilityRules
         /// <returns>A parameter list for the delegate parameters.</returns>
         internal static ParameterListSyntax GetDelegateParameterList(IMethodSymbol methodSymbol, int argumentIndex)
         {
-            var delegateType = (INamedTypeSymbol)methodSymbol.Parameters[argumentIndex].Type;
+            var realIndex = Math.Min(argumentIndex, methodSymbol.Parameters.Length - 1);
+
+            var type = methodSymbol.Parameters[realIndex].Type;
+
+            if (methodSymbol.Parameters[realIndex].IsParams)
+            {
+                if (type is IArrayTypeSymbol arrayTypeSymbol)
+                {
+                    type = arrayTypeSymbol.ElementType;
+                }
+                else
+                {
+                    // Just to make sure that we do not crash if in future versions of the compiler other types are allowed for params.
+                    // This if statement should be extended if e.g. Span params are introduced into the language.
+                    return null;
+                }
+            }
+
+            var delegateType = (INamedTypeSymbol)type;
             var delegateParameters = delegateType.DelegateInvokeMethod.Parameters;
 
             var syntaxParameters = GetSyntaxParametersFromSymbolParameters(delegateParameters);
@@ -95,8 +113,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
             // invocation -> argument list -> argument -> anonymous method
             var argumentListSyntax = argumentSyntax?.Parent as ArgumentListSyntax;
 
-            var originalInvocationExpression = argumentListSyntax?.Parent as InvocationExpressionSyntax;
-            if (originalInvocationExpression != null)
+            if (argumentListSyntax?.Parent is InvocationExpressionSyntax originalInvocationExpression)
             {
                 SymbolInfo originalSymbolInfo = semanticModel.GetSymbolInfo(originalInvocationExpression);
                 Location location = originalInvocationExpression.GetLocation();
@@ -105,6 +122,12 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
                 // Determine the parameter list from the method that is invoked, as delegates without parameters are allowed, but they cannot be replaced by a lambda without parameters.
                 var parameterList = GetDelegateParameterList((IMethodSymbol)originalSymbolInfo.Symbol, argumentIndex);
+
+                if (parameterList == null)
+                {
+                    // This might happen if the call was using params witha type unknown to the analyzer, e.g. params Span<T>.
+                    return false;
+                }
 
                 // In some cases passing a delegate as an argument to a method is required to call the right overload
                 // When there is an other overload that takes an expression.


### PR DESCRIPTION
This was found using the Tester on the monodevelop source.