### PR TITLE
Fix path mapping in reports for codecov.io

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -7,6 +7,8 @@ coverage:
       default: false
     patch:
       default: false
+  fixes:
+    - "build/StyleCop.Analyzers/::StyleCop.Analyzers/"
 
 comment:
   layout: "diff"


### PR DESCRIPTION
Fixes failure to compare coverage reports following #2803