### PR TITLE
Fix incorrect style key in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -33,7 +33,7 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
-csharp_new_line_within_query_expression_clauses = true
+csharp_new_line_between_query_expression_clauses = true
 
 # Indentation preferences
 csharp_indent_block_contents = true


### PR DESCRIPTION
https://github.com/dotnet/roslyn/blob/2e9e83b7cb1d30a3f9c77b6c96c422493905ff4d/src/Workspaces/CSharp/Portable/Formatting/CSharpFormattingOptions.cs#L400