### PR TITLE
IsAnalyzerSuppressed improvement

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/FileHeaderTestBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/FileHeaderTestBase.cs
@@ -4,13 +4,13 @@
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
 
     /// <summary>
@@ -97,6 +97,9 @@ namespace Bar
         protected virtual IEnumerable<string> GetDisabledDiagnostics()
             => new[] { FileHeaderAnalyzers.SA1639Descriptor.Id };
 
+        protected virtual IEnumerable<string> GetExplicitlyEnabledDiagnostics()
+            => Enumerable.Empty<string>();
+
         protected Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken)
             => this.VerifyCSharpFixAsync(source, new[] { expected }, fixedSource: null, cancellationToken);
 
@@ -121,6 +124,7 @@ namespace Bar
             test.ExpectedDiagnostics.AddRange(expected);
             test.RemainingDiagnostics.AddRange(remainingDiagnostics);
             test.DisabledDiagnostics.AddRange(this.GetDisabledDiagnostics());
+            test.ExplicitlyEnabledDiagnostics.AddRange(this.GetExplicitlyEnabledDiagnostics());
             return test.RunAsync(cancellationToken);
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1639UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1639UnitTests.cs
@@ -91,5 +91,11 @@ namespace Bar
         {
             return Enumerable.Empty<string>();
         }
+
+        /// <inheritdoc/>
+        protected override IEnumerable<string> GetExplicitlyEnabledDiagnostics()
+        {
+            yield return FileHeaderAnalyzers.SA1639Descriptor.Id;
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/StyleCopCodeFixVerifier`2.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/StyleCopCodeFixVerifier`2.cs
@@ -177,6 +177,27 @@ namespace StyleCop.Analyzers.Test.Verifiers
             /// </value>
             public string SettingsFileName { get; set; } = SettingsHelper.SettingsFileName;
 
+            /// <summary>
+            /// Gets the list of diagnostic identifier that will be explicitly enabled in the compilation options.
+            /// </summary>
+            /// <value>
+            /// The list of explicitly enabled diagnostic identifiers.
+            /// </value>
+            public List<string> ExplicitlyEnabledDiagnostics { get; } = new List<string>();
+
+            protected override CompilationOptions CreateCompilationOptions()
+            {
+                var compilationOptions = base.CreateCompilationOptions();
+                var specificDiagnosticOptions = compilationOptions.SpecificDiagnosticOptions;
+
+                foreach (var id in this.ExplicitlyEnabledDiagnostics)
+                {
+                    specificDiagnosticOptions = specificDiagnosticOptions.SetItem(id, ReportDiagnostic.Warn);
+                }
+
+                return compilationOptions.WithSpecificDiagnosticOptions(specificDiagnosticOptions);
+            }
+
             protected override IEnumerable<CodeFixProvider> GetCodeFixProviders()
             {
                 var codeFixProvider = new TCodeFix();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
@@ -182,7 +182,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             var compilation = context.Compilation;
 
             // Disabling SA1633 will disable all other header related diagnostics.
-            if (!compilation.IsAnalyzerSuppressed(SA1633Identifier))
+            if (!compilation.IsAnalyzerSuppressed(SA1633DescriptorMissing))
             {
                 context.RegisterSyntaxTreeAction((ctx, settings) => Analyzer.HandleSyntaxTree(ctx, settings, compilation));
             }
@@ -215,12 +215,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                         return;
                     }
 
-                    if (!compilation.IsAnalyzerSuppressed(SA1634Identifier))
+                    if (!compilation.IsAnalyzerSuppressed(SA1634Descriptor))
                     {
                         CheckCopyrightHeader(context, settings.DocumentationRules, compilation, fileHeader);
                     }
 
-                    if (!compilation.IsAnalyzerSuppressed(SA1639Identifier))
+                    if (!compilation.IsAnalyzerSuppressed(SA1639Descriptor))
                     {
                         CheckSummaryHeader(context, compilation, fileHeader);
                     }
@@ -234,7 +234,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                         return;
                     }
 
-                    if (!compilation.IsAnalyzerSuppressed(SA1635Identifier))
+                    if (!compilation.IsAnalyzerSuppressed(SA1635Descriptor))
                     {
                         if (string.IsNullOrWhiteSpace(fileHeader.CopyrightText))
                         {
@@ -242,7 +242,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                             return;
                         }
 
-                        if (compilation.IsAnalyzerSuppressed(SA1636Identifier))
+                        if (compilation.IsAnalyzerSuppressed(SA1636Descriptor))
                         {
                             return;
                         }
@@ -265,17 +265,17 @@ namespace StyleCop.Analyzers.DocumentationRules
                     return;
                 }
 
-                if (!compilation.IsAnalyzerSuppressed(SA1637Identifier))
+                if (!compilation.IsAnalyzerSuppressed(SA1637Descriptor))
                 {
                     CheckFile(context, compilation, fileHeader, copyrightElement);
                 }
 
-                if (!compilation.IsAnalyzerSuppressed(SA1640Identifier))
+                if (!compilation.IsAnalyzerSuppressed(SA1640Descriptor))
                 {
                     CheckCompanyName(context, documentationSettings, compilation, fileHeader, copyrightElement);
                 }
 
-                if (!compilation.IsAnalyzerSuppressed(SA1635Identifier))
+                if (!compilation.IsAnalyzerSuppressed(SA1635Descriptor))
                 {
                     CheckCopyrightText(context, documentationSettings, compilation, fileHeader, copyrightElement);
                 }
@@ -291,7 +291,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                     return;
                 }
 
-                if (compilation.IsAnalyzerSuppressed(SA1638Identifier))
+                if (compilation.IsAnalyzerSuppressed(SA1638Descriptor))
                 {
                     return;
                 }
@@ -314,7 +314,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                     return;
                 }
 
-                if (compilation.IsAnalyzerSuppressed(SA1636Identifier))
+                if (compilation.IsAnalyzerSuppressed(SA1636Descriptor))
                 {
                     return;
                 }
@@ -345,7 +345,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                     return;
                 }
 
-                if (compilation.IsAnalyzerSuppressed(SA1641Identifier))
+                if (compilation.IsAnalyzerSuppressed(SA1641Descriptor))
                 {
                     return;
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DiagnosticOptionsHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DiagnosticOptionsHelper.cs
@@ -19,44 +19,52 @@ namespace StyleCop.Analyzers.Helpers
         /// Determines if the diagnostic identified by the given identifier is currently suppressed.
         /// </summary>
         /// <param name="context">The context that will be used to determine if the diagnostic is currently suppressed.</param>
-        /// <param name="diagnosticId">The diagnostic identifier to check.</param>
+        /// <param name="descriptor">The diagnostic descriptor to check.</param>
         /// <returns>True if the diagnostic is currently suppressed.</returns>
-        internal static bool IsAnalyzerSuppressed(this SyntaxNodeAnalysisContext context, string diagnosticId)
+        internal static bool IsAnalyzerSuppressed(this SyntaxNodeAnalysisContext context, DiagnosticDescriptor descriptor)
         {
-            return context.SemanticModel.Compilation.IsAnalyzerSuppressed(diagnosticId);
+            return context.SemanticModel.Compilation.IsAnalyzerSuppressed(descriptor);
         }
 
         /// <summary>
         /// Determines if the diagnostic identified by the given identifier is currently suppressed.
         /// </summary>
         /// <param name="context">The context that will be used to determine if the diagnostic is currently suppressed.</param>
-        /// <param name="diagnosticId">The diagnostic identifier to check.</param>
+        /// <param name="descriptor">The diagnostic descriptor to check.</param>
         /// <returns>True if the diagnostic is currently suppressed.</returns>
-        internal static bool IsAnalyzerSuppressed(this CompilationStartAnalysisContext context, string diagnosticId)
+        internal static bool IsAnalyzerSuppressed(this CompilationStartAnalysisContext context, DiagnosticDescriptor descriptor)
         {
-            return context.Compilation.IsAnalyzerSuppressed(diagnosticId);
+            return context.Compilation.IsAnalyzerSuppressed(descriptor);
         }
 
         /// <summary>
         /// Determines if the diagnostic identified by the given identifier is currently suppressed.
         /// </summary>
         /// <param name="compilation">The compilation that will be used to determine if the diagnostic is currently suppressed.</param>
-        /// <param name="diagnosticId">The diagnostic identifier to check.</param>
+        /// <param name="descriptor">The diagnostic descriptor to check.</param>
         /// <returns>True if the diagnostic is currently suppressed.</returns>
-        internal static bool IsAnalyzerSuppressed(this Compilation compilation, string diagnosticId)
+        internal static bool IsAnalyzerSuppressed(this Compilation compilation, DiagnosticDescriptor descriptor)
         {
-            return compilation.Options.IsAnalyzerSuppressed(diagnosticId);
+            return compilation.Options.IsAnalyzerSuppressed(descriptor);
         }
 
         /// <summary>
         /// Determines if the diagnostic identified by the given identifier is currently suppressed.
         /// </summary>
         /// <param name="compilationOptions">The compilation options that will be used to determine if the diagnostic is currently suppressed.</param>
-        /// <param name="diagnosticId">The diagnostic identifier to check.</param>
+        /// <param name="descriptor">The diagnostic descriptor to check.</param>
         /// <returns>True if the diagnostic is currently suppressed.</returns>
-        internal static bool IsAnalyzerSuppressed(this CompilationOptions compilationOptions, string diagnosticId)
+        internal static bool IsAnalyzerSuppressed(this CompilationOptions compilationOptions, DiagnosticDescriptor descriptor)
         {
-            return compilationOptions.SpecificDiagnosticOptions.GetValueOrDefault(diagnosticId, ReportDiagnostic.Default) == ReportDiagnostic.Suppress;
+            switch (compilationOptions.SpecificDiagnosticOptions.GetValueOrDefault(descriptor.Id))
+            {
+            case ReportDiagnostic.Suppress:
+                return true;
+            case ReportDiagnostic.Default:
+                return !descriptor.IsEnabledByDefault;
+            default:
+                return false;
+            }
         }
 
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501StatementMustNotBeOnASingleLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1501StatementMustNotBeOnASingleLine.cs
@@ -82,7 +82,7 @@ namespace StyleCop.Analyzers.LayoutRules
         private static void HandleCompilationStart(CompilationStartAnalysisContext context)
         {
             // If SA1503 is suppressed, we need to handle compound blocks as well.
-            if (context.IsAnalyzerSuppressed(SA1503BracesMustNotBeOmitted.DiagnosticId))
+            if (context.IsAnalyzerSuppressed(SA1503BracesMustNotBeOmitted.Descriptor))
             {
                 context.RegisterSyntaxNodeAction(HandleIfStatement, SyntaxKind.IfStatement);
                 context.RegisterSyntaxNodeAction(ctx => CheckChildStatement(ctx, ctx.Node, ((DoStatementSyntax)ctx.Node).Statement), SyntaxKind.DoStatement);
@@ -146,7 +146,7 @@ namespace StyleCop.Analyzers.LayoutRules
                 }
             }
 
-            if (!context.IsAnalyzerSuppressed(SA1520UseBracesConsistently.DiagnosticId))
+            if (!context.IsAnalyzerSuppressed(SA1520UseBracesConsistently.Descriptor))
             {
                 // inconsistencies will be reported as SA1520, as long as it's not suppressed
                 if (clauses.OfType<BlockSyntax>().Any())
@@ -190,7 +190,7 @@ namespace StyleCop.Analyzers.LayoutRules
                 return;
             }
 
-            if (!context.IsAnalyzerSuppressed(SA1519BracesMustNotBeOmittedFromMultiLineChildStatement.DiagnosticId))
+            if (!context.IsAnalyzerSuppressed(SA1519BracesMustNotBeOmittedFromMultiLineChildStatement.Descriptor))
             {
                 // diagnostics for multi-line statements is handled by SA1519, as long as it's not suppressed
                 FileLinePositionSpan lineSpan = childStatement.GetLineSpan();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503BracesMustNotBeOmitted.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1503BracesMustNotBeOmitted.cs
@@ -61,13 +61,17 @@ namespace StyleCop.Analyzers.LayoutRules
         /// The ID for diagnostics produced by the <see cref="SA1503BracesMustNotBeOmitted"/> analyzer.
         /// </summary>
         public const string DiagnosticId = "SA1503";
+
+        /// <summary>
+        /// The diagnostic descriptor for the <see cref="SA1503BracesMustNotBeOmitted"/> analyzer.
+        /// </summary>
+        public static readonly DiagnosticDescriptor Descriptor =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.LayoutRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+
         private const string Title = "Braces should not be omitted";
         private const string MessageFormat = "Braces should not be omitted";
         private const string Description = "The opening and closing braces for a C# statement have been omitted.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1503.md";
-
-        private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.LayoutRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
         private static readonly Action<SyntaxNodeAnalysisContext> IfStatementAction = HandleIfStatement;
         private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> UsingStatementAction = HandleUsingStatement;
@@ -111,7 +115,7 @@ namespace StyleCop.Analyzers.LayoutRules
                 }
             }
 
-            if (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA1520UseBracesConsistently.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
+            if (!context.IsAnalyzerSuppressed(SA1520UseBracesConsistently.Descriptor))
             {
                 // inconsistencies will be reported as SA1520, as long as it's not suppressed
                 if (clauses.OfType<BlockSyntax>().Any())
@@ -144,7 +148,7 @@ namespace StyleCop.Analyzers.LayoutRules
                 return;
             }
 
-            if (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA1519BracesMustNotBeOmittedFromMultiLineChildStatement.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
+            if (!context.IsAnalyzerSuppressed(SA1519BracesMustNotBeOmittedFromMultiLineChildStatement.Descriptor))
             {
                 // diagnostics for multi-line statements is handled by SA1519, as long as it's not suppressed
                 FileLinePositionSpan lineSpan = childStatement.GetLineSpan();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1507CodeMustNotContainMultipleBlankLinesInARow.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1507CodeMustNotContainMultipleBlankLinesInARow.cs
@@ -46,13 +46,17 @@ namespace StyleCop.Analyzers.LayoutRules
         /// analyzer.
         /// </summary>
         public const string DiagnosticId = "SA1507";
+
+        /// <summary>
+        /// The diagnostic descriptor for the <see cref="SA1507CodeMustNotContainMultipleBlankLinesInARow"/> analyzer.
+        /// </summary>
+        public static readonly DiagnosticDescriptor Descriptor =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.LayoutRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+
         private const string Title = "Code should not contain multiple blank lines in a row";
         private const string MessageFormat = "Code should not contain multiple blank lines in a row";
         private const string Description = "The C# code contains multiple blank lines in a row.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1507.md";
-
-        private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.LayoutRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
         private static readonly Action<SyntaxTreeAnalysisContext> SyntaxTreeAction = HandleSyntaxTree;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1512SingleLineCommentsMustNotBeFollowedByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1512SingleLineCommentsMustNotBeFollowedByBlankLine.cs
@@ -103,11 +103,10 @@ namespace StyleCop.Analyzers.LayoutRules
 
         private static void HandleCompilationStart(CompilationStartAnalysisContext context)
         {
-            var diagnosticOptions = context.Compilation.Options.SpecificDiagnosticOptions;
-            context.RegisterSyntaxTreeAction(c => HandleSyntaxTreeAnalysis(c, diagnosticOptions));
+            context.RegisterSyntaxTreeAction(c => HandleSyntaxTreeAnalysis(c, context.Compilation));
         }
 
-        private static void HandleSyntaxTreeAnalysis(SyntaxTreeAnalysisContext context, ImmutableDictionary<string, ReportDiagnostic> specificDiagnosticOptions)
+        private static void HandleSyntaxTreeAnalysis(SyntaxTreeAnalysisContext context, Compilation compilation)
         {
             var syntaxRoot = context.Tree.GetRoot(context.CancellationToken);
 
@@ -144,7 +143,7 @@ namespace StyleCop.Analyzers.LayoutRules
                 }
                 else if (trailingBlankLineCount > 1)
                 {
-                    if (specificDiagnosticOptions.GetValueOrDefault(SA1507CodeMustNotContainMultipleBlankLinesInARow.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
+                    if (!compilation.IsAnalyzerSuppressed(SA1507CodeMustNotContainMultipleBlankLinesInARow.Descriptor))
                     {
                         // ignore comments that are followed by multiple blank lines -> the multiple blank lines will be reported by SA1507
                         continue;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1519BracesMustNotBeOmittedFromMultiLineChildStatement.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1519BracesMustNotBeOmittedFromMultiLineChildStatement.cs
@@ -36,13 +36,17 @@ namespace StyleCop.Analyzers.LayoutRules
         /// The ID for diagnostics produced by the <see cref="SA1519BracesMustNotBeOmittedFromMultiLineChildStatement"/> analyzer.
         /// </summary>
         public const string DiagnosticId = "SA1519";
+
+        /// <summary>
+        /// The diagnostic descriptor for the <see cref="SA1519BracesMustNotBeOmittedFromMultiLineChildStatement"/> analyzer.
+        /// </summary>
+        public static readonly DiagnosticDescriptor Descriptor =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.LayoutRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+
         private const string Title = "Braces should not be omitted from multi-line child statement";
         private const string MessageFormat = "Braces should not be omitted from multi-line child statement";
         private const string Description = "The opening and closing braces for a multi-line C# statement have been omitted.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1519.md";
-
-        private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.LayoutRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
         private static readonly Action<SyntaxNodeAnalysisContext> IfStatementAction = HandleIfStatement;
         private static readonly Action<SyntaxNodeAnalysisContext> DoStatementAction = HandleDoStatement;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1520UseBracesConsistently.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1520UseBracesConsistently.cs
@@ -42,13 +42,17 @@ namespace StyleCop.Analyzers.LayoutRules
         /// The ID for diagnostics produced by the <see cref="SA1520UseBracesConsistently"/> analyzer.
         /// </summary>
         public const string DiagnosticId = "SA1520";
+
+        /// <summary>
+        /// The diagnostic descriptor for the <see cref="SA1520UseBracesConsistently"/> analyzer.
+        /// </summary>
+        public static readonly DiagnosticDescriptor Descriptor =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.LayoutRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+
         private const string Title = "Use braces consistently";
         private const string MessageFormat = "Use braces consistently";
         private const string Description = "The opening and closing braces of a chained if/else if/else construct were included for some clauses, but omitted for others.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1520.md";
-
-        private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.LayoutRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
         private static readonly Action<SyntaxNodeAnalysisContext> IfStatementAction = HandleIfStatement;
 
@@ -109,7 +113,7 @@ namespace StyleCop.Analyzers.LayoutRules
                 return;
             }
 
-            if (context.SemanticModel.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(SA1519BracesMustNotBeOmittedFromMultiLineChildStatement.DiagnosticId, ReportDiagnostic.Default) != ReportDiagnostic.Suppress)
+            if (!context.IsAnalyzerSuppressed(SA1519BracesMustNotBeOmittedFromMultiLineChildStatement.Descriptor))
             {
                 // diagnostics for multi-line statements is handled by SA1519, as long as it's not suppressed
                 FileLinePositionSpan lineSpan = childStatement.GetLineSpan();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119StatementMustNotUseUnnecessaryParenthesis.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119StatementMustNotUseUnnecessaryParenthesis.cs
@@ -10,6 +10,7 @@ namespace StyleCop.Analyzers.MaintainabilityRules
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
     using StyleCop.Analyzers.Lightup;
 
     /// <summary>
@@ -88,7 +89,7 @@ namespace StyleCop.Analyzers.MaintainabilityRules
             // Only register the syntax node action if the diagnostic is enabled. This is important because
             // otherwise the diagnostic for fading out the parenthesis is still active, even if the main diagnostic
             // is disabled
-            if (context.Compilation.Options.SpecificDiagnosticOptions.GetValueOrDefault(Descriptor.Id) != Microsoft.CodeAnalysis.ReportDiagnostic.Suppress)
+            if (!context.IsAnalyzerSuppressed(Descriptor))
             {
                 context.RegisterSyntaxNodeAction(ParenthesizedExpressionAction, SyntaxKind.ParenthesizedExpression);
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA110xQueryClauses.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA110xQueryClauses.cs
@@ -103,10 +103,10 @@ namespace StyleCop.Analyzers.ReadabilityRules
             HandleQueryClause(queryExpression.FromClause, tokensToCheck);
             HandleQueryBody(queryExpression.Body, tokensToCheck);
 
-            bool isEnabledSA1102 = !context.IsAnalyzerSuppressed(SA1102Identifier);
-            bool isEnabledSA1103 = !context.IsAnalyzerSuppressed(SA1103Identifier);
-            bool isEnabledSA1104 = !context.IsAnalyzerSuppressed(SA1104Identifier);
-            bool isEnabledSA1105 = !context.IsAnalyzerSuppressed(SA1105Identifier);
+            bool isEnabledSA1102 = !context.IsAnalyzerSuppressed(SA1102Descriptor);
+            bool isEnabledSA1103 = !context.IsAnalyzerSuppressed(SA1103Descriptor);
+            bool isEnabledSA1104 = !context.IsAnalyzerSuppressed(SA1104Descriptor);
+            bool isEnabledSA1105 = !context.IsAnalyzerSuppressed(SA1105Descriptor);
 
             bool allOnSameLine = true;
             bool allOnSeparateLine = true;


### PR DESCRIPTION
 Improved the `IsAnalyzerSuppressed` code based on the code shown in #2823. Replaced all remaining usages of `SpecificDiagnosticOptions.GetValueOrDefault` by `IsAnalyzerSuppressed`

Closes #2823
