### PR TITLE
Permanently disable SA1644 (Documentation headers should not contain blank lines)

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/DocumentationRules/SA1644CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/DocumentationRules/SA1644CSharp7UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.DocumentationRules
+{
+    using StyleCop.Analyzers.Test.DocumentationRules;
+
+    public class SA1644CSharp7UnitTests : SA1644UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1644UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1644UnitTests.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.DocumentationRules
+{
+    using Microsoft.CodeAnalysis;
+    using StyleCop.Analyzers.DocumentationRules;
+    using Xunit;
+
+    /// <summary>
+    /// This class contains unit tests for <see cref="SA1644DocumentationHeadersMustNotContainBlankLines"/>.
+    /// </summary>
+    public class SA1644UnitTests
+    {
+        [Fact]
+        public void TestDisabledByDefaultAndNotConfigurable()
+        {
+            var analyzer = new SA1644DocumentationHeadersMustNotContainBlankLines();
+            Assert.Single(analyzer.SupportedDiagnostics);
+            Assert.False(analyzer.SupportedDiagnostics[0].IsEnabledByDefault);
+            Assert.Contains(WellKnownDiagnosticTags.NotConfigurable, analyzer.SupportedDiagnostics[0].CustomTags);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1644DocumentationHeadersMustNotContainBlankLines.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1644DocumentationHeadersMustNotContainBlankLines.cs
@@ -66,7 +66,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1644.md";
 
         private static readonly DiagnosticDescriptor Descriptor =
-            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.DocumentationRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledNoTests, Description, HelpLink, WellKnownDiagnosticTags.NotConfigurable);
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.DocumentationRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledByDefault, Description, HelpLink, WellKnownDiagnosticTags.NotConfigurable);
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
@@ -75,7 +75,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// <inheritdoc/>
         public override void Initialize(AnalysisContext context)
         {
-            // TODO: Implement analysis
+            // This diagnostic is not implemented (by design) in StyleCopAnalyzers.
         }
     }
 }

--- a/documentation/KnownChanges.md
+++ b/documentation/KnownChanges.md
@@ -33,6 +33,7 @@ lists each of these issues, along with a link to the issue where the decision wa
 | SA1630 | Documentation text should contain whitespace | [#1057](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1057) |
 | SA1631 | Documentation should meet character percentage | [#1057](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1057) |
 | SA1632 | Documentation text should meet minimum character length | [#1057](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1057) |
+| SA1644 | DocumentationHeadersMustNotContainBlankLines | [#164](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/164) |
 | SA1645 | Included documentation file does not exist | [#165](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/165) |
 | SA1646 | Included documentation XPath does not exist | [#166](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/166) |
 | SA1647 | Include node does not contain valid file and path | [#167](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/167) |

--- a/documentation/SA1644.md
+++ b/documentation/SA1644.md
@@ -15,6 +15,9 @@
 </tr>
 </table>
 
+:warning: This rule has been intentionally omitted from StyleCop Analyzers. See [KnownChanges.md](KnownChanges.md) for
+additional information.
+
 ## Cause
 
 A section within the Xml documentation header for a C# element contains blank lines.


### PR DESCRIPTION
Blocked on a decision in #164.

Closes #164