### PR TITLE
Update documentation analyzer to handle ref returns

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/DocumentationRules/SA1623CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/DocumentationRules/SA1623CSharp7UnitTests.cs
@@ -48,6 +48,9 @@ namespace StyleCop.Analyzers.Test.CSharp7.DocumentationRules
         [InlineData("protected internal", "int", "{ private get => 0; set => this.field = value; }", "Sets")]
         [InlineData("internal", "int", "{ get => 0; private set => this.field = value; }", "Gets")]
         [InlineData("internal", "int", "{ private get => 0; set => this.field = value; }", "Sets")]
+
+        [WorkItem(2861, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2861")]
+        [InlineData("public", "ref int", "{ get => throw null; }", "Gets")]
         public async Task VerifyDocumentationWithWrongStartingTextWillProduceDiagnosticWithExpressionBodiedAccessorsAsync(string accessibility, string type, string accessors, string expectedArgument)
         {
             var testCode = $@"

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
@@ -12,6 +12,7 @@ namespace StyleCop.Analyzers.DocumentationRules
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.Helpers;
+    using StyleCop.Analyzers.Lightup;
 
     /// <summary>
     /// Analyzes the correct usage of property summary documentation.
@@ -60,7 +61,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, XmlNodeSyntax syntax, XElement completeDocumentation, Location diagnosticLocation)
         {
             var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
-            var propertyType = context.SemanticModel.GetTypeInfo(propertyDeclaration.Type);
+            var propertyType = context.SemanticModel.GetTypeInfo(propertyDeclaration.Type.StripRefFromType());
             var settings = context.Options.GetStyleCopSettings(context.CancellationToken);
             var culture = new CultureInfo(settings.DocumentationRules.DocumentationCulture);
             var resourceManager = DocumentationResources.ResourceManager;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TypeSyntaxHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TypeSyntaxHelper.cs
@@ -3,6 +3,7 @@
 
 namespace StyleCop.Analyzers.Helpers
 {
+    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using StyleCop.Analyzers.Lightup;
@@ -54,6 +55,16 @@ namespace StyleCop.Analyzers.Helpers
             default:
                 return false;
             }
+        }
+
+        public static TypeSyntax StripRefFromType(this TypeSyntax syntax)
+        {
+            if (syntax.IsKind(SyntaxKindEx.RefType))
+            {
+                syntax = ((RefTypeSyntaxWrapper)syntax).Type;
+            }
+
+            return syntax;
         }
     }
 }


### PR DESCRIPTION
Fixes #2861

I audited the code base and this is the only situation impacted by this bug (a limitation that `GetTypeInfo` does not return a type for ref types).