### PR TITLE
Update the lightup layer to account for changes in C# 7.1-7.3

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/SA1207CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/SA1207CodeFixProvider.cs
@@ -5,6 +5,7 @@ namespace StyleCop.Analyzers.OrderingRules
 {
     using System.Collections.Immutable;
     using System.Composition;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -59,21 +60,23 @@ namespace StyleCop.Analyzers.OrderingRules
                 return document;
             }
 
-            var newDeclarationNode = originalDeclarationNode.ReplaceTokens(childTokens, ComputeReplacementToken);
+            bool hasInternalKeyword = childTokens.Any(token => token.IsKind(SyntaxKind.InternalKeyword));
+            var newDeclarationNode = originalDeclarationNode.ReplaceTokens(childTokens, (originalToken, rewrittenToken) => ComputeReplacementToken(originalToken, rewrittenToken, hasInternalKeyword));
 
             var newSyntaxRoot = syntaxRoot.ReplaceNode(originalDeclarationNode, newDeclarationNode);
             return document.WithSyntaxRoot(newSyntaxRoot);
         }
 
-        private static SyntaxToken ComputeReplacementToken(SyntaxToken originalToken, SyntaxToken rewrittenToken)
+        private static SyntaxToken ComputeReplacementToken(SyntaxToken originalToken, SyntaxToken rewrittenToken, bool hasInternalKeyword)
         {
-            if (originalToken.IsKind(SyntaxKind.InternalKeyword))
+            if (originalToken.IsKind(SyntaxKind.InternalKeyword)
+                || originalToken.IsKind(SyntaxKind.PrivateKeyword))
             {
                 return SyntaxFactory.Token(SyntaxKind.ProtectedKeyword).WithTriviaFrom(rewrittenToken);
             }
             else if (originalToken.IsKind(SyntaxKind.ProtectedKeyword))
             {
-                return SyntaxFactory.Token(SyntaxKind.InternalKeyword).WithTriviaFrom(rewrittenToken);
+                return SyntaxFactory.Token(hasInternalKeyword ? SyntaxKind.InternalKeyword : SyntaxKind.PrivateKeyword).WithTriviaFrom(rewrittenToken);
             }
             else
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1505CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1505CSharp7UnitTests.cs
@@ -39,7 +39,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
 }
 ";
 
-            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
 ";
 
             var expectedDiagnostic = Diagnostic().WithLocation(10, 13);
-            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1505CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1505CSharp7UnitTests.cs
@@ -5,12 +5,13 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.LayoutRules;
     using StyleCop.Analyzers.Test.LayoutRules;
+    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1505OpeningBracesMustNotBeFollowedByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1505CodeFixProvider>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.LayoutRules.SA1505OpeningBracesMustNotBeFollowedByBlankLine>;
 
     public class SA1505CSharp7UnitTests : SA1505UnitTests
     {
@@ -38,7 +39,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
 }
 ";
 
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -84,7 +85,128 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
 ";
 
             var expectedDiagnostic = Diagnostic().WithLocation(10, 13);
-            await VerifyCSharpFixAsync(testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* v1 = stackalloc int[]
+            {
+
+                1,
+                2,
+                3
+            };
+        }
+    }
+}
+";
+
+            var fixedTestCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* v1 = stackalloc int[]
+            {
+                1,
+                2,
+                3
+            };
+        }
+    }
+}
+";
+
+            var expectedDiagnostic = Diagnostic().WithLocation(8, 13);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestImplicitStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* v1 = stackalloc[]
+            {
+
+                1,
+                2,
+                3
+            };
+        }
+    }
+}
+";
+
+            var fixedTestCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* v1 = stackalloc[]
+            {
+                1,
+                2,
+                3
+            };
+        }
+    }
+}
+";
+
+            var expectedDiagnostic = Diagnostic().WithLocation(8, 13);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            return VerifyCSharpFixAsync(languageVersion, source, new[] { expected }, fixedSource, cancellationToken);
+        }
+
+        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            var test = new CSharpTest(languageVersion)
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            if (source == fixedSource)
+            {
+                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.FixedState.MarkupHandling = MarkupMode.Allow;
+                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
+            }
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
+        private class CSharpTest : StyleCopCodeFixVerifier<SA1505OpeningBracesMustNotBeFollowedByBlankLine, SA1505CodeFixProvider>.CSharpTest
+        {
+            public CSharpTest(LanguageVersion languageVersion)
+            {
+                this.SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
+                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
+                });
+            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1505CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1505CSharp7UnitTests.cs
@@ -7,11 +7,11 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
-    using StyleCop.Analyzers.LayoutRules;
     using StyleCop.Analyzers.Test.LayoutRules;
-    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.LayoutRules.SA1505OpeningBracesMustNotBeFollowedByBlankLine>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.LayoutRules.SA1505OpeningBracesMustNotBeFollowedByBlankLine,
+        StyleCop.Analyzers.LayoutRules.SA1505CodeFixProvider>;
 
     public class SA1505CSharp7UnitTests : SA1505UnitTests
     {
@@ -170,43 +170,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
 
             var expectedDiagnostic = Diagnostic().WithLocation(8, 13);
             await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            return VerifyCSharpFixAsync(languageVersion, source, new[] { expected }, fixedSource, cancellationToken);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            var test = new CSharpTest(languageVersion)
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
-
-            if (source == fixedSource)
-            {
-                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.FixedState.MarkupHandling = MarkupMode.Allow;
-                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
-            }
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
-        }
-
-        private class CSharpTest : StyleCopCodeFixVerifier<SA1505OpeningBracesMustNotBeFollowedByBlankLine, SA1505CodeFixProvider>.CSharpTest
-        {
-            public CSharpTest(LanguageVersion languageVersion)
-            {
-                this.SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
-                });
-            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1508CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1508CSharp7UnitTests.cs
@@ -5,12 +5,13 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.LayoutRules;
     using StyleCop.Analyzers.Test.LayoutRules;
+    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1508ClosingBracesMustNotBePrecededByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1508CodeFixProvider>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.LayoutRules.SA1508ClosingBracesMustNotBePrecededByBlankLine>;
 
     public class SA1508CSharp7UnitTests : SA1508UnitTests
     {
@@ -38,7 +39,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
 }
 ";
 
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -84,7 +85,128 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
 ";
 
             var expectedDiagnostic = Diagnostic().WithLocation(13, 13);
-            await VerifyCSharpFixAsync(testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* v1 = stackalloc int[]
+            {
+                1,
+                2,
+                3
+
+            };
+        }
+    }
+}
+";
+
+            var fixedTestCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* v1 = stackalloc int[]
+            {
+                1,
+                2,
+                3
+            };
+        }
+    }
+}
+";
+
+            var expectedDiagnostic = Diagnostic().WithLocation(13, 13);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestImplicitStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* v1 = stackalloc[]
+            {
+                1,
+                2,
+                3
+
+            };
+        }
+    }
+}
+";
+
+            var fixedTestCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* v1 = stackalloc[]
+            {
+                1,
+                2,
+                3
+            };
+        }
+    }
+}
+";
+
+            var expectedDiagnostic = Diagnostic().WithLocation(13, 13);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            return VerifyCSharpFixAsync(languageVersion, source, new[] { expected }, fixedSource, cancellationToken);
+        }
+
+        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            var test = new CSharpTest(languageVersion)
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            if (source == fixedSource)
+            {
+                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.FixedState.MarkupHandling = MarkupMode.Allow;
+                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
+            }
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
+        private class CSharpTest : StyleCopCodeFixVerifier<SA1508ClosingBracesMustNotBePrecededByBlankLine, SA1508CodeFixProvider>.CSharpTest
+        {
+            public CSharpTest(LanguageVersion languageVersion)
+            {
+                this.SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
+                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
+                });
+            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1508CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1508CSharp7UnitTests.cs
@@ -7,11 +7,11 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
-    using StyleCop.Analyzers.LayoutRules;
     using StyleCop.Analyzers.Test.LayoutRules;
-    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.LayoutRules.SA1508ClosingBracesMustNotBePrecededByBlankLine>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.LayoutRules.SA1508ClosingBracesMustNotBePrecededByBlankLine,
+        StyleCop.Analyzers.LayoutRules.SA1508CodeFixProvider>;
 
     public class SA1508CSharp7UnitTests : SA1508UnitTests
     {
@@ -170,43 +170,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
 
             var expectedDiagnostic = Diagnostic().WithLocation(13, 13);
             await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            return VerifyCSharpFixAsync(languageVersion, source, new[] { expected }, fixedSource, cancellationToken);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            var test = new CSharpTest(languageVersion)
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
-
-            if (source == fixedSource)
-            {
-                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.FixedState.MarkupHandling = MarkupMode.Allow;
-                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
-            }
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
-        }
-
-        private class CSharpTest : StyleCopCodeFixVerifier<SA1508ClosingBracesMustNotBePrecededByBlankLine, SA1508CodeFixProvider>.CSharpTest
-        {
-            public CSharpTest(LanguageVersion languageVersion)
-            {
-                this.SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
-                });
-            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1508CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1508CSharp7UnitTests.cs
@@ -39,7 +39,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
 }
 ";
 
-            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
 ";
 
             var expectedDiagnostic = Diagnostic().WithLocation(13, 13);
-            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1509CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1509CSharp7UnitTests.cs
@@ -41,7 +41,7 @@ class Foo
 }";
 
             DiagnosticResult expected = Diagnostic().WithLocation(8, 9);
-            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -72,7 +72,7 @@ class Foo
 }";
 
             DiagnosticResult expected = Diagnostic().WithLocation(9, 9);
-            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1509CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1509CSharp7UnitTests.cs
@@ -5,13 +5,13 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.LayoutRules;
     using StyleCop.Analyzers.Test.LayoutRules;
-    using TestHelper;
+    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1509OpeningBracesMustNotBePrecededByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1509CodeFixProvider>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.LayoutRules.SA1509OpeningBracesMustNotBePrecededByBlankLine>;
 
     public class SA1509CSharp7UnitTests : SA1509UnitTests
     {
@@ -41,7 +41,7 @@ class Foo
 }";
 
             DiagnosticResult expected = Diagnostic().WithLocation(8, 9);
-            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -72,7 +72,128 @@ class Foo
 }";
 
             DiagnosticResult expected = Diagnostic().WithLocation(9, 9);
-            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* v1 = stackalloc int[]
+
+            {
+                1,
+                2,
+                3
+            };
+        }
+    }
+}
+";
+
+            var fixedTestCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* v1 = stackalloc int[]
+            {
+                1,
+                2,
+                3
+            };
+        }
+    }
+}
+";
+
+            var expectedDiagnostic = Diagnostic().WithLocation(9, 13);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestImplicitStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* v1 = stackalloc[]
+
+            {
+                1,
+                2,
+                3
+            };
+        }
+    }
+}
+";
+
+            var fixedTestCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* v1 = stackalloc[]
+            {
+                1,
+                2,
+                3
+            };
+        }
+    }
+}
+";
+
+            var expectedDiagnostic = Diagnostic().WithLocation(9, 13);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            return VerifyCSharpFixAsync(languageVersion, source, new[] { expected }, fixedSource, cancellationToken);
+        }
+
+        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            var test = new CSharpTest(languageVersion)
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            if (source == fixedSource)
+            {
+                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.FixedState.MarkupHandling = MarkupMode.Allow;
+                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
+            }
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
+        private class CSharpTest : StyleCopCodeFixVerifier<SA1509OpeningBracesMustNotBePrecededByBlankLine, SA1509CodeFixProvider>.CSharpTest
+        {
+            public CSharpTest(LanguageVersion languageVersion)
+            {
+                this.SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
+                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
+                });
+            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1509CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1509CSharp7UnitTests.cs
@@ -7,11 +7,11 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
-    using StyleCop.Analyzers.LayoutRules;
     using StyleCop.Analyzers.Test.LayoutRules;
-    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.LayoutRules.SA1509OpeningBracesMustNotBePrecededByBlankLine>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.LayoutRules.SA1509OpeningBracesMustNotBePrecededByBlankLine,
+        StyleCop.Analyzers.LayoutRules.SA1509CodeFixProvider>;
 
     public class SA1509CSharp7UnitTests : SA1509UnitTests
     {
@@ -157,43 +157,6 @@ class Foo
 
             var expectedDiagnostic = Diagnostic().WithLocation(9, 13);
             await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            return VerifyCSharpFixAsync(languageVersion, source, new[] { expected }, fixedSource, cancellationToken);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            var test = new CSharpTest(languageVersion)
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
-
-            if (source == fixedSource)
-            {
-                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.FixedState.MarkupHandling = MarkupMode.Allow;
-                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
-            }
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
-        }
-
-        private class CSharpTest : StyleCopCodeFixVerifier<SA1509OpeningBracesMustNotBePrecededByBlankLine, SA1509CodeFixProvider>.CSharpTest
-        {
-            public CSharpTest(LanguageVersion languageVersion)
-            {
-                this.SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
-                });
-            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1513CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1513CSharp7UnitTests.cs
@@ -5,12 +5,13 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.LayoutRules;
     using StyleCop.Analyzers.Test.LayoutRules;
+    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1513ClosingBraceMustBeFollowedByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1513CodeFixProvider>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.LayoutRules.SA1513ClosingBraceMustBeFollowedByBlankLine>;
 
     public class SA1513CSharp7UnitTests : SA1513UnitTests
     {
@@ -52,7 +53,7 @@ public class Foo
 }
 ";
 
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -139,7 +140,97 @@ public class Foo
                 Diagnostic().WithLocation(27, 10),
             };
 
-            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* v1 = stackalloc int[]
+            {
+                1,
+                2,
+                3
+            };
+            int* v2 = stackalloc int[]
+            {
+                1,
+                2,
+                3
+            };
+        }
+    }
+}
+";
+
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestImplicitStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* v1 = stackalloc[]
+            {
+                1,
+                2,
+                3
+            };
+            int* v2 = stackalloc[]
+            {
+                1,
+                2,
+                3
+            };
+        }
+    }
+}
+";
+
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            var test = new CSharpTest(languageVersion)
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            if (source == fixedSource)
+            {
+                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.FixedState.MarkupHandling = MarkupMode.Allow;
+                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
+            }
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
+        private class CSharpTest : StyleCopCodeFixVerifier<SA1513ClosingBraceMustBeFollowedByBlankLine, SA1513CodeFixProvider>.CSharpTest
+        {
+            public CSharpTest(LanguageVersion languageVersion)
+            {
+                this.SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
+                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
+                });
+            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1513CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1513CSharp7UnitTests.cs
@@ -7,11 +7,11 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
-    using StyleCop.Analyzers.LayoutRules;
     using StyleCop.Analyzers.Test.LayoutRules;
-    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.LayoutRules.SA1513ClosingBraceMustBeFollowedByBlankLine>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.LayoutRules.SA1513ClosingBraceMustBeFollowedByBlankLine,
+        StyleCop.Analyzers.LayoutRules.SA1513CodeFixProvider>;
 
     public class SA1513CSharp7UnitTests : SA1513UnitTests
     {
@@ -199,38 +199,6 @@ public class Foo
 ";
 
             await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            var test = new CSharpTest(languageVersion)
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
-
-            if (source == fixedSource)
-            {
-                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.FixedState.MarkupHandling = MarkupMode.Allow;
-                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
-            }
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
-        }
-
-        private class CSharpTest : StyleCopCodeFixVerifier<SA1513ClosingBraceMustBeFollowedByBlankLine, SA1513CodeFixProvider>.CSharpTest
-        {
-            public CSharpTest(LanguageVersion languageVersion)
-            {
-                this.SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
-                });
-            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1513CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1513CSharp7UnitTests.cs
@@ -53,7 +53,7 @@ public class Foo
 }
 ";
 
-            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ public class Foo
                 Diagnostic().WithLocation(27, 10),
             };
 
-            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/ArgumentSyntaxExtensionsTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/ArgumentSyntaxExtensionsTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.Lightup
+{
+    using Microsoft.CodeAnalysis.CSharp;
+    using StyleCop.Analyzers.Lightup;
+    using Xunit;
+
+    public class ArgumentSyntaxExtensionsTests
+    {
+        [Fact]
+        public void TestRefKindKeyword()
+        {
+            var argumentSyntax = SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression))
+                .WithRefKindKeyword(SyntaxFactory.Token(SyntaxKind.InKeyword));
+            Assert.Equal(argumentSyntax.RefKindKeyword, ArgumentSyntaxExtensions.RefKindKeyword(argumentSyntax));
+            Assert.Equal(argumentSyntax.RefOrOutKeyword, ArgumentSyntaxExtensions.RefKindKeyword(argumentSyntax));
+        }
+
+        [Fact]
+        public void TestWithRefKindKeyword()
+        {
+            var argumentSyntax = SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
+
+            var refKindKeyword = SyntaxFactory.Token(SyntaxKind.InKeyword);
+            Assert.Equal(default, ArgumentSyntaxExtensions.RefKindKeyword(argumentSyntax));
+            var argumentWithInKeyword = ArgumentSyntaxExtensions.WithRefKindKeyword(argumentSyntax, refKindKeyword);
+            Assert.NotNull(argumentWithInKeyword);
+            Assert.True(refKindKeyword.IsEquivalentTo(argumentWithInKeyword.RefKindKeyword));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/CrefParameterSyntaxExtensionsTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/CrefParameterSyntaxExtensionsTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.Lightup
+{
+    using Microsoft.CodeAnalysis.CSharp;
+    using StyleCop.Analyzers.Lightup;
+    using Xunit;
+
+    public class CrefParameterSyntaxExtensionsTests
+    {
+        [Fact]
+        public void TestRefKindKeyword()
+        {
+            var crefParameterSyntax = SyntaxFactory.CrefParameter(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)))
+                .WithRefKindKeyword(SyntaxFactory.Token(SyntaxKind.InKeyword));
+            Assert.Equal(crefParameterSyntax.RefKindKeyword, CrefParameterSyntaxExtensions.RefKindKeyword(crefParameterSyntax));
+            Assert.Equal(crefParameterSyntax.RefOrOutKeyword, CrefParameterSyntaxExtensions.RefKindKeyword(crefParameterSyntax));
+        }
+
+        [Fact]
+        public void TestWithRefKindKeyword()
+        {
+            var crefParameterSyntax = SyntaxFactory.CrefParameter(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)));
+
+            var refKindKeyword = SyntaxFactory.Token(SyntaxKind.InKeyword);
+            Assert.Equal(default, CrefParameterSyntaxExtensions.RefKindKeyword(crefParameterSyntax));
+            var crefParameterWithInKeyword = CrefParameterSyntaxExtensions.WithRefKindKeyword(crefParameterSyntax, refKindKeyword);
+            Assert.NotNull(crefParameterWithInKeyword);
+            Assert.True(refKindKeyword.IsEquivalentTo(crefParameterWithInKeyword.RefKindKeyword));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/ImplicitStackAllocArrayCreationExpressionSyntaxWrapperTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/ImplicitStackAllocArrayCreationExpressionSyntaxWrapperTests.cs
@@ -1,0 +1,130 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.Lightup
+{
+    using System;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using StyleCop.Analyzers.Lightup;
+    using Xunit;
+
+    public class ImplicitStackAllocArrayCreationExpressionSyntaxWrapperTests
+    {
+        [Fact]
+        public void TestNull()
+        {
+            var syntaxNode = default(SyntaxNode);
+            var wrapper = (ImplicitStackAllocArrayCreationExpressionSyntaxWrapper)syntaxNode;
+            Assert.Null(wrapper.SyntaxNode);
+            Assert.Throws<NullReferenceException>(() => wrapper.StackAllocKeyword);
+            Assert.Throws<NullReferenceException>(() => wrapper.OpenBracketToken);
+            Assert.Throws<NullReferenceException>(() => wrapper.CloseBracketToken);
+            Assert.Throws<NullReferenceException>(() => wrapper.Initializer);
+            Assert.Throws<NullReferenceException>(() => wrapper.WithStackAllocKeyword(SyntaxFactory.Token(SyntaxKind.StackAllocKeyword)));
+            Assert.Throws<NullReferenceException>(() => wrapper.WithOpenBracketToken(SyntaxFactory.Token(SyntaxKind.OpenBracketToken)));
+            Assert.Throws<NullReferenceException>(() => wrapper.WithCloseBracketToken(SyntaxFactory.Token(SyntaxKind.CloseBracketToken)));
+            Assert.Throws<NullReferenceException>(() => wrapper.WithInitializer(SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression)));
+            Assert.Throws<NullReferenceException>(() => wrapper.AddInitializerExpressions());
+        }
+
+        [Fact]
+        public void TestProperties()
+        {
+            var syntaxNode = this.CreateImplicitStackAllocArrayCreationExpression();
+            Assert.True(syntaxNode.IsKind(SyntaxKind.ImplicitStackAllocArrayCreationExpression));
+            Assert.True(syntaxNode.IsKind(SyntaxKindEx.ImplicitStackAllocArrayCreationExpression));
+
+            var wrapper = (ImplicitStackAllocArrayCreationExpressionSyntaxWrapper)syntaxNode;
+            Assert.Same(syntaxNode, wrapper.SyntaxNode);
+            Assert.Equal(syntaxNode.StackAllocKeyword, wrapper.StackAllocKeyword); // This is a struct, so we can't use Same()
+            Assert.Equal(syntaxNode.OpenBracketToken, wrapper.OpenBracketToken); // This is a struct, so we can't use Same()
+            Assert.Equal(syntaxNode.CloseBracketToken, wrapper.CloseBracketToken); // This is a struct, so we can't use Same()
+            Assert.Same(syntaxNode.Initializer, wrapper.Initializer);
+
+            var newStackAllocKeyword = SyntaxFactory.Token(SyntaxKind.StackAllocKeyword);
+            var wrapperWithModifiedStackAllocKeyword = wrapper.WithStackAllocKeyword(newStackAllocKeyword);
+            Assert.NotNull(wrapperWithModifiedStackAllocKeyword.SyntaxNode);
+            Assert.NotEqual(syntaxNode.StackAllocKeyword, wrapperWithModifiedStackAllocKeyword.StackAllocKeyword);
+            Assert.Equal(SyntaxKind.StackAllocKeyword, wrapperWithModifiedStackAllocKeyword.StackAllocKeyword.Kind());
+            Assert.Equal("stackalloc", wrapperWithModifiedStackAllocKeyword.StackAllocKeyword.Text);
+
+            var newOpenBracketToken = SyntaxFactory.Token(SyntaxKind.OpenBracketToken);
+            var wrapperWithModifiedOpenBracketToken = wrapper.WithOpenBracketToken(newOpenBracketToken);
+            Assert.NotNull(wrapperWithModifiedOpenBracketToken.SyntaxNode);
+            Assert.NotEqual(syntaxNode.OpenBracketToken, wrapperWithModifiedOpenBracketToken.OpenBracketToken);
+            Assert.Equal(SyntaxKind.OpenBracketToken, wrapperWithModifiedOpenBracketToken.OpenBracketToken.Kind());
+            Assert.Equal("[", wrapperWithModifiedOpenBracketToken.OpenBracketToken.Text);
+
+            var newCloseBracketToken = SyntaxFactory.Token(SyntaxKind.CloseBracketToken);
+            var wrapperWithModifiedCloseBracketToken = wrapper.WithCloseBracketToken(newCloseBracketToken);
+            Assert.NotNull(wrapperWithModifiedCloseBracketToken.SyntaxNode);
+            Assert.NotEqual(syntaxNode.CloseBracketToken, wrapperWithModifiedCloseBracketToken.CloseBracketToken);
+            Assert.Equal(SyntaxKind.CloseBracketToken, wrapperWithModifiedCloseBracketToken.CloseBracketToken.Kind());
+            Assert.Equal("]", wrapperWithModifiedCloseBracketToken.CloseBracketToken.Text);
+
+            var newInitializer = SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression);
+            var wrapperWithModifiedInitializer = wrapper.WithInitializer(newInitializer);
+            Assert.NotNull(wrapperWithModifiedInitializer.SyntaxNode);
+            Assert.NotSame(syntaxNode.Initializer, wrapperWithModifiedInitializer.Initializer);
+            Assert.Empty(wrapperWithModifiedInitializer.Initializer.Expressions);
+
+            var addedInitializerExpressions = new ExpressionSyntax[] { SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(2)) };
+            var wrapperWithAddedInitializerExpressions = wrapper.AddInitializerExpressions(addedInitializerExpressions);
+            Assert.NotNull(wrapperWithAddedInitializerExpressions.SyntaxNode);
+            Assert.NotSame(syntaxNode.Initializer, wrapperWithAddedInitializerExpressions.Initializer);
+            Assert.Equal(2, wrapperWithAddedInitializerExpressions.Initializer.Expressions.Count);
+            Assert.Equal("1", wrapperWithAddedInitializerExpressions.Initializer.Expressions[0].ToString());
+            Assert.Equal("2", wrapperWithAddedInitializerExpressions.Initializer.Expressions[1].ToString());
+        }
+
+        [Fact]
+        public void TestIsInstance()
+        {
+            Assert.False(ImplicitStackAllocArrayCreationExpressionSyntaxWrapper.IsInstance(null));
+            Assert.False(ImplicitStackAllocArrayCreationExpressionSyntaxWrapper.IsInstance(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)));
+
+            var syntaxNode = this.CreateImplicitStackAllocArrayCreationExpression();
+            Assert.True(ImplicitStackAllocArrayCreationExpressionSyntaxWrapper.IsInstance(syntaxNode));
+        }
+
+        [Fact]
+        public void TestConversionsNull()
+        {
+            var syntaxNode = default(SyntaxNode);
+            var wrapper = (ImplicitStackAllocArrayCreationExpressionSyntaxWrapper)syntaxNode;
+
+            ExpressionSyntax syntax = wrapper;
+            Assert.Null(syntax);
+        }
+
+        [Fact]
+        public void TestConversions()
+        {
+            var syntaxNode = this.CreateImplicitStackAllocArrayCreationExpression();
+            var wrapper = (ImplicitStackAllocArrayCreationExpressionSyntaxWrapper)syntaxNode;
+
+            ExpressionSyntax syntax = wrapper;
+            Assert.Same(syntaxNode, syntax);
+        }
+
+        [Fact]
+        public void TestInvalidConversion()
+        {
+            var syntaxNode = SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
+            Assert.Throws<InvalidCastException>(() => (ImplicitStackAllocArrayCreationExpressionSyntaxWrapper)syntaxNode);
+        }
+
+        private ImplicitStackAllocArrayCreationExpressionSyntax CreateImplicitStackAllocArrayCreationExpression()
+        {
+            return SyntaxFactory.ImplicitStackAllocArrayCreationExpression(
+                stackAllocKeyword: SyntaxFactory.Token(SyntaxKind.StackAllocKeyword),
+                openBracketToken: SyntaxFactory.Token(SyntaxKind.OpenBracketToken),
+                closeBracketToken: SyntaxFactory.Token(SyntaxKind.CloseBracketToken),
+                initializer: SyntaxFactory.InitializerExpression(
+                    SyntaxKind.ArrayInitializerExpression,
+                    SyntaxFactory.SingletonSeparatedList<ExpressionSyntax>(SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1)))));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/RefTypeSyntaxWrapperTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/RefTypeSyntaxWrapperTests.cs
@@ -19,9 +19,11 @@ namespace StyleCop.Analyzers.Test.CSharp7.Lightup
             var wrapper = (RefTypeSyntaxWrapper)syntaxNode;
             Assert.Null(wrapper.SyntaxNode);
             Assert.Throws<NullReferenceException>(() => wrapper.RefKeyword);
+            Assert.Throws<NullReferenceException>(() => wrapper.ReadOnlyKeyword);
             Assert.Throws<NullReferenceException>(() => wrapper.Type);
             Assert.Throws<NullReferenceException>(() => wrapper.WithType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword))));
             Assert.Throws<NullReferenceException>(() => wrapper.WithRefKeyword(SyntaxFactory.Token(SyntaxKind.RefKeyword)));
+            Assert.Throws<NullReferenceException>(() => wrapper.WithReadOnlyKeyword(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword)));
         }
 
         [Fact]
@@ -35,6 +37,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.Lightup
             Assert.Same(syntaxNode, wrapper.SyntaxNode);
             Assert.Same(syntaxNode.Type, wrapper.Type);
             Assert.True(syntaxNode.RefKeyword.IsEquivalentTo(wrapper.RefKeyword));
+            Assert.Equal(default, syntaxNode.ReadOnlyKeyword);
 
             var newType = SyntaxFactory.PointerType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.BoolKeyword)));
             var wrapperWithModifiedType = wrapper.WithType(newType);
@@ -47,6 +50,13 @@ namespace StyleCop.Analyzers.Test.CSharp7.Lightup
             Assert.NotNull(wrapperWithModifiedRefKeyword.SyntaxNode);
             Assert.Single(wrapperWithModifiedRefKeyword.RefKeyword.LeadingTrivia);
             Assert.Equal(" ", wrapperWithModifiedRefKeyword.RefKeyword.LeadingTrivia.ToString());
+
+            var readOnlyKeyword = SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword).WithLeadingTrivia(SyntaxFactory.Space);
+            var wrapperWithReadOnlyKeyword = wrapper.WithReadOnlyKeyword(readOnlyKeyword);
+            Assert.NotNull(wrapperWithReadOnlyKeyword.SyntaxNode);
+            Assert.Single(wrapperWithReadOnlyKeyword.ReadOnlyKeyword.LeadingTrivia);
+            Assert.Equal(" ", wrapperWithReadOnlyKeyword.ReadOnlyKeyword.LeadingTrivia.ToString());
+            Assert.True(wrapperWithReadOnlyKeyword.ReadOnlyKeyword.IsEquivalentTo(readOnlyKeyword));
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/StackAllocArrayCreationExpressionSyntaxExtensionsTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/StackAllocArrayCreationExpressionSyntaxExtensionsTests.cs
@@ -22,12 +22,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.Lightup
         public void TestWithInitializer()
         {
             var stackAllocSyntax = SyntaxFactory.StackAllocArrayCreationExpression(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)));
-
-            // With default value is allowed
             var stackAllocWithDefaultInitializer = StackAllocArrayCreationExpressionSyntaxExtensions.WithInitializer(stackAllocSyntax, null);
             Assert.Null(StackAllocArrayCreationExpressionSyntaxExtensions.Initializer(stackAllocWithDefaultInitializer));
-
-            // Non-default throws an exception
             var initializer = SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression);
             var stackAllocWithInitializer = StackAllocArrayCreationExpressionSyntaxExtensions.WithInitializer(stackAllocSyntax, initializer);
             Assert.NotNull(stackAllocWithInitializer.Initializer);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/StackAllocArrayCreationExpressionSyntaxExtensionsTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/StackAllocArrayCreationExpressionSyntaxExtensionsTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.Lightup
+{
+    using Microsoft.CodeAnalysis.CSharp;
+    using StyleCop.Analyzers.Lightup;
+    using Xunit;
+
+    public class StackAllocArrayCreationExpressionSyntaxExtensionsTests
+    {
+        [Fact]
+        public void TestInitializer()
+        {
+            var stackAllocSyntax = SyntaxFactory.StackAllocArrayCreationExpression(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)))
+                .WithInitializer(SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression));
+            Assert.NotNull(StackAllocArrayCreationExpressionSyntaxExtensions.Initializer(stackAllocSyntax));
+            Assert.Equal(SyntaxKind.ArrayInitializerExpression, StackAllocArrayCreationExpressionSyntaxExtensions.Initializer(stackAllocSyntax).Kind());
+        }
+
+        [Fact]
+        public void TestWithInitializer()
+        {
+            var stackAllocSyntax = SyntaxFactory.StackAllocArrayCreationExpression(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)));
+
+            // With default value is allowed
+            var stackAllocWithDefaultInitializer = StackAllocArrayCreationExpressionSyntaxExtensions.WithInitializer(stackAllocSyntax, null);
+            Assert.Null(StackAllocArrayCreationExpressionSyntaxExtensions.Initializer(stackAllocWithDefaultInitializer));
+
+            // Non-default throws an exception
+            var initializer = SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression);
+            var stackAllocWithInitializer = StackAllocArrayCreationExpressionSyntaxExtensions.WithInitializer(stackAllocSyntax, initializer);
+            Assert.NotNull(stackAllocWithInitializer.Initializer);
+            Assert.Equal(SyntaxKind.ArrayInitializerExpression, stackAllocWithInitializer.Initializer.Kind());
+            Assert.True(stackAllocWithInitializer.Initializer.IsEquivalentTo(initializer));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1413CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1413CSharp7UnitTests.cs
@@ -3,9 +3,142 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.MaintainabilityRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.MaintainabilityRules;
     using StyleCop.Analyzers.Test.MaintainabilityRules;
+    using StyleCop.Analyzers.Test.Verifiers;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.MaintainabilityRules.SA1413UseTrailingCommasInMultiLineInitializers>;
 
     public class SA1413CSharp7UnitTests : SA1413UnitTests
     {
+        [Fact]
+        public async Task TestStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc int[] { 1, 1 };
+            int* data2 = stackalloc int[] { 1, 1, };
+            int* data3 = stackalloc int[]
+            {
+                1,
+                1
+            };
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc int[] { 1, 1 };
+            int* data2 = stackalloc int[] { 1, 1, };
+            int* data3 = stackalloc int[]
+            {
+                1,
+                1,
+            };
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithLocation(12, 17),
+            };
+
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestImplicitStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc[] { 1, 1 };
+            int* data2 = stackalloc[] { 1, 1, };
+            int* data3 = stackalloc[]
+            {
+                1,
+                1
+            };
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc[] { 1, 1 };
+            int* data2 = stackalloc[] { 1, 1, };
+            int* data3 = stackalloc[]
+            {
+                1,
+                1,
+            };
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithLocation(12, 17),
+            };
+
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            var test = new CSharpTest(languageVersion)
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            if (source == fixedSource)
+            {
+                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.FixedState.MarkupHandling = MarkupMode.Allow;
+                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
+            }
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
+        private class CSharpTest : StyleCopCodeFixVerifier<SA1413UseTrailingCommasInMultiLineInitializers, SA1413CodeFixProvider>.CSharpTest
+        {
+            public CSharpTest(LanguageVersion languageVersion)
+            {
+                this.SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
+                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
+                });
+            }
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1413CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1413CSharp7UnitTests.cs
@@ -7,11 +7,11 @@ namespace StyleCop.Analyzers.Test.CSharp7.MaintainabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
-    using StyleCop.Analyzers.MaintainabilityRules;
     using StyleCop.Analyzers.Test.MaintainabilityRules;
-    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.MaintainabilityRules.SA1413UseTrailingCommasInMultiLineInitializers>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.MaintainabilityRules.SA1413UseTrailingCommasInMultiLineInitializers,
+        StyleCop.Analyzers.MaintainabilityRules.SA1413CodeFixProvider>;
 
     public class SA1413CSharp7UnitTests : SA1413UnitTests
     {
@@ -107,38 +107,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.MaintainabilityRules
             };
 
             await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            var test = new CSharpTest(languageVersion)
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
-
-            if (source == fixedSource)
-            {
-                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.FixedState.MarkupHandling = MarkupMode.Allow;
-                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
-            }
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
-        }
-
-        private class CSharpTest : StyleCopCodeFixVerifier<SA1413UseTrailingCommasInMultiLineInitializers, SA1413CodeFixProvider>.CSharpTest
-        {
-            public CSharpTest(LanguageVersion languageVersion)
-            {
-                this.SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
-                });
-            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/OrderingRules/SA1206CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/OrderingRules/SA1206CSharp7UnitTests.cs
@@ -7,11 +7,11 @@ namespace StyleCop.Analyzers.Test.CSharp7.OrderingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
-    using StyleCop.Analyzers.OrderingRules;
     using StyleCop.Analyzers.Test.OrderingRules;
-    using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.OrderingRules.SA1206DeclarationKeywordsMustFollowOrder,
+        StyleCop.Analyzers.OrderingRules.SA1206CodeFixProvider>;
 
     public class SA1206CSharp7UnitTests : SA1206UnitTests
     {
@@ -32,7 +32,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.OrderingRules
     }}
 }}
 ";
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpDiagnosticAsync(LanguageVersion.Latest, testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -51,29 +51,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.OrderingRules
             {
                 Diagnostic().WithLocation(3, 14).WithArguments("private", "readonly"),
             };
-            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        private static DiagnosticResult Diagnostic()
-            => StyleCopCodeFixVerifier<SA1206DeclarationKeywordsMustFollowOrder, SA1206CodeFixProvider>.Diagnostic();
-
-        private static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken)
-        {
-            var test = new StyleCopCodeFixVerifier<SA1206DeclarationKeywordsMustFollowOrder, SA1206CodeFixProvider>.CSharpTest
-            {
-                TestCode = source,
-                SolutionTransforms =
-                {
-                    (solution, projectId) =>
-                    {
-                        var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                        return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.Latest));
-                    },
-                },
-            };
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
+            await VerifyCSharpDiagnosticAsync(LanguageVersion.Latest, testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/OrderingRules/SA1207CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/OrderingRules/SA1207CSharp7UnitTests.cs
@@ -3,9 +3,78 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.OrderingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.OrderingRules;
     using StyleCop.Analyzers.Test.OrderingRules;
+    using StyleCop.Analyzers.Test.Verifiers;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.OrderingRules.SA1207ProtectedMustComeBeforeInternal>;
 
     public class SA1207CSharp7UnitTests : SA1207UnitTests
     {
+        [Fact]
+        public async Task TestPrivateProtectedAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        protected private int testField;
+    }
+}
+";
+
+            var fixedTestCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        private protected int testField;
+    }
+}
+";
+
+            var expectedDiagnostic = Diagnostic().WithArguments("private", "protected").WithLocation(5, 19);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_2, testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            return VerifyCSharpFixAsync(languageVersion, source, new[] { expected }, fixedSource, cancellationToken);
+        }
+
+        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            var test = new CSharpTest(languageVersion)
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            if (source == fixedSource)
+            {
+                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.FixedState.MarkupHandling = MarkupMode.Allow;
+                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
+            }
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
+        private class CSharpTest : StyleCopCodeFixVerifier<SA1207ProtectedMustComeBeforeInternal, SA1207CodeFixProvider>.CSharpTest
+        {
+            public CSharpTest(LanguageVersion languageVersion)
+            {
+                this.SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
+                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
+                });
+            }
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/OrderingRules/SA1207CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/OrderingRules/SA1207CSharp7UnitTests.cs
@@ -6,12 +6,11 @@ namespace StyleCop.Analyzers.Test.CSharp7.OrderingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CSharp;
-    using Microsoft.CodeAnalysis.Testing;
-    using StyleCop.Analyzers.OrderingRules;
     using StyleCop.Analyzers.Test.OrderingRules;
-    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.OrderingRules.SA1207ProtectedMustComeBeforeInternal>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.OrderingRules.SA1207ProtectedMustComeBeforeInternal,
+        StyleCop.Analyzers.OrderingRules.SA1207CodeFixProvider>;
 
     public class SA1207CSharp7UnitTests : SA1207UnitTests
     {
@@ -38,43 +37,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.OrderingRules
 
             var expectedDiagnostic = Diagnostic().WithArguments("private", "protected").WithLocation(5, 19);
             await VerifyCSharpFixAsync(LanguageVersion.CSharp7_2, testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            return VerifyCSharpFixAsync(languageVersion, source, new[] { expected }, fixedSource, cancellationToken);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            var test = new CSharpTest(languageVersion)
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
-
-            if (source == fixedSource)
-            {
-                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.FixedState.MarkupHandling = MarkupMode.Allow;
-                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
-            }
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
-        }
-
-        private class CSharpTest : StyleCopCodeFixVerifier<SA1207ProtectedMustComeBeforeInternal, SA1207CodeFixProvider>.CSharpTest
-        {
-            public CSharpTest(LanguageVersion languageVersion)
-            {
-                this.SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
-                });
-            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1131CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1131CSharp7UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1131UseReadableConditions,
@@ -57,20 +56,7 @@ struct TestStruct
 }}
 ";
             DiagnosticResult expected = Diagnostic().WithLocation(8, 18);
-            await new CSharpTest
-            {
-                TestCode = testCode,
-                ExpectedDiagnostics = { expected },
-                FixedCode = fixedCode,
-                SolutionTransforms =
-                {
-                    (solution, projectId) =>
-                    {
-                        var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                        return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.Latest));
-                    },
-                },
-            }.RunAsync(CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(LanguageVersion.Latest, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1137CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1137CSharp7UnitTests.cs
@@ -5,12 +5,13 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.ReadabilityRules;
     using StyleCop.Analyzers.Test.ReadabilityRules;
+    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1137ElementsShouldHaveTheSameIndentation,
-        StyleCop.Analyzers.ReadabilityRules.IndentationCodeFixProvider>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.ReadabilityRules.SA1137ElementsShouldHaveTheSameIndentation>;
 
     public class SA1137CSharp7UnitTests : SA1137UnitTests
     {
@@ -54,7 +55,7 @@ int z) ZeroAlignment;
                 Diagnostic().WithLocation(12, 1),
             };
 
-            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -97,7 +98,159 @@ class Container
                 Diagnostic().WithLocation(12, 1),
             };
 
-            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc int[]
+            {
+                0,
+              0,
+0,
+            };
+            int* data2 = stackalloc int[]
+            {
+0,
+              0,
+                0,
+            };
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc int[]
+            {
+                0,
+                0,
+                0,
+            };
+            int* data2 = stackalloc int[]
+            {
+0,
+0,
+0,
+            };
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithLocation(10, 1),
+                Diagnostic().WithLocation(11, 1),
+                Diagnostic().WithLocation(16, 1),
+                Diagnostic().WithLocation(17, 1),
+            };
+
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestImplicitStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc[]
+            {
+                0,
+              0,
+0,
+            };
+            int* data2 = stackalloc[]
+            {
+0,
+              0,
+                0,
+            };
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc[]
+            {
+                0,
+                0,
+                0,
+            };
+            int* data2 = stackalloc[]
+            {
+0,
+0,
+0,
+            };
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithLocation(10, 1),
+                Diagnostic().WithLocation(11, 1),
+                Diagnostic().WithLocation(16, 1),
+                Diagnostic().WithLocation(17, 1),
+            };
+
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            var test = new CSharpTest(languageVersion)
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            if (source == fixedSource)
+            {
+                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.FixedState.MarkupHandling = MarkupMode.Allow;
+                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
+            }
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
+        private class CSharpTest : StyleCopCodeFixVerifier<SA1137ElementsShouldHaveTheSameIndentation, IndentationCodeFixProvider>.CSharpTest
+        {
+            public CSharpTest(LanguageVersion languageVersion)
+            {
+                this.SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
+                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
+                });
+            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1137CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1137CSharp7UnitTests.cs
@@ -7,11 +7,11 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
-    using StyleCop.Analyzers.ReadabilityRules;
     using StyleCop.Analyzers.Test.ReadabilityRules;
-    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.ReadabilityRules.SA1137ElementsShouldHaveTheSameIndentation>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.ReadabilityRules.SA1137ElementsShouldHaveTheSameIndentation,
+        StyleCop.Analyzers.ReadabilityRules.IndentationCodeFixProvider>;
 
     public class SA1137CSharp7UnitTests : SA1137UnitTests
     {
@@ -219,38 +219,6 @@ class Container
             };
 
             await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            var test = new CSharpTest(languageVersion)
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
-
-            if (source == fixedSource)
-            {
-                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.FixedState.MarkupHandling = MarkupMode.Allow;
-                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
-            }
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
-        }
-
-        private class CSharpTest : StyleCopCodeFixVerifier<SA1137ElementsShouldHaveTheSameIndentation, IndentationCodeFixProvider>.CSharpTest
-        {
-            public CSharpTest(LanguageVersion languageVersion)
-            {
-                this.SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
-                });
-            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1137CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1137CSharp7UnitTests.cs
@@ -55,7 +55,7 @@ int z) ZeroAlignment;
                 Diagnostic().WithLocation(12, 1),
             };
 
-            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -98,7 +98,7 @@ class Container
                 Diagnostic().WithLocation(12, 1),
             };
 
-            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1000CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1000CSharp7UnitTests.cs
@@ -5,9 +5,9 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1000KeywordsMustBeSpacedCorrectly,
@@ -235,6 +235,19 @@ namespace TestNamespace
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestStackAllocImplicitArrayStatementAsync()
+        {
+            string statementWithoutSpace = @"int* x = stackalloc[] { 3 };";
+
+            string statementWithSpace = @"int* x = stackalloc [] { 3 };";
+
+            await this.TestKeywordStatementAsync(statementWithoutSpace, DiagnosticResult.EmptyDiagnosticResults, statementWithoutSpace, languageVersion: LanguageVersion.CSharp7_3).ConfigureAwait(false);
+
+            // this case is handled by SA1026, so it shouldn't be reported here
+            await this.TestKeywordStatementAsync(statementWithSpace, DiagnosticResult.EmptyDiagnosticResults, statementWithSpace, languageVersion: LanguageVersion.CSharp7_3).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1001CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1001CSharp7UnitTests.cs
@@ -53,7 +53,7 @@ public class Foo
                 Diagnostic().WithLocation(7, 65).WithArguments(" not", "preceded"),
             };
 
-            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -85,7 +85,7 @@ public class Foo
 }";
 
             DiagnosticResult expected = Diagnostic().WithLocation(7, 34).WithArguments(" not", "preceded");
-            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -117,7 +117,7 @@ public class Foo
 }";
 
             DiagnosticResult expected = Diagnostic().WithLocation(7, 21).WithArguments(" not", "preceded");
-            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1001CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1001CSharp7UnitTests.cs
@@ -7,11 +7,11 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
-    using StyleCop.Analyzers.SpacingRules;
     using StyleCop.Analyzers.Test.SpacingRules;
-    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.SpacingRules.SA1001CommasMustBeSpacedCorrectly>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1001CommasMustBeSpacedCorrectly,
+        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1001CSharp7UnitTests : SA1001UnitTests
     {
@@ -196,43 +196,6 @@ public class Foo
             };
 
             await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            return VerifyCSharpFixAsync(languageVersion, source, new[] { expected }, fixedSource, cancellationToken);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            var test = new CSharpTest(languageVersion)
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
-
-            if (source == fixedSource)
-            {
-                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.FixedState.MarkupHandling = MarkupMode.Allow;
-                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
-            }
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
-        }
-
-        private class CSharpTest : StyleCopCodeFixVerifier<SA1001CommasMustBeSpacedCorrectly, TokenSpacingCodeFixProvider>.CSharpTest
-        {
-            public CSharpTest(LanguageVersion languageVersion)
-            {
-                this.SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
-                });
-            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1002CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1002CSharp7UnitTests.cs
@@ -7,11 +7,11 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
-    using StyleCop.Analyzers.SpacingRules;
     using StyleCop.Analyzers.Test.SpacingRules;
-    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.SpacingRules.SA1002SemicolonsMustBeSpacedCorrectly>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1002SemicolonsMustBeSpacedCorrectly,
+        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1002CSharp7UnitTests : SA1002UnitTests
     {
@@ -83,38 +83,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
             };
 
             await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            var test = new CSharpTest(languageVersion)
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
-
-            if (source == fixedSource)
-            {
-                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.FixedState.MarkupHandling = MarkupMode.Allow;
-                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
-            }
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
-        }
-
-        private class CSharpTest : StyleCopCodeFixVerifier<SA1002SemicolonsMustBeSpacedCorrectly, TokenSpacingCodeFixProvider>.CSharpTest
-        {
-            public CSharpTest(LanguageVersion languageVersion)
-            {
-                this.SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
-                });
-            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1010CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1010CSharp7UnitTests.cs
@@ -7,11 +7,11 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
-    using StyleCop.Analyzers.SpacingRules;
     using StyleCop.Analyzers.Test.SpacingRules;
-    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.SpacingRules.SA1010OpeningSquareBracketsMustBeSpacedCorrectly>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1010OpeningSquareBracketsMustBeSpacedCorrectly,
+        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1010CSharp7UnitTests : SA1010UnitTests
     {
@@ -101,38 +101,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
             };
 
             await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            var test = new CSharpTest(languageVersion)
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
-
-            if (source == fixedSource)
-            {
-                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.FixedState.MarkupHandling = MarkupMode.Allow;
-                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
-            }
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
-        }
-
-        private class CSharpTest : StyleCopCodeFixVerifier<SA1010OpeningSquareBracketsMustBeSpacedCorrectly, TokenSpacingCodeFixProvider>.CSharpTest
-        {
-            public CSharpTest(LanguageVersion languageVersion)
-            {
-                this.SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
-                });
-            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1010CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1010CSharp7UnitTests.cs
@@ -3,9 +3,136 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.SpacingRules;
     using StyleCop.Analyzers.Test.SpacingRules;
+    using StyleCop.Analyzers.Test.Verifiers;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.SpacingRules.SA1010OpeningSquareBracketsMustBeSpacedCorrectly>;
 
     public class SA1010CSharp7UnitTests : SA1010UnitTests
     {
+        [Fact]
+        public async Task TestStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc int [ ] { 1 , 1 };
+            int* data2 = stackalloc int [] { 1 , 1 };
+            int* data3 = stackalloc int[] { 1 , 1 };
+            int* data4 = stackalloc int[
+] { 1 , 1 };
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc int[] { 1 , 1 };
+            int* data2 = stackalloc int[] { 1 , 1 };
+            int* data3 = stackalloc int[] { 1 , 1 };
+            int* data4 = stackalloc int[
+] { 1 , 1 };
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithArguments("not be preceded").WithLocation(7, 41),
+                Diagnostic().WithArguments("not be followed").WithLocation(7, 41),
+                Diagnostic().WithArguments("not be preceded").WithLocation(8, 41),
+            };
+
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestImplicitStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc [ ] { 1 , 1 };
+            int* data2 = stackalloc [] { 1 , 1 };
+            int* data3 = stackalloc[] { 1 , 1 };
+            int* data4 = stackalloc[
+] { 1 , 1 };
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc [] { 1 , 1 };
+            int* data2 = stackalloc [] { 1 , 1 };
+            int* data3 = stackalloc[] { 1 , 1 };
+            int* data4 = stackalloc[
+] { 1 , 1 };
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithArguments("not be followed").WithLocation(7, 37),
+            };
+
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            var test = new CSharpTest(languageVersion)
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            if (source == fixedSource)
+            {
+                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.FixedState.MarkupHandling = MarkupMode.Allow;
+                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
+            }
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
+        private class CSharpTest : StyleCopCodeFixVerifier<SA1010OpeningSquareBracketsMustBeSpacedCorrectly, TokenSpacingCodeFixProvider>.CSharpTest
+        {
+            public CSharpTest(LanguageVersion languageVersion)
+            {
+                this.SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
+                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
+                });
+            }
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1011CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1011CSharp7UnitTests.cs
@@ -5,12 +5,13 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.SpacingRules;
     using StyleCop.Analyzers.Test.SpacingRules;
+    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1011ClosingSquareBracketsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.SpacingRules.SA1011ClosingSquareBracketsMustBeSpacedCorrectly>;
 
     public class SA1011CSharp7UnitTests : SA1011UnitTests
     {
@@ -36,7 +37,135 @@ public class Foo
     }
 }";
 
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc int[ ] { 1 , 1 };
+            int* data2 = stackalloc int[ ]{ 1 , 1 };
+            int* data3 = stackalloc int[] { 1 , 1 };
+            int* data4 = stackalloc int[]{ 1 , 1 };
+            int* data5 = stackalloc int[]
+{ 1 , 1 };
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc int[] { 1 , 1 };
+            int* data2 = stackalloc int[] { 1 , 1 };
+            int* data3 = stackalloc int[] { 1 , 1 };
+            int* data4 = stackalloc int[] { 1 , 1 };
+            int* data5 = stackalloc int[]
+{ 1 , 1 };
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithArguments(" not", "preceded").WithLocation(7, 42),
+                Diagnostic().WithArguments(" not", "preceded").WithLocation(8, 42),
+                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(8, 42),
+                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(10, 41),
+            };
+
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestImplicitStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc[ ] { 1 , 1 };
+            int* data2 = stackalloc[ ]{ 1 , 1 };
+            int* data3 = stackalloc[] { 1 , 1 };
+            int* data4 = stackalloc[]{ 1 , 1 };
+            int* data5 = stackalloc[]
+{ 1 , 1 };
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc[] { 1 , 1 };
+            int* data2 = stackalloc[] { 1 , 1 };
+            int* data3 = stackalloc[] { 1 , 1 };
+            int* data4 = stackalloc[] { 1 , 1 };
+            int* data5 = stackalloc[]
+{ 1 , 1 };
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithArguments(" not", "preceded").WithLocation(7, 38),
+                Diagnostic().WithArguments(" not", "preceded").WithLocation(8, 38),
+                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(8, 38),
+                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(10, 37),
+            };
+
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            var test = new CSharpTest(languageVersion)
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            if (source == fixedSource)
+            {
+                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.FixedState.MarkupHandling = MarkupMode.Allow;
+                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
+            }
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
+        private class CSharpTest : StyleCopCodeFixVerifier<SA1011ClosingSquareBracketsMustBeSpacedCorrectly, TokenSpacingCodeFixProvider>.CSharpTest
+        {
+            public CSharpTest(LanguageVersion languageVersion)
+            {
+                this.SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
+                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
+                });
+            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1011CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1011CSharp7UnitTests.cs
@@ -37,7 +37,7 @@ public class Foo
     }
 }";
 
-            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1011CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1011CSharp7UnitTests.cs
@@ -7,11 +7,11 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
-    using StyleCop.Analyzers.SpacingRules;
     using StyleCop.Analyzers.Test.SpacingRules;
-    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.SpacingRules.SA1011ClosingSquareBracketsMustBeSpacedCorrectly>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1011ClosingSquareBracketsMustBeSpacedCorrectly,
+        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1011CSharp7UnitTests : SA1011UnitTests
     {
@@ -134,38 +134,6 @@ public class Foo
             };
 
             await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            var test = new CSharpTest(languageVersion)
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
-
-            if (source == fixedSource)
-            {
-                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.FixedState.MarkupHandling = MarkupMode.Allow;
-                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
-            }
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
-        }
-
-        private class CSharpTest : StyleCopCodeFixVerifier<SA1011ClosingSquareBracketsMustBeSpacedCorrectly, TokenSpacingCodeFixProvider>.CSharpTest
-        {
-            public CSharpTest(LanguageVersion languageVersion)
-            {
-                this.SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
-                });
-            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1012CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1012CSharp7UnitTests.cs
@@ -3,9 +3,166 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.SpacingRules;
     using StyleCop.Analyzers.Test.SpacingRules;
+    using StyleCop.Analyzers.Test.Verifiers;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.SpacingRules.SA1012OpeningBracesMustBeSpacedCorrectly>;
 
     public class SA1012CSharp7UnitTests : SA1012UnitTests
     {
+        [Fact]
+        public async Task TestStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc int[] { 1 , 1 };
+            int* data2 = stackalloc int[] {1 , 1 };
+            int* data3 = stackalloc int[]{ 1 , 1 };
+            int* data4 = stackalloc int[]{1 , 1 };
+            int* data5 = stackalloc int[] {
+1 , 1 };
+            int* data6 = stackalloc int[]
+            {1 , 1 };
+            int* data7 = stackalloc int[]
+            {
+                1 , 1 };
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc int[] { 1 , 1 };
+            int* data2 = stackalloc int[] { 1 , 1 };
+            int* data3 = stackalloc int[] { 1 , 1 };
+            int* data4 = stackalloc int[] { 1 , 1 };
+            int* data5 = stackalloc int[] {
+1 , 1 };
+            int* data6 = stackalloc int[]
+            { 1 , 1 };
+            int* data7 = stackalloc int[]
+            {
+                1 , 1 };
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(8, 43),
+                Diagnostic().WithArguments(string.Empty, "preceded").WithLocation(9, 42),
+                Diagnostic().WithArguments(string.Empty, "preceded").WithLocation(10, 42),
+                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(10, 42),
+                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(14, 13),
+            };
+
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestImplicitStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc[] { 1 , 1 };
+            int* data2 = stackalloc[] {1 , 1 };
+            int* data3 = stackalloc[]{ 1 , 1 };
+            int* data4 = stackalloc[]{1 , 1 };
+            int* data5 = stackalloc[] {
+1 , 1 };
+            int* data6 = stackalloc[]
+            {1 , 1 };
+            int* data7 = stackalloc[]
+            {
+                1 , 1 };
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc[] { 1 , 1 };
+            int* data2 = stackalloc[] { 1 , 1 };
+            int* data3 = stackalloc[] { 1 , 1 };
+            int* data4 = stackalloc[] { 1 , 1 };
+            int* data5 = stackalloc[] {
+1 , 1 };
+            int* data6 = stackalloc[]
+            { 1 , 1 };
+            int* data7 = stackalloc[]
+            {
+                1 , 1 };
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(8, 39),
+                Diagnostic().WithArguments(string.Empty, "preceded").WithLocation(9, 38),
+                Diagnostic().WithArguments(string.Empty, "preceded").WithLocation(10, 38),
+                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(10, 38),
+                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(14, 13),
+            };
+
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            var test = new CSharpTest(languageVersion)
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            if (source == fixedSource)
+            {
+                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.FixedState.MarkupHandling = MarkupMode.Allow;
+                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
+            }
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
+        private class CSharpTest : StyleCopCodeFixVerifier<SA1012OpeningBracesMustBeSpacedCorrectly, TokenSpacingCodeFixProvider>.CSharpTest
+        {
+            public CSharpTest(LanguageVersion languageVersion)
+            {
+                this.SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
+                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
+                });
+            }
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1012CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1012CSharp7UnitTests.cs
@@ -7,11 +7,11 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
-    using StyleCop.Analyzers.SpacingRules;
     using StyleCop.Analyzers.Test.SpacingRules;
-    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.SpacingRules.SA1012OpeningBracesMustBeSpacedCorrectly>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1012OpeningBracesMustBeSpacedCorrectly,
+        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1012CSharp7UnitTests : SA1012UnitTests
     {
@@ -131,38 +131,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
             };
 
             await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            var test = new CSharpTest(languageVersion)
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
-
-            if (source == fixedSource)
-            {
-                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.FixedState.MarkupHandling = MarkupMode.Allow;
-                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
-            }
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
-        }
-
-        private class CSharpTest : StyleCopCodeFixVerifier<SA1012OpeningBracesMustBeSpacedCorrectly, TokenSpacingCodeFixProvider>.CSharpTest
-        {
-            public CSharpTest(LanguageVersion languageVersion)
-            {
-                this.SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
-                });
-            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1013CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1013CSharp7UnitTests.cs
@@ -5,13 +5,13 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.SpacingRules;
     using StyleCop.Analyzers.Test.SpacingRules;
-    using TestHelper;
+    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1013ClosingBracesMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.SpacingRules.SA1013ClosingBracesMustBeSpacedCorrectly>;
 
     public class SA1013CSharp7UnitTests : SA1013UnitTests
     {
@@ -49,7 +49,153 @@ public class Foo
                 Diagnostic().WithLocation(7, 45).WithArguments(string.Empty, "preceded"),
             };
 
-            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc int[] { 1 , 1 } ;
+            int* data2 = stackalloc int[] { 1 , 1 };
+            int* data3 = stackalloc int[] { 1 , 1} ;
+            int* data4 = stackalloc int[] { 1 , 1};
+            int* data5 = stackalloc int[] { 1 , 1
+};
+            int* data6 = stackalloc int[]
+            { 1 , 1};
+            int* data7 = stackalloc int[]
+            {
+                1 , 1 } ;
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc int[] { 1 , 1 } ;
+            int* data2 = stackalloc int[] { 1 , 1 };
+            int* data3 = stackalloc int[] { 1 , 1 } ;
+            int* data4 = stackalloc int[] { 1 , 1 };
+            int* data5 = stackalloc int[] { 1 , 1
+};
+            int* data6 = stackalloc int[]
+            { 1 , 1 };
+            int* data7 = stackalloc int[]
+            {
+                1 , 1 } ;
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithArguments(string.Empty, "preceded").WithLocation(9, 50),
+                Diagnostic().WithArguments(string.Empty, "preceded").WithLocation(10, 50),
+                Diagnostic().WithArguments(string.Empty, "preceded").WithLocation(14, 20),
+            };
+
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestImplicitStackAllocArrayCreationExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc[] { 1 , 1 } ;
+            int* data2 = stackalloc[] { 1 , 1 };
+            int* data3 = stackalloc[] { 1 , 1} ;
+            int* data4 = stackalloc[] { 1 , 1};
+            int* data5 = stackalloc[] { 1 , 1
+};
+            int* data6 = stackalloc[]
+            { 1 , 1};
+            int* data7 = stackalloc[]
+            {
+                1 , 1 } ;
+        }
+    }
+}
+";
+
+            var fixedCode = @"namespace TestNamespace
+{
+    public class TestClass
+    {
+        public unsafe void TestMethod()
+        {
+            int* data1 = stackalloc[] { 1 , 1 } ;
+            int* data2 = stackalloc[] { 1 , 1 };
+            int* data3 = stackalloc[] { 1 , 1 } ;
+            int* data4 = stackalloc[] { 1 , 1 };
+            int* data5 = stackalloc[] { 1 , 1
+};
+            int* data6 = stackalloc[]
+            { 1 , 1 };
+            int* data7 = stackalloc[]
+            {
+                1 , 1 } ;
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithArguments(string.Empty, "preceded").WithLocation(9, 46),
+                Diagnostic().WithArguments(string.Empty, "preceded").WithLocation(10, 46),
+                Diagnostic().WithArguments(string.Empty, "preceded").WithLocation(14, 20),
+            };
+
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            var test = new CSharpTest(languageVersion)
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            if (source == fixedSource)
+            {
+                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.FixedState.MarkupHandling = MarkupMode.Allow;
+                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
+            }
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
+        private class CSharpTest : StyleCopCodeFixVerifier<SA1013ClosingBracesMustBeSpacedCorrectly, TokenSpacingCodeFixProvider>.CSharpTest
+        {
+            public CSharpTest(LanguageVersion languageVersion)
+            {
+                this.SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
+                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
+                });
+            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1013CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1013CSharp7UnitTests.cs
@@ -7,11 +7,11 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
-    using StyleCop.Analyzers.SpacingRules;
     using StyleCop.Analyzers.Test.SpacingRules;
-    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.SpacingRules.SA1013ClosingBracesMustBeSpacedCorrectly>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1013ClosingBracesMustBeSpacedCorrectly,
+        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1013CSharp7UnitTests : SA1013UnitTests
     {
@@ -164,38 +164,6 @@ public class Foo
             };
 
             await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            var test = new CSharpTest(languageVersion)
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
-
-            if (source == fixedSource)
-            {
-                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.FixedState.MarkupHandling = MarkupMode.Allow;
-                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
-            }
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
-        }
-
-        private class CSharpTest : StyleCopCodeFixVerifier<SA1013ClosingBracesMustBeSpacedCorrectly, TokenSpacingCodeFixProvider>.CSharpTest
-        {
-            public CSharpTest(LanguageVersion languageVersion)
-            {
-                this.SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
-                });
-            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1013CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1013CSharp7UnitTests.cs
@@ -49,7 +49,7 @@ public class Foo
                 Diagnostic().WithLocation(7, 45).WithArguments(string.Empty, "preceded"),
             };
 
-            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1026CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1026CSharp7UnitTests.cs
@@ -7,11 +7,11 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
-    using StyleCop.Analyzers.SpacingRules;
     using StyleCop.Analyzers.Test.SpacingRules;
-    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.SpacingRules.SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation,
+        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1026CSharp7UnitTests : SA1026UnitTests
     {
@@ -31,38 +31,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
             DiagnosticResult[] expected = { Diagnostic().WithArguments("stackalloc").WithLocation(1, 54) };
 
             await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, expectedCode, CancellationToken.None).ConfigureAwait(false);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            var test = new CSharpTest(languageVersion)
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
-
-            if (source == fixedSource)
-            {
-                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.FixedState.MarkupHandling = MarkupMode.Allow;
-                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
-            }
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
-        }
-
-        private class CSharpTest : StyleCopCodeFixVerifier<SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation, TokenSpacingCodeFixProvider>.CSharpTest
-        {
-            public CSharpTest(LanguageVersion languageVersion)
-            {
-                this.SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
-                });
-            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1026CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1026CSharp7UnitTests.cs
@@ -3,9 +3,66 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.SpacingRules;
     using StyleCop.Analyzers.Test.SpacingRules;
+    using StyleCop.Analyzers.Test.Verifiers;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.SpacingRules.SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation>;
 
     public class SA1026CSharp7UnitTests : SA1026UnitTests
     {
+        [Theory]
+        [InlineData(" ")]
+        [InlineData("  ")]
+        [InlineData("\t")]
+        [InlineData("\r")]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        [InlineData(" \t \r\n")]
+        [InlineData(" \t \r\n\t ")]
+        public async Task TestImplicitStackAllocArrayCreationExpressionAsync(string space)
+        {
+            string testCode = $"public class Foo {{ public unsafe Foo() {{ int* ints = stackalloc{space}[] {{ 1, 2, 3 }}; }} }}";
+            const string expectedCode = "public class Foo { public unsafe Foo() { int* ints = stackalloc[] { 1, 2, 3 }; } }";
+            DiagnosticResult[] expected = { Diagnostic().WithArguments("stackalloc").WithLocation(1, 54) };
+
+            await VerifyCSharpFixAsync(LanguageVersion.CSharp7_3, testCode, expected, expectedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
+        {
+            var test = new CSharpTest(languageVersion)
+            {
+                TestCode = source,
+                FixedCode = fixedSource,
+            };
+
+            if (source == fixedSource)
+            {
+                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.FixedState.MarkupHandling = MarkupMode.Allow;
+                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
+                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
+            }
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
+        private class CSharpTest : StyleCopCodeFixVerifier<SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation, TokenSpacingCodeFixProvider>.CSharpTest
+        {
+            public CSharpTest(LanguageVersion languageVersion)
+            {
+                this.SolutionTransforms.Add((solution, projectId) =>
+                {
+                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
+                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
+                });
+            }
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/StyleCop.Analyzers.Test.CSharp7.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/StyleCop.Analyzers.Test.CSharp7.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.8.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" PrivateAssets="all" />
   </ItemGroup>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
@@ -8,9 +8,10 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
-    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1600ElementsMustBeDocumented>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.DocumentationRules.SA1600ElementsMustBeDocumented,
+        StyleCop.Analyzers.DocumentationRules.SA1600CodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1600ElementsMustBeDocumented"/>.
@@ -1397,52 +1398,6 @@ public class OuterClass
             await this.TestNestedTypeDeclarationDocumentationAsync(type, "internal", false, true).ConfigureAwait(false);
             await this.TestNestedTypeDeclarationDocumentationAsync(type, "protected internal", false, true).ConfigureAwait(false);
             await this.TestNestedTypeDeclarationDocumentationAsync(type, "public", false, true).ConfigureAwait(false);
-        }
-
-        private static Task VerifyCSharpDiagnosticAsync(LanguageVersion languageVersion, string source, DiagnosticResult expected, CancellationToken cancellationToken)
-            => VerifyCSharpDiagnosticAsync(languageVersion, source, new[] { expected }, cancellationToken);
-
-        private static Task VerifyCSharpDiagnosticAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, CancellationToken cancellationToken)
-        {
-            var test = new CSharpTest(languageVersion)
-            {
-                TestCode = source,
-            };
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
-        }
-
-        private static Task VerifyCSharpFixAsync(LanguageVersion languageVersion, string source, DiagnosticResult[] expected, string fixedSource, CancellationToken cancellationToken)
-        {
-            var test = new CSharpTest(languageVersion)
-            {
-                TestCode = source,
-                FixedCode = fixedSource,
-            };
-
-            if (source == fixedSource)
-            {
-                test.FixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.FixedState.MarkupHandling = MarkupMode.Allow;
-                test.BatchFixedState.InheritanceMode = StateInheritanceMode.AutoInheritAll;
-                test.BatchFixedState.MarkupHandling = MarkupMode.Allow;
-            }
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            return test.RunAsync(cancellationToken);
-        }
-
-        private class CSharpTest : StyleCopCodeFixVerifier<SA1600ElementsMustBeDocumented, SA1600CodeFixProvider>.CSharpTest
-        {
-            public CSharpTest(LanguageVersion languageVersion)
-            {
-                this.SolutionTransforms.Add((solution, projectId) =>
-                {
-                    var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                    return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
-                });
-            }
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Lightup/ArgumentSyntaxExtensionsTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Lightup/ArgumentSyntaxExtensionsTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.Lightup
+{
+    using System;
+    using Microsoft.CodeAnalysis.CSharp;
+    using StyleCop.Analyzers.Lightup;
+    using Xunit;
+
+    public class ArgumentSyntaxExtensionsTests
+    {
+        [Fact]
+        public void TestRefKindKeyword()
+        {
+            var argumentSyntax = SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
+            Assert.Equal(default, ArgumentSyntaxExtensions.RefKindKeyword(argumentSyntax));
+        }
+
+        [Fact]
+        public void TestWithRefKindKeyword()
+        {
+            var argumentSyntax = SyntaxFactory.Argument(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
+
+            // With default value is allowed
+            var argumentWithDefaultRefKind = ArgumentSyntaxExtensions.WithRefKindKeyword(argumentSyntax, default);
+            Assert.Equal(default, ArgumentSyntaxExtensions.RefKindKeyword(argumentWithDefaultRefKind));
+
+            // Non-default throws an exception
+            var refKind = SyntaxFactory.Token(SyntaxKind.RefKeyword);
+            Assert.Throws<NotSupportedException>(() => ArgumentSyntaxExtensions.WithRefKindKeyword(argumentSyntax, refKind));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Lightup/CrefParameterSyntaxExtensionsTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Lightup/CrefParameterSyntaxExtensionsTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.Lightup
+{
+    using System;
+    using Microsoft.CodeAnalysis.CSharp;
+    using StyleCop.Analyzers.Lightup;
+    using Xunit;
+
+    public class CrefParameterSyntaxExtensionsTests
+    {
+        [Fact]
+        public void TestRefKindKeyword()
+        {
+            var crefParameterSyntax = SyntaxFactory.CrefParameter(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)));
+            Assert.Equal(default, CrefParameterSyntaxExtensions.RefKindKeyword(crefParameterSyntax));
+        }
+
+        [Fact]
+        public void TestWithRefKindKeyword()
+        {
+            var crefParameterSyntax = SyntaxFactory.CrefParameter(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)));
+
+            // With default value is allowed
+            var crefParameterWithDefaultRefKind = CrefParameterSyntaxExtensions.WithRefKindKeyword(crefParameterSyntax, default);
+            Assert.Equal(default, CrefParameterSyntaxExtensions.RefKindKeyword(crefParameterWithDefaultRefKind));
+
+            // Non-default throws an exception
+            var refKind = SyntaxFactory.Token(SyntaxKind.RefKeyword);
+            Assert.Throws<NotSupportedException>(() => CrefParameterSyntaxExtensions.WithRefKindKeyword(crefParameterSyntax, refKind));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Lightup/INamedTypeSymbolExtensionsTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Lightup/INamedTypeSymbolExtensionsTests.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.Lightup
+{
+    using System;
+    using Microsoft.CodeAnalysis;
+    using StyleCop.Analyzers.Lightup;
+    using Xunit;
+
+    public class INamedTypeSymbolExtensionsTests
+    {
+        [Fact]
+        public void TestNull()
+        {
+            INamedTypeSymbol symbol = null;
+            Assert.Throws<NullReferenceException>(() => INamedTypeSymbolExtensions.IsSerializable(symbol));
+            Assert.Throws<NullReferenceException>(() => INamedTypeSymbolExtensions.TupleElements(symbol));
+            Assert.Throws<NullReferenceException>(() => INamedTypeSymbolExtensions.TupleUnderlyingType(symbol));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Lightup/ITypeParameterSymbolExtensionsTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Lightup/ITypeParameterSymbolExtensionsTests.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.Lightup
+{
+    using System;
+    using Microsoft.CodeAnalysis;
+    using StyleCop.Analyzers.Lightup;
+    using Xunit;
+
+    public class ITypeParameterSymbolExtensionsTests
+    {
+        [Fact]
+        public void TestNull()
+        {
+            ITypeParameterSymbol symbol = null;
+            Assert.Throws<NullReferenceException>(() => ITypeParameterSymbolExtensions.HasUnmanagedTypeConstraint(symbol));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Lightup/ImplicitStackAllocArrayCreationExpressionSyntaxWrapperTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Lightup/ImplicitStackAllocArrayCreationExpressionSyntaxWrapperTests.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.Lightup
+{
+    using System;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using StyleCop.Analyzers.Lightup;
+    using Xunit;
+
+    public class ImplicitStackAllocArrayCreationExpressionSyntaxWrapperTests
+    {
+        [Fact]
+        public void TestNull()
+        {
+            var syntaxNode = default(SyntaxNode);
+            var wrapper = (ImplicitStackAllocArrayCreationExpressionSyntaxWrapper)syntaxNode;
+            Assert.Null(wrapper.SyntaxNode);
+            Assert.Throws<NullReferenceException>(() => wrapper.StackAllocKeyword);
+            Assert.Throws<NullReferenceException>(() => wrapper.OpenBracketToken);
+            Assert.Throws<NullReferenceException>(() => wrapper.CloseBracketToken);
+            Assert.Throws<NullReferenceException>(() => wrapper.Initializer);
+            Assert.Throws<NullReferenceException>(() => wrapper.WithStackAllocKeyword(SyntaxFactory.Token(SyntaxKind.StackAllocKeyword)));
+            Assert.Throws<NullReferenceException>(() => wrapper.WithOpenBracketToken(SyntaxFactory.Token(SyntaxKind.OpenBracketToken)));
+            Assert.Throws<NullReferenceException>(() => wrapper.WithCloseBracketToken(SyntaxFactory.Token(SyntaxKind.CloseBracketToken)));
+            Assert.Throws<NullReferenceException>(() => wrapper.WithInitializer(SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression)));
+            Assert.Throws<NullReferenceException>(() => wrapper.AddInitializerExpressions());
+        }
+
+        [Fact]
+        public void TestIsInstance()
+        {
+            Assert.False(ImplicitStackAllocArrayCreationExpressionSyntaxWrapper.IsInstance(null));
+            Assert.False(ImplicitStackAllocArrayCreationExpressionSyntaxWrapper.IsInstance(SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression)));
+        }
+
+        [Fact]
+        public void TestConversionsNull()
+        {
+            var syntaxNode = default(SyntaxNode);
+            var wrapper = (ImplicitStackAllocArrayCreationExpressionSyntaxWrapper)syntaxNode;
+
+            ExpressionSyntax syntax = wrapper;
+            Assert.Null(syntax);
+        }
+
+        [Fact]
+        public void TestInvalidConversion()
+        {
+            var syntaxNode = SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression);
+            Assert.Throws<InvalidCastException>(() => (ImplicitStackAllocArrayCreationExpressionSyntaxWrapper)syntaxNode);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Lightup/RefTypeSyntaxWrapperTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Lightup/RefTypeSyntaxWrapperTests.cs
@@ -20,8 +20,10 @@ namespace StyleCop.Analyzers.Test.Lightup
             Assert.Null(wrapper.SyntaxNode);
             Assert.Throws<NullReferenceException>(() => wrapper.Type);
             Assert.Throws<NullReferenceException>(() => wrapper.RefKeyword);
+            Assert.Throws<NullReferenceException>(() => wrapper.ReadOnlyKeyword);
             Assert.Throws<NullReferenceException>(() => wrapper.WithType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword))));
-            Assert.Throws<NullReferenceException>(() => wrapper.WithRefKeyword(SyntaxFactory.Token(SyntaxKind.IsKeyword)));
+            Assert.Throws<NullReferenceException>(() => wrapper.WithRefKeyword(SyntaxFactory.Token(SyntaxKind.RefKeyword)));
+            Assert.Throws<NullReferenceException>(() => wrapper.WithReadOnlyKeyword(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword)));
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Lightup/StackAllocArrayCreationExpressionSyntaxExtensionsTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Lightup/StackAllocArrayCreationExpressionSyntaxExtensionsTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.Lightup
+{
+    using System;
+    using Microsoft.CodeAnalysis.CSharp;
+    using StyleCop.Analyzers.Lightup;
+    using Xunit;
+
+    public class StackAllocArrayCreationExpressionSyntaxExtensionsTests
+    {
+        [Fact]
+        public void TestInitializer()
+        {
+            var stackAllocSyntax = SyntaxFactory.StackAllocArrayCreationExpression(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)));
+            Assert.Null(StackAllocArrayCreationExpressionSyntaxExtensions.Initializer(stackAllocSyntax));
+        }
+
+        [Fact]
+        public void TestWithInitializer()
+        {
+            var stackAllocSyntax = SyntaxFactory.StackAllocArrayCreationExpression(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword)));
+
+            // With default value is allowed
+            var stackAllocWithDefaultInitializer = StackAllocArrayCreationExpressionSyntaxExtensions.WithInitializer(stackAllocSyntax, null);
+            Assert.Null(StackAllocArrayCreationExpressionSyntaxExtensions.Initializer(stackAllocWithDefaultInitializer));
+
+            // Non-default throws an exception
+            var initializer = SyntaxFactory.InitializerExpression(SyntaxKind.ArrayInitializerExpression);
+            Assert.Throws<NotSupportedException>(() => StackAllocArrayCreationExpressionSyntaxExtensions.WithInitializer(stackAllocSyntax, initializer));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1207UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1207UnitTests.cs
@@ -129,7 +129,8 @@ public class Foo
             var testCode = TestCodeTemplate.Replace("$$", invalidDeclaration);
             var fixedTestCode = TestCodeTemplate.Replace("$$", fixedDeclaration);
 
-            await VerifyCSharpFixAsync(testCode, Diagnostic().WithLocation(4, 4 + diagnosticColumn), fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+            DiagnosticResult expected = Diagnostic().WithArguments("protected", "internal").WithLocation(4, 4 + diagnosticColumn);
+            await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1000UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1000UnitTests.cs
@@ -962,27 +962,7 @@ namespace Namespace
             string testCode = string.Format(testCodeFormat, asyncModifier, statement, unsafeModifier, awaitMethod, returnType);
             string fixedTest = string.Format(testCodeFormat, asyncModifier, fixedStatement, unsafeModifier, awaitMethod, returnType);
 
-            var test = new CSharpTest
-            {
-                TestCode = testCode,
-                FixedCode = fixedTest,
-                SolutionTransforms =
-                {
-                    (solution, projectId) =>
-                    {
-                        if (languageVersion.HasValue)
-                        {
-                            var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
-                            solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion.Value));
-                        }
-
-                        return solution;
-                    },
-                },
-            };
-
-            test.ExpectedDiagnostics.AddRange(expected);
-            await test.RunAsync(CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(languageVersion, testCode, expected, fixedTest, CancellationToken.None).ConfigureAwait(false);
         }
 
         private Task TestKeywordDeclarationAsync(string statement, DiagnosticResult expected, string fixedStatement)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1000UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1000UnitTests.cs
@@ -5,9 +5,9 @@ namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1000KeywordsMustBeSpacedCorrectly,
@@ -931,12 +931,12 @@ class ClassName
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
-        protected Task TestKeywordStatementAsync(string statement, DiagnosticResult expected, string fixedStatement, string returnType = "void", bool asyncMethod = false)
+        protected Task TestKeywordStatementAsync(string statement, DiagnosticResult expected, string fixedStatement, string returnType = "void", bool asyncMethod = false, LanguageVersion? languageVersion = default)
         {
-            return this.TestKeywordStatementAsync(statement, new[] { expected }, fixedStatement, returnType, asyncMethod);
+            return this.TestKeywordStatementAsync(statement, new[] { expected }, fixedStatement, returnType, asyncMethod, languageVersion);
         }
 
-        protected async Task TestKeywordStatementAsync(string statement, DiagnosticResult[] expected, string fixedStatement, string returnType = "void", bool asyncMethod = false)
+        protected async Task TestKeywordStatementAsync(string statement, DiagnosticResult[] expected, string fixedStatement, string returnType = "void", bool asyncMethod = false, LanguageVersion? languageVersion = default)
         {
             string testCodeFormat = @"
 using System;
@@ -966,6 +966,19 @@ namespace Namespace
             {
                 TestCode = testCode,
                 FixedCode = fixedTest,
+                SolutionTransforms =
+                {
+                    (solution, projectId) =>
+                    {
+                        if (languageVersion.HasValue)
+                        {
+                            var parseOptions = (CSharpParseOptions)solution.GetProject(projectId).ParseOptions;
+                            solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion.Value));
+                        }
+
+                        return solution;
+                    },
+                },
             };
 
             test.ExpectedDiagnostics.AddRange(expected);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1026UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1026UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation,
@@ -45,7 +44,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
         {
             string testCode = string.Format("public class Foo {{ public Foo() {{ var ints = new{0}[] {{ 1, 2, 3 }}; }} }}", space);
             const string expectedCode = "public class Foo { public Foo() { var ints = new[] { 1, 2, 3 }; } }";
-            DiagnosticResult expected = Diagnostic().WithLocation(1, 46);
+            DiagnosticResult expected = Diagnostic().WithArguments("new").WithLocation(1, 46);
 
             await VerifyCSharpFixAsync(testCode, expected, expectedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/ArgumentSyntaxExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/ArgumentSyntaxExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Lightup
+{
+    using System;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+    internal static class ArgumentSyntaxExtensions
+    {
+        private static readonly Func<ArgumentSyntax, SyntaxToken> RefKindKeywordAccessor;
+        private static readonly Func<ArgumentSyntax, SyntaxToken, ArgumentSyntax> WithRefKindKeywordAccessor;
+
+        static ArgumentSyntaxExtensions()
+        {
+            RefKindKeywordAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<ArgumentSyntax, SyntaxToken>(typeof(ArgumentSyntax), nameof(RefKindKeyword));
+            WithRefKindKeywordAccessor = LightupHelpers.CreateSyntaxWithPropertyAccessor<ArgumentSyntax, SyntaxToken>(typeof(AccessorDeclarationSyntax), nameof(RefKindKeyword));
+        }
+
+        public static SyntaxToken RefKindKeyword(this ArgumentSyntax syntax)
+        {
+            return RefKindKeywordAccessor(syntax);
+        }
+
+        public static ArgumentSyntax WithRefKindKeyword(this ArgumentSyntax syntax, SyntaxToken refKindKeyword)
+        {
+            return WithRefKindKeywordAccessor(syntax, refKindKeyword);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/ArgumentSyntaxExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/ArgumentSyntaxExtensions.cs
@@ -15,7 +15,7 @@ namespace StyleCop.Analyzers.Lightup
         static ArgumentSyntaxExtensions()
         {
             RefKindKeywordAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<ArgumentSyntax, SyntaxToken>(typeof(ArgumentSyntax), nameof(RefKindKeyword));
-            WithRefKindKeywordAccessor = LightupHelpers.CreateSyntaxWithPropertyAccessor<ArgumentSyntax, SyntaxToken>(typeof(AccessorDeclarationSyntax), nameof(RefKindKeyword));
+            WithRefKindKeywordAccessor = LightupHelpers.CreateSyntaxWithPropertyAccessor<ArgumentSyntax, SyntaxToken>(typeof(ArgumentSyntax), nameof(RefKindKeyword));
         }
 
         public static SyntaxToken RefKindKeyword(this ArgumentSyntax syntax)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/CSharp71.md
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/CSharp71.md
@@ -22,8 +22,8 @@ See [dotnet/roslyn@5520eac](https://github.com/dotnet/roslyn/commit/5520eaccd5d2
 
 ## Syntax
 
-* [ ] `Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7_1 = 701 -> Microsoft.CodeAnalysis.CSharp.LanguageVersion`
-* [ ] `Microsoft.CodeAnalysis.CSharp.SyntaxKind.ConflictMarkerTrivia = 8564 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind`
-* [ ] `Microsoft.CodeAnalysis.CSharp.SyntaxKind.DefaultLiteralExpression = 8755 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind`
+* [x] `Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7_1 = 701 -> Microsoft.CodeAnalysis.CSharp.LanguageVersion`
+* [x] `Microsoft.CodeAnalysis.CSharp.SyntaxKind.ConflictMarkerTrivia = 8564 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind`
+* [x] `Microsoft.CodeAnalysis.CSharp.SyntaxKind.DefaultLiteralExpression = 8755 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind`
 * [ ] `static Microsoft.CodeAnalysis.CSharp.SyntaxFacts.IsReservedTupleElementName(string elementName) -> bool`
 * [ ] `static Microsoft.CodeAnalysis.CSharp.SyntaxFacts.TryGetInferredMemberName(this Microsoft.CodeAnalysis.SyntaxNode syntax) -> string`

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/CSharp72.md
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/CSharp72.md
@@ -712,14 +712,14 @@ See [dotnet/roslyn@30a68f1](https://github.com/dotnet/roslyn/commit/30a68f16a0cb
 
 * [ ] `Microsoft.CodeAnalysis.CSharp.Conversion.IsStackAlloc.get -> bool`
 * [ ] `Microsoft.CodeAnalysis.CSharp.Conversion.ToCommonConversion() -> Microsoft.CodeAnalysis.Operations.CommonConversion`
-* [ ] `Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7_2 = 702 -> Microsoft.CodeAnalysis.CSharp.LanguageVersion`
 * [ ] `static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetConversion(this Microsoft.CodeAnalysis.Operations.IConversionOperation conversionExpression) -> Microsoft.CodeAnalysis.CSharp.Conversion`
 * [ ] `static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetInConversion(this Microsoft.CodeAnalysis.Operations.ICompoundAssignmentOperation compoundAssignment) -> Microsoft.CodeAnalysis.CSharp.Conversion`
 * [ ] `static Microsoft.CodeAnalysis.CSharp.CSharpExtensions.GetOutConversion(this Microsoft.CodeAnalysis.Operations.ICompoundAssignmentOperation compoundAssignment) -> Microsoft.CodeAnalysis.CSharp.Conversion`
 
 ## Syntax
 
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.ReadOnlyKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken`
+* [x] `Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7_2 = 702 -> Microsoft.CodeAnalysis.CSharp.LanguageVersion`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.ReadOnlyKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken`
 * [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken refKeyword, Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.WithReadOnlyKeyword(Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax.WithReadOnlyKeyword(Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax`
 * [ ] `static Microsoft.CodeAnalysis.CSharp.SyntaxFactory.RefType(Microsoft.CodeAnalysis.SyntaxToken refKeyword, Microsoft.CodeAnalysis.SyntaxToken readOnlyKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type) -> Microsoft.CodeAnalysis.CSharp.Syntax.RefTypeSyntax`

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/CSharp73.md
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/CSharp73.md
@@ -13,8 +13,8 @@ See [dotnet/roslyn@e60c9fe](https://github.com/dotnet/roslyn/commit/e60c9fe8accc
 * [ ] `Microsoft.CodeAnalysis.Emit.EmitOptions.EmitOptions(bool metadataOnly, Microsoft.CodeAnalysis.Emit.DebugInformationFormat debugInformationFormat, string pdbFilePath, string outputNameOverride, int fileAlignment, ulong baseAddress, bool highEntropyVirtualAddressSpace, Microsoft.CodeAnalysis.SubsystemVersion subsystemVersion, string runtimeMetadataVersion, bool tolerateErrors, bool includePrivateMembers, System.Collections.Immutable.ImmutableArray<Microsoft.CodeAnalysis.Emit.InstrumentationKind> instrumentationKinds) -> void`
 * [ ] `Microsoft.CodeAnalysis.Emit.EmitOptions.PdbChecksumAlgorithm.get -> System.Security.Cryptography.HashAlgorithmName`
 * [ ] `Microsoft.CodeAnalysis.Emit.EmitOptions.WithPdbChecksumAlgorithm(System.Security.Cryptography.HashAlgorithmName name) -> Microsoft.CodeAnalysis.Emit.EmitOptions`
-* [ ] `Microsoft.CodeAnalysis.INamedTypeSymbol.IsSerializable.get -> bool`
-* [ ] `Microsoft.CodeAnalysis.ITypeParameterSymbol.HasUnmanagedTypeConstraint.get -> bool`
+* [x] `Microsoft.CodeAnalysis.INamedTypeSymbol.IsSerializable.get -> bool`
+* [x] `Microsoft.CodeAnalysis.ITypeParameterSymbol.HasUnmanagedTypeConstraint.get -> bool`
 * [ ] `Microsoft.CodeAnalysis.MetadataImportOptions`
 * [ ] `Microsoft.CodeAnalysis.MetadataImportOptions.All = 2 -> Microsoft.CodeAnalysis.MetadataImportOptions`
 * [ ] `Microsoft.CodeAnalysis.MetadataImportOptions.Internal = 1 -> Microsoft.CodeAnalysis.MetadataImportOptions`
@@ -62,27 +62,27 @@ See [dotnet/roslyn@e60c9fe](https://github.com/dotnet/roslyn/commit/e60c9fe8accc
 
 ## Syntax
 
-* [ ] `Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7_3 = 703 -> Microsoft.CodeAnalysis.CSharp.LanguageVersion`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.RefKindKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.WithRefKindKeyword(Microsoft.CodeAnalysis.SyntaxToken refKindKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.RefKindKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.WithRefKindKeyword(Microsoft.CodeAnalysis.SyntaxToken refKindKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.AddInitializerExpressions(params Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax[] items) -> Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.CloseBracketToken.get -> Microsoft.CodeAnalysis.SyntaxToken`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.Initializer.get -> Microsoft.CodeAnalysis.CSharp.Syntax.InitializerExpressionSyntax`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.OpenBracketToken.get -> Microsoft.CodeAnalysis.SyntaxToken`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.StackAllocKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken`
+* [x] `Microsoft.CodeAnalysis.CSharp.LanguageVersion.CSharp7_3 = 703 -> Microsoft.CodeAnalysis.CSharp.LanguageVersion`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.RefKindKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax.WithRefKindKeyword(Microsoft.CodeAnalysis.SyntaxToken refKindKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.ArgumentSyntax`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.RefKindKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax.WithRefKindKeyword(Microsoft.CodeAnalysis.SyntaxToken refKindKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.CrefParameterSyntax`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.AddInitializerExpressions(params Microsoft.CodeAnalysis.CSharp.Syntax.ExpressionSyntax[] items) -> Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.CloseBracketToken.get -> Microsoft.CodeAnalysis.SyntaxToken`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.Initializer.get -> Microsoft.CodeAnalysis.CSharp.Syntax.InitializerExpressionSyntax`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.OpenBracketToken.get -> Microsoft.CodeAnalysis.SyntaxToken`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.StackAllocKeyword.get -> Microsoft.CodeAnalysis.SyntaxToken`
 * [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken stackAllocKeyword, Microsoft.CodeAnalysis.SyntaxToken openBracketToken, Microsoft.CodeAnalysis.SyntaxToken closeBracketToken, Microsoft.CodeAnalysis.CSharp.Syntax.InitializerExpressionSyntax initializer) -> Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.WithCloseBracketToken(Microsoft.CodeAnalysis.SyntaxToken closeBracketToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.WithInitializer(Microsoft.CodeAnalysis.CSharp.Syntax.InitializerExpressionSyntax initializer) -> Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.WithOpenBracketToken(Microsoft.CodeAnalysis.SyntaxToken openBracketToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.WithStackAllocKeyword(Microsoft.CodeAnalysis.SyntaxToken stackAllocKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.StackAllocArrayCreationExpressionSyntax.Initializer.get -> Microsoft.CodeAnalysis.CSharp.Syntax.InitializerExpressionSyntax`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.WithCloseBracketToken(Microsoft.CodeAnalysis.SyntaxToken closeBracketToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.WithInitializer(Microsoft.CodeAnalysis.CSharp.Syntax.InitializerExpressionSyntax initializer) -> Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.WithOpenBracketToken(Microsoft.CodeAnalysis.SyntaxToken openBracketToken) -> Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.WithStackAllocKeyword(Microsoft.CodeAnalysis.SyntaxToken stackAllocKeyword) -> Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.StackAllocArrayCreationExpressionSyntax.Initializer.get -> Microsoft.CodeAnalysis.CSharp.Syntax.InitializerExpressionSyntax`
 * [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.StackAllocArrayCreationExpressionSyntax.Update(Microsoft.CodeAnalysis.SyntaxToken stackAllocKeyword, Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax type, Microsoft.CodeAnalysis.CSharp.Syntax.InitializerExpressionSyntax initializer) -> Microsoft.CodeAnalysis.CSharp.Syntax.StackAllocArrayCreationExpressionSyntax`
-* [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.StackAllocArrayCreationExpressionSyntax.WithInitializer(Microsoft.CodeAnalysis.CSharp.Syntax.InitializerExpressionSyntax initializer) -> Microsoft.CodeAnalysis.CSharp.Syntax.StackAllocArrayCreationExpressionSyntax`
+* [x] `Microsoft.CodeAnalysis.CSharp.Syntax.StackAllocArrayCreationExpressionSyntax.WithInitializer(Microsoft.CodeAnalysis.CSharp.Syntax.InitializerExpressionSyntax initializer) -> Microsoft.CodeAnalysis.CSharp.Syntax.StackAllocArrayCreationExpressionSyntax`
 * [ ] `Microsoft.CodeAnalysis.CSharp.Syntax.TypeSyntax.IsUnmanaged.get -> bool`
-* [ ] `Microsoft.CodeAnalysis.CSharp.SyntaxKind.ImplicitStackAllocArrayCreationExpression = 9053 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind`
+* [x] `Microsoft.CodeAnalysis.CSharp.SyntaxKind.ImplicitStackAllocArrayCreationExpression = 9053 -> Microsoft.CodeAnalysis.CSharp.SyntaxKind`
 * [ ] `override Microsoft.CodeAnalysis.CSharp.CSharpSyntaxRewriter.VisitImplicitStackAllocArrayCreationExpression(Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax node) -> Microsoft.CodeAnalysis.SyntaxNode`
 * [ ] `override Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.Accept(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor visitor) -> void`
 * [ ] `override Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax.Accept<TResult>(Microsoft.CodeAnalysis.CSharp.CSharpSyntaxVisitor<TResult> visitor) -> TResult`

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/CrefParameterSyntaxExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/CrefParameterSyntaxExtensions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Lightup
+{
+    using System;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+    internal static class CrefParameterSyntaxExtensions
+    {
+        private static readonly Func<CrefParameterSyntax, SyntaxToken> RefKindKeywordAccessor;
+        private static readonly Func<CrefParameterSyntax, SyntaxToken, CrefParameterSyntax> WithRefKindKeywordAccessor;
+
+        static CrefParameterSyntaxExtensions()
+        {
+            RefKindKeywordAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<CrefParameterSyntax, SyntaxToken>(typeof(CrefParameterSyntax), nameof(RefKindKeyword));
+            WithRefKindKeywordAccessor = LightupHelpers.CreateSyntaxWithPropertyAccessor<CrefParameterSyntax, SyntaxToken>(typeof(AccessorDeclarationSyntax), nameof(RefKindKeyword));
+        }
+
+        public static SyntaxToken RefKindKeyword(this CrefParameterSyntax syntax)
+        {
+            return RefKindKeywordAccessor(syntax);
+        }
+
+        public static CrefParameterSyntax WithRefKindKeyword(this CrefParameterSyntax syntax, SyntaxToken refKindKeyword)
+        {
+            return WithRefKindKeywordAccessor(syntax, refKindKeyword);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/CrefParameterSyntaxExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/CrefParameterSyntaxExtensions.cs
@@ -15,7 +15,7 @@ namespace StyleCop.Analyzers.Lightup
         static CrefParameterSyntaxExtensions()
         {
             RefKindKeywordAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<CrefParameterSyntax, SyntaxToken>(typeof(CrefParameterSyntax), nameof(RefKindKeyword));
-            WithRefKindKeywordAccessor = LightupHelpers.CreateSyntaxWithPropertyAccessor<CrefParameterSyntax, SyntaxToken>(typeof(AccessorDeclarationSyntax), nameof(RefKindKeyword));
+            WithRefKindKeywordAccessor = LightupHelpers.CreateSyntaxWithPropertyAccessor<CrefParameterSyntax, SyntaxToken>(typeof(CrefParameterSyntax), nameof(RefKindKeyword));
         }
 
         public static SyntaxToken RefKindKeyword(this CrefParameterSyntax syntax)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/INamedTypeSymbolExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/INamedTypeSymbolExtensions.cs
@@ -11,11 +11,13 @@ namespace StyleCop.Analyzers.Lightup
     {
         private static readonly Func<INamedTypeSymbol, INamedTypeSymbol> TupleUnderlyingTypeAccessor;
         private static readonly Func<INamedTypeSymbol, ImmutableArray<IFieldSymbol>> TupleElementsAccessor;
+        private static readonly Func<INamedTypeSymbol, bool> IsSerializableAccessor;
 
         static INamedTypeSymbolExtensions()
         {
             TupleUnderlyingTypeAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<INamedTypeSymbol, INamedTypeSymbol>(typeof(INamedTypeSymbol), nameof(TupleUnderlyingType));
             TupleElementsAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<INamedTypeSymbol, ImmutableArray<IFieldSymbol>>(typeof(INamedTypeSymbol), nameof(TupleElements));
+            IsSerializableAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<INamedTypeSymbol, bool>(typeof(INamedTypeSymbol), nameof(IsSerializable));
         }
 
         public static INamedTypeSymbol TupleUnderlyingType(this INamedTypeSymbol symbol)
@@ -26,6 +28,11 @@ namespace StyleCop.Analyzers.Lightup
         public static ImmutableArray<IFieldSymbol> TupleElements(this INamedTypeSymbol symbol)
         {
             return TupleElementsAccessor(symbol);
+        }
+
+        public static bool IsSerializable(this INamedTypeSymbol symbol)
+        {
+            return IsSerializableAccessor(symbol);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/ITypeParameterSymbolExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/ITypeParameterSymbolExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Lightup
+{
+    using System;
+    using Microsoft.CodeAnalysis;
+
+    internal static class ITypeParameterSymbolExtensions
+    {
+        private static readonly Func<ITypeParameterSymbol, bool> HasUnmanagedTypeConstraintAccessor;
+
+        static ITypeParameterSymbolExtensions()
+        {
+            HasUnmanagedTypeConstraintAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<ITypeParameterSymbol, bool>(typeof(ITypeParameterSymbol), nameof(HasUnmanagedTypeConstraint));
+        }
+
+        public static bool HasUnmanagedTypeConstraint(this ITypeParameterSymbol symbol)
+        {
+            return HasUnmanagedTypeConstraintAccessor(symbol);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/ImplicitStackAllocArrayCreationExpressionSyntaxWrapper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/ImplicitStackAllocArrayCreationExpressionSyntaxWrapper.cs
@@ -5,7 +5,6 @@ namespace StyleCop.Analyzers.Lightup
 {
     using System;
     using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
 
     internal struct ImplicitStackAllocArrayCreationExpressionSyntaxWrapper : ISyntaxWrapper<ExpressionSyntax>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/ImplicitStackAllocArrayCreationExpressionSyntaxWrapper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/ImplicitStackAllocArrayCreationExpressionSyntaxWrapper.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Lightup
+{
+    using System;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+    internal struct ImplicitStackAllocArrayCreationExpressionSyntaxWrapper : ISyntaxWrapper<ExpressionSyntax>
+    {
+        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.CSharp.Syntax.ImplicitStackAllocArrayCreationExpressionSyntax";
+        private static readonly Type WrappedType;
+
+        private static readonly Func<ExpressionSyntax, SyntaxToken> StackAllocKeywordAccessor;
+        private static readonly Func<ExpressionSyntax, SyntaxToken> OpenBracketTokenAccessor;
+        private static readonly Func<ExpressionSyntax, SyntaxToken> CloseBracketTokenAccessor;
+        private static readonly Func<ExpressionSyntax, InitializerExpressionSyntax> InitializerAccessor;
+        private static readonly Func<ExpressionSyntax, SyntaxToken, ExpressionSyntax> WithStackAllocKeywordAccessor;
+        private static readonly Func<ExpressionSyntax, SyntaxToken, ExpressionSyntax> WithOpenBracketTokenAccessor;
+        private static readonly Func<ExpressionSyntax, SyntaxToken, ExpressionSyntax> WithCloseBracketTokenAccessor;
+        private static readonly Func<ExpressionSyntax, InitializerExpressionSyntax, ExpressionSyntax> WithInitializerAccessor;
+
+        private readonly ExpressionSyntax node;
+
+        static ImplicitStackAllocArrayCreationExpressionSyntaxWrapper()
+        {
+            WrappedType = WrapperHelper.GetWrappedType(typeof(ImplicitStackAllocArrayCreationExpressionSyntaxWrapper));
+            StackAllocKeywordAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<ExpressionSyntax, SyntaxToken>(WrappedType, nameof(StackAllocKeyword));
+            OpenBracketTokenAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<ExpressionSyntax, SyntaxToken>(WrappedType, nameof(OpenBracketToken));
+            CloseBracketTokenAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<ExpressionSyntax, SyntaxToken>(WrappedType, nameof(CloseBracketToken));
+            InitializerAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<ExpressionSyntax, InitializerExpressionSyntax>(WrappedType, nameof(Initializer));
+            WithStackAllocKeywordAccessor = LightupHelpers.CreateSyntaxWithPropertyAccessor<ExpressionSyntax, SyntaxToken>(WrappedType, nameof(StackAllocKeyword));
+            WithOpenBracketTokenAccessor = LightupHelpers.CreateSyntaxWithPropertyAccessor<ExpressionSyntax, SyntaxToken>(WrappedType, nameof(OpenBracketToken));
+            WithCloseBracketTokenAccessor = LightupHelpers.CreateSyntaxWithPropertyAccessor<ExpressionSyntax, SyntaxToken>(WrappedType, nameof(CloseBracketToken));
+            WithInitializerAccessor = LightupHelpers.CreateSyntaxWithPropertyAccessor<ExpressionSyntax, InitializerExpressionSyntax>(WrappedType, nameof(Initializer));
+        }
+
+        private ImplicitStackAllocArrayCreationExpressionSyntaxWrapper(ExpressionSyntax node)
+        {
+            this.node = node;
+        }
+
+        public ExpressionSyntax SyntaxNode => this.node;
+
+        public SyntaxToken StackAllocKeyword
+        {
+            get
+            {
+                return StackAllocKeywordAccessor(this.SyntaxNode);
+            }
+        }
+
+        public SyntaxToken OpenBracketToken
+        {
+            get
+            {
+                return OpenBracketTokenAccessor(this.SyntaxNode);
+            }
+        }
+
+        public SyntaxToken CloseBracketToken
+        {
+            get
+            {
+                return CloseBracketTokenAccessor(this.SyntaxNode);
+            }
+        }
+
+        public InitializerExpressionSyntax Initializer
+        {
+            get
+            {
+                return InitializerAccessor(this.SyntaxNode);
+            }
+        }
+
+        public static explicit operator ImplicitStackAllocArrayCreationExpressionSyntaxWrapper(SyntaxNode node)
+        {
+            if (node == null)
+            {
+                return default(ImplicitStackAllocArrayCreationExpressionSyntaxWrapper);
+            }
+
+            if (!IsInstance(node))
+            {
+                throw new InvalidCastException($"Cannot cast '{node.GetType().FullName}' to '{WrappedTypeName}'");
+            }
+
+            return new ImplicitStackAllocArrayCreationExpressionSyntaxWrapper((ExpressionSyntax)node);
+        }
+
+        public static implicit operator ExpressionSyntax(ImplicitStackAllocArrayCreationExpressionSyntaxWrapper wrapper)
+        {
+            return wrapper.node;
+        }
+
+        public static bool IsInstance(SyntaxNode node)
+        {
+            return node != null && LightupHelpers.CanWrapNode(node, WrappedType);
+        }
+
+        public ImplicitStackAllocArrayCreationExpressionSyntaxWrapper WithStackAllocKeyword(SyntaxToken stackAllocKeyword)
+        {
+            return new ImplicitStackAllocArrayCreationExpressionSyntaxWrapper(WithStackAllocKeywordAccessor(this.SyntaxNode, stackAllocKeyword));
+        }
+
+        public ImplicitStackAllocArrayCreationExpressionSyntaxWrapper WithOpenBracketToken(SyntaxToken openBracketToken)
+        {
+            return new ImplicitStackAllocArrayCreationExpressionSyntaxWrapper(WithOpenBracketTokenAccessor(this.SyntaxNode, openBracketToken));
+        }
+
+        public ImplicitStackAllocArrayCreationExpressionSyntaxWrapper WithCloseBracketToken(SyntaxToken closeBracketToken)
+        {
+            return new ImplicitStackAllocArrayCreationExpressionSyntaxWrapper(WithCloseBracketTokenAccessor(this.SyntaxNode, closeBracketToken));
+        }
+
+        public ImplicitStackAllocArrayCreationExpressionSyntaxWrapper WithInitializer(InitializerExpressionSyntax initializer)
+        {
+            return new ImplicitStackAllocArrayCreationExpressionSyntaxWrapper(WithInitializerAccessor(this.SyntaxNode, initializer));
+        }
+
+        public ImplicitStackAllocArrayCreationExpressionSyntaxWrapper AddInitializerExpressions(params ExpressionSyntax[] items)
+        {
+            return new ImplicitStackAllocArrayCreationExpressionSyntaxWrapper(this.WithInitializer(this.Initializer.AddExpressions(items)));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LanguageVersionEx.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LanguageVersionEx.cs
@@ -9,6 +9,11 @@ namespace StyleCop.Analyzers.Lightup
     {
         public const LanguageVersion Default = 0;
         public const LanguageVersion CSharp7 = (LanguageVersion)7;
+#pragma warning disable SA1310 // Field names should not contain underscore
+        public const LanguageVersion CSharp7_1 = (LanguageVersion)701;
+        public const LanguageVersion CSharp7_2 = (LanguageVersion)702;
+        public const LanguageVersion CSharp7_3 = (LanguageVersion)703;
+#pragma warning restore SA1310 // Field names should not contain underscore
         public const LanguageVersion Latest = (LanguageVersion)int.MaxValue;
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LightupHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LightupHelpers.cs
@@ -17,7 +17,16 @@ namespace StyleCop.Analyzers.Lightup
             = new ConcurrentDictionary<Type, ConcurrentDictionary<SyntaxKind, bool>>();
 
         public static bool SupportsCSharp7 { get; }
-            = Enum.GetNames(typeof(SyntaxKind)).Contains(nameof(SyntaxKindEx.IsPatternExpression));
+            = Enum.GetNames(typeof(LanguageVersion)).Contains(nameof(LanguageVersionEx.CSharp7));
+
+        public static bool SupportsCSharp71 { get; }
+            = Enum.GetNames(typeof(LanguageVersion)).Contains(nameof(LanguageVersionEx.CSharp7_1));
+
+        public static bool SupportsCSharp72 { get; }
+            = Enum.GetNames(typeof(LanguageVersion)).Contains(nameof(LanguageVersionEx.CSharp7_2));
+
+        public static bool SupportsCSharp73 { get; }
+            = Enum.GetNames(typeof(LanguageVersion)).Contains(nameof(LanguageVersionEx.CSharp7_3));
 
         internal static bool CanWrapNode(SyntaxNode node, Type underlyingType)
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/RefTypeSyntaxWrapper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/RefTypeSyntaxWrapper.cs
@@ -13,8 +13,10 @@ namespace StyleCop.Analyzers.Lightup
         private static readonly Type WrappedType;
 
         private static readonly Func<TypeSyntax, SyntaxToken> RefKeywordAccessor;
+        private static readonly Func<TypeSyntax, SyntaxToken> ReadOnlyKeywordAccessor;
         private static readonly Func<TypeSyntax, TypeSyntax> TypeAccessor;
         private static readonly Func<TypeSyntax, SyntaxToken, TypeSyntax> WithRefKeywordAccessor;
+        private static readonly Func<TypeSyntax, SyntaxToken, TypeSyntax> WithReadOnlyKeywordAccessor;
         private static readonly Func<TypeSyntax, TypeSyntax, TypeSyntax> WithTypeAccessor;
 
         private readonly TypeSyntax node;
@@ -23,8 +25,10 @@ namespace StyleCop.Analyzers.Lightup
         {
             WrappedType = WrapperHelper.GetWrappedType(typeof(RefTypeSyntaxWrapper));
             RefKeywordAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<TypeSyntax, SyntaxToken>(WrappedType, nameof(RefKeyword));
+            ReadOnlyKeywordAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<TypeSyntax, SyntaxToken>(WrappedType, nameof(ReadOnlyKeyword));
             TypeAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<TypeSyntax, TypeSyntax>(WrappedType, nameof(Type));
             WithRefKeywordAccessor = LightupHelpers.CreateSyntaxWithPropertyAccessor<TypeSyntax, SyntaxToken>(WrappedType, nameof(RefKeyword));
+            WithReadOnlyKeywordAccessor = LightupHelpers.CreateSyntaxWithPropertyAccessor<TypeSyntax, SyntaxToken>(WrappedType, nameof(ReadOnlyKeyword));
             WithTypeAccessor = LightupHelpers.CreateSyntaxWithPropertyAccessor<TypeSyntax, TypeSyntax>(WrappedType, nameof(Type));
         }
 
@@ -40,6 +44,14 @@ namespace StyleCop.Analyzers.Lightup
             get
             {
                 return RefKeywordAccessor(this.SyntaxNode);
+            }
+        }
+
+        public SyntaxToken ReadOnlyKeyword
+        {
+            get
+            {
+                return ReadOnlyKeywordAccessor(this.SyntaxNode);
             }
         }
 
@@ -79,6 +91,11 @@ namespace StyleCop.Analyzers.Lightup
         public RefTypeSyntaxWrapper WithRefKeyword(SyntaxToken refKeyword)
         {
             return new RefTypeSyntaxWrapper(WithRefKeywordAccessor(this.SyntaxNode, refKeyword));
+        }
+
+        public RefTypeSyntaxWrapper WithReadOnlyKeyword(SyntaxToken readOnlyKeyword)
+        {
+            return new RefTypeSyntaxWrapper(WithReadOnlyKeywordAccessor(this.SyntaxNode, readOnlyKeyword));
         }
 
         public RefTypeSyntaxWrapper WithType(TypeSyntax type)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/StackAllocArrayCreationExpressionSyntaxExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/StackAllocArrayCreationExpressionSyntaxExtensions.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Lightup
+{
+    using System;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+    internal static class StackAllocArrayCreationExpressionSyntaxExtensions
+    {
+        private static readonly Func<StackAllocArrayCreationExpressionSyntax, InitializerExpressionSyntax> InitializerAccessor;
+        private static readonly Func<StackAllocArrayCreationExpressionSyntax, InitializerExpressionSyntax, StackAllocArrayCreationExpressionSyntax> WithInitializerAccessor;
+
+        static StackAllocArrayCreationExpressionSyntaxExtensions()
+        {
+            InitializerAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<StackAllocArrayCreationExpressionSyntax, InitializerExpressionSyntax>(typeof(StackAllocArrayCreationExpressionSyntax), nameof(Initializer));
+            WithInitializerAccessor = LightupHelpers.CreateSyntaxWithPropertyAccessor<StackAllocArrayCreationExpressionSyntax, InitializerExpressionSyntax>(typeof(StackAllocArrayCreationExpressionSyntax), nameof(Initializer));
+        }
+
+        public static InitializerExpressionSyntax Initializer(this StackAllocArrayCreationExpressionSyntax syntax)
+        {
+            return InitializerAccessor(syntax);
+        }
+
+        public static StackAllocArrayCreationExpressionSyntax WithInitializer(this StackAllocArrayCreationExpressionSyntax syntax, InitializerExpressionSyntax initializer)
+        {
+            return WithInitializerAccessor(syntax, initializer);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/SyntaxKindEx.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/SyntaxKindEx.cs
@@ -8,6 +8,7 @@ namespace StyleCop.Analyzers.Lightup
     internal static class SyntaxKindEx
     {
         public const SyntaxKind UnderscoreToken = (SyntaxKind)8491;
+        public const SyntaxKind ConflictMarkerTrivia = (SyntaxKind)8564;
         public const SyntaxKind IsPatternExpression = (SyntaxKind)8657;
         public const SyntaxKind DefaultLiteralExpression = (SyntaxKind)8755;
         public const SyntaxKind LocalFunctionStatement = (SyntaxKind)8830;
@@ -26,5 +27,6 @@ namespace StyleCop.Analyzers.Lightup
         public const SyntaxKind RefExpression = (SyntaxKind)9050;
         public const SyntaxKind RefType = (SyntaxKind)9051;
         public const SyntaxKind ThrowExpression = (SyntaxKind)9052;
+        public const SyntaxKind ImplicitStackAllocArrayCreationExpression = (SyntaxKind)9053;
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/WrapperHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/WrapperHelper.cs
@@ -31,6 +31,7 @@ namespace StyleCop.Analyzers.Lightup
             builder.Add(typeof(DiscardDesignationSyntaxWrapper), codeAnalysisAssembly.GetType(DiscardDesignationSyntaxWrapper.WrappedTypeName));
             builder.Add(typeof(ForEachVariableStatementSyntaxWrapper), codeAnalysisAssembly.GetType(ForEachVariableStatementSyntaxWrapper.WrappedTypeName));
             builder.Add(typeof(IsPatternExpressionSyntaxWrapper), codeAnalysisAssembly.GetType(IsPatternExpressionSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(ImplicitStackAllocArrayCreationExpressionSyntaxWrapper), codeAnalysisAssembly.GetType(ImplicitStackAllocArrayCreationExpressionSyntaxWrapper.WrappedTypeName));
             builder.Add(typeof(LocalFunctionStatementSyntaxWrapper), codeAnalysisAssembly.GetType(LocalFunctionStatementSyntaxWrapper.WrappedTypeName));
             builder.Add(typeof(ParenthesizedVariableDesignationSyntaxWrapper), codeAnalysisAssembly.GetType(ParenthesizedVariableDesignationSyntaxWrapper.WrappedTypeName));
             builder.Add(typeof(PatternSyntaxWrapper), codeAnalysisAssembly.GetType(PatternSyntaxWrapper.WrappedTypeName));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1207ProtectedMustComeBeforeInternal.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1207ProtectedMustComeBeforeInternal.cs
@@ -11,11 +11,12 @@ namespace StyleCop.Analyzers.OrderingRules
 
     /// <summary>
     /// The keyword <c>protected</c> is positioned after the keyword <c>internal</c> within the declaration of a
-    /// protected internal C# element.
+    /// protected internal C# element, or the keyword <c>private</c> is positioned after the keyword <c>protected</c>.
     /// </summary>
     /// <remarks>
     /// <para>A violation of this rule occurs when a protected internal element's access modifiers are written as
-    /// <c>internal protected</c>. In reality, an element with the keywords <c>protected internal</c> will have the same
+    /// <c>internal protected</c>, or when a private protected element's access modifiers are written as
+    /// <c>protected private</c>. In reality, an element with the keywords <c>protected internal</c> will have the same
     /// access level as an element with the keywords <c>internal protected</c>. To make the code easier to read and more
     /// consistent, StyleCop standardizes the ordering of these keywords, so that a protected internal element will
     /// always be described as such, and never as internal protected. This can help to reduce confusion about whether
@@ -29,8 +30,8 @@ namespace StyleCop.Analyzers.OrderingRules
         /// </summary>
         public const string DiagnosticId = "SA1207";
         private const string Title = "Protected should come before internal";
-        private const string MessageFormat = "The keyword 'protected' should come before 'internal'.";
-        private const string Description = "The keyword 'protected' is positioned after the keyword 'internal' within the declaration of a protected internal C# element.";
+        private const string MessageFormat = "The keyword '{0}' should come before '{1}'.";
+        private const string Description = "The keyword '{0}' is positioned after the keyword '{1}' within the declaration of a {0} {1} C# element.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md";
 
         private static readonly DiagnosticDescriptor Descriptor =
@@ -72,6 +73,7 @@ namespace StyleCop.Analyzers.OrderingRules
                 return;
             }
 
+            bool protectedKeywordFound = false;
             bool internalKeywordFound = false;
             foreach (var childToken in childTokens)
             {
@@ -80,10 +82,22 @@ namespace StyleCop.Analyzers.OrderingRules
                     internalKeywordFound = true;
                     continue;
                 }
-
-                if (internalKeywordFound && childToken.IsKind(SyntaxKind.ProtectedKeyword))
+                else if (childToken.IsKind(SyntaxKind.ProtectedKeyword))
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, childToken.GetLocation()));
+                    if (internalKeywordFound)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, childToken.GetLocation(), "protected", "internal"));
+                        break;
+                    }
+                    else
+                    {
+                        protectedKeywordFound = true;
+                        continue;
+                    }
+                }
+                else if (protectedKeywordFound && childToken.IsKind(SyntaxKind.PrivateKeyword))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, childToken.GetLocation(), "private", "protected"));
                     break;
                 }
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
@@ -21,15 +21,16 @@ namespace StyleCop.Analyzers.SpacingRules
     /// <strong>fixed</strong>, <strong>for</strong>, <strong>foreach</strong>, <strong>from</strong>,
     /// <strong>group</strong>, <strong>if</strong>, <strong>in</strong>, <strong>into</strong>, <strong>join</strong>,
     /// <strong>let</strong>, <strong>lock</strong>, <strong>orderby</strong>, <strong>out</strong>,
-    /// <strong>ref</strong>, <strong>return</strong>, <strong>select</strong>, <strong>stackalloc</strong>,
-    /// <strong>switch</strong>, <strong>throw</strong>, <strong>using</strong>, <strong>var</strong>,
-    /// <strong>where</strong>, <strong>while</strong>, <strong>yield</strong>.</para>
+    /// <strong>ref</strong>, <strong>return</strong>, <strong>select</strong>, <strong>switch</strong>,
+    /// <strong>throw</strong>, <strong>using</strong>, <strong>var</strong>, <strong>where</strong>,
+    /// <strong>while</strong>, <strong>yield</strong>.</para>
     ///
     /// <para>The following keywords should not be followed by any space: <strong>checked</strong>,
     /// <strong>default</strong>, <strong>sizeof</strong>, <strong>typeof</strong>, <strong>unchecked</strong>.</para>
     ///
-    /// <para>The <strong>new</strong> keyword should always be followed by a space, unless it is used to create a new
-    /// array, in which case there should be no space between the new keyword and the opening array bracket.</para>
+    /// <para>The <strong>new</strong> and <strong>stackalloc</strong> keywords should always be followed by a space,
+    /// except where used to create a new implicitly-typed array, in which case there should be no space between the
+    /// keyword and the opening array bracket.</para>
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal class SA1000KeywordsMustBeSpacedCorrectly : DiagnosticAnalyzer
@@ -102,7 +103,6 @@ namespace StyleCop.Analyzers.SpacingRules
                 case SyntaxKind.OutKeyword:
                 case SyntaxKind.RefKeyword:
                 case SyntaxKind.SelectKeyword:
-                case SyntaxKind.StackAllocKeyword:
                 case SyntaxKind.SwitchKeyword:
                 case SyntaxKind.UsingKeyword:
                 case SyntaxKind.WhereKeyword:
@@ -141,7 +141,8 @@ namespace StyleCop.Analyzers.SpacingRules
                     break;
 
                 case SyntaxKind.NewKeyword:
-                    HandleNewKeywordToken(ref context, token);
+                case SyntaxKind.StackAllocKeyword:
+                    HandleNewOrStackAllocKeywordToken(ref context, token);
                     break;
 
                 case SyntaxKind.ReturnKeyword:
@@ -267,7 +268,7 @@ namespace StyleCop.Analyzers.SpacingRules
             reportDiagnostic(ref context, Diagnostic.Create(Descriptor, token.GetLocation(), TokenSpacingProperties.RemoveFollowing, token.Text, " not"));
         }
 
-        private static void HandleNewKeywordToken(ref SyntaxTreeAnalysisContext context, SyntaxToken token)
+        private static void HandleNewOrStackAllocKeywordToken(ref SyntaxTreeAnalysisContext context, SyntaxToken token)
         {
             if (token.IsMissing)
             {
@@ -279,7 +280,8 @@ namespace StyleCop.Analyzers.SpacingRules
             switch (nextToken.Kind())
             {
             case SyntaxKind.OpenBracketToken:
-                if (token.Parent.IsKind(SyntaxKind.ImplicitArrayCreationExpression))
+                if (token.Parent.IsKind(SyntaxKind.ImplicitArrayCreationExpression)
+                    || token.Parent.IsKind(SyntaxKindEx.ImplicitStackAllocArrayCreationExpression))
                 {
                     // This is handled by SA1026
                     return;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010OpeningSquareBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010OpeningSquareBracketsMustBeSpacedCorrectly.cs
@@ -79,7 +79,14 @@ namespace StyleCop.Analyzers.SpacingRules
                 precededBySpace = token.IsPrecededByWhitespace(context.CancellationToken);
 
                 // ignore if handled by SA1026
-                ignorePrecedingSpaceProblem = precededBySpace && token.GetPreviousToken().IsKind(SyntaxKind.NewKeyword);
+                if (precededBySpace)
+                {
+                    var previousToken = token.GetPreviousToken();
+                    if (previousToken.IsKind(SyntaxKind.NewKeyword) || previousToken.IsKind(SyntaxKind.StackAllocKeyword))
+                    {
+                        ignorePrecedingSpaceProblem = true;
+                    }
+                }
             }
 
             bool followedBySpace = token.IsFollowedByWhitespace();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation.cs
@@ -10,6 +10,7 @@ namespace StyleCop.Analyzers.SpacingRules
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.Helpers;
+    using StyleCop.Analyzers.Lightup;
 
     /// <summary>
     /// An implicitly typed new array allocation within a C# code file is not spaced correctly.
@@ -40,6 +41,7 @@ namespace StyleCop.Analyzers.SpacingRules
             new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.SpacingRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
         private static readonly Action<SyntaxNodeAnalysisContext> ImplicitArrayCreationExpressionAction = HandleImplicitArrayCreationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> ImplicitStackAllocArrayCreationExpressionAction = HandleImplicitStackAllocArrayCreationExpression;
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
@@ -52,6 +54,7 @@ namespace StyleCop.Analyzers.SpacingRules
             context.EnableConcurrentExecution();
 
             context.RegisterSyntaxNodeAction(ImplicitArrayCreationExpressionAction, SyntaxKind.ImplicitArrayCreationExpression);
+            context.RegisterSyntaxNodeAction(ImplicitStackAllocArrayCreationExpressionAction, SyntaxKindEx.ImplicitStackAllocArrayCreationExpression);
         }
 
         private static void HandleImplicitArrayCreationExpression(SyntaxNodeAnalysisContext context)
@@ -61,7 +64,18 @@ namespace StyleCop.Analyzers.SpacingRules
 
             if (newKeywordToken.IsFollowedByWhitespace() || newKeywordToken.IsLastInLine())
             {
-                context.ReportDiagnostic(Diagnostic.Create(Descriptor, newKeywordToken.GetLocation(), TokenSpacingProperties.RemoveFollowing));
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, newKeywordToken.GetLocation(), TokenSpacingProperties.RemoveFollowing, "new"));
+            }
+        }
+
+        private static void HandleImplicitStackAllocArrayCreationExpression(SyntaxNodeAnalysisContext context)
+        {
+            var arrayCreation = (ImplicitStackAllocArrayCreationExpressionSyntaxWrapper)context.Node;
+            var stackAllocKeywordToken = arrayCreation.StackAllocKeyword;
+
+            if (stackAllocKeywordToken.IsFollowedByWhitespace() || stackAllocKeywordToken.IsLastInLine())
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, stackAllocKeywordToken.GetLocation(), TokenSpacingProperties.RemoveFollowing, "stackalloc"));
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SpacingResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SpacingResources.Designer.cs
@@ -332,7 +332,7 @@ namespace StyleCop.Analyzers.SpacingRules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to An implicitly typed new array allocation within a C# code file is not spaced correctly..
+        ///   Looks up a localized string similar to An implicitly typed array allocation within a C# code file is not spaced correctly..
         /// </summary>
         internal static string SA1026Description {
             get {
@@ -341,7 +341,7 @@ namespace StyleCop.Analyzers.SpacingRules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The keyword &apos;new&apos; should not be followed by a space or a blank line..
+        ///   Looks up a localized string similar to The keyword &apos;{0}&apos; should not be followed by a space or a blank line..
         /// </summary>
         internal static string SA1026MessageFormat {
             get {
@@ -350,7 +350,7 @@ namespace StyleCop.Analyzers.SpacingRules {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Code should not contain space after new keyword in implicitly typed array allocation.
+        ///   Looks up a localized string similar to Code should not contain space after new or stackalloc keyword in implicitly typed array allocation.
         /// </summary>
         internal static string SA1026Title {
             get {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SpacingResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SpacingResources.resx
@@ -208,13 +208,13 @@
     <value>Code should not contain multiple whitespace in a row</value>
   </data>
   <data name="SA1026Description" xml:space="preserve">
-    <value>An implicitly typed new array allocation within a C# code file is not spaced correctly.</value>
+    <value>An implicitly typed array allocation within a C# code file is not spaced correctly.</value>
   </data>
   <data name="SA1026MessageFormat" xml:space="preserve">
-    <value>The keyword 'new' should not be followed by a space or a blank line.</value>
+    <value>The keyword '{0}' should not be followed by a space or a blank line.</value>
   </data>
   <data name="SA1026Title" xml:space="preserve">
-    <value>Code should not contain space after new keyword in implicitly typed array allocation</value>
+    <value>Code should not contain space after new or stackalloc keyword in implicitly typed array allocation</value>
   </data>
   <data name="SA1027CodeFix" xml:space="preserve">
     <value>Replace tabs with spaces</value>

--- a/documentation/SA1000.md
+++ b/documentation/SA1000.md
@@ -25,14 +25,14 @@ A violation of this rule occurs when the spacing around a keyword is incorrect.
 
 The following C# keywords should always be followed by a single space: `await`, `case`, `catch`, `fixed`, `for`,
 `foreach`, `from`, `group`, `if`, `in`, `into`, `join`, `let`, `lock`, `orderby`, `out`, `ref`, `return`, `select`,
-`stackalloc`, `switch`, `using`, `var`, `where`, `while`, `yield`.
+`switch`, `using`, `var`, `where`, `while`, `yield`.
 
 The following keywords should not be followed by any space: `checked`, `default`, `sizeof`, `typeof`, `unchecked`.
 
-The `new` keyword should always be followed by a space, except in the following cases:
+The `new` and `stackalloc` keywords should always be followed by a space, except in the following cases:
 
-* The `new` keyword is used to create a new array. In this case there should be no space between the `new` keyword and
-  the opening array bracket.
+* The `new` or `stackalloc` keyword is used to create a new implicitly-typed array. In this case there should be no
+  space between the keyword and the opening array bracket.
 * The `new` keyword is part of a generic type constraint. In this case there should be no space between the `new`
   keyword and the opening parenthesis.
 

--- a/documentation/SA1026.md
+++ b/documentation/SA1026.md
@@ -17,24 +17,25 @@
 
 ## Cause
 
-An implicitly typed new array allocation within a C# code file is not spaced correctly.
+An implicitly typed array allocation within a C# code file is not spaced correctly.
 
 ## Rule description
 
-A violation of this rule occurs whenever the code contains an implicitly typed new array allocation which is not spaced correctly. Within an implicitly typed new array allocation, there should not be any space or a blank line between the new keyword and the opening array bracket. For example:
+A violation of this rule occurs whenever the code contains an implicitly-typed array allocation which is not spaced correctly. Within an implicitly typed array allocation, there should not be any space or a blank line between the `new` or `stackalloc` keyword and the opening array bracket. For example:
 
 ```csharp
 var a = new[] { 1, 10, 100, 1000 };
+Span<int> a = stackalloc[] { 1, 10, 100, 1000 };
 ```
 
 ## How to fix violations
 
-To fix a violation of this rule, remove any whitespace between the new keyword and the opening array bracket.
+To fix a violation of this rule, remove any whitespace between the `new` or `stackalloc` keyword and the opening array bracket.
 
 ## How to suppress violations
 
 ```csharp
-#pragma warning disable SA1026 // Code should not contain space after new keyword in implicitly typed array allocation
+#pragma warning disable SA1026 // Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
 var ints = new [] { 1, 2, 3 };
-#pragma warning restore SA1026 // Code should not contain space after new keyword in implicitly typed array allocation
+#pragma warning restore SA1026 // Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
 ```

--- a/documentation/SA1207.md
+++ b/documentation/SA1207.md
@@ -17,15 +17,15 @@
 
 ## Cause
 
-The keyword *protected* is positioned after the keyword *internal* within the declaration of a protected internal C# element.
+The keyword *protected* is positioned after the keyword *internal* within the declaration of a protected internal C# element, or the keyword *private* is positioned after the keyword *protected*.
 
 ## Rule description
 
-A violation of this rule occurs when a protected internal element's access modifiers are written as *internal protected*. In reality, an element with the keywords *protected internal* will have the same access level as an element with the keywords *internal protected*. To make the code easier to read and more consistent, StyleCop standardizes the ordering of these keywords, so that a protected internal element will always be described as such, and never as internal protected. This can help to reduce confusion about whether these access levels are indeed the same.
+A violation of this rule occurs when a protected internal element's access modifiers are written as *internal protected*, or when a private protected element's access modifiers are written as *protected private*. In reality, an element with the keywords *protected internal* will have the same access level as an element with the keywords *internal protected*. To make the code easier to read and more consistent, StyleCop standardizes the ordering of these keywords, so that a protected internal element will always be described as such, and never as internal protected. This can help to reduce confusion about whether these access levels are indeed the same.
 
 ## How to fix violations
 
-To fix an instance of this violation, place the *protected* keyword before the *internal* keyword.
+To fix an instance of this violation, place the *protected* keyword before the *internal* keyword, or place the *private* keyword before the *protected* keyword.
 
 ## How to suppress violations
 


### PR DESCRIPTION
Includes tests, and updates rules to handle `stackalloc` initializers and implicitly-typed `stackalloc` arrays.

* [x] SA1000
* [x] SA1001
* [x] SA1002
* [x] SA1010
* [x] SA1011
* [x] SA1012
* [x] SA1013
* [x] SA1026
* [x] SA1137
* [x] SA1413
* [x] SA1505
* [x] SA1508
* [x] SA1509
* [x] SA1513
