### PR TITLE
Attempt to configure OpenCover for faster builds

### DIFF
--- a/build/opencover-report.ps1
+++ b/build/opencover-report.ps1
@@ -110,6 +110,7 @@ If ($AppVeyor) {
 
 &$opencover_console `
 	-register:user `
+	-threshold:1 -oldStyle `
 	-returntargetcode `
 	-hideskipped:All `
 	-filter:"+[StyleCop*]*" `
@@ -127,6 +128,7 @@ If ($AppVeyor -and -not $?) {
 
 &$opencover_console `
 	-register:user `
+	-threshold:1 -oldStyle `
 	-returntargetcode `
 	-hideskipped:All `
 	-filter:"+[StyleCop*]*" `


### PR DESCRIPTION
This is an experiment to see if we can drop the 15 minute AppVeyor builds to something more reasonable.