### PR TITLE
Fix for #2918 - Update 'SA1627MessageFormat' in 'DocumentationResources.resx'

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
@@ -226,7 +226,7 @@
     <value>The XML header documentation for a C# code element contains an empty tag.</value>
   </data>
   <data name="SA1627MessageFormat" xml:space="preserve">
-    <value>The documentation text within the \'{0}\' tag should not be empty.</value>
+    <value>The documentation text within the '{0}' tag should not be empty.</value>
   </data>
   <data name="SA1627Title" xml:space="preserve">
     <value>Documentation text should not be empty</value>


### PR DESCRIPTION
In SA1627MessageFormat text \\' replaced by '