### PR TITLE
SA1642 - Fix single line summary when changing the reference

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -184,7 +184,6 @@ namespace StyleCop.Analyzers.DocumentationRules
                 list = BuildStandardTextSyntaxList(typeDeclaration, standardText[0], standardText[1] + trailingString);
             }
 
-            
             newContent = newContent.InsertRange(0, list);
 
             newContent = RemoveTrailingEmptyLines(newContent);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -119,15 +119,7 @@ namespace StyleCop.Analyzers.DocumentationRules
 
         internal static SyntaxList<XmlNodeSyntax> BuildStandardTextSyntaxList(BaseTypeDeclarationSyntax typeDeclaration, string preText, string postText)
         {
-            TypeParameterListSyntax typeParameterList;
-            if (typeDeclaration is ClassDeclarationSyntax classDeclaration)
-            {
-                typeParameterList = classDeclaration.TypeParameterList;
-            }
-            else
-            {
-                typeParameterList = (typeDeclaration as StructDeclarationSyntax)?.TypeParameterList;
-            }
+            TypeParameterListSyntax typeParameterList = GetTypeParameterList(typeDeclaration);
 
             return XmlSyntaxFactory.List(
                 XmlSyntaxFactory.Text(preText),
@@ -137,21 +129,23 @@ namespace StyleCop.Analyzers.DocumentationRules
 
         internal static SyntaxList<XmlNodeSyntax> BuildStandardTextSyntaxList(BaseTypeDeclarationSyntax typeDeclaration, string newLineText, string preText, string postText)
         {
-            TypeParameterListSyntax typeParameterList;
-            if (typeDeclaration is ClassDeclarationSyntax classDeclaration)
-            {
-                typeParameterList = classDeclaration.TypeParameterList;
-            }
-            else
-            {
-                typeParameterList = (typeDeclaration as StructDeclarationSyntax)?.TypeParameterList;
-            }
+            TypeParameterListSyntax typeParameterList = GetTypeParameterList(typeDeclaration);
 
             return XmlSyntaxFactory.List(
                 XmlSyntaxFactory.NewLine(newLineText),
                 XmlSyntaxFactory.Text(preText),
                 BuildSeeElement(typeDeclaration.Identifier, typeParameterList),
                 XmlSyntaxFactory.Text(postText.EndsWith(".") ? postText : (postText + ".")));
+        }
+
+        private static TypeParameterListSyntax GetTypeParameterList(BaseTypeDeclarationSyntax typeDeclaration)
+        {
+            if (typeDeclaration is ClassDeclarationSyntax classDeclaration)
+            {
+                return classDeclaration.TypeParameterList;
+            }
+
+            return (typeDeclaration as StructDeclarationSyntax)?.TypeParameterList;
         }
 
         private static Task<Document> GetTransformedDocumentAsync(Document document, SyntaxNode root, XmlElementSyntax node, CancellationToken cancellationToken)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
@@ -939,8 +939,7 @@ public class TestClass
 {{
     public class ClassName
     {{
-        /// <summary>
-        /// Initializes a new instance of the <see cref=""ClassName""/> class.</summary>
+        /// <summary>Initializes a new instance of the <see cref=""ClassName""/> class.</summary>
         public ClassName()
         {{
         }}
@@ -948,6 +947,30 @@ public class TestClass
 }}";
 
             DiagnosticResult expected = Diagnostic().WithLocation(5, 13);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(2963, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2963")]
+        public async Task TestConstructorNoCRefDocumentationSingleLineAsync()
+        {
+            var testCode = @"
+public class TestClass
+{
+    /// <summary>Initializes a new instance of the TestClass class.</summary>
+    public TestClass() { }
+}
+";
+
+            var fixedCode = @"
+public class TestClass
+{
+    /// <summary>Initializes a new instance of the <see cref=""TestClass""/> class.</summary>
+    public TestClass() { }
+}
+";
+
+            var expected = Diagnostic().WithLocation(4, 9);
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
The issue resulted from always passing in a newline character

When using the code fix provider. This was resolved by determining
if the summary was multiline or not. If it isn't multiline the newLineText
is no longer passed.

Fixes #2963