### PR TITLE
Update Microsoft.Build.Locator to version 1.2.2

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Status.Generator/StyleCop.Analyzers.Status.Generator.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Status.Generator/StyleCop.Analyzers.Status.Generator.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.24.0" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.0.13" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.9.0-beta4-62830-01" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="2.9.0-beta4-62830-01" />
     <PackageReference Include="Newtonsoft.Json" Version="7.0.1-beta3" />

--- a/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
+++ b/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
@@ -23,7 +23,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.0.13" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="	2.9.0-beta4-62830-01" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="	2.9.0-beta4-62830-01" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="	2.9.0-beta4-62830-01" />


### PR DESCRIPTION
This should allow StyleCopTester and Status.Generator to work on machines with only VS 2019 installed.

Fixes #2979