### PR TITLE
Remove extraneous periods in rule messages

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1505OpeningBracesMustNotBeFollowedByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1505OpeningBracesMustNotBeFollowedByBlankLine.cs
@@ -46,7 +46,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// </summary>
         public const string DiagnosticId = "SA1505";
         private const string Title = "Opening braces should not be followed by blank line";
-        private const string MessageFormat = "An opening brace should not be followed by a blank line.";
+        private const string MessageFormat = "An opening brace should not be followed by a blank line";
         private const string Description = "An opening brace within a C# element, statement, or expression is followed by a blank line.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1505.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1508ClosingBracesMustNotBePrecededByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1508ClosingBracesMustNotBePrecededByBlankLine.cs
@@ -45,7 +45,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// </summary>
         public const string DiagnosticId = "SA1508";
         private const string Title = "Closing braces should not be preceded by blank line";
-        private const string MessageFormat = "A closing brace should not be preceded by a blank line.";
+        private const string MessageFormat = "A closing brace should not be preceded by a blank line";
         private const string Description = "A closing brace within a C# element, statement, or expression is preceded by a blank line.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1508.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1509OpeningBracesMustNotBePrecededByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1509OpeningBracesMustNotBePrecededByBlankLine.cs
@@ -46,7 +46,7 @@ namespace StyleCop.Analyzers.LayoutRules
         /// </summary>
         public const string DiagnosticId = "SA1509";
         private const string Title = "Opening braces should not be preceded by blank line";
-        private const string MessageFormat = "Opening braces should not be preceded by blank line.";
+        private const string MessageFormat = "Opening braces should not be preceded by blank line";
         private const string Description = "An opening brace within a C# element, statement, or expression is preceded by a blank line.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1509.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1303ConstFieldNamesMustBeginWithUpperCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1303ConstFieldNamesMustBeginWithUpperCaseLetter.cs
@@ -32,7 +32,7 @@ namespace StyleCop.Analyzers.NamingRules
         /// </summary>
         public const string DiagnosticId = "SA1303";
         private const string Title = "Const field names should begin with upper-case letter";
-        private const string MessageFormat = "Const field names should begin with upper-case letter.";
+        private const string MessageFormat = "Const field names should begin with upper-case letter";
         private const string Description = "The name of a constant C# field should begin with an upper-case letter.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1303.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1207ProtectedMustComeBeforeInternal.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1207ProtectedMustComeBeforeInternal.cs
@@ -30,7 +30,7 @@ namespace StyleCop.Analyzers.OrderingRules
         /// </summary>
         public const string DiagnosticId = "SA1207";
         private const string Title = "Protected should come before internal";
-        private const string MessageFormat = "The keyword '{0}' should come before '{1}'.";
+        private const string MessageFormat = "The keyword '{0}' should come before '{1}'";
         private const string Description = "The keyword '{0}' is positioned after the keyword '{1}' within the declaration of a {0} {1} C# element.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1207.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1209UsingAliasDirectivesMustBePlacedAfterOtherUsingDirectives.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1209UsingAliasDirectivesMustBePlacedAfterOtherUsingDirectives.cs
@@ -29,7 +29,7 @@ namespace StyleCop.Analyzers.OrderingRules
         /// </summary>
         public const string DiagnosticId = "SA1209";
         private const string Title = "Using alias directives should be placed after other using directives";
-        private const string MessageFormat = "Using alias directives should be placed after all using namespace directives.";
+        private const string MessageFormat = "Using alias directives should be placed after all using namespace directives";
         private const string Description = "A using-alias directive is positioned before a regular using directive.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1209.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1210UsingDirectivesMustBeOrderedAlphabeticallyByNamespace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1210UsingDirectivesMustBeOrderedAlphabeticallyByNamespace.cs
@@ -33,7 +33,7 @@ namespace StyleCop.Analyzers.OrderingRules
         /// </summary>
         public const string DiagnosticId = "SA1210";
         private const string Title = "Using directives should be ordered alphabetically by namespace";
-        private const string MessageFormat = "Using directives should be ordered alphabetically by the namespaces.";
+        private const string MessageFormat = "Using directives should be ordered alphabetically by the namespaces";
         private const string Description = "The using directives within a C# code file are not sorted alphabetically by namespace.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1210.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1212PropertyAccessorsMustFollowOrder.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1212PropertyAccessorsMustFollowOrder.cs
@@ -45,7 +45,7 @@ namespace StyleCop.Analyzers.OrderingRules
         /// </summary>
         public const string DiagnosticId = "SA1212";
         private const string Title = "Property accessors should follow order";
-        private const string MessageFormat = "A get accessor appears after a set accessor within a property or indexer.";
+        private const string MessageFormat = "A get accessor appears after a set accessor within a property or indexer";
         private const string Description = "A get accessor appears after a set accessor within a property or indexer.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1212.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1213EventAccessorsMustFollowOrder.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1213EventAccessorsMustFollowOrder.cs
@@ -45,7 +45,7 @@ namespace StyleCop.Analyzers.OrderingRules
         /// </summary>
         public const string DiagnosticId = "SA1213";
         private const string Title = "Event accessors should follow order";
-        private const string MessageFormat = "Event accessors should follow order.";
+        private const string MessageFormat = "Event accessors should follow order";
         private const string Description = "An add accessor appears after a remove accessor within an event.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1213.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1216UsingStaticDirectivesMustBePlacedAtTheCorrectLocation.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1216UsingStaticDirectivesMustBePlacedAtTheCorrectLocation.cs
@@ -29,7 +29,7 @@ namespace StyleCop.Analyzers.OrderingRules
         /// </summary>
         public const string DiagnosticId = "SA1216";
         private const string Title = "Using static directives should be placed at the correct location.";
-        private const string MessageFormat = "Using static directives should be placed at the correct location.";
+        private const string MessageFormat = "Using static directives should be placed at the correct location";
         private const string Description = "A using static directive is positioned before a regular or after an alias using directive.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1216.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
@@ -40,7 +40,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// </summary>
         public const string DiagnosticId = "SA1000";
         private const string Title = "Keywords should be spaced correctly";
-        private const string MessageFormat = "The keyword '{0}' should{1} be followed by a space.";
+        private const string MessageFormat = "The keyword '{0}' should{1} be followed by a space";
         private const string Description = "The spacing around a C# keyword is incorrect.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1000.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002SemicolonsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1002SemicolonsMustBeSpacedCorrectly.cs
@@ -27,7 +27,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// </summary>
         public const string DiagnosticId = "SA1002";
         private const string Title = "Semicolons should be spaced correctly";
-        private const string MessageFormat = "Semicolons should{0} be {1} by a space.";
+        private const string MessageFormat = "Semicolons should{0} be {1} by a space";
         private const string Description = "The spacing around a semicolon is incorrect, within a C# code file.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1002.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
@@ -35,7 +35,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// </summary>
         public const string DiagnosticId = "SA1009";
         private const string Title = "Closing parenthesis should be spaced correctly";
-        private const string MessageFormat = "Closing parenthesis should{0} be {1} by a space.";
+        private const string MessageFormat = "Closing parenthesis should{0} be {1} by a space";
         private const string Description = "A closing parenthesis within a C# statement is not spaced correctly.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1009.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010OpeningSquareBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1010OpeningSquareBracketsMustBeSpacedCorrectly.cs
@@ -30,7 +30,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// </summary>
         public const string DiagnosticId = "SA1010";
         private const string Title = "Opening square brackets should be spaced correctly";
-        private const string MessageFormat = "Opening square brackets should {0} by a space.";
+        private const string MessageFormat = "Opening square brackets should {0} by a space";
         private const string Description = "An opening square bracket within a C# statement is not spaced correctly.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1010.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011ClosingSquareBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011ClosingSquareBracketsMustBeSpacedCorrectly.cs
@@ -34,7 +34,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// </summary>
         public const string DiagnosticId = "SA1011";
         private const string Title = "Closing square brackets should be spaced correctly";
-        private const string MessageFormat = "Closing square bracket should{0} be {1} by a space.";
+        private const string MessageFormat = "Closing square bracket should{0} be {1} by a space";
         private const string Description = "A closing square bracket within a C# statement is not spaced correctly.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1011.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1012OpeningBracesMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1012OpeningBracesMustBeSpacedCorrectly.cs
@@ -33,7 +33,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// </summary>
         public const string DiagnosticId = "SA1012";
         private const string Title = "Opening braces should be spaced correctly";
-        private const string MessageFormat = "Opening brace should{0} be {1} by a space.";
+        private const string MessageFormat = "Opening brace should{0} be {1} by a space";
         private const string Description = "An opening brace within a C# element is not spaced correctly.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1012.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1013ClosingBracesMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1013ClosingBracesMustBeSpacedCorrectly.cs
@@ -32,7 +32,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// </summary>
         public const string DiagnosticId = "SA1013";
         private const string Title = "Closing braces should be spaced correctly";
-        private const string MessageFormat = "Closing brace should{0} be {1} by a space.";
+        private const string MessageFormat = "Closing brace should{0} be {1} by a space";
         private const string Description = "A closing brace within a C# element is not spaced correctly.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1013.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1014OpeningGenericBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1014OpeningGenericBracketsMustBeSpacedCorrectly.cs
@@ -28,7 +28,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// </summary>
         public const string DiagnosticId = "SA1014";
         private const string Title = "Opening generic brackets should be spaced correctly";
-        private const string MessageFormat = "Opening generic brackets should not be {0} by a space.";
+        private const string MessageFormat = "Opening generic brackets should not be {0} by a space";
         private const string Description = "An opening generic bracket within a C# element is not spaced correctly.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1014.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1015ClosingGenericBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1015ClosingGenericBracketsMustBeSpacedCorrectly.cs
@@ -31,7 +31,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// </summary>
         public const string DiagnosticId = "SA1015";
         private const string Title = "Closing generic brackets should be spaced correctly";
-        private const string MessageFormat = "Closing generic bracket should{0} be {1} by a space.";
+        private const string MessageFormat = "Closing generic bracket should{0} be {1} by a space";
         private const string Description = "A closing generic bracket within a C# element is not spaced correctly.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1015.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1019MemberAccessSymbolsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1019MemberAccessSymbolsMustBeSpacedCorrectly.cs
@@ -26,7 +26,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// </summary>
         public const string DiagnosticId = "SA1019";
         private const string Title = "Member access symbols should be spaced correctly";
-        private const string MessageFormat = "Member access symbol '{0}' should not be {1} by a space.";
+        private const string MessageFormat = "Member access symbol '{0}' should not be {1} by a space";
         private const string Description = "The spacing around a member access symbol is incorrect, within a C# code file.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1019.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1020IncrementDecrementSymbolsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1020IncrementDecrementSymbolsMustBeSpacedCorrectly.cs
@@ -28,7 +28,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// </summary>
         public const string DiagnosticId = "SA1020";
         private const string Title = "Increment decrement symbols should be spaced correctly";
-        private const string MessageFormat = "{0} symbol '{1}' should not be {2} by a space.";
+        private const string MessageFormat = "{0} symbol '{1}' should not be {2} by a space";
         private const string Description = "An increment or decrement symbol within a C# element is not spaced correctly.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1020.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021NegativeSignsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1021NegativeSignsMustBeSpacedCorrectly.cs
@@ -31,7 +31,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// </summary>
         public const string DiagnosticId = "SA1021";
         private const string Title = "Negative signs should be spaced correctly";
-        private const string MessageFormat = "Negative sign should{0} be {1} by a space.";
+        private const string MessageFormat = "Negative sign should{0} be {1} by a space";
         private const string Description = "A negative sign within a C# element is not spaced correctly.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1021.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022PositiveSignsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1022PositiveSignsMustBeSpacedCorrectly.cs
@@ -31,7 +31,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// </summary>
         public const string DiagnosticId = "SA1022";
         private const string Title = "Positive signs should be spaced correctly";
-        private const string MessageFormat = "Positive sign should{0} be {1} by a space.";
+        private const string MessageFormat = "Positive sign should{0} be {1} by a space";
         private const string Description = "A positive sign within a C# element is not spaced correctly.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1022.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly.cs
@@ -47,7 +47,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// </summary>
         public const string DiagnosticId = "SA1023";
         private const string Title = "Dereference and access of symbols should be spaced correctly";
-        private const string MessageFormat = "Dereference symbol '*' should {0}.";
+        private const string MessageFormat = "Dereference symbol '*' should {0}";
         private const string Description = "A dereference symbol or an access-of symbol within a C# element is not spaced correctly.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1023.md";
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1024ColonsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1024ColonsMustBeSpacedCorrectly.cs
@@ -64,7 +64,7 @@ namespace StyleCop.Analyzers.SpacingRules
         /// </summary>
         public const string DiagnosticId = "SA1024";
         private const string Title = "Colons Should Be Spaced Correctly";
-        private const string MessageFormat = "Colon should{0} be {1}{2} by a space.";
+        private const string MessageFormat = "Colon should{0} be {1}{2} by a space";
         private const string Description = "A colon within a C# element is not spaced correctly.";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1024.md";
 


### PR DESCRIPTION
Currently some rule messages end in periods and some don't. This pull request makes them all uniform without periods.