### PR TITLE
Do not require space before open parenthesis in a range expression (#3040)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ build/nuget/
 *.psess
 *.vsp
 *.vspx
+
+# NCrunch artifacts
+*.ncrunch*
+_NCrunch*/

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,3 @@ build/nuget/
 *.psess
 *.vsp
 *.vspx
-
-# NCrunch artifacts
-*.ncrunch*
-_NCrunch*/

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
@@ -5,6 +5,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.SpacingRules;
     using TestHelper;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1008CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1008CSharp8UnitTests.cs
@@ -3,9 +3,59 @@
 
 namespace StyleCop.Analyzers.Test.CSharp8.SpacingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp7.SpacingRules;
+    using Xunit;
+
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly>;
 
     public class SA1008CSharp8UnitTests : SA1008CSharp7UnitTests
     {
+        /// <summary>
+        /// Verifies that spacing after a range expression double dots isn't required.
+        /// </summary>
+        /// <remarks>
+        /// <para>Double dots of range expressions already provide enough spacing for readability so there is no
+        /// need to prefix the opening parenthesis with a space.</para>
+        /// </remarks>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestBeforeRangeExpressionAsync()
+        {
+            var testCode = @"namespace TestNamespace
+{
+    using System;
+    public class TestClass
+    {
+        public string TestMethod()
+        {
+            string str = ""test"";
+            int finalLen = 4;
+            return str[..(finalLen - 1)];
+        }
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostic = new[]
+            {
+                // I couldn't remove these compiler errors, so i expect them in the output
+                // instead.
+                DiagnosticResult.CompilerError("CS0518").WithLocation(10, 24),
+                DiagnosticResult.CompilerError("CS0518").WithLocation(10, 26),
+            };
+
+            await VerifyCSharpDiagnosticAsync(
+                LanguageVersion.CSharp8,
+                testCode,
+                string.Empty,
+                expectedDiagnostic,
+                CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
@@ -208,7 +208,8 @@ namespace StyleCop.Analyzers.SpacingRules
 
             case SyntaxKind.ParenthesizedExpression:
             case SyntaxKindEx.TupleExpression:
-                if (prevToken.Parent.IsKind(SyntaxKind.Interpolation))
+                if (prevToken.Parent.IsKind(SyntaxKind.Interpolation)
+                    || token.Parent.Parent.IsKind(SyntaxKindEx.RangeExpression))
                 {
                     haveLeadingSpace = false;
                     break;


### PR DESCRIPTION
This is my proposal to fix #3040 . Some troubles I had:

- C# 8.0 code emits compiler errors so I had to add them to the list of expected diagnostic results which isn't ideal.
- I didn't add tests for "fixed code" tests. I wasn't sure if I was supposed to.