### PR TITLE
Initial Azure Pipelines build configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,9 @@
 root = true
 
+[*.yml]
+indent_style = space
+indent_size = 2
+
 [*.cs]
 charset = utf-8-bom
 insert_final_newline = true

--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Codecov" version="1.8.0" />
+  <package id="Codecov" version="1.9.0" />
   <package id="OpenCover" version="4.6.519" />
   <package id="ReportGenerator" version="2.3.5.0" targetFramework="net452" />
   <package id="xunit.runner.console" version="2.4.1" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="roslyn" value="https://dotnet.myget.org/F/roslyn/api/v3/index.json" />
     <add key="roslyn-analyzers" value="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" />
 

--- a/StyleCop.Analyzers/version.json
+++ b/StyleCop.Analyzers/version.json
@@ -13,7 +13,7 @@
   },
   "cloudBuild": {
     "buildNumber": {
-      "enabled": true
+      "enabled": false
     }
   }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,20 +12,6 @@ build:
   project: StyleCopAnalyzers.sln
   verbosity: minimal
 test_script:
-- cd build
-- ps: |
-    if ($env:Configuration -eq 'Debug') {
-      .\opencover-report.ps1 -Debug -NoBuild -NoReport -AppVeyor
-      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
-      $packageConfig = [xml](Get-Content ..\.nuget\packages.config)
-      $codecov_version = $packageConfig.SelectSingleNode('/packages/package[@id="Codecov"]').version
-      $codecov = "..\packages\Codecov.$codecov_version\tools\codecov.exe"
-      &$codecov -f '..\build\OpenCover.Reports\OpenCover.StyleCopAnalyzers.xml'
-    } else {
-      .\opencover-report.ps1 -NoBuild -NoReport -AppVeyor
-      if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
-    }
-- cd ..
 - .\StyleCop.Analyzers\StyleCop.Analyzers.Status.Generator\bin\%Configuration%\net46\StyleCop.Analyzers.Status.Generator.exe .\StyleCopAnalyzers.sln > StyleCop.Analyzers.Status.json
 cache:
   - packages -> **\packages.config

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,12 @@ jobs:
       filePath: build/opencover-report.ps1
       arguments: '$(_debugArg) -NoBuild -NoReport -Azure'
 
+  - task: PublishTestResults@2
+    displayName: Publish test results
+    inputs:
+      testResultsFormat: xUnit
+      testResultsFiles: 'build/*.xml'
+
   - task: PublishBuildArtifacts@1
     displayName: Publish build logs
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,10 +38,17 @@ jobs:
       solution: '$(BuildSolution)'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
+      msbuildArgs: '/bl'
 
   - task: PowerShell@2
     displayName: Run Tests
     inputs:
       workingDirectory: '$(Build.SourcesDirectory)/build'
       filePath: build/opencover-report.ps1
-      arguments: '$(_debugArg) -NoBuild -NoReport'
+      arguments: '$(_debugArg) -NoBuild -NoReport -Azure'
+
+  - task: PublishBuildArtifacts@1
+    displayName: Publish build logs
+    inputs:
+      pathtoPublish: msbuild.binlog
+    condition: failed()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ jobs:
 - job: Build
   variables:
     BuildSolution: StyleCopAnalyzers.sln
-    BuildPlatform: AnyCPU
+    BuildPlatform: Any CPU
   strategy:
     matrix:
       Debug:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,11 +5,10 @@ pool:
   - visualstudio
   - vstest
 
-parameters:
-  solution: StyleCopAnalyzers.sln
-
 jobs:
 - job: Build and Test
+  parameters:
+    solution: StyleCopAnalyzers.sln
   variables:
     BuildPlatform: AnyCPU
   strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,7 +38,7 @@ jobs:
       solution: '$(BuildSolution)'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
-      msbuildArgs: '/bl'
+      msbuildArgs: '/bl:$(Build.SourcesDirectory)/msbuild.binlog'
 
   - task: PowerShell@2
     displayName: Run Tests

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,11 +18,6 @@ jobs:
       Release:
         BuildConfiguration: Release
   steps:
-  - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet 4.4.1'
-    inputs:
-      versionSpec: 4.4.1
-
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -52,6 +52,8 @@ jobs:
     inputs:
       testResultsFormat: xUnit
       testResultsFiles: 'build/*.xml'
+      mergeTestResults: true
+      testRunTitle: '$(BuildConfiguration)'
 
   - task: PowerShell@2
     displayName: Upload coverage reports to codecov.io

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,7 @@ jobs:
   variables:
     BuildSolution: StyleCopAnalyzers.sln
     BuildPlatform: Any CPU
+    OriginalBuildNumber: $(Build.BuildNumber)
   strategy:
     matrix:
       Debug:
@@ -65,7 +66,7 @@ jobs:
         $packageConfig = [xml](Get-Content ..\.nuget\packages.config)
         $codecov_version = $packageConfig.SelectSingleNode('/packages/package[@id="Codecov"]').version
         $codecov = "..\packages\Codecov.$codecov_version\tools\codecov.exe"
-        &$codecov -f '..\build\OpenCover.Reports\OpenCover.StyleCopAnalyzers.xml' --required
+        &$codecov -f '..\build\OpenCover.Reports\OpenCover.StyleCopAnalyzers.xml' -b $(OriginalBuildNumber) --required
 
   - task: PublishBuildArtifacts@1
     displayName: Publish build logs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,6 @@ jobs:
   variables:
     BuildSolution: StyleCopAnalyzers.sln
     BuildPlatform: Any CPU
-    OriginalBuildNumber: $(Build.BuildNumber)
   strategy:
     matrix:
       Debug:
@@ -21,6 +20,9 @@ jobs:
         BuildConfiguration: Release
         _debugArg: ''
   steps:
+  - powershell: Write-Host "##vso[task.setvariable variable=OriginalBuildNumber;]$(Build.BuildNumber)"
+    displayName: Set original build number
+
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet 5.3.1'
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,10 @@ jobs:
     matrix:
       Debug:
         BuildConfiguration: Debug
+        _debugArg: '-Debug'
       Release:
         BuildConfiguration: Release
+        _debugArg: ''
   steps:
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet 5.3.1'
@@ -36,3 +38,8 @@ jobs:
       solution: '$(BuildSolution)'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'
+
+  - task: PowerShell@2
+    displayName: Run Tests
+    script: .\opencover-report.ps1
+    arguments: '$(_debugArg) -NoBuild -NoReport'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,7 +65,7 @@ jobs:
         $packageConfig = [xml](Get-Content ..\.nuget\packages.config)
         $codecov_version = $packageConfig.SelectSingleNode('/packages/package[@id="Codecov"]').version
         $codecov = "..\packages\Codecov.$codecov_version\tools\codecov.exe"
-        &$codecov -f '..\build\OpenCover.Reports\OpenCover.StyleCopAnalyzers.xml'
+        &$codecov -f '..\build\OpenCover.Reports\OpenCover.StyleCopAnalyzers.xml' --required
 
   - task: PublishBuildArtifacts@1
     displayName: Publish build logs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,6 +58,7 @@ jobs:
     condition: eq(variables['BuildConfiguration'], 'Debug')
     inputs:
       workingDirectory: '$(Build.SourcesDirectory)/build'
+      targetType: inline
       script: |
         $packageConfig = [xml](Get-Content ..\.nuget\packages.config)
         $codecov_version = $packageConfig.SelectSingleNode('/packages/package[@id="Codecov"]').version

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,5 +43,5 @@ jobs:
     displayName: Run Tests
     inputs:
       workingDirectory: '$(Build.SourcesDirectory)/build'
-      filePath: opencover-report.ps1
+      filePath: build/opencover-report.ps1
       arguments: '$(_debugArg) -NoBuild -NoReport'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,5 +42,6 @@ jobs:
   - task: PowerShell@2
     displayName: Run Tests
     inputs:
-      script: .\opencover-report.ps1
+      workingDirectory: '$(Build.SourcesDirectory)/build'
+      filePath: opencover-report.ps1
       arguments: '$(_debugArg) -NoBuild -NoReport'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,17 @@ jobs:
       testResultsFormat: xUnit
       testResultsFiles: 'build/*.xml'
 
+  - task: PowerShell@2
+    displayName: Upload coverage reports to codecov.io
+    condition: eq(variables['BuildConfiguration'], 'Debug')
+    inputs:
+      workingDirectory: '$(Build.SourcesDirectory)/build'
+      script: |
+        $packageConfig = [xml](Get-Content ..\.nuget\packages.config)
+        $codecov_version = $packageConfig.SelectSingleNode('/packages/package[@id="Codecov"]').version
+        $codecov = "..\packages\Codecov.$codecov_version\tools\codecov.exe"
+        &$codecov -f '..\build\OpenCover.Reports\OpenCover.StyleCopAnalyzers.xml'
+
   - task: PublishBuildArtifacts@1
     displayName: Publish build logs
     inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 pool:
   name: Azure Pipelines
+  vmImage: windows-latest
   demands:
   - msbuild
   - visualstudio

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ pool:
   - vstest
 
 jobs:
-- job: Build and Test
+- job: Build
   variables:
     BuildSolution: StyleCopAnalyzers.sln
     BuildPlatform: AnyCPU

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,37 @@
+pool:
+  name: Azure Pipelines
+  demands:
+  - msbuild
+  - visualstudio
+  - vstest
+
+parameters:
+  solution: StyleCopAnalyzers.sln
+
+jobs:
+- job: Build and Test
+  variables:
+    BuildPlatform: AnyCPU
+  strategy:
+    matrix:
+      Debug:
+        BuildConfiguration: Debug
+      Release:
+        BuildConfiguration: Release
+  steps:
+  - task: NuGetToolInstaller@0
+    displayName: 'Use NuGet 4.4.1'
+    inputs:
+      versionSpec: 4.4.1
+
+  - task: NuGetCommand@2
+    displayName: 'NuGet restore'
+    inputs:
+      restoreSolution: '$(Parameters.solution)'
+
+  - task: VSBuild@1
+    displayName: 'Build solution StyleCopAnalyzers.sln'
+    inputs:
+      solution: '$(Parameters.solution)'
+      platform: '$(BuildPlatform)'
+      configuration: '$(BuildConfiguration)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,9 +20,6 @@ jobs:
         BuildConfiguration: Release
         _debugArg: ''
   steps:
-  - powershell: Write-Host "##vso[task.setvariable variable=OriginalBuildNumber;]$(Build.BuildNumber)"
-    displayName: Set original build number
-
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet 5.3.1'
     inputs:
@@ -68,7 +65,7 @@ jobs:
         $packageConfig = [xml](Get-Content ..\.nuget\packages.config)
         $codecov_version = $packageConfig.SelectSingleNode('/packages/package[@id="Codecov"]').version
         $codecov = "..\packages\Codecov.$codecov_version\tools\codecov.exe"
-        &$codecov -f '..\build\OpenCover.Reports\OpenCover.StyleCopAnalyzers.xml' -b $(OriginalBuildNumber) --required
+        &$codecov -f '..\build\OpenCover.Reports\OpenCover.StyleCopAnalyzers.xml' --required
 
   - task: PublishBuildArtifacts@1
     displayName: Publish build logs

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,9 +7,8 @@ pool:
 
 jobs:
 - job: Build and Test
-  parameters:
-    solution: StyleCopAnalyzers.sln
   variables:
+    BuildSolution: StyleCopAnalyzers.sln
     BuildPlatform: AnyCPU
   strategy:
     matrix:
@@ -26,11 +25,11 @@ jobs:
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
     inputs:
-      restoreSolution: '$(Parameters.solution)'
+      restoreSolution: '$(BuildSolution)'
 
   - task: VSBuild@1
     displayName: 'Build solution StyleCopAnalyzers.sln'
     inputs:
-      solution: '$(Parameters.solution)'
+      solution: '$(BuildSolution)'
       platform: '$(BuildPlatform)'
       configuration: '$(BuildConfiguration)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,10 +18,17 @@ jobs:
       Release:
         BuildConfiguration: Release
   steps:
+  - task: NuGetToolInstaller@0
+    displayName: 'Use NuGet 5.3.1'
+    inputs:
+      versionSpec: 5.3.1
+
   - task: NuGetCommand@2
     displayName: 'NuGet restore'
     inputs:
       restoreSolution: '$(BuildSolution)'
+      feedsToUse: 'config'
+      nugetConfigPath: '$(Build.WorkingDirectory)/NuGet.config'
 
   - task: VSBuild@1
     displayName: 'Build solution StyleCopAnalyzers.sln'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,7 +28,7 @@ jobs:
     inputs:
       restoreSolution: '$(BuildSolution)'
       feedsToUse: 'config'
-      nugetConfigPath: '$(Build.WorkingDirectory)/NuGet.config'
+      nugetConfigPath: 'NuGet.config'
 
   - task: VSBuild@1
     displayName: 'Build solution StyleCopAnalyzers.sln'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,5 +41,6 @@ jobs:
 
   - task: PowerShell@2
     displayName: Run Tests
-    script: .\opencover-report.ps1
-    arguments: '$(_debugArg) -NoBuild -NoReport'
+    inputs:
+      script: .\opencover-report.ps1
+      arguments: '$(_debugArg) -NoBuild -NoReport'

--- a/build/opencover-report.ps1
+++ b/build/opencover-report.ps1
@@ -2,7 +2,8 @@ param (
 	[switch]$Debug,
 	[switch]$NoBuild,
 	[switch]$NoReport,
-	[switch]$AppVeyor
+	[switch]$AppVeyor,
+	[switch]$Azure
 )
 
 If (-not $NoBuild) {
@@ -51,6 +52,9 @@ $register_mode = 'user'
 If ($AppVeyor) {
 	$AppVeyorArg = '-appveyor'
 	$register_mode = 'Path32'
+} ElseIf ($Azure) {
+	$AppVeyorArg = '-vsts'
+	$register_mode = 'Path32'
 }
 
 &$opencover_console `
@@ -65,7 +69,7 @@ If ($AppVeyor) {
 	-target:"$xunit_runner_console_net452" `
 	-targetargs:"$target_dll -noshadow $AppVeyorArg"
 
-If ($AppVeyor -and -not $?) {
+If (($AppVeyor -or $Azure) -and -not $?) {
 	$host.UI.WriteErrorLine('Build failed; coverage analysis aborted.')
 	Exit $LASTEXITCODE
 }
@@ -83,7 +87,7 @@ If ($AppVeyor -and -not $?) {
 	-target:"$xunit_runner_console_net46" `
 	-targetargs:"$target_dll_csharp7 -noshadow $AppVeyorArg"
 
-If ($AppVeyor -and -not $?) {
+If (($AppVeyor -or $Azure) -and -not $?) {
 	$host.UI.WriteErrorLine('Build failed; coverage analysis aborted.')
 	Exit $LASTEXITCODE
 }
@@ -101,7 +105,7 @@ If ($AppVeyor -and -not $?) {
 	-target:"$xunit_runner_console_net472" `
 	-targetargs:"$target_dll_csharp8 -noshadow $AppVeyorArg"
 
-If ($AppVeyor -and -not $?) {
+If (($AppVeyor -or $Azure) -and -not $?) {
 	$host.UI.WriteErrorLine('Build failed; coverage analysis aborted.')
 	Exit $LASTEXITCODE
 }

--- a/build/opencover-report.ps1
+++ b/build/opencover-report.ps1
@@ -53,7 +53,6 @@ If ($AppVeyor) {
 	$AppVeyorArg = '-appveyor'
 	$register_mode = 'Path32'
 } ElseIf ($Azure) {
-	$AppVeyorArg = '-vsts'
 	$register_mode = 'Path32'
 }
 
@@ -67,7 +66,7 @@ If ($AppVeyor) {
 	-excludebyfile:*\*Designer.cs `
 	-output:"$report_folder\OpenCover.StyleCopAnalyzers.xml" `
 	-target:"$xunit_runner_console_net452" `
-	-targetargs:"$target_dll -noshadow $AppVeyorArg"
+	-targetargs:"$target_dll -noshadow $AppVeyorArg -xml StyleCopAnalyzers.xunit.xml"
 
 If (($AppVeyor -or $Azure) -and -not $?) {
 	$host.UI.WriteErrorLine('Build failed; coverage analysis aborted.')
@@ -85,7 +84,7 @@ If (($AppVeyor -or $Azure) -and -not $?) {
 	-output:"$report_folder\OpenCover.StyleCopAnalyzers.xml" `
 	-mergebyhash -mergeoutput `
 	-target:"$xunit_runner_console_net46" `
-	-targetargs:"$target_dll_csharp7 -noshadow $AppVeyorArg"
+	-targetargs:"$target_dll_csharp7 -noshadow $AppVeyorArg -xml StyleCopAnalyzers.CSharp7.xunit.xml"
 
 If (($AppVeyor -or $Azure) -and -not $?) {
 	$host.UI.WriteErrorLine('Build failed; coverage analysis aborted.')
@@ -103,7 +102,7 @@ If (($AppVeyor -or $Azure) -and -not $?) {
 	-output:"$report_folder\OpenCover.StyleCopAnalyzers.xml" `
 	-mergebyhash -mergeoutput `
 	-target:"$xunit_runner_console_net472" `
-	-targetargs:"$target_dll_csharp8 -noshadow $AppVeyorArg"
+	-targetargs:"$target_dll_csharp8 -noshadow $AppVeyorArg -xml StyleCopAnalyzers.CSharp8.xunit.xml"
 
 If (($AppVeyor -or $Azure) -and -not $?) {
 	$host.UI.WriteErrorLine('Build failed; coverage analysis aborted.')


### PR DESCRIPTION
This pull request moves the testing portion of PRs to Azure Pipelines for improved performance. AppVeyor builds are still active since Azure Pipelines does not provide the artifact support required by our status page.