### PR TITLE
Add "Returns" as a known prefix for SA1623

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1623UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1623UnitTests.cs
@@ -292,6 +292,10 @@ public class TestClass
         [InlineData("public", "int", "{ set {} }", "Gets or sets", "Sets")] // Regression test for #2253
         [InlineData("public", "int", "{ get; private set; }", "Sets", "Gets")] // Regression test for #2253
         [InlineData("public", "int", "{ private get; set; }", "Gets", "Sets")] // Regression test for #2253
+        [InlineData("public", "int", "{ get; }", "Returns", "Gets")]
+        [InlineData("public", "int", "{ get; set; }", "Returns", "Gets or sets")]
+        [InlineData("public", "bool", "{ get; }", "Returns a value indicating whether", "Gets a value indicating whether")]
+        [InlineData("public", "bool", "{ get; set; }", "Returns a value indicating whether", "Gets or sets a value indicating whether")]
         public async Task IncorrectSummaryTagWithKnownPrefixShouldBeFixedCorrectlyAsync(string accessibility, string type, string accessors, string summaryPrefix, string expectedArgument)
         {
             var testCode = $@"

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.Designer.cs
@@ -1718,6 +1718,24 @@ namespace StyleCop.Analyzers.DocumentationRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Returns.
+        /// </summary>
+        internal static string StartingTextReturns {
+            get {
+                return ResourceManager.GetString("StartingTextReturns", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Returns a value indicating whether.
+        /// </summary>
+        internal static string StartingTextReturnsWhether {
+            get {
+                return ResourceManager.GetString("StartingTextReturnsWhether", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Sets.
         /// </summary>
         internal static string StartingTextSets {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.resx
@@ -669,6 +669,12 @@
   <data name="StartingTextGetsWhether" xml:space="preserve">
     <value>Gets a value indicating whether</value>
   </data>
+  <data name="StartingTextReturns" xml:space="preserve">
+    <value>Returns</value>
+  </data>
+  <data name="StartingTextReturnsWhether" xml:space="preserve">
+    <value>Returns a value indicating whether</value>
+  </data>
   <data name="StartingTextSets" xml:space="preserve">
     <value>Sets</value>
   </data>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
@@ -75,7 +75,8 @@ namespace StyleCop.Analyzers.DocumentationRules
                     propertyDeclaration,
                     resourceManager.GetString(nameof(DocumentationResources.StartingTextGetsWhether), culture),
                     resourceManager.GetString(nameof(DocumentationResources.StartingTextSetsWhether), culture),
-                    resourceManager.GetString(nameof(DocumentationResources.StartingTextGetsOrSetsWhether), culture));
+                    resourceManager.GetString(nameof(DocumentationResources.StartingTextGetsOrSetsWhether), culture),
+                    resourceManager.GetString(nameof(DocumentationResources.StartingTextReturnsWhether), culture));
             }
             else
             {
@@ -86,11 +87,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                     propertyDeclaration,
                     resourceManager.GetString(nameof(DocumentationResources.StartingTextGets), culture),
                     resourceManager.GetString(nameof(DocumentationResources.StartingTextSets), culture),
-                    resourceManager.GetString(nameof(DocumentationResources.StartingTextGetsOrSets), culture));
+                    resourceManager.GetString(nameof(DocumentationResources.StartingTextGetsOrSets), culture),
+                    resourceManager.GetString(nameof(DocumentationResources.StartingTextReturns), culture));
             }
         }
 
-        private static void AnalyzeSummaryElement(SyntaxNodeAnalysisContext context, XmlNodeSyntax syntax, Location diagnosticLocation, PropertyDeclarationSyntax propertyDeclaration, string startingTextGets, string startingTextSets, string startingTextGetsOrSets)
+        private static void AnalyzeSummaryElement(SyntaxNodeAnalysisContext context, XmlNodeSyntax syntax, Location diagnosticLocation, PropertyDeclarationSyntax propertyDeclaration, string startingTextGets, string startingTextSets, string startingTextGetsOrSets, string startingTextReturns)
         {
             var diagnosticProperties = ImmutableDictionary.CreateBuilder<string, string>();
             ArrowExpressionClauseSyntax expressionBody = propertyDeclaration.ExpressionBody;
@@ -133,6 +135,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             bool prefixIsGetsOrSets = text.StartsWith(startingTextGetsOrSets, StringComparison.OrdinalIgnoreCase);
             bool prefixIsGets = !prefixIsGetsOrSets && text.StartsWith(startingTextGets, StringComparison.OrdinalIgnoreCase);
             bool prefixIsSets = text.StartsWith(startingTextSets, StringComparison.OrdinalIgnoreCase);
+            bool prefixIsReturns = text.StartsWith(startingTextReturns, StringComparison.OrdinalIgnoreCase);
 
             bool getterVisible, setterVisible;
             if (getter != null && setter != null)
@@ -227,7 +230,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                     // Both getter and setter are visible.
                     if (!prefixIsGetsOrSets)
                     {
-                        ReportSA1623(context, diagnosticLocation, diagnosticProperties, text, expectedStartingText: startingTextGetsOrSets, unexpectedStartingText1: startingTextGets, unexpectedStartingText2: startingTextSets);
+                        ReportSA1623(context, diagnosticLocation, diagnosticProperties, text, expectedStartingText: startingTextGetsOrSets, unexpectedStartingText1: startingTextGets, unexpectedStartingText2: startingTextSets, unexpectedStartingText3: startingTextReturns);
                     }
                 }
                 else if (setter != null)
@@ -241,7 +244,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                         }
                         else
                         {
-                            ReportSA1623(context, diagnosticLocation, diagnosticProperties, text, expectedStartingText: startingTextGets, unexpectedStartingText1: startingTextSets);
+                            ReportSA1623(context, diagnosticLocation, diagnosticProperties, text, expectedStartingText: startingTextGets, unexpectedStartingText1: startingTextSets, unexpectedStartingText2: startingTextReturns);
                         }
                     }
                 }
@@ -250,7 +253,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                     // Getter exists and is visible. Setter does not exist.
                     if (!prefixIsGets)
                     {
-                        ReportSA1623(context, diagnosticLocation, diagnosticProperties, text, expectedStartingText: startingTextGets, unexpectedStartingText1: startingTextSets, unexpectedStartingText2: startingTextGetsOrSets);
+                        ReportSA1623(context, diagnosticLocation, diagnosticProperties, text, expectedStartingText: startingTextGets, unexpectedStartingText1: startingTextSets, unexpectedStartingText2: startingTextGetsOrSets, unexpectedStartingText3: startingTextReturns);
                     }
                 }
             }
@@ -267,7 +270,7 @@ namespace StyleCop.Analyzers.DocumentationRules
                         }
                         else
                         {
-                            ReportSA1623(context, diagnosticLocation, diagnosticProperties, text, expectedStartingText: startingTextSets, unexpectedStartingText1: startingTextGets);
+                            ReportSA1623(context, diagnosticLocation, diagnosticProperties, text, expectedStartingText: startingTextSets, unexpectedStartingText1: startingTextGets, unexpectedStartingText2: startingTextReturns);
                         }
                     }
                 }
@@ -276,13 +279,13 @@ namespace StyleCop.Analyzers.DocumentationRules
                     // Setter exists and is visible. Getter does not exist.
                     if (!prefixIsSets)
                     {
-                        ReportSA1623(context, diagnosticLocation, diagnosticProperties, text, expectedStartingText: startingTextSets, unexpectedStartingText1: startingTextGetsOrSets, unexpectedStartingText2: startingTextGets);
+                        ReportSA1623(context, diagnosticLocation, diagnosticProperties, text, expectedStartingText: startingTextSets, unexpectedStartingText1: startingTextGetsOrSets, unexpectedStartingText2: startingTextGets, unexpectedStartingText3: startingTextReturns);
                     }
                 }
             }
         }
 
-        private static void ReportSA1623(SyntaxNodeAnalysisContext context, Location diagnosticLocation, ImmutableDictionary<string, string>.Builder diagnosticProperties, string text, string expectedStartingText, string unexpectedStartingText1, string unexpectedStartingText2 = null)
+        private static void ReportSA1623(SyntaxNodeAnalysisContext context, Location diagnosticLocation, ImmutableDictionary<string, string>.Builder diagnosticProperties, string text, string expectedStartingText, string unexpectedStartingText1, string unexpectedStartingText2 = null, string unexpectedStartingText3 = null)
         {
             diagnosticProperties.Add(ExpectedTextKey, expectedStartingText);
 
@@ -293,6 +296,10 @@ namespace StyleCop.Analyzers.DocumentationRules
             else if ((unexpectedStartingText2 != null) && text.StartsWith(unexpectedStartingText2, StringComparison.OrdinalIgnoreCase))
             {
                 diagnosticProperties.Add(TextToRemoveKey, text.Substring(0, unexpectedStartingText2.Length));
+            }
+            else if ((unexpectedStartingText3 != null) && text.StartsWith(unexpectedStartingText3, StringComparison.OrdinalIgnoreCase))
+            {
+                diagnosticProperties.Add(TextToRemoveKey, text.Substring(0, unexpectedStartingText3.Length));
             }
 
             context.ReportDiagnostic(Diagnostic.Create(SA1623Descriptor, diagnosticLocation, diagnosticProperties.ToImmutable(), expectedStartingText));


### PR DESCRIPTION
It is common for a "Get" method summary to start with "Returns". After refactoring it to a property, we can use this code fix provider to update it quickly.