### PR TITLE
Simplify names

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/PropertySummaryDocumentationCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/PropertySummaryDocumentationCodeFixProvider.cs
@@ -14,7 +14,6 @@ namespace StyleCop.Analyzers.DocumentationRules
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using StyleCop.Analyzers.Helpers;
-    using StyleCop.Analyzers.Helpers.ObjectPools;
 
     /// <summary>
     /// Implements the code fix for property summary documentation.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1600CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1600CodeFixProvider.cs
@@ -3,7 +3,6 @@
 
 namespace StyleCop.Analyzers.DocumentationRules
 {
-    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Composition;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/FixAllContextHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/FixAllContextHelper.cs
@@ -12,7 +12,6 @@ namespace StyleCop.Analyzers.Helpers
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeFixes;
-    using Microsoft.CodeAnalysis.Diagnostics;
 
     internal static class FixAllContextHelper
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/NamingRules/SA1302CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/NamingRules/SA1302CodeFixProvider.cs
@@ -5,7 +5,6 @@ namespace StyleCop.Analyzers.NamingRules
 {
     using System.Collections.Immutable;
     using System.Composition;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/UsingCodeFixProvider.UsingsSorter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/UsingCodeFixProvider.UsingsSorter.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.OrderingRules
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.Globalization;
     using System.Linq;
     using System.Threading;
     using Microsoft.CodeAnalysis;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1130CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1130CodeFixProvider.cs
@@ -3,7 +3,6 @@
 
 namespace StyleCop.Analyzers.ReadabilityRules
 {
-    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Composition;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1135CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1135CodeFixProvider.cs
@@ -3,7 +3,6 @@
 
 namespace StyleCop.Analyzers.ReadabilityRules
 {
-    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Composition;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1139CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1139CodeFixProvider.cs
@@ -3,7 +3,6 @@
 
 namespace StyleCop.Analyzers.ReadabilityRules
 {
-    using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Composition;
     using System.Linq;
@@ -14,7 +13,6 @@ namespace StyleCop.Analyzers.ReadabilityRules
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
-    using Microsoft.CodeAnalysis.Text;
     using StyleCop.Analyzers.Helpers;
 
     /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1142CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1142CodeFixProvider.cs
@@ -13,8 +13,6 @@ namespace StyleCop.Analyzers.ReadabilityRules
     using Microsoft.CodeAnalysis.CodeActions;
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.CSharp;
-    using Microsoft.CodeAnalysis.CSharp.Syntax;
-    using Microsoft.CodeAnalysis.Simplification;
     using StyleCop.Analyzers.Helpers;
     using StyleCop.Analyzers.Lightup;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Settings/SettingsFileCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Settings/SettingsFileCodeFixProvider.cs
@@ -3,7 +3,6 @@
 
 namespace StyleCop.Analyzers.Settings
 {
-    using System;
     using System.Collections.Immutable;
     using System.Composition;
     using System.Linq;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Status.Generator/SolutionReader.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Status.Generator/SolutionReader.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Status.Generator
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.IO;
     using System.Linq;
     using System.Reflection;
     using System.Text.RegularExpressions;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/DocumentationRules/SA1623CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/DocumentationRules/SA1623CSharp7UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.DocumentationRules
     using StyleCop.Analyzers.Test.DocumentationRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.DocumentationRules.PropertySummaryDocumentationAnalyzer,
-        StyleCop.Analyzers.DocumentationRules.PropertySummaryDocumentationCodeFixProvider>;
+        Analyzers.DocumentationRules.PropertySummaryDocumentationAnalyzer,
+        Analyzers.DocumentationRules.PropertySummaryDocumentationCodeFixProvider>;
 
     public class SA1623CSharp7UnitTests : SA1623UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/DocumentationRules/SA1624CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/DocumentationRules/SA1624CSharp7UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.DocumentationRules
     using StyleCop.Analyzers.Test.DocumentationRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.DocumentationRules.PropertySummaryDocumentationAnalyzer,
-        StyleCop.Analyzers.DocumentationRules.PropertySummaryDocumentationCodeFixProvider>;
+        Analyzers.DocumentationRules.PropertySummaryDocumentationAnalyzer,
+        Analyzers.DocumentationRules.PropertySummaryDocumentationCodeFixProvider>;
 
     public class SA1624CSharp7UnitTests : SA1624UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1500CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1500CSharp7UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1500CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1500CSharp7UnitTests.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     public class SA1500CSharp7UnitTests : SA1500UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1502CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1502CSharp7UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
     using StyleCop.Analyzers.Test.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
-        StyleCop.Analyzers.LayoutRules.SA1502CodeFixProvider>;
+        Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
+        Analyzers.LayoutRules.SA1502CodeFixProvider>;
 
     public class SA1502CSharp7UnitTests : SA1502UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1505CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1505CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
     using StyleCop.Analyzers.Test.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1505OpeningBracesMustNotBeFollowedByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1505CodeFixProvider>;
+        Analyzers.LayoutRules.SA1505OpeningBracesMustNotBeFollowedByBlankLine,
+        Analyzers.LayoutRules.SA1505CodeFixProvider>;
 
     public class SA1505CSharp7UnitTests : SA1505UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1508CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1508CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
     using StyleCop.Analyzers.Test.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1508ClosingBracesMustNotBePrecededByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1508CodeFixProvider>;
+        Analyzers.LayoutRules.SA1508ClosingBracesMustNotBePrecededByBlankLine,
+        Analyzers.LayoutRules.SA1508CodeFixProvider>;
 
     public class SA1508CSharp7UnitTests : SA1508UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1509CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1509CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
     using StyleCop.Analyzers.Test.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1509OpeningBracesMustNotBePrecededByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1509CodeFixProvider>;
+        Analyzers.LayoutRules.SA1509OpeningBracesMustNotBePrecededByBlankLine,
+        Analyzers.LayoutRules.SA1509CodeFixProvider>;
 
     public class SA1509CSharp7UnitTests : SA1509UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1513CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1513CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
     using StyleCop.Analyzers.Test.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1513ClosingBraceMustBeFollowedByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1513CodeFixProvider>;
+        Analyzers.LayoutRules.SA1513ClosingBraceMustBeFollowedByBlankLine,
+        Analyzers.LayoutRules.SA1513CodeFixProvider>;
 
     public class SA1513CSharp7UnitTests : SA1513UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1515CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/LayoutRules/SA1515CSharp7UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.LayoutRules
     using StyleCop.Analyzers.Test.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1515SingleLineCommentMustBePrecededByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1515CodeFixProvider>;
+        Analyzers.LayoutRules.SA1515SingleLineCommentMustBePrecededByBlankLine,
+        Analyzers.LayoutRules.SA1515CodeFixProvider>;
 
     public class SA1515CSharp7UnitTests : SA1515UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/ConstantPatternSyntaxWrapperTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/ConstantPatternSyntaxWrapperTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.Lightup
     using System;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
-    using StyleCop.Analyzers.Helpers;
     using StyleCop.Analyzers.Lightup;
     using Xunit;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/DeclarationPatternSyntaxWrapperTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/DeclarationPatternSyntaxWrapperTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.Lightup
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
-    using StyleCop.Analyzers.Helpers;
     using StyleCop.Analyzers.Lightup;
     using Xunit;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/LocalFunctionStatementSyntaxWrapperTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/LocalFunctionStatementSyntaxWrapperTests.cs
@@ -204,7 +204,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.Lightup
                 identifier: SyntaxFactory.Identifier("Identifier"),
                 typeParameterList: SyntaxFactory.TypeParameterList(SyntaxFactory.SeparatedList(ImmutableArray.Create(SyntaxFactory.TypeParameter("T1")))),
                 parameterList: SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(ImmutableArray.Create(SyntaxFactory.Parameter(SyntaxFactory.Identifier("param1"))))),
-                constraintClauses: SyntaxFactory.List<TypeParameterConstraintClauseSyntax>(ImmutableArray.Create(SyntaxFactory.TypeParameterConstraintClause(SyntaxFactory.IdentifierName("constraint1")))),
+                constraintClauses: SyntaxFactory.List(ImmutableArray.Create(SyntaxFactory.TypeParameterConstraintClause(SyntaxFactory.IdentifierName("constraint1")))),
                 body: SyntaxFactory.Block(SyntaxFactory.BreakStatement()),
                 expressionBody: SyntaxFactory.ArrowExpressionClause(SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(0))));
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/SingleVariableDesignationSyntaxWrapperTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/SingleVariableDesignationSyntaxWrapperTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.Lightup
     using System;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
-    using StyleCop.Analyzers.Helpers;
     using StyleCop.Analyzers.Lightup;
     using Xunit;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/TupleElementSyntaxWrapperTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/Lightup/TupleElementSyntaxWrapperTests.cs
@@ -4,7 +4,6 @@
 namespace StyleCop.Analyzers.Test.CSharp7.Lightup
 {
     using System;
-    using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1119CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1119CSharp7UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.MaintainabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.MaintainabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.MaintainabilityRules.SA1119StatementMustNotUseUnnecessaryParenthesis,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1119CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1119CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.MaintainabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.MaintainabilityRules.SA1119StatementMustNotUseUnnecessaryParenthesis,
-        StyleCop.Analyzers.MaintainabilityRules.SA1119CodeFixProvider>;
+        Analyzers.MaintainabilityRules.SA1119StatementMustNotUseUnnecessaryParenthesis,
+        Analyzers.MaintainabilityRules.SA1119CodeFixProvider>;
 
     public class SA1119CSharp7UnitTests : SA1119UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1400CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1400CSharp7UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.MaintainabilityRules
     using StyleCop.Analyzers.Test.MaintainabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.MaintainabilityRules.SA1400AccessModifierMustBeDeclared,
-        StyleCop.Analyzers.MaintainabilityRules.SA1400CodeFixProvider>;
+        Analyzers.MaintainabilityRules.SA1400AccessModifierMustBeDeclared,
+        Analyzers.MaintainabilityRules.SA1400CodeFixProvider>;
 
     public class SA1400CSharp7UnitTests : SA1400UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1408CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1408CSharp7UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.MaintainabilityRules
     using StyleCop.Analyzers.Test.MaintainabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.MaintainabilityRules.SA1408ConditionalExpressionsMustDeclarePrecedence,
-        StyleCop.Analyzers.MaintainabilityRules.SA1407SA1408CodeFixProvider>;
+        Analyzers.MaintainabilityRules.SA1408ConditionalExpressionsMustDeclarePrecedence,
+        Analyzers.MaintainabilityRules.SA1407SA1408CodeFixProvider>;
 
     public class SA1408CSharp7UnitTests : SA1408UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1413CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1413CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.MaintainabilityRules
     using StyleCop.Analyzers.Test.MaintainabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.MaintainabilityRules.SA1413UseTrailingCommasInMultiLineInitializers,
-        StyleCop.Analyzers.MaintainabilityRules.SA1413CodeFixProvider>;
+        Analyzers.MaintainabilityRules.SA1413UseTrailingCommasInMultiLineInitializers,
+        Analyzers.MaintainabilityRules.SA1413CodeFixProvider>;
 
     public class SA1413CSharp7UnitTests : SA1413UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1414CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1414CSharp7UnitTests.cs
@@ -3,10 +3,6 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.MaintainabilityRules
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1414CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1414CSharp7UnitTests.cs
@@ -13,7 +13,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.MaintainabilityRules
     using StyleCop.Analyzers.MaintainabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<
-        StyleCop.Analyzers.MaintainabilityRules.SA1414TupleTypesInSignaturesShouldHaveElementNames>;
+        Analyzers.MaintainabilityRules.SA1414TupleTypesInSignaturesShouldHaveElementNames>;
 
     /// <summary>
     /// This class contains the CSharp 7.x unit tests for SA1414.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1300CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1300CSharp7UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.NamingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.NamingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SA1300ElementMustBeginWithUpperCaseLetter,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1300CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1300CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SA1300ElementMustBeginWithUpperCaseLetter,
-        StyleCop.Analyzers.NamingRules.RenameToUpperCaseCodeFixProvider>;
+        Analyzers.NamingRules.SA1300ElementMustBeginWithUpperCaseLetter,
+        Analyzers.NamingRules.RenameToUpperCaseCodeFixProvider>;
 
     public class SA1300CSharp7UnitTests : SA1300UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1305CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1305CSharp7UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.NamingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.NamingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.NamingRules.SA1305FieldNamesMustNotUseHungarianNotation>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1305CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1305CSharp7UnitTests.cs
@@ -9,7 +9,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.NamingRules
     using StyleCop.Analyzers.Test.NamingRules;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.NamingRules.SA1305FieldNamesMustNotUseHungarianNotation>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.NamingRules.SA1305FieldNamesMustNotUseHungarianNotation>;
 
     public class SA1305CSharp7UnitTests : SA1305UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1312CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1312CSharp7UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.NamingRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Settings.ObjectModel;
     using StyleCop.Analyzers.Test.NamingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SA1312VariableNamesMustBeginWithLowerCaseLetter,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1312CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1312CSharp7UnitTests.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SA1312VariableNamesMustBeginWithLowerCaseLetter,
-        StyleCop.Analyzers.NamingRules.RenameToLowerCaseCodeFixProvider>;
+        Analyzers.NamingRules.SA1312VariableNamesMustBeginWithLowerCaseLetter,
+        Analyzers.NamingRules.RenameToLowerCaseCodeFixProvider>;
 
     public class SA1312CSharp7UnitTests : SA1312UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1316CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/NamingRules/SA1316CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.NamingRules
     using StyleCop.Analyzers.NamingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SA1316TupleElementNamesShouldUseCorrectCasing,
-        StyleCop.Analyzers.NamingRules.SA1316CodeFixProvider>;
+        Analyzers.NamingRules.SA1316TupleElementNamesShouldUseCorrectCasing,
+        Analyzers.NamingRules.SA1316CodeFixProvider>;
 
     /// <summary>
     /// This class contains the CSharp 7.x unit tests for SA1316.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/OrderingRules/SA1206CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/OrderingRules/SA1206CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.OrderingRules
     using StyleCop.Analyzers.Test.OrderingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1206DeclarationKeywordsMustFollowOrder,
-        StyleCop.Analyzers.OrderingRules.SA1206CodeFixProvider>;
+        Analyzers.OrderingRules.SA1206DeclarationKeywordsMustFollowOrder,
+        Analyzers.OrderingRules.SA1206CodeFixProvider>;
 
     public class SA1206CSharp7UnitTests : SA1206UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/OrderingRules/SA1207CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/OrderingRules/SA1207CSharp7UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.OrderingRules
     using StyleCop.Analyzers.Test.OrderingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1207ProtectedMustComeBeforeInternal,
-        StyleCop.Analyzers.OrderingRules.SA1207CodeFixProvider>;
+        Analyzers.OrderingRules.SA1207ProtectedMustComeBeforeInternal,
+        Analyzers.OrderingRules.SA1207CodeFixProvider>;
 
     public class SA1207CSharp7UnitTests : SA1207UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1101CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1101CSharp7UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using StyleCop.Analyzers.Test.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1101PrefixLocalCallsWithThis,
-        StyleCop.Analyzers.ReadabilityRules.SA1101CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1101PrefixLocalCallsWithThis,
+        Analyzers.ReadabilityRules.SA1101CodeFixProvider>;
 
     public class SA1101CSharp7UnitTests : SA1101UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1110CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1110CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1110OpeningParenthesisMustBeOnDeclarationLine,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1110OpeningParenthesisMustBeOnDeclarationLine,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1110CSharp7UnitTests : SA1110UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1110CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1110CSharp7UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1110OpeningParenthesisMustBeOnDeclarationLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1111CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1111CSharp7UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1111ClosingParenthesisMustBeOnLineOfLastParameter,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1111CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1111CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1111ClosingParenthesisMustBeOnLineOfLastParameter,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1111ClosingParenthesisMustBeOnLineOfLastParameter,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1111CSharp7UnitTests : SA1111UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1112CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1112CSharp7UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1112ClosingParenthesisMustBeOnLineOfOpeningParenthesis,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1112CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1112CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1112ClosingParenthesisMustBeOnLineOfOpeningParenthesis,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1112ClosingParenthesisMustBeOnLineOfOpeningParenthesis,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1112CSharp7UnitTests : SA1112UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1113CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1113CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1113CommaMustBeOnSameLineAsPreviousParameter,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1113CommaMustBeOnSameLineAsPreviousParameter,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1113CSharp7UnitTests : SA1113UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1113CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1113CSharp7UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1113CommaMustBeOnSameLineAsPreviousParameter,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1114CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1114CSharp7UnitTests.cs
@@ -9,7 +9,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using StyleCop.Analyzers.Test.ReadabilityRules;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.ReadabilityRules.SA1114ParameterListMustFollowDeclaration>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1114ParameterListMustFollowDeclaration>;
 
     public class SA1114CSharp7UnitTests : SA1114UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1114CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1114CSharp7UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1114ParameterListMustFollowDeclaration>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1115CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1115CSharp7UnitTests.cs
@@ -9,7 +9,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using StyleCop.Analyzers.Test.ReadabilityRules;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.ReadabilityRules.SA1115ParameterMustFollowComma>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1115ParameterMustFollowComma>;
 
     public class SA1115CSharp7UnitTests : SA1115UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1115CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1115CSharp7UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1115ParameterMustFollowComma>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1116CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1116CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1116SplitParametersMustStartOnLineAfterDeclaration,
-        StyleCop.Analyzers.ReadabilityRules.SA1116CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1116SplitParametersMustStartOnLineAfterDeclaration,
+        Analyzers.ReadabilityRules.SA1116CodeFixProvider>;
 
     public class SA1116CSharp7UnitTests : SA1116UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1116CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1116CSharp7UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1116SplitParametersMustStartOnLineAfterDeclaration,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1117CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1117CSharp7UnitTests.cs
@@ -9,7 +9,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using StyleCop.Analyzers.Test.ReadabilityRules;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.ReadabilityRules.SA1117ParametersMustBeOnSameLineOrSeparateLines>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1117ParametersMustBeOnSameLineOrSeparateLines>;
 
     public class SA1117CSharp7UnitTests : SA1117UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1117CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1117CSharp7UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1117ParametersMustBeOnSameLineOrSeparateLines>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1122CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1122CSharp7UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using StyleCop.Analyzers.Test.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1122UseStringEmptyForEmptyStrings,
-        StyleCop.Analyzers.ReadabilityRules.SA1122CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1122UseStringEmptyForEmptyStrings,
+        Analyzers.ReadabilityRules.SA1122CodeFixProvider>;
 
     public class SA1122CSharp7UnitTests : SA1122UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1125CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1125CSharp7UnitTests.cs
@@ -10,7 +10,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using StyleCop.Analyzers.Test.ReadabilityRules;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.ReadabilityRules.SA1125UseShorthandForNullableTypes>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1125UseShorthandForNullableTypes>;
 
     public class SA1125CSharp7UnitTests : SA1125UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1125CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1125CSharp7UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1125UseShorthandForNullableTypes>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1127CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1127CSharp7UnitTests.cs
@@ -8,8 +8,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using StyleCop.Analyzers.Test.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1127GenericTypeConstraintsMustBeOnOwnLine,
-        StyleCop.Analyzers.ReadabilityRules.SA1127CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1127GenericTypeConstraintsMustBeOnOwnLine,
+        Analyzers.ReadabilityRules.SA1127CodeFixProvider>;
 
     public class SA1127CSharp7UnitTests : SA1127UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1130CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1130CSharp7UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using StyleCop.Analyzers.Test.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1130UseLambdaSyntax,
-        StyleCop.Analyzers.ReadabilityRules.SA1130CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1130UseLambdaSyntax,
+        Analyzers.ReadabilityRules.SA1130CodeFixProvider>;
 
     public class SA1130CSharp7UnitTests : SA1130UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1131CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1131CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using StyleCop.Analyzers.Test.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1131UseReadableConditions,
-        StyleCop.Analyzers.ReadabilityRules.SA1131CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1131UseReadableConditions,
+        Analyzers.ReadabilityRules.SA1131CodeFixProvider>;
 
     public class SA1131CSharp7UnitTests : SA1131UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1135CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1135CSharp7UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using StyleCop.Analyzers.Test.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1135UsingDirectivesMustBeQualified,
-        StyleCop.Analyzers.ReadabilityRules.SA1135CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1135UsingDirectivesMustBeQualified,
+        Analyzers.ReadabilityRules.SA1135CodeFixProvider>;
 
     public class SA1135CSharp7UnitTests : SA1135UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1137CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1137CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using StyleCop.Analyzers.Test.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1137ElementsShouldHaveTheSameIndentation,
-        StyleCop.Analyzers.ReadabilityRules.IndentationCodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1137ElementsShouldHaveTheSameIndentation,
+        Analyzers.ReadabilityRules.IndentationCodeFixProvider>;
 
     public class SA1137CSharp7UnitTests : SA1137UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1139CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1139CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1139UseLiteralSuffixNotationInsteadOfCasting,
-        StyleCop.Analyzers.ReadabilityRules.SA1139CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1139UseLiteralSuffixNotationInsteadOfCasting,
+        Analyzers.ReadabilityRules.SA1139CodeFixProvider>;
 
     public class SA1139CSharp7UnitTests : SA1139UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1139CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1139CSharp7UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1139UseLiteralSuffixNotationInsteadOfCasting,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1141CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1141CSharp7UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using StyleCop.Analyzers.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1141UseTupleSyntax,
-        StyleCop.Analyzers.ReadabilityRules.SA1141CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1141UseTupleSyntax,
+        Analyzers.ReadabilityRules.SA1141CodeFixProvider>;
 
     /// <summary>
     /// This class contains the CSharp 7.x unit tests for SA1141.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1142CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1142CSharp7UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using StyleCop.Analyzers.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1142ReferToTupleElementsByName,
-        StyleCop.Analyzers.ReadabilityRules.SA1142CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1142ReferToTupleElementsByName,
+        Analyzers.ReadabilityRules.SA1142CodeFixProvider>;
 
     /// <summary>
     /// This class contains the CSharp 7.x unit tests for SA1142.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1000CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1000CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using StyleCop.Analyzers.Test.SpacingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1000KeywordsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1000KeywordsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1000CSharp7UnitTests : SA1000UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1001CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1001CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using StyleCop.Analyzers.Test.SpacingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1001CommasMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1001CommasMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1001CSharp7UnitTests : SA1001UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1002CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1002CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using StyleCop.Analyzers.Test.SpacingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1002SemicolonsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1002SemicolonsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1002CSharp7UnitTests : SA1002UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1003CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1003CSharp7UnitTests.cs
@@ -12,8 +12,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 
     using static StyleCop.Analyzers.SpacingRules.SA1003SymbolsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1003SymbolsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.SA1003CodeFixProvider>;
+        Analyzers.SpacingRules.SA1003SymbolsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.SA1003CodeFixProvider>;
 
     public class SA1003CSharp7UnitTests : SA1003UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1003CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1003CSharp7UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.SpacingRules;
-    using TestHelper;
     using Xunit;
 
     using static StyleCop.Analyzers.SpacingRules.SA1003SymbolsMustBeSpacedCorrectly;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
@@ -5,10 +5,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.SpacingRules;
-    using TestHelper;
     using Xunit;
 
     using static StyleCop.Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
@@ -13,8 +13,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 
     using static StyleCop.Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1008CSharp7UnitTests : SA1008UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1009CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1009CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1009ClosingParenthesisMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1009ClosingParenthesisMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1009ClosingParenthesisMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1009CSharp7UnitTests : SA1009UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1010CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1010CSharp7UnitTests.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1010OpeningSquareBracketsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1010OpeningSquareBracketsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1010OpeningSquareBracketsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1010CSharp7UnitTests : SA1010UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1011CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1011CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using StyleCop.Analyzers.Test.SpacingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1011ClosingSquareBracketsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1011ClosingSquareBracketsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1011CSharp7UnitTests : SA1011UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1012CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1012CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using StyleCop.Analyzers.Test.SpacingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1012OpeningBracesMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1012OpeningBracesMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1012CSharp7UnitTests : SA1012UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1013CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1013CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using StyleCop.Analyzers.Test.SpacingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1013ClosingBracesMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1013ClosingBracesMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1013CSharp7UnitTests : SA1013UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1015CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1015CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1015ClosingGenericBracketsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1015ClosingGenericBracketsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1015ClosingGenericBracketsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1015CSharp7UnitTests : SA1015UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1018CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1018CSharp7UnitTests.cs
@@ -8,8 +8,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using StyleCop.Analyzers.Test.SpacingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1018NullableTypeSymbolsMustNotBePrecededBySpace,
-        StyleCop.Analyzers.SpacingRules.SA1018CodeFixProvider>;
+        Analyzers.SpacingRules.SA1018NullableTypeSymbolsMustNotBePrecededBySpace,
+        Analyzers.SpacingRules.SA1018CodeFixProvider>;
 
     public class SA1018CSharp7UnitTests : SA1018UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1024CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1024CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1024ColonsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1024ColonsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1024ColonsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1024CSharp7UnitTests : SA1024UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1026CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1026CSharp7UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
     using StyleCop.Analyzers.Test.SpacingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1026CSharp7UnitTests : SA1026UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/LayoutRules/SA1503CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/LayoutRules/SA1503CSharp8UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp8.LayoutRules
     using StyleCop.Analyzers.Test.CSharp7.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1503BracesMustNotBeOmitted,
-        StyleCop.Analyzers.LayoutRules.SA1503CodeFixProvider>;
+        Analyzers.LayoutRules.SA1503BracesMustNotBeOmitted,
+        Analyzers.LayoutRules.SA1503CodeFixProvider>;
 
     public class SA1503CSharp8UnitTests : SA1503CSharp7UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/LayoutRules/SA1514CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/LayoutRules/SA1514CSharp8UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp8.LayoutRules
     using StyleCop.Analyzers.Test.CSharp7.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1514ElementDocumentationHeaderMustBePrecededByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1514CodeFixProvider>;
+        Analyzers.LayoutRules.SA1514ElementDocumentationHeaderMustBePrecededByBlankLine,
+        Analyzers.LayoutRules.SA1514CodeFixProvider>;
 
     public class SA1514CSharp8UnitTests : SA1514CSharp7UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/Lightup/StackAllocArrayCreationExpressionSyntaxExtensionsTestsCSharp8.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/Lightup/StackAllocArrayCreationExpressionSyntaxExtensionsTestsCSharp8.cs
@@ -3,10 +3,7 @@
 
 namespace StyleCop.Analyzers.Test.CSharp8.Lightup
 {
-    using Microsoft.CodeAnalysis.CSharp;
-    using StyleCop.Analyzers.Lightup;
     using StyleCop.Analyzers.Test.CSharp7.Lightup;
-    using Xunit;
 
     public class StackAllocArrayCreationExpressionSyntaxExtensionsTestsCSharp8 : StackAllocArrayCreationExpressionSyntaxExtensionsTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/MaintainabilityRules/SA1413CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/MaintainabilityRules/SA1413CSharp8UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp8.MaintainabilityRules
     using StyleCop.Analyzers.Test.CSharp7.MaintainabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.MaintainabilityRules.SA1413UseTrailingCommasInMultiLineInitializers,
-        StyleCop.Analyzers.MaintainabilityRules.SA1413CodeFixProvider>;
+        Analyzers.MaintainabilityRules.SA1413UseTrailingCommasInMultiLineInitializers,
+        Analyzers.MaintainabilityRules.SA1413CodeFixProvider>;
 
     public class SA1413CSharp8UnitTests : SA1413CSharp7UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/ReadabilityRules/SA1106CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/ReadabilityRules/SA1106CSharp8UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp8.ReadabilityRules
     using StyleCop.Analyzers.Test.CSharp7.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1106CodeMustNotContainEmptyStatements,
-        StyleCop.Analyzers.ReadabilityRules.SA1106CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1106CodeMustNotContainEmptyStatements,
+        Analyzers.ReadabilityRules.SA1106CodeFixProvider>;
 
     public class SA1106CSharp8UnitTests : SA1106CSharp7UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/ReadabilityRules/SA1122CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/ReadabilityRules/SA1122CSharp8UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp8.ReadabilityRules
     using StyleCop.Analyzers.Test.CSharp7.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1122UseStringEmptyForEmptyStrings,
-        StyleCop.Analyzers.ReadabilityRules.SA1122CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1122UseStringEmptyForEmptyStrings,
+        Analyzers.ReadabilityRules.SA1122CodeFixProvider>;
 
     public class SA1122CSharp8UnitTests : SA1122CSharp7UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1002CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1002CSharp8UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp8.SpacingRules
     using StyleCop.Analyzers.Test.CSharp7.SpacingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1002SemicolonsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1002SemicolonsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1002CSharp8UnitTests : SA1002CSharp7UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1008CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1008CSharp8UnitTests.cs
@@ -14,8 +14,8 @@ namespace StyleCop.Analyzers.Test.CSharp8.SpacingRules
     using static StyleCop.Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly;
 
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-            StyleCop.Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly,
-            StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+            Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly,
+            Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1008CSharp8UnitTests : SA1008CSharp7UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1009CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1009CSharp8UnitTests.cs
@@ -12,8 +12,8 @@ namespace StyleCop.Analyzers.Test.CSharp8.SpacingRules
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1009ClosingParenthesisMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1009ClosingParenthesisMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1009ClosingParenthesisMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1009CSharp8UnitTests : SA1009CSharp7UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1011CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1011CSharp8UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.CSharp8.SpacingRules
     using StyleCop.Analyzers.Test.CSharp7.SpacingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1011ClosingSquareBracketsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1011ClosingSquareBracketsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1011CSharp8UnitTests : SA1011CSharp7UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1013CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1013CSharp8UnitTests.cs
@@ -14,8 +14,8 @@ namespace StyleCop.Analyzers.Test.CSharp8.SpacingRules
     using Xunit;
 
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1013ClosingBracesMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1013ClosingBracesMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1013CSharp8UnitTests : SA1013CSharp7UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1019CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1019CSharp8UnitTests.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.CSharp8.SpacingRules
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1019MemberAccessSymbolsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1019MemberAccessSymbolsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1019MemberAccessSymbolsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1019CSharp8UnitTests : SA1019CSharp7UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1024CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1024CSharp8UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.CSharp8.SpacingRules
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1024ColonsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1024ColonsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1024ColonsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1024CSharp8UnitTests : SA1024CSharp7UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/InheritdocCodeFixProviderUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/InheritdocCodeFixProviderUnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/InheritdocCodeFixProviderUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/InheritdocCodeFixProviderUnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.DocumentationRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.DocumentationRules.SA1600ElementsMustBeDocumented,
-        StyleCop.Analyzers.DocumentationRules.InheritdocCodeFixProvider>;
+        Analyzers.DocumentationRules.SA1600ElementsMustBeDocumented,
+        Analyzers.DocumentationRules.InheritdocCodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="InheritdocCodeFixProvider"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/NoXmlFileHeaderUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/NoXmlFileHeaderUnitTests.cs
@@ -10,7 +10,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.FileHeaderAnalyzers>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.FileHeaderAnalyzers>;
 
     /// <summary>
     /// Unit tests for file header that do not follow the XML syntax.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/NoXmlFileHeaderUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/NoXmlFileHeaderUnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.FileHeaderAnalyzers>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.DocumentationRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.DocumentationRules.SA1600ElementsMustBeDocumented,
-        StyleCop.Analyzers.DocumentationRules.SA1600CodeFixProvider>;
+        Analyzers.DocumentationRules.SA1600ElementsMustBeDocumented,
+        Analyzers.DocumentationRules.SA1600CodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1600ElementsMustBeDocumented"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
@@ -10,7 +10,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1601PartialElementsMustBeDocumented>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1601PartialElementsMustBeDocumented>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1601PartialElementsMustBeDocumented"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1601PartialElementsMustBeDocumented>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1602UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1602UnitTests.cs
@@ -9,7 +9,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.DocumentationRules;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1602EnumerationItemsMustBeDocumented>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.DocumentationRules.SA1602EnumerationItemsMustBeDocumented>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1602EnumerationItemsMustBeDocumented"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1602UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1602UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.DocumentationRules.SA1602EnumerationItemsMustBeDocumented>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1604UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1604UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1604ElementDocumentationMustHaveSummary>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1604UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1604UnitTests.cs
@@ -10,7 +10,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1604ElementDocumentationMustHaveSummary>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1604ElementDocumentationMustHaveSummary>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1604ElementDocumentationMustHaveSummary"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1605UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1605UnitTests.cs
@@ -10,7 +10,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1605PartialElementDocumentationMustHaveSummary>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1605PartialElementDocumentationMustHaveSummary>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1605PartialElementDocumentationMustHaveSummary"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1605UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1605UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1605PartialElementDocumentationMustHaveSummary>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1606UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1606UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1606ElementDocumentationMustHaveSummaryText>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1606UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1606UnitTests.cs
@@ -10,7 +10,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1606ElementDocumentationMustHaveSummaryText>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1606ElementDocumentationMustHaveSummaryText>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1606ElementDocumentationMustHaveSummaryText"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1607UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1607UnitTests.cs
@@ -10,7 +10,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1607PartialElementDocumentationMustHaveSummaryText>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1607PartialElementDocumentationMustHaveSummaryText>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1607PartialElementDocumentationMustHaveSummaryText"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1607UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1607UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1607PartialElementDocumentationMustHaveSummaryText>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1608UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1608UnitTests.cs
@@ -10,7 +10,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1608ElementDocumentationMustNotHaveDefaultSummary>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1608ElementDocumentationMustNotHaveDefaultSummary>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1608ElementDocumentationMustNotHaveDefaultSummary"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1608UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1608UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1608ElementDocumentationMustNotHaveDefaultSummary>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1609UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1609UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1609PropertyDocumentationMustHaveValue>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1609UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1609UnitTests.cs
@@ -10,7 +10,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1609PropertyDocumentationMustHaveValue>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1609PropertyDocumentationMustHaveValue>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1609PropertyDocumentationMustHaveValue"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1610UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1610UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1610PropertyDocumentationMustHaveValueText>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1610UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1610UnitTests.cs
@@ -10,7 +10,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1610PropertyDocumentationMustHaveValueText>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1610PropertyDocumentationMustHaveValueText>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1610PropertyDocumentationMustHaveValueText"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1611UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1611UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1611ElementParametersMustBeDocumented>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1611UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1611UnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1611ElementParametersMustBeDocumented>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1611ElementParametersMustBeDocumented>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1611ElementParametersMustBeDocumented"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1612UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1612UnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1612ElementParameterDocumentationMustMatchElementParameters>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1612ElementParameterDocumentationMustMatchElementParameters>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1612ElementParameterDocumentationMustMatchElementParameters"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1612UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1612UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1612ElementParameterDocumentationMustMatchElementParameters>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1613UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1613UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1613ElementParameterDocumentationMustDeclareParameterName>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1613UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1613UnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1613ElementParameterDocumentationMustDeclareParameterName>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1613ElementParameterDocumentationMustDeclareParameterName>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1613ElementParameterDocumentationMustDeclareParameterName"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1614UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1614UnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1614ElementParameterDocumentationMustHaveText>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1614ElementParameterDocumentationMustHaveText>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1614ElementParameterDocumentationMustHaveText"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1614UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1614UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1614ElementParameterDocumentationMustHaveText>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1615UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1615UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1615ElementReturnValueMustBeDocumented>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1615UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1615UnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1615ElementReturnValueMustBeDocumented>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1615ElementReturnValueMustBeDocumented>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1615ElementReturnValueMustBeDocumented"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1616UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1616UnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1616ElementReturnValueDocumentationMustHaveText>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1616ElementReturnValueDocumentationMustHaveText>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1616ElementReturnValueDocumentationMustHaveText"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1616UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1616UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1616ElementReturnValueDocumentationMustHaveText>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1617UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1617UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1617VoidReturnValueMustNotBeDocumented>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1617UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1617UnitTests.cs
@@ -10,7 +10,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1617VoidReturnValueMustNotBeDocumented>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1617VoidReturnValueMustNotBeDocumented>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1617VoidReturnValueMustNotBeDocumented"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1618UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1618UnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1618GenericTypeParametersMustBeDocumented>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1618GenericTypeParametersMustBeDocumented>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1618GenericTypeParametersMustBeDocumented"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1618UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1618UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1618GenericTypeParametersMustBeDocumented>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1619UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1619UnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1619GenericTypeParametersMustBeDocumentedPartialClass>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1619GenericTypeParametersMustBeDocumentedPartialClass>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1619GenericTypeParametersMustBeDocumentedPartialClass"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1619UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1619UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1619GenericTypeParametersMustBeDocumentedPartialClass>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1620UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1620UnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.GenericTypeParameterDocumentationAnalyzer>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.GenericTypeParameterDocumentationAnalyzer>;
 
     /// <summary>
     /// This class contains unit tests for the SA1620 diagnostic.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1620UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1620UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.GenericTypeParameterDocumentationAnalyzer>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1621UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1621UnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.GenericTypeParameterDocumentationAnalyzer>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.GenericTypeParameterDocumentationAnalyzer>;
 
     /// <summary>
     /// This class contains unit tests for the SA1621 diagnostic.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1621UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1621UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.GenericTypeParameterDocumentationAnalyzer>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1622UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1622UnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.GenericTypeParameterDocumentationAnalyzer>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.GenericTypeParameterDocumentationAnalyzer>;
 
     /// <summary>
     /// This class contains unit tests for SA1622.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1622UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1622UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.GenericTypeParameterDocumentationAnalyzer>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1623UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1623UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.DocumentationRules.PropertySummaryDocumentationAnalyzer,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1623UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1623UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.DocumentationRules.PropertySummaryDocumentationAnalyzer,
-        StyleCop.Analyzers.DocumentationRules.PropertySummaryDocumentationCodeFixProvider>;
+        Analyzers.DocumentationRules.PropertySummaryDocumentationAnalyzer,
+        Analyzers.DocumentationRules.PropertySummaryDocumentationCodeFixProvider>;
 
     /// <summary>
     /// This class contains the unit tests for SA1623.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1624UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1624UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.DocumentationRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.DocumentationRules.PropertySummaryDocumentationAnalyzer,
-        StyleCop.Analyzers.DocumentationRules.PropertySummaryDocumentationCodeFixProvider>;
+        Analyzers.DocumentationRules.PropertySummaryDocumentationAnalyzer,
+        Analyzers.DocumentationRules.PropertySummaryDocumentationCodeFixProvider>;
 
     /// <summary>
     /// This class contains the unit tests for SA1624.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1625UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1625UnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1625ElementDocumentationMustNotBeCopiedAndPasted>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1625ElementDocumentationMustNotBeCopiedAndPasted>;
 
     /// <summary>
     /// This class contains the unit tests for SA1625.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1625UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1625UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1625ElementDocumentationMustNotBeCopiedAndPasted>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1626UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1626UnitTests.cs
@@ -6,8 +6,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using StyleCop.Analyzers.DocumentationRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.DocumentationRules.SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1626UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1626UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.DocumentationRules.SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes,
-        StyleCop.Analyzers.DocumentationRules.SA1626CodeFixProvider>;
+        Analyzers.DocumentationRules.SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes,
+        Analyzers.DocumentationRules.SA1626CodeFixProvider>;
 
     public class SA1626UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1627UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1627UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1627DocumentationTextMustNotBeEmpty>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1627UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1627UnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1627DocumentationTextMustNotBeEmpty>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1627DocumentationTextMustNotBeEmpty>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1627DocumentationTextMustNotBeEmpty"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1629UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1629UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1629DocumentationTextMustEndWithAPeriod>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1629UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1629UnitTests.cs
@@ -10,7 +10,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1629DocumentationTextMustEndWithAPeriod>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1629DocumentationTextMustEndWithAPeriod>;
 
     /// <summary>
     /// The class contains unit tests for <see cref="SA1629DocumentationTextMustEndWithAPeriod"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1633UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1633UnitTests.cs
@@ -9,7 +9,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.DocumentationRules;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.FileHeaderAnalyzers>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.FileHeaderAnalyzers>;
 
     /// <summary>
     /// Unit tests for the SA1633 diagnostic.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1633UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1633UnitTests.cs
@@ -7,9 +7,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
-    using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.FileHeaderAnalyzers>;
 
     /// <summary>
     /// Unit tests for the SA1633 diagnostic.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1642ConstructorSummaryDocumentationMustBeginWithStandardText>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1642ConstructorSummaryDocumentationMustBeginWithStandardText>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1642ConstructorSummaryDocumentationMustBeginWithStandardText"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1642UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Helpers;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1642ConstructorSummaryDocumentationMustBeginWithStandardText>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1643UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1643UnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1643DestructorSummaryDocumentationMustBeginWithStandardText>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1643DestructorSummaryDocumentationMustBeginWithStandardText>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1643DestructorSummaryDocumentationMustBeginWithStandardText"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1643UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1643UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Helpers;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1643DestructorSummaryDocumentationMustBeginWithStandardText>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1648UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1648UnitTests.cs
@@ -10,7 +10,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1648InheritDocMustBeUsedWithInheritingClass>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1648InheritDocMustBeUsedWithInheritingClass>;
 
     /// <summary>
     /// Unit tests for the <see cref="SA1648InheritDocMustBeUsedWithInheritingClass"/> analyzer.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1648UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1648UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1648InheritDocMustBeUsedWithInheritingClass>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1649UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1649UnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1649FileNameMustMatchTypeName>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1649FileNameMustMatchTypeName>;
 
     /// <summary>
     /// Unit tests for the SA1649 diagnostic.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1649UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1649UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1649FileNameMustMatchTypeName>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1651UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1651UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1651DoNotUsePlaceholderElements>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1651UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1651UnitTests.cs
@@ -10,7 +10,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1651DoNotUsePlaceholderElements>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.DocumentationRules.SA1651DoNotUsePlaceholderElements>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1651DoNotUsePlaceholderElements"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/HelperTests/ObjectPools/ObjectPoolTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/HelperTests/ObjectPools/ObjectPoolTests.cs
@@ -3,7 +3,6 @@
 
 namespace StyleCop.Analyzers.Test.HelperTests.ObjectPools
 {
-    using System;
     using StyleCop.Analyzers.Helpers.ObjectPools;
     using Xunit;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.ArrayInitializers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.ArrayInitializers.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.ArrayInitializers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.ArrayInitializers.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Blocks.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Blocks.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Blocks.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Blocks.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Classes.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Classes.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Classes.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Classes.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Constructors.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Constructors.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Constructors.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Constructors.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Delegates.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Delegates.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Delegates.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Delegates.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Destructors.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Destructors.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Destructors.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Destructors.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.DoWhiles.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.DoWhiles.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.DoWhiles.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.DoWhiles.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Enums.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Enums.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Enums.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Enums.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Events.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Events.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Events.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Events.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Ifs.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Ifs.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Ifs.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Ifs.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Indexers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Indexers.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Indexers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Indexers.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Interfaces.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Interfaces.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Interfaces.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Interfaces.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.LambdaExpressions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.LambdaExpressions.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.LambdaExpressions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.LambdaExpressions.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Methods.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Methods.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Methods.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Methods.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Namespaces.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Namespaces.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Namespaces.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Namespaces.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.ObjectInitializers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.ObjectInitializers.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.ObjectInitializers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.ObjectInitializers.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Properties.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Properties.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Properties.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Properties.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
     using StyleCop.Analyzers.Lightup;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.StatementBlocks.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.StatementBlocks.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.StatementBlocks.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.StatementBlocks.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Structs.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Structs.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Structs.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Structs.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Switches.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Switches.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Switches.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.Switches.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.TryCatchFinallys.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.TryCatchFinallys.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.TryCatchFinallys.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.TryCatchFinallys.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
-        StyleCop.Analyzers.LayoutRules.SA1500CodeFixProvider>;
+        Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,
+        Analyzers.LayoutRules.SA1500CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1500BracesForMultiLineStatementsMustNotShareLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1500/SA1500UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1500BracesForMultiLineStatementsMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
@@ -12,8 +12,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1501StatementMustNotBeOnASingleLine,
-        StyleCop.Analyzers.LayoutRules.SA1501CodeFixProvider>;
+        Analyzers.LayoutRules.SA1501StatementMustNotBeOnASingleLine,
+        Analyzers.LayoutRules.SA1501CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1501StatementMustNotBeOnASingleLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1501UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1501StatementMustNotBeOnASingleLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Constructors.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Constructors.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using StyleCop.Analyzers.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
-        StyleCop.Analyzers.LayoutRules.SA1502CodeFixProvider>;
+        Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
+        Analyzers.LayoutRules.SA1502CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the constructors part of <see cref="SA1502ElementMustNotBeOnASingleLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Destructors.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Destructors.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using StyleCop.Analyzers.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
-        StyleCop.Analyzers.LayoutRules.SA1502CodeFixProvider>;
+        Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
+        Analyzers.LayoutRules.SA1502CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the destructors part of <see cref="SA1502ElementMustNotBeOnASingleLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Enums.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Enums.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using StyleCop.Analyzers.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
-        StyleCop.Analyzers.LayoutRules.SA1502CodeFixProvider>;
+        Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
+        Analyzers.LayoutRules.SA1502CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the enums part of <see cref="SA1502ElementMustNotBeOnASingleLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Events.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Events.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using StyleCop.Analyzers.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
-        StyleCop.Analyzers.LayoutRules.SA1502CodeFixProvider>;
+        Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
+        Analyzers.LayoutRules.SA1502CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the events part of <see cref="SA1502ElementMustNotBeOnASingleLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Indexers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Indexers.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using StyleCop.Analyzers.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
-        StyleCop.Analyzers.LayoutRules.SA1502CodeFixProvider>;
+        Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
+        Analyzers.LayoutRules.SA1502CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the indexers part of <see cref="SA1502ElementMustNotBeOnASingleLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Interfaces.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Interfaces.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using StyleCop.Analyzers.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
-        StyleCop.Analyzers.LayoutRules.SA1502CodeFixProvider>;
+        Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
+        Analyzers.LayoutRules.SA1502CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the interfaces part of <see cref="SA1502ElementMustNotBeOnASingleLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Methods.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Methods.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using StyleCop.Analyzers.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
-        StyleCop.Analyzers.LayoutRules.SA1502CodeFixProvider>;
+        Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
+        Analyzers.LayoutRules.SA1502CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the methods part of <see cref="SA1502ElementMustNotBeOnASingleLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Namespaces.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Namespaces.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using StyleCop.Analyzers.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
-        StyleCop.Analyzers.LayoutRules.SA1502CodeFixProvider>;
+        Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
+        Analyzers.LayoutRules.SA1502CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the namespaces part of <see cref="SA1502ElementMustNotBeOnASingleLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Operators.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Operators.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Operators.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Operators.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
-        StyleCop.Analyzers.LayoutRules.SA1502CodeFixProvider>;
+        Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
+        Analyzers.LayoutRules.SA1502CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the operators part of <see cref="SA1502ElementMustNotBeOnASingleLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Properties.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.Properties.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using StyleCop.Analyzers.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
-        StyleCop.Analyzers.LayoutRules.SA1502CodeFixProvider>;
+        Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
+        Analyzers.LayoutRules.SA1502CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the properties part of <see cref="SA1502ElementMustNotBeOnASingleLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.TypeDeclarations.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1502/SA1502UnitTests.TypeDeclarations.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using StyleCop.Analyzers.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
-        StyleCop.Analyzers.LayoutRules.SA1502CodeFixProvider>;
+        Analyzers.LayoutRules.SA1502ElementMustNotBeOnASingleLine,
+        Analyzers.LayoutRules.SA1502CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the type declaration part of <see cref="SA1502ElementMustNotBeOnASingleLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1503UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1503UnitTests.cs
@@ -12,8 +12,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1503BracesMustNotBeOmitted,
-        StyleCop.Analyzers.LayoutRules.SA1503CodeFixProvider>;
+        Analyzers.LayoutRules.SA1503BracesMustNotBeOmitted,
+        Analyzers.LayoutRules.SA1503CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1503BracesMustNotBeOmitted"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1503UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1503UnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using Microsoft.CodeAnalysis.Testing;
     using Microsoft.CodeAnalysis.Text;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1503BracesMustNotBeOmitted,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1504UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1504UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1504AllAccessorsMustBeSingleLineOrMultiLine,
-        StyleCop.Analyzers.LayoutRules.SA1504CodeFixProvider>;
+        Analyzers.LayoutRules.SA1504AllAccessorsMustBeSingleLineOrMultiLine,
+        Analyzers.LayoutRules.SA1504CodeFixProvider>;
 
     public class SA1504UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1504UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1504UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1504AllAccessorsMustBeSingleLineOrMultiLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1505UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1505UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using StyleCop.Analyzers.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1505OpeningBracesMustNotBeFollowedByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1505CodeFixProvider>;
+        Analyzers.LayoutRules.SA1505OpeningBracesMustNotBeFollowedByBlankLine,
+        Analyzers.LayoutRules.SA1505CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the <see cref="SA1505OpeningBracesMustNotBeFollowedByBlankLine"/> class.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1506UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1506UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1506ElementDocumentationHeadersMustNotBeFollowedByBlankLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1506UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1506UnitTests.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1506ElementDocumentationHeadersMustNotBeFollowedByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1506CodeFixProvider>;
+        Analyzers.LayoutRules.SA1506ElementDocumentationHeadersMustNotBeFollowedByBlankLine,
+        Analyzers.LayoutRules.SA1506CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the <see cref="SA1506ElementDocumentationHeadersMustNotBeFollowedByBlankLine"/> class.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1507UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1507UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1507CodeMustNotContainMultipleBlankLinesInARow,
-        StyleCop.Analyzers.LayoutRules.SA1507CodeFixProvider>;
+        Analyzers.LayoutRules.SA1507CodeMustNotContainMultipleBlankLinesInARow,
+        Analyzers.LayoutRules.SA1507CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1507CodeMustNotContainMultipleBlankLinesInARow"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1507UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1507UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1507CodeMustNotContainMultipleBlankLinesInARow,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1508UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1508UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1508ClosingBracesMustNotBePrecededByBlankLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1508UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1508UnitTests.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1508ClosingBracesMustNotBePrecededByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1508CodeFixProvider>;
+        Analyzers.LayoutRules.SA1508ClosingBracesMustNotBePrecededByBlankLine,
+        Analyzers.LayoutRules.SA1508CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the <see cref="SA1508ClosingBracesMustNotBePrecededByBlankLine"/> class.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1509UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1509UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1509OpeningBracesMustNotBePrecededByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1509CodeFixProvider>;
+        Analyzers.LayoutRules.SA1509OpeningBracesMustNotBePrecededByBlankLine,
+        Analyzers.LayoutRules.SA1509CodeFixProvider>;
 
     public class SA1509UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1509UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1509UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1509OpeningBracesMustNotBePrecededByBlankLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1510UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1510UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1510ChainedStatementBlocksMustNotBePrecededByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1510CodeFixProvider>;
+        Analyzers.LayoutRules.SA1510ChainedStatementBlocksMustNotBePrecededByBlankLine,
+        Analyzers.LayoutRules.SA1510CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1510ChainedStatementBlocksMustNotBePrecededByBlankLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1510UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1510UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1510ChainedStatementBlocksMustNotBePrecededByBlankLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1511UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1511UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1511WhileDoFooterMustNotBePrecededByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1511CodeFixProvider>;
+        Analyzers.LayoutRules.SA1511WhileDoFooterMustNotBePrecededByBlankLine,
+        Analyzers.LayoutRules.SA1511CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1511WhileDoFooterMustNotBePrecededByBlankLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1511UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1511UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1511WhileDoFooterMustNotBePrecededByBlankLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1512UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1512UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1512SingleLineCommentsMustNotBeFollowedByBlankLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1512UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1512UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1512SingleLineCommentsMustNotBeFollowedByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1512CodeFixProvider>;
+        Analyzers.LayoutRules.SA1512SingleLineCommentsMustNotBeFollowedByBlankLine,
+        Analyzers.LayoutRules.SA1512CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1512SingleLineCommentsMustNotBeFollowedByBlankLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1513UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1513UnitTests.cs
@@ -3,14 +3,10 @@
 
 namespace StyleCop.Analyzers.Test.LayoutRules
 {
-    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis.CodeFixes;
-    using Microsoft.CodeAnalysis.Diagnostics;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1513ClosingBraceMustBeFollowedByBlankLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1513UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1513UnitTests.cs
@@ -13,8 +13,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1513ClosingBraceMustBeFollowedByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1513CodeFixProvider>;
+        Analyzers.LayoutRules.SA1513ClosingBraceMustBeFollowedByBlankLine,
+        Analyzers.LayoutRules.SA1513CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1513ClosingBraceMustBeFollowedByBlankLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1514UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1514UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1514ElementDocumentationHeaderMustBePrecededByBlankLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1514UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1514UnitTests.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1514ElementDocumentationHeaderMustBePrecededByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1514CodeFixProvider>;
+        Analyzers.LayoutRules.SA1514ElementDocumentationHeaderMustBePrecededByBlankLine,
+        Analyzers.LayoutRules.SA1514CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the <see cref="SA1514ElementDocumentationHeaderMustBePrecededByBlankLine"/> class.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1515UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1515UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1515SingleLineCommentMustBePrecededByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1515CodeFixProvider>;
+        Analyzers.LayoutRules.SA1515SingleLineCommentMustBePrecededByBlankLine,
+        Analyzers.LayoutRules.SA1515CodeFixProvider>;
 
     public class SA1515UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1515UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1515UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1515SingleLineCommentMustBePrecededByBlankLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1516UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1516UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using StyleCop.Analyzers.LayoutRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1516ElementsMustBeSeparatedByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1516CodeFixProvider>;
+        Analyzers.LayoutRules.SA1516ElementsMustBeSeparatedByBlankLine,
+        Analyzers.LayoutRules.SA1516CodeFixProvider>;
 
     public class SA1516UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1516UsingGroupsUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1516UsingGroupsUnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using StyleCop.Analyzers.Settings.ObjectModel;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1516ElementsMustBeSeparatedByBlankLine,
-        StyleCop.Analyzers.LayoutRules.SA1516CodeFixProvider>;
+        Analyzers.LayoutRules.SA1516ElementsMustBeSeparatedByBlankLine,
+        Analyzers.LayoutRules.SA1516CodeFixProvider>;
 
     /// <summary>
     /// Verifies the using directives functionality of <see cref="SA1516ElementsMustBeSeparatedByBlankLine"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1517UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1517UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.LayoutRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1517CodeMustNotContainBlankLinesAtStartOfFile,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1517UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1517UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1517CodeMustNotContainBlankLinesAtStartOfFile,
-        StyleCop.Analyzers.LayoutRules.SA1517CodeFixProvider>;
+        Analyzers.LayoutRules.SA1517CodeMustNotContainBlankLinesAtStartOfFile,
+        Analyzers.LayoutRules.SA1517CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1517CodeMustNotContainBlankLinesAtStartOfFile"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1518UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1518UnitTests.cs
@@ -10,7 +10,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using StyleCop.Analyzers.LayoutRules;
     using StyleCop.Analyzers.Settings.ObjectModel;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.LayoutRules.SA1518UseLineEndingsCorrectlyAtEndOfFile>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1518UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1518UnitTests.cs
@@ -12,7 +12,7 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.LayoutRules.SA1518UseLineEndingsCorrectlyAtEndOfFile>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.LayoutRules.SA1518UseLineEndingsCorrectlyAtEndOfFile>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1518UseLineEndingsCorrectlyAtEndOfFile"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1519UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1519UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1519BracesMustNotBeOmittedFromMultiLineChildStatement,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1519UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1519UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1519BracesMustNotBeOmittedFromMultiLineChildStatement,
-        StyleCop.Analyzers.LayoutRules.SA1503CodeFixProvider>;
+        Analyzers.LayoutRules.SA1519BracesMustNotBeOmittedFromMultiLineChildStatement,
+        Analyzers.LayoutRules.SA1503CodeFixProvider>;
 
     public class SA1519UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1520UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1520UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.LayoutRules.SA1520UseBracesConsistently,
-        StyleCop.Analyzers.LayoutRules.SA1503CodeFixProvider>;
+        Analyzers.LayoutRules.SA1520UseBracesConsistently,
+        Analyzers.LayoutRules.SA1503CodeFixProvider>;
 
     public class SA1520UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1520UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1520UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.LayoutRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.LayoutRules.SA1520UseBracesConsistently,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/Serialization/JsonWriterTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LightJson/Serialization/JsonWriterTests.cs
@@ -3,7 +3,6 @@
 
 namespace StyleCop.Analyzers.Test.LightJson.Serialization
 {
-    using System;
     using global::LightJson;
     using global::LightJson.Serialization;
     using Xunit;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/FileMayOnlyContainTestBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/FileMayOnlyContainTestBase.cs
@@ -10,7 +10,6 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using Microsoft.CodeAnalysis.Testing;
-    using Microsoft.CodeAnalysis.Testing.Verifiers;
     using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1119UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1119UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using StyleCop.Analyzers.MaintainabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.MaintainabilityRules.SA1119StatementMustNotUseUnnecessaryParenthesis,
-        StyleCop.Analyzers.MaintainabilityRules.SA1119CodeFixProvider>;
+        Analyzers.MaintainabilityRules.SA1119StatementMustNotUseUnnecessaryParenthesis,
+        Analyzers.MaintainabilityRules.SA1119CodeFixProvider>;
 
     public class SA1119UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1400UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1400UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.MaintainabilityRules.SA1400AccessModifierMustBeDeclared,
-        StyleCop.Analyzers.MaintainabilityRules.SA1400CodeFixProvider>;
+        Analyzers.MaintainabilityRules.SA1400AccessModifierMustBeDeclared,
+        Analyzers.MaintainabilityRules.SA1400CodeFixProvider>;
 
     public class SA1400UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1400UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1400UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.MaintainabilityRules.SA1400AccessModifierMustBeDeclared,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1401UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1401UnitTests.cs
@@ -9,7 +9,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using StyleCop.Analyzers.MaintainabilityRules;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.MaintainabilityRules.SA1401FieldsMustBePrivate>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.MaintainabilityRules.SA1401FieldsMustBePrivate>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1401FieldsMustBePrivate"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1401UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1401UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.MaintainabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.MaintainabilityRules.SA1401FieldsMustBePrivate>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402ForDelegateUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402ForDelegateUnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
 
     public class SA1402ForDelegateUnitTests : SA1402ForNonBlockDeclarationUnitTestsBase

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402ForEnumUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402ForEnumUnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
 
     public class SA1402ForEnumUnitTests : SA1402ForNonBlockDeclarationUnitTestsBase

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402ForNonBlockDeclarationUnitTestsBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402ForNonBlockDeclarationUnitTestsBase.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.MaintainabilityRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
 
     public abstract class SA1402ForNonBlockDeclarationUnitTestsBase
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1404UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1404UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.MaintainabilityRules.SA1404CodeAnalysisSuppressionMustHaveJustification,
-        StyleCop.Analyzers.MaintainabilityRules.SA1404CodeFixProvider>;
+        Analyzers.MaintainabilityRules.SA1404CodeAnalysisSuppressionMustHaveJustification,
+        Analyzers.MaintainabilityRules.SA1404CodeFixProvider>;
 
     public class SA1404UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1404UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1404UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.MaintainabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.MaintainabilityRules.SA1404CodeAnalysisSuppressionMustHaveJustification,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1407UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1407UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.MaintainabilityRules.SA1407ArithmeticExpressionsMustDeclarePrecedence,
-        StyleCop.Analyzers.MaintainabilityRules.SA1407SA1408CodeFixProvider>;
+        Analyzers.MaintainabilityRules.SA1407ArithmeticExpressionsMustDeclarePrecedence,
+        Analyzers.MaintainabilityRules.SA1407SA1408CodeFixProvider>;
 
     public class SA1407UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1407UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1407UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.MaintainabilityRules.SA1407ArithmeticExpressionsMustDeclarePrecedence,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1408UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1408UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.MaintainabilityRules.SA1408ConditionalExpressionsMustDeclarePrecedence,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1408UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1408UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.MaintainabilityRules.SA1408ConditionalExpressionsMustDeclarePrecedence,
-        StyleCop.Analyzers.MaintainabilityRules.SA1407SA1408CodeFixProvider>;
+        Analyzers.MaintainabilityRules.SA1408ConditionalExpressionsMustDeclarePrecedence,
+        Analyzers.MaintainabilityRules.SA1407SA1408CodeFixProvider>;
 
     public class SA1408UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1410UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1410UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.MaintainabilityRules.SA1410RemoveDelegateParenthesisWhenPossible,
-        StyleCop.Analyzers.MaintainabilityRules.SA1410SA1411CodeFixProvider>;
+        Analyzers.MaintainabilityRules.SA1410RemoveDelegateParenthesisWhenPossible,
+        Analyzers.MaintainabilityRules.SA1410SA1411CodeFixProvider>;
 
     public class SA1410UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1410UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1410UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.MaintainabilityRules.SA1410RemoveDelegateParenthesisWhenPossible,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1411UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1411UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.MaintainabilityRules.SA1411AttributeConstructorMustNotUseUnnecessaryParenthesis,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1411UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1411UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.MaintainabilityRules.SA1411AttributeConstructorMustNotUseUnnecessaryParenthesis,
-        StyleCop.Analyzers.MaintainabilityRules.SA1410SA1411CodeFixProvider>;
+        Analyzers.MaintainabilityRules.SA1411AttributeConstructorMustNotUseUnnecessaryParenthesis,
+        Analyzers.MaintainabilityRules.SA1410SA1411CodeFixProvider>;
 
     public class SA1411UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1412UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1412UnitTests.cs
@@ -12,8 +12,8 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using Microsoft.CodeAnalysis.Text;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.MaintainabilityRules.SA1412StoreFilesAsUtf8,
-        StyleCop.Analyzers.MaintainabilityRules.SA1412CodeFixProvider>;
+        Analyzers.MaintainabilityRules.SA1412StoreFilesAsUtf8,
+        Analyzers.MaintainabilityRules.SA1412CodeFixProvider>;
 
     public class SA1412UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1413UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1413UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.MaintainabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.MaintainabilityRules.SA1413UseTrailingCommasInMultiLineInitializers,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1413UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1413UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.MaintainabilityRules.SA1413UseTrailingCommasInMultiLineInitializers,
-        StyleCop.Analyzers.MaintainabilityRules.SA1413CodeFixProvider>;
+        Analyzers.MaintainabilityRules.SA1413UseTrailingCommasInMultiLineInitializers,
+        Analyzers.MaintainabilityRules.SA1413CodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1413UseTrailingCommasInMultiLineInitializers"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.Helpers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SA1300ElementMustBeginWithUpperCaseLetter,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SA1300ElementMustBeginWithUpperCaseLetter,
-        StyleCop.Analyzers.NamingRules.RenameToUpperCaseCodeFixProvider>;
+        Analyzers.NamingRules.SA1300ElementMustBeginWithUpperCaseLetter,
+        Analyzers.NamingRules.RenameToUpperCaseCodeFixProvider>;
 
     [UseCulture("en-US")]
     public class SA1300UnitTests

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1302UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1302UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SA1302InterfaceNamesMustBeginWithI,
-        StyleCop.Analyzers.NamingRules.SA1302CodeFixProvider>;
+        Analyzers.NamingRules.SA1302InterfaceNamesMustBeginWithI,
+        Analyzers.NamingRules.SA1302CodeFixProvider>;
 
     public class SA1302UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1302UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1302UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SA1302InterfaceNamesMustBeginWithI,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1303UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1303UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SA1303ConstFieldNamesMustBeginWithUpperCaseLetter,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1303UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1303UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SA1303ConstFieldNamesMustBeginWithUpperCaseLetter,
-        StyleCop.Analyzers.NamingRules.RenameToUpperCaseCodeFixProvider>;
+        Analyzers.NamingRules.SA1303ConstFieldNamesMustBeginWithUpperCaseLetter,
+        Analyzers.NamingRules.RenameToUpperCaseCodeFixProvider>;
 
     public class SA1303UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1304UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1304UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SA1304NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter,
-        StyleCop.Analyzers.NamingRules.RenameToUpperCaseCodeFixProvider>;
+        Analyzers.NamingRules.SA1304NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter,
+        Analyzers.NamingRules.RenameToUpperCaseCodeFixProvider>;
 
     public class SA1304UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1304UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1304UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SA1304NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1305UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1305UnitTests.cs
@@ -9,7 +9,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using Microsoft.CodeAnalysis.Testing;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.NamingRules.SA1305FieldNamesMustNotUseHungarianNotation>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.NamingRules.SA1305FieldNamesMustNotUseHungarianNotation>;
 
     public class SA1305UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1305UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1305UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.NamingRules.SA1305FieldNamesMustNotUseHungarianNotation>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1306UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1306UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.NamingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SA1306FieldNamesMustBeginWithLowerCaseLetter,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1306UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1306UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SA1306FieldNamesMustBeginWithLowerCaseLetter,
-        StyleCop.Analyzers.NamingRules.RenameToLowerCaseCodeFixProvider>;
+        Analyzers.NamingRules.SA1306FieldNamesMustBeginWithLowerCaseLetter,
+        Analyzers.NamingRules.RenameToLowerCaseCodeFixProvider>;
 
     public class SA1306UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1307UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1307UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SA1307AccessibleFieldsMustBeginWithUpperCaseLetter,
-        StyleCop.Analyzers.NamingRules.RenameToUpperCaseCodeFixProvider>;
+        Analyzers.NamingRules.SA1307AccessibleFieldsMustBeginWithUpperCaseLetter,
+        Analyzers.NamingRules.RenameToUpperCaseCodeFixProvider>;
 
     public class SA1307UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1307UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1307UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SA1307AccessibleFieldsMustBeginWithUpperCaseLetter,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1308UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1308UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SA1308VariableNamesMustNotBePrefixed,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1308UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1308UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SA1308VariableNamesMustNotBePrefixed,
-        StyleCop.Analyzers.NamingRules.SA1308CodeFixProvider>;
+        Analyzers.NamingRules.SA1308VariableNamesMustNotBePrefixed,
+        Analyzers.NamingRules.SA1308CodeFixProvider>;
 
     public class SA1308UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1309UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1309UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SA1309FieldNamesMustNotBeginWithUnderscore,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1309UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1309UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SA1309FieldNamesMustNotBeginWithUnderscore,
-        StyleCop.Analyzers.NamingRules.SA1309CodeFixProvider>;
+        Analyzers.NamingRules.SA1309FieldNamesMustNotBeginWithUnderscore,
+        Analyzers.NamingRules.SA1309CodeFixProvider>;
 
     public class SA1309UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1310UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1310UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SA1310FieldNamesMustNotContainUnderscore,
-        StyleCop.Analyzers.NamingRules.SA1310CodeFixProvider>;
+        Analyzers.NamingRules.SA1310FieldNamesMustNotContainUnderscore,
+        Analyzers.NamingRules.SA1310CodeFixProvider>;
 
     public class SA1310UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1310UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1310UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SA1310FieldNamesMustNotContainUnderscore,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1311UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1311UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SA1311StaticReadonlyFieldsMustBeginWithUpperCaseLetter,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1311UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1311UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SA1311StaticReadonlyFieldsMustBeginWithUpperCaseLetter,
-        StyleCop.Analyzers.NamingRules.RenameToUpperCaseCodeFixProvider>;
+        Analyzers.NamingRules.SA1311StaticReadonlyFieldsMustBeginWithUpperCaseLetter,
+        Analyzers.NamingRules.RenameToUpperCaseCodeFixProvider>;
 
     public class SA1311UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1312UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1312UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.Helpers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SA1312VariableNamesMustBeginWithLowerCaseLetter,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1312UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1312UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SA1312VariableNamesMustBeginWithLowerCaseLetter,
-        StyleCop.Analyzers.NamingRules.RenameToLowerCaseCodeFixProvider>;
+        Analyzers.NamingRules.SA1312VariableNamesMustBeginWithLowerCaseLetter,
+        Analyzers.NamingRules.RenameToLowerCaseCodeFixProvider>;
 
     [UseCulture("en-US")]
     public class SA1312UnitTests

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.Helpers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SA1313ParameterNamesMustBeginWithLowerCaseLetter,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SA1313ParameterNamesMustBeginWithLowerCaseLetter,
-        StyleCop.Analyzers.NamingRules.RenameToLowerCaseCodeFixProvider>;
+        Analyzers.NamingRules.SA1313ParameterNamesMustBeginWithLowerCaseLetter,
+        Analyzers.NamingRules.RenameToLowerCaseCodeFixProvider>;
 
     [UseCulture("en-US")]
     public class SA1313UnitTests

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1314UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1314UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SA1314TypeParameterNamesMustBeginWithT,
-        StyleCop.Analyzers.NamingRules.SA1314CodeFixProvider>;
+        Analyzers.NamingRules.SA1314TypeParameterNamesMustBeginWithT,
+        Analyzers.NamingRules.SA1314CodeFixProvider>;
 
     public class SA1314UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1314UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1314UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SA1314TypeParameterNamesMustBeginWithT,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SX1309SUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SX1309SUnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SX1309SStaticFieldNamesMustBeginWithUnderscore,
-        StyleCop.Analyzers.NamingRules.SX1309CodeFixProvider>;
+        Analyzers.NamingRules.SX1309SStaticFieldNamesMustBeginWithUnderscore,
+        Analyzers.NamingRules.SX1309CodeFixProvider>;
 
     public class SX1309SUnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SX1309SUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SX1309SUnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SX1309SStaticFieldNamesMustBeginWithUnderscore,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SX1309UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SX1309UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.NamingRules.SX1309FieldNamesMustBeginWithUnderscore,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SX1309UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SX1309UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.NamingRules.SX1309FieldNamesMustBeginWithUnderscore,
-        StyleCop.Analyzers.NamingRules.SX1309CodeFixProvider>;
+        Analyzers.NamingRules.SX1309FieldNamesMustBeginWithUnderscore,
+        Analyzers.NamingRules.SX1309CodeFixProvider>;
 
     public class SX1309UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/CombinedUsingDirectivesVerifier.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/CombinedUsingDirectivesVerifier.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
 
     internal static class CombinedUsingDirectivesVerifier
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1200OutsideNamespaceUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1200OutsideNamespaceUnitTests.cs
@@ -10,7 +10,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using StyleCop.Analyzers.OrderingRules;
     using StyleCop.Analyzers.Settings.ObjectModel;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
 
     /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1200PreserveUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1200PreserveUnitTests.cs
@@ -5,12 +5,10 @@ namespace StyleCop.Analyzers.Test.OrderingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
     using StyleCop.Analyzers.Settings.ObjectModel;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
 
     /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1200UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1200UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.OrderingRules.SA1200UsingDirectivesMustBePlacedCorrectly,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1200UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1200UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1200UsingDirectivesMustBePlacedCorrectly,
-        StyleCop.Analyzers.OrderingRules.UsingCodeFixProvider>;
+        Analyzers.OrderingRules.SA1200UsingDirectivesMustBePlacedCorrectly,
+        Analyzers.OrderingRules.UsingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the <see cref="SA1200UsingDirectivesMustBePlacedCorrectly"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1201UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1201UnitTests.cs
@@ -14,8 +14,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using Xunit;
 
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1201ElementsMustAppearInTheCorrectOrder,
-        StyleCop.Analyzers.OrderingRules.ElementOrderCodeFixProvider>;
+        Analyzers.OrderingRules.SA1201ElementsMustAppearInTheCorrectOrder,
+        Analyzers.OrderingRules.ElementOrderCodeFixProvider>;
 
     public class SA1201UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1201UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1201UnitTests.cs
@@ -5,12 +5,7 @@ namespace StyleCop.Analyzers.Test.OrderingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
-
-    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Testing;
-    using Microsoft.CodeAnalysis.Text;
-
-    using TestHelper;
     using Xunit;
 
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.OrderingRules.SA1202ElementsMustBeOrderedByAccess,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1202ElementsMustBeOrderedByAccess,
-        StyleCop.Analyzers.OrderingRules.ElementOrderCodeFixProvider>;
+        Analyzers.OrderingRules.SA1202ElementsMustBeOrderedByAccess,
+        Analyzers.OrderingRules.ElementOrderCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1202ElementsMustBeOrderedByAccess"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1203UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1203UnitTests.cs
@@ -8,8 +8,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using Microsoft.CodeAnalysis.Testing;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1203ConstantsMustAppearBeforeFields,
-        StyleCop.Analyzers.OrderingRules.ElementOrderCodeFixProvider>;
+        Analyzers.OrderingRules.SA1203ConstantsMustAppearBeforeFields,
+        Analyzers.OrderingRules.ElementOrderCodeFixProvider>;
 
     public class SA1203UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1204UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1204UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1204StaticElementsMustAppearBeforeInstanceElements,
-        StyleCop.Analyzers.OrderingRules.ElementOrderCodeFixProvider>;
+        Analyzers.OrderingRules.SA1204StaticElementsMustAppearBeforeInstanceElements,
+        Analyzers.OrderingRules.ElementOrderCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1204StaticElementsMustAppearBeforeInstanceElements"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1204UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1204UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.OrderingRules.SA1204StaticElementsMustAppearBeforeInstanceElements,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1205UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1205UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using StyleCop.Analyzers.OrderingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1205PartialElementsMustDeclareAccess,
-        StyleCop.Analyzers.OrderingRules.SA1205CodeFixProvider>;
+        Analyzers.OrderingRules.SA1205PartialElementsMustDeclareAccess,
+        Analyzers.OrderingRules.SA1205CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the <see cref="SA1205PartialElementsMustDeclareAccess"/> class.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1206CodeFixProviderUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1206CodeFixProviderUnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1206DeclarationKeywordsMustFollowOrder,
-        StyleCop.Analyzers.OrderingRules.SA1206CodeFixProvider>;
+        Analyzers.OrderingRules.SA1206DeclarationKeywordsMustFollowOrder,
+        Analyzers.OrderingRules.SA1206CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the <see cref="UsingCodeFixProvider"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1206CodeFixProviderUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1206CodeFixProviderUnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.OrderingRules.SA1206DeclarationKeywordsMustFollowOrder,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1206UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1206UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1206DeclarationKeywordsMustFollowOrder,
-        StyleCop.Analyzers.OrderingRules.SA1206CodeFixProvider>;
+        Analyzers.OrderingRules.SA1206DeclarationKeywordsMustFollowOrder,
+        Analyzers.OrderingRules.SA1206CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1206DeclarationKeywordsMustFollowOrder"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1206UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1206UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.OrderingRules.SA1206DeclarationKeywordsMustFollowOrder,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1207UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1207UnitTests.cs
@@ -12,8 +12,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using StyleCop.Analyzers.OrderingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1207ProtectedMustComeBeforeInternal,
-        StyleCop.Analyzers.OrderingRules.SA1207CodeFixProvider>;
+        Analyzers.OrderingRules.SA1207ProtectedMustComeBeforeInternal,
+        Analyzers.OrderingRules.SA1207CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the <see cref="SA1207ProtectedMustComeBeforeInternal"/> class.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1208UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1208UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1208SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectives,
-        StyleCop.Analyzers.OrderingRules.UsingCodeFixProvider>;
+        Analyzers.OrderingRules.SA1208SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectives,
+        Analyzers.OrderingRules.UsingCodeFixProvider>;
 
     public class SA1208UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1208UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1208UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.OrderingRules.SA1208SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectives,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1209UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1209UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1209UsingAliasDirectivesMustBePlacedAfterOtherUsingDirectives,
-        StyleCop.Analyzers.OrderingRules.UsingCodeFixProvider>;
+        Analyzers.OrderingRules.SA1209UsingAliasDirectivesMustBePlacedAfterOtherUsingDirectives,
+        Analyzers.OrderingRules.UsingCodeFixProvider>;
 
     public class SA1209UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1209UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1209UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.OrderingRules.SA1209UsingAliasDirectivesMustBePlacedAfterOtherUsingDirectives,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210CombinedSystemDirectivesUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210CombinedSystemDirectivesUnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using StyleCop.Analyzers.OrderingRules;
     using StyleCop.Analyzers.Settings.ObjectModel;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.OrderingRules.SA1210UsingDirectivesMustBeOrderedAlphabeticallyByNamespace>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210CombinedSystemDirectivesUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210CombinedSystemDirectivesUnitTests.cs
@@ -11,7 +11,7 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using StyleCop.Analyzers.Test.Verifiers;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.OrderingRules.SA1210UsingDirectivesMustBeOrderedAlphabeticallyByNamespace>;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<Analyzers.OrderingRules.SA1210UsingDirectivesMustBeOrderedAlphabeticallyByNamespace>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1210UsingDirectivesMustBeOrderedAlphabeticallyByNamespace"/> for the special case

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210UnitTests.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1210UsingDirectivesMustBeOrderedAlphabeticallyByNamespace,
-        StyleCop.Analyzers.OrderingRules.UsingCodeFixProvider>;
+        Analyzers.OrderingRules.SA1210UsingDirectivesMustBeOrderedAlphabeticallyByNamespace,
+        Analyzers.OrderingRules.UsingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1210UsingDirectivesMustBeOrderedAlphabeticallyByNamespace"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210UnitTests.cs
@@ -3,12 +3,10 @@
 
 namespace StyleCop.Analyzers.Test.OrderingRules
 {
-    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.OrderingRules.SA1210UsingDirectivesMustBeOrderedAlphabeticallyByNamespace,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1211UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1211UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.OrderingRules.SA1211UsingAliasDirectivesMustBeOrderedAlphabeticallyByAliasName,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1211UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1211UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1211UsingAliasDirectivesMustBeOrderedAlphabeticallyByAliasName,
-        StyleCop.Analyzers.OrderingRules.UsingCodeFixProvider>;
+        Analyzers.OrderingRules.SA1211UsingAliasDirectivesMustBeOrderedAlphabeticallyByAliasName,
+        Analyzers.OrderingRules.UsingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1211UsingAliasDirectivesMustBeOrderedAlphabeticallyByAliasName"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1212UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1212UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1212PropertyAccessorsMustFollowOrder,
-        StyleCop.Analyzers.OrderingRules.SA1212SA1213CodeFixProvider>;
+        Analyzers.OrderingRules.SA1212PropertyAccessorsMustFollowOrder,
+        Analyzers.OrderingRules.SA1212SA1213CodeFixProvider>;
 
     public class SA1212UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1212UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1212UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.OrderingRules.SA1212PropertyAccessorsMustFollowOrder,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1213UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1213UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1213EventAccessorsMustFollowOrder,
-        StyleCop.Analyzers.OrderingRules.SA1212SA1213CodeFixProvider>;
+        Analyzers.OrderingRules.SA1213EventAccessorsMustFollowOrder,
+        Analyzers.OrderingRules.SA1212SA1213CodeFixProvider>;
 
     public class SA1213UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1213UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1213UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.OrderingRules.SA1213EventAccessorsMustFollowOrder,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1214UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1214UnitTests.cs
@@ -8,8 +8,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using Microsoft.CodeAnalysis.Testing;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1214ReadonlyElementsMustAppearBeforeNonReadonlyElements,
-        StyleCop.Analyzers.OrderingRules.ElementOrderCodeFixProvider>;
+        Analyzers.OrderingRules.SA1214ReadonlyElementsMustAppearBeforeNonReadonlyElements,
+        Analyzers.OrderingRules.ElementOrderCodeFixProvider>;
 
     public class SA1214UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1215UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1215UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.OrderingRules.SA1214ReadonlyElementsMustAppearBeforeNonReadonlyElements,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1215UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1215UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1214ReadonlyElementsMustAppearBeforeNonReadonlyElements,
-        StyleCop.Analyzers.OrderingRules.ElementOrderCodeFixProvider>;
+        Analyzers.OrderingRules.SA1214ReadonlyElementsMustAppearBeforeNonReadonlyElements,
+        Analyzers.OrderingRules.ElementOrderCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1214ReadonlyElementsMustAppearBeforeNonReadonlyElements"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1216UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1216UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.OrderingRules.SA1216UsingStaticDirectivesMustBePlacedAtTheCorrectLocation,
-        StyleCop.Analyzers.OrderingRules.UsingCodeFixProvider>;
+        Analyzers.OrderingRules.SA1216UsingStaticDirectivesMustBePlacedAtTheCorrectLocation,
+        Analyzers.OrderingRules.UsingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1216UsingStaticDirectivesMustBePlacedAtTheCorrectLocation"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1216UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1216UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.OrderingRules.SA1216UsingStaticDirectivesMustBePlacedAtTheCorrectLocation,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/UsingCodeFixProviderCombinedSystemDirectivesUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/UsingCodeFixProviderCombinedSystemDirectivesUnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using StyleCop.Analyzers.OrderingRules;
     using StyleCop.Analyzers.Settings.ObjectModel;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static CombinedUsingDirectivesVerifier;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/UsingCodeFixProviderGroupSeparationUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/UsingCodeFixProviderGroupSeparationUnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using StyleCop.Analyzers.OrderingRules;
     using StyleCop.Analyzers.Settings.ObjectModel;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static CombinedUsingDirectivesVerifier;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/UsingCodeFixProviderRegressionUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/UsingCodeFixProviderRegressionUnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static CombinedUsingDirectivesVerifier;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/UsingCodeFixProviderUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/UsingCodeFixProviderUnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using StyleCop.Analyzers.OrderingRules;
     using StyleCop.Analyzers.Settings.ObjectModel;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
     using static CombinedUsingDirectivesVerifier;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1100UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1100UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists,
-        StyleCop.Analyzers.ReadabilityRules.SA1100CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists,
+        Analyzers.ReadabilityRules.SA1100CodeFixProvider>;
 
     public class SA1100UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1100UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1100UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1101UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1101UnitTests.cs
@@ -8,8 +8,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using Microsoft.CodeAnalysis.Testing;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1101PrefixLocalCallsWithThis,
-        StyleCop.Analyzers.ReadabilityRules.SA1101CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1101PrefixLocalCallsWithThis,
+        Analyzers.ReadabilityRules.SA1101CodeFixProvider>;
 
     public class SA1101UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1102UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1102UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA110xQueryClauses,
-        StyleCop.Analyzers.ReadabilityRules.SA1102CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA110xQueryClauses,
+        Analyzers.ReadabilityRules.SA1102CodeFixProvider>;
 
     public class SA1102UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1102UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1102UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA110xQueryClauses,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1103UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1103UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using StyleCop.Analyzers.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA110xQueryClauses,
-        StyleCop.Analyzers.ReadabilityRules.SA1103CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA110xQueryClauses,
+        Analyzers.ReadabilityRules.SA1103CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the SA1103 analyzer.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1104UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1104UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA110xQueryClauses,
-        StyleCop.Analyzers.ReadabilityRules.SA1104SA1105CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA110xQueryClauses,
+        Analyzers.ReadabilityRules.SA1104SA1105CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the SA1104 analyzer.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1104UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1104UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA110xQueryClauses,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1105UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1105UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA110xQueryClauses,
-        StyleCop.Analyzers.ReadabilityRules.SA1104SA1105CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA110xQueryClauses,
+        Analyzers.ReadabilityRules.SA1104SA1105CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the SA1105 analyzer.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1105UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1105UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA110xQueryClauses,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1106UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1106UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1106CodeMustNotContainEmptyStatements,
-        StyleCop.Analyzers.ReadabilityRules.SA1106CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1106CodeMustNotContainEmptyStatements,
+        Analyzers.ReadabilityRules.SA1106CodeFixProvider>;
 
     public class SA1106UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1106UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1106UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1106CodeMustNotContainEmptyStatements,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1107UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1107UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using StyleCop.Analyzers.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1107CodeMustNotContainMultipleStatementsOnOneLine,
-        StyleCop.Analyzers.ReadabilityRules.SA1107CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1107CodeMustNotContainMultipleStatementsOnOneLine,
+        Analyzers.ReadabilityRules.SA1107CodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1107CodeMustNotContainMultipleStatementsOnOneLine"/> and

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1108UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1108UnitTests.cs
@@ -8,7 +8,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using Microsoft.CodeAnalysis.Testing;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.ReadabilityRules.SA1108BlockStatementsMustNotContainEmbeddedComments>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1108BlockStatementsMustNotContainEmbeddedComments>;
 
     public class SA1108UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1108UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1108UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1108BlockStatementsMustNotContainEmbeddedComments>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1110UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1110UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1110OpeningParenthesisMustBeOnDeclarationLine,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1110OpeningParenthesisMustBeOnDeclarationLine,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1110UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1110UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1110UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1110OpeningParenthesisMustBeOnDeclarationLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1111UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1111UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1111ClosingParenthesisMustBeOnLineOfLastParameter,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1111ClosingParenthesisMustBeOnLineOfLastParameter,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1111UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1111UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1111UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1111ClosingParenthesisMustBeOnLineOfLastParameter,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1112UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1112UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1112ClosingParenthesisMustBeOnLineOfOpeningParenthesis,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1112UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1112UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1112ClosingParenthesisMustBeOnLineOfOpeningParenthesis,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1112ClosingParenthesisMustBeOnLineOfOpeningParenthesis,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1112UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1113UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1113UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1113CommaMustBeOnSameLineAsPreviousParameter,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1113UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1113UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1113CommaMustBeOnSameLineAsPreviousParameter,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1113CommaMustBeOnSameLineAsPreviousParameter,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1113UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1114UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1114UnitTests.cs
@@ -8,7 +8,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using Microsoft.CodeAnalysis.Testing;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.ReadabilityRules.SA1114ParameterListMustFollowDeclaration>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1114ParameterListMustFollowDeclaration>;
 
     public class SA1114UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1114UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1114UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1114ParameterListMustFollowDeclaration>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1115UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1115UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1115ParameterMustFollowComma>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1115UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1115UnitTests.cs
@@ -8,7 +8,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using Microsoft.CodeAnalysis.Testing;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.ReadabilityRules.SA1115ParameterMustFollowComma>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1115ParameterMustFollowComma>;
 
     public class SA1115UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1116UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1116UnitTests.cs
@@ -14,8 +14,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1116SplitParametersMustStartOnLineAfterDeclaration,
-        StyleCop.Analyzers.ReadabilityRules.SA1116CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1116SplitParametersMustStartOnLineAfterDeclaration,
+        Analyzers.ReadabilityRules.SA1116CodeFixProvider>;
 
     public class SA1116UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1116UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1116UnitTests.cs
@@ -11,7 +11,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1116SplitParametersMustStartOnLineAfterDeclaration,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1117UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1117UnitTests.cs
@@ -13,7 +13,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using Microsoft.CodeAnalysis.Testing;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.ReadabilityRules.SA1117ParametersMustBeOnSameLineOrSeparateLines>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1117ParametersMustBeOnSameLineOrSeparateLines>;
 
     public class SA1117UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1117UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1117UnitTests.cs
@@ -11,7 +11,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1117ParametersMustBeOnSameLineOrSeparateLines>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1118UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1118UnitTests.cs
@@ -8,7 +8,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using Microsoft.CodeAnalysis.Testing;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.ReadabilityRules.SA1118ParameterMustNotSpanMultipleLines>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1118ParameterMustNotSpanMultipleLines>;
 
     public class SA1118UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1118UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1118UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1118ParameterMustNotSpanMultipleLines>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1120UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1120UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1120CommentsMustContainText,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1120UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1120UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1120CommentsMustContainText,
-        StyleCop.Analyzers.ReadabilityRules.SA1120CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1120CommentsMustContainText,
+        Analyzers.ReadabilityRules.SA1120CodeFixProvider>;
 
     public class SA1120UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1121UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1121UnitTests.cs
@@ -14,7 +14,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1121UseBuiltInTypeAlias,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1121UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1121UnitTests.cs
@@ -17,8 +17,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1121UseBuiltInTypeAlias,
-        StyleCop.Analyzers.ReadabilityRules.SA1121CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1121UseBuiltInTypeAlias,
+        Analyzers.ReadabilityRules.SA1121CodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1121UseBuiltInTypeAlias"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1122UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1122UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1122UseStringEmptyForEmptyStrings,
-        StyleCop.Analyzers.ReadabilityRules.SA1122CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1122UseStringEmptyForEmptyStrings,
+        Analyzers.ReadabilityRules.SA1122CodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1122UseStringEmptyForEmptyStrings"/> and

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1122UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1122UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1122UseStringEmptyForEmptyStrings,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1123UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1123UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1123DoNotPlaceRegionsWithinElements,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1123UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1123UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1123DoNotPlaceRegionsWithinElements,
-        StyleCop.Analyzers.ReadabilityRules.RemoveRegionCodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1123DoNotPlaceRegionsWithinElements,
+        Analyzers.ReadabilityRules.RemoveRegionCodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1123DoNotPlaceRegionsWithinElements"/> and

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1124UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1124UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1124DoNotUseRegions,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1124UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1124UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1124DoNotUseRegions,
-        StyleCop.Analyzers.ReadabilityRules.RemoveRegionCodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1124DoNotUseRegions,
+        Analyzers.ReadabilityRules.RemoveRegionCodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1124DoNotUseRegions"/> and

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1125UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1125UnitTests.cs
@@ -12,7 +12,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using StyleCop.Analyzers.ReadabilityRules;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.ReadabilityRules.SA1125UseShorthandForNullableTypes>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1125UseShorthandForNullableTypes>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1125UseShorthandForNullableTypes"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1125UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1125UnitTests.cs
@@ -10,7 +10,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.ReadabilityRules.SA1125UseShorthandForNullableTypes>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1127UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1127UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1127GenericTypeConstraintsMustBeOnOwnLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1127UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1127UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1127GenericTypeConstraintsMustBeOnOwnLine,
-        StyleCop.Analyzers.ReadabilityRules.SA1127CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1127GenericTypeConstraintsMustBeOnOwnLine,
+        Analyzers.ReadabilityRules.SA1127CodeFixProvider>;
 
     public class SA1127UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1128UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1128UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using Microsoft.CodeAnalysis.Testing;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1128ConstructorInitializerMustBeOnOwnLine,
-        StyleCop.Analyzers.ReadabilityRules.SA1128CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1128ConstructorInitializerMustBeOnOwnLine,
+        Analyzers.ReadabilityRules.SA1128CodeFixProvider>;
 
     public class SA1128UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1129UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1129UnitTests.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1129DoNotUseDefaultValueTypeConstructor,
-        StyleCop.Analyzers.ReadabilityRules.SA1129CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1129DoNotUseDefaultValueTypeConstructor,
+        Analyzers.ReadabilityRules.SA1129CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the <see cref="SA1129DoNotUseDefaultValueTypeConstructor"/> class.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1129UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1129UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1129DoNotUseDefaultValueTypeConstructor,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1130UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1130UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1130UseLambdaSyntax,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1130UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1130UnitTests.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1130UseLambdaSyntax,
-        StyleCop.Analyzers.ReadabilityRules.SA1130CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1130UseLambdaSyntax,
+        Analyzers.ReadabilityRules.SA1130CodeFixProvider>;
 
     public class SA1130UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1131UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1131UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1131UseReadableConditions,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1131UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1131UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1131UseReadableConditions,
-        StyleCop.Analyzers.ReadabilityRules.SA1131CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1131UseReadableConditions,
+        Analyzers.ReadabilityRules.SA1131CodeFixProvider>;
 
     public class SA1131UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1132UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1132UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1132DoNotCombineFields,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1132UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1132UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1132DoNotCombineFields,
-        StyleCop.Analyzers.ReadabilityRules.SA1132CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1132DoNotCombineFields,
+        Analyzers.ReadabilityRules.SA1132CodeFixProvider>;
 
     public class SA1132UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1133UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1133UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1133DoNotCombineAttributes,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1133UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1133UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1133DoNotCombineAttributes,
-        StyleCop.Analyzers.ReadabilityRules.SA1133CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1133DoNotCombineAttributes,
+        Analyzers.ReadabilityRules.SA1133CodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for the <see cref="SA1133DoNotCombineAttributes"/> class.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1134UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1134UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1134AttributesMustNotShareLine,
-        StyleCop.Analyzers.ReadabilityRules.SA1134CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1134AttributesMustNotShareLine,
+        Analyzers.ReadabilityRules.SA1134CodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for SA1134.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1134UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1134UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1134AttributesMustNotShareLine,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1135UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1135UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using StyleCop.Analyzers.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1135UsingDirectivesMustBeQualified,
-        StyleCop.Analyzers.ReadabilityRules.SA1135CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1135UsingDirectivesMustBeQualified,
+        Analyzers.ReadabilityRules.SA1135CodeFixProvider>;
 
     public class SA1135UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1136UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1136UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1136EnumValuesShouldBeOnSeparateLines,
-        StyleCop.Analyzers.ReadabilityRules.SA1136CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1136EnumValuesShouldBeOnSeparateLines,
+        Analyzers.ReadabilityRules.SA1136CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the <see cref="SA1136EnumValuesShouldBeOnSeparateLines"/> analyzer.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1136UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1136UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1136EnumValuesShouldBeOnSeparateLines,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1137UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1137UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1137ElementsShouldHaveTheSameIndentation,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1137UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1137UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1137ElementsShouldHaveTheSameIndentation,
-        StyleCop.Analyzers.ReadabilityRules.IndentationCodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1137ElementsShouldHaveTheSameIndentation,
+        Analyzers.ReadabilityRules.IndentationCodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1137ElementsShouldHaveTheSameIndentation"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1139UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1139UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SA1139UseLiteralSuffixNotationInsteadOfCasting,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1139UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1139UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1139UseLiteralSuffixNotationInsteadOfCasting,
-        StyleCop.Analyzers.ReadabilityRules.SA1139CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1139UseLiteralSuffixNotationInsteadOfCasting,
+        Analyzers.ReadabilityRules.SA1139CodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for SA1139.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1141UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1141UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using StyleCop.Analyzers.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SA1141UseTupleSyntax,
-        StyleCop.Analyzers.ReadabilityRules.SA1141CodeFixProvider>;
+        Analyzers.ReadabilityRules.SA1141UseTupleSyntax,
+        Analyzers.ReadabilityRules.SA1141CodeFixProvider>;
 
     /// <summary>
     /// This class contains the unit tests for SA1141.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SX1101UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SX1101UnitTests.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.ReadabilityRules.SX1101DoNotPrefixLocalMembersWithThis,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SX1101UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SX1101UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.ReadabilityRules.SX1101DoNotPrefixLocalMembersWithThis,
-        StyleCop.Analyzers.ReadabilityRules.SX1101CodeFixProvider>;
+        Analyzers.ReadabilityRules.SX1101DoNotPrefixLocalMembersWithThis,
+        Analyzers.ReadabilityRules.SX1101CodeFixProvider>;
 
     public class SX1101UnitTests
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Settings/SettingsFileCodeFixProviderUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Settings/SettingsFileCodeFixProviderUnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.Settings
     using StyleCop.Analyzers.Settings;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.DocumentationRules.FileHeaderAnalyzers,
-        StyleCop.Analyzers.Settings.SettingsFileCodeFixProvider>;
+        Analyzers.DocumentationRules.FileHeaderAnalyzers,
+        Analyzers.Settings.SettingsFileCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the <see cref="SettingsFileCodeFixProvider"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1000UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1000UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using StyleCop.Analyzers.SpacingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1000KeywordsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1000KeywordsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1000KeywordsMustBeSpacedCorrectly"/> and

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1001CommasMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1001CommasMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1001CommasMustBeSpacedCorrectly"/> and

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.SpacingRules.SA1001CommasMustBeSpacedCorrectly,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1002UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1002UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1002SemicolonsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1002SemicolonsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1002SemicolonsMustBeSpacedCorrectly"/> and

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1002UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1002UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.SpacingRules.SA1002SemicolonsMustBeSpacedCorrectly,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1003UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1003UnitTests.cs
@@ -12,8 +12,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
 
     using static StyleCop.Analyzers.SpacingRules.SA1003SymbolsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1003SymbolsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.SA1003CodeFixProvider>;
+        Analyzers.SpacingRules.SA1003SymbolsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.SA1003CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1003SymbolsMustBeSpacedCorrectly"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1003UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1003UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
 
     using static StyleCop.Analyzers.SpacingRules.SA1003SymbolsMustBeSpacedCorrectly;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1004UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1004UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1004DocumentationLinesMustBeginWithSingleSpace,
-        StyleCop.Analyzers.SpacingRules.SA1004CodeFixProvider>;
+        Analyzers.SpacingRules.SA1004DocumentationLinesMustBeginWithSingleSpace,
+        Analyzers.SpacingRules.SA1004CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1004DocumentationLinesMustBeginWithSingleSpace"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1004UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1004UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.SpacingRules.SA1004DocumentationLinesMustBeginWithSingleSpace,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1005UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1005UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using StyleCop.Analyzers.SpacingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1005SingleLineCommentsMustBeginWithSingleSpace,
-        StyleCop.Analyzers.SpacingRules.SA1005CodeFixProvider>;
+        Analyzers.SpacingRules.SA1005SingleLineCommentsMustBeginWithSingleSpace,
+        Analyzers.SpacingRules.SA1005CodeFixProvider>;
 
     /// <summary>
     /// Unit test for <see cref="SA1005SingleLineCommentsMustBeginWithSingleSpace"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1006UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1006UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1006PreprocessorKeywordsMustNotBePrecededBySpace,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1006PreprocessorKeywordsMustNotBePrecededBySpace,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1006PreprocessorKeywordsMustNotBePrecededBySpace"/> and

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1006UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1006UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.SpacingRules.SA1006PreprocessorKeywordsMustNotBePrecededBySpace,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1007UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1007UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.SpacingRules.SA1007OperatorKeywordMustBeFollowedBySpace,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1007UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1007UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1007OperatorKeywordMustBeFollowedBySpace,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1007OperatorKeywordMustBeFollowedBySpace,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1007OperatorKeywordMustBeFollowedBySpace"/> and

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1008UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1008UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1008UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1008UnitTests.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for the <see cref="SA1008OpeningParenthesisMustBeSpacedCorrectly"/> class.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1009UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1009UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1009ClosingParenthesisMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1009ClosingParenthesisMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1009ClosingParenthesisMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1009ClosingParenthesisMustBeSpacedCorrectly"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1010UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1010UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1010OpeningSquareBracketsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1010OpeningSquareBracketsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1010OpeningSquareBracketsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1010OpeningSquareBracketsMustBeSpacedCorrectly"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1011UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1011UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1011ClosingSquareBracketsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1011ClosingSquareBracketsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1011ClosingSquareBracketsMustBeSpacedCorrectly"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1011UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1011UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.SpacingRules.SA1011ClosingSquareBracketsMustBeSpacedCorrectly,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1012UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1012UnitTests.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1012OpeningBracesMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1012OpeningBracesMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1012OpeningBracesMustBeSpacedCorrectly"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1012UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1012UnitTests.cs
@@ -5,10 +5,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.SpacingRules.SA1012OpeningBracesMustBeSpacedCorrectly,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1013UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1013UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1013ClosingBracesMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1013ClosingBracesMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1013ClosingBracesMustBeSpacedCorrectly"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1013UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1013UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.SpacingRules.SA1013ClosingBracesMustBeSpacedCorrectly,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1014UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1014UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.SpacingRules.SA1014OpeningGenericBracketsMustBeSpacedCorrectly,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1014UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1014UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1014OpeningGenericBracketsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1014OpeningGenericBracketsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1014OpeningGenericBracketsMustBeSpacedCorrectly"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1015UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1015UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1015ClosingGenericBracketsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1015ClosingGenericBracketsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1015ClosingGenericBracketsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1015ClosingGenericBracketsMustBeSpacedCorrectly"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1016UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1016UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.SpacingRules.SA1016OpeningAttributeBracketsMustBeSpacedCorrectly,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1016UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1016UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1016OpeningAttributeBracketsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1016OpeningAttributeBracketsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1016OpeningAttributeBracketsMustBeSpacedCorrectly"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1017UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1017UnitTests.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1017ClosingAttributeBracketsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1017ClosingAttributeBracketsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1017ClosingAttributeBracketsMustBeSpacedCorrectly"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1017UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1017UnitTests.cs
@@ -5,10 +5,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.SpacingRules.SA1017ClosingAttributeBracketsMustBeSpacedCorrectly,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1018UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1018UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.SpacingRules.SA1018NullableTypeSymbolsMustNotBePrecededBySpace,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1018UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1018UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1018NullableTypeSymbolsMustNotBePrecededBySpace,
-        StyleCop.Analyzers.SpacingRules.SA1018CodeFixProvider>;
+        Analyzers.SpacingRules.SA1018NullableTypeSymbolsMustNotBePrecededBySpace,
+        Analyzers.SpacingRules.SA1018CodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for the <see cref="SA1018NullableTypeSymbolsMustNotBePrecededBySpace"/> class.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1019UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1019UnitTests.cs
@@ -13,8 +13,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1019MemberAccessSymbolsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1019MemberAccessSymbolsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1019MemberAccessSymbolsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for the <see cref="SA1019MemberAccessSymbolsMustBeSpacedCorrectly"/> class.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1020UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1020UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.SpacingRules.SA1020IncrementDecrementSymbolsMustBeSpacedCorrectly,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1020UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1020UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1020IncrementDecrementSymbolsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1020IncrementDecrementSymbolsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1020IncrementDecrementSymbolsMustBeSpacedCorrectly"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1023UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1023UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1024UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1024UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1024ColonsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1024ColonsMustBeSpacedCorrectly,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1024ColonsMustBeSpacedCorrectly,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1024ColonsMustBeSpacedCorrectly"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1025UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1025UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.SpacingRules.SA1025CodeMustNotContainMultipleWhitespaceInARow,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1025UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1025UnitTests.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1025CodeMustNotContainMultipleWhitespaceInARow,
-        StyleCop.Analyzers.SpacingRules.SA1025CodeFixProvider>;
+        Analyzers.SpacingRules.SA1025CodeMustNotContainMultipleWhitespaceInARow,
+        Analyzers.SpacingRules.SA1025CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1025CodeMustNotContainMultipleWhitespaceInARow"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1026UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1026UnitTests.cs
@@ -9,8 +9,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using StyleCop.Analyzers.SpacingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation,
-        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+        Analyzers.SpacingRules.SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation,
+        Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1027AlternateIndentationUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1027AlternateIndentationUnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using StyleCop.Analyzers.Settings.ObjectModel;
     using StyleCop.Analyzers.SpacingRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
 
     /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1027UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1027UnitTests.cs
@@ -10,8 +10,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1027UseTabsCorrectly,
-        StyleCop.Analyzers.SpacingRules.SA1027CodeFixProvider>;
+        Analyzers.SpacingRules.SA1027UseTabsCorrectly,
+        Analyzers.SpacingRules.SA1027CodeFixProvider>;
 
     /// <summary>
     /// Unit tests for <see cref="SA1027UseTabsCorrectly"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1027UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1027UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.SpacingRules.SA1027UseTabsCorrectly,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1027UseTabsUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1027UseTabsUnitTests.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using StyleCop.Analyzers.Settings.ObjectModel;
     using StyleCop.Analyzers.SpacingRules;
     using StyleCop.Analyzers.Test.Verifiers;
-    using TestHelper;
     using Xunit;
 
     /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
@@ -11,8 +11,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
-        StyleCop.Analyzers.SpacingRules.SA1028CodeMustNotContainTrailingWhitespace,
-        StyleCop.Analyzers.SpacingRules.SA1028CodeFixProvider>;
+        Analyzers.SpacingRules.SA1028CodeMustNotContainTrailingWhitespace,
+        Analyzers.SpacingRules.SA1028CodeFixProvider>;
 
     /// <summary>
     /// This class contains unit tests for <see cref="SA1028CodeMustNotContainTrailingWhitespace"/> and

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         Analyzers.SpacingRules.SA1028CodeMustNotContainTrailingWhitespace,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpecialRules/SA0001UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpecialRules/SA0001UnitTests.cs
@@ -10,7 +10,7 @@ namespace StyleCop.Analyzers.Test.SpecialRules
     using StyleCop.Analyzers.SpecialRules;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.SpecialRules.SA0001XmlCommentAnalysisDisabled>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.SpecialRules.SA0001XmlCommentAnalysisDisabled>;
 
     /// <summary>
     /// Unit tests for <see cref="SA0001XmlCommentAnalysisDisabled"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpecialRules/SA0001UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpecialRules/SA0001UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.SpecialRules
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpecialRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.SpecialRules.SA0001XmlCommentAnalysisDisabled>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpecialRules/SA0002UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpecialRules/SA0002UnitTests.cs
@@ -14,7 +14,6 @@ namespace StyleCop.Analyzers.Test.SpecialRules
     using Microsoft.CodeAnalysis.Text;
     using StyleCop.Analyzers.Settings;
     using StyleCop.Analyzers.SpecialRules;
-    using TestHelper;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.SpecialRules.SA0002InvalidSettingsFile>;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpecialRules/SA0002UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpecialRules/SA0002UnitTests.cs
@@ -16,7 +16,7 @@ namespace StyleCop.Analyzers.Test.SpecialRules
     using StyleCop.Analyzers.SpecialRules;
     using TestHelper;
     using Xunit;
-    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.SpecialRules.SA0002InvalidSettingsFile>;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<Analyzers.SpecialRules.SA0002InvalidSettingsFile>;
 
     /// <summary>
     /// Unit tests for <see cref="SA0002InvalidSettingsFile"/>.

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/DiagnosticVerifierTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/DiagnosticVerifierTests.cs
@@ -15,7 +15,7 @@ namespace StyleCop.Analyzers.Test.Verifiers
     using StyleCop.Analyzers.SpacingRules;
     using Xunit;
     using Xunit.Sdk;
-    using static StyleCopDiagnosticVerifier<StyleCop.Analyzers.SpacingRules.SA1002SemicolonsMustBeSpacedCorrectly>;
+    using static StyleCopDiagnosticVerifier<Analyzers.SpacingRules.SA1002SemicolonsMustBeSpacedCorrectly>;
 
     /// <summary>
     /// This class verifies that <see cref="CSharpCodeFixVerifier{TAnalyzer, TCodeFix, TVerifier}"/> will correctly report failing tests.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PartialElementDocumentationSummaryBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PartialElementDocumentationSummaryBase.cs
@@ -4,7 +4,6 @@
 namespace StyleCop.Analyzers.DocumentationRules
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Text;
     using System.Xml.Linq;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
@@ -12,7 +12,6 @@ namespace StyleCop.Analyzers.DocumentationRules
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.Helpers;
-    using StyleCop.Analyzers.Lightup;
 
     /// <summary>
     /// Analyzes the correct usage of property summary documentation.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1604ElementDocumentationMustHaveSummary.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1604ElementDocumentationMustHaveSummary.cs
@@ -10,7 +10,6 @@ namespace StyleCop.Analyzers.DocumentationRules
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.Helpers;
-    using StyleCop.Analyzers.Settings.ObjectModel;
 
     /// <summary>
     /// The XML header documentation for a C# element is missing a <c>&lt;summary&gt;</c> tag.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1625ElementDocumentationMustNotBeCopiedAndPasted.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1625ElementDocumentationMustNotBeCopiedAndPasted.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.DocumentationRules
     using System.Collections.Immutable;
     using System.Globalization;
     using System.Linq;
-    using System.Resources;
     using System.Xml.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1643DestructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1643DestructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.DocumentationRules
     using System.Globalization;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
-    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
 
     /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1649FileNameMustMatchTypeName.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1649FileNameMustMatchTypeName.cs
@@ -5,7 +5,6 @@ namespace StyleCop.Analyzers.DocumentationRules
 {
     using System;
     using System.Collections.Immutable;
-    using System.IO;
     using System.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DiagnosticOptionsHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/DiagnosticOptionsHelper.cs
@@ -7,7 +7,6 @@
 namespace StyleCop.Analyzers.Helpers
 {
     using System;
-    using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Diagnostics;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/FileHeaderHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/FileHeaderHelpers.cs
@@ -5,7 +5,6 @@ namespace StyleCop.Analyzers.Helpers
 {
     using System;
     using System.Linq;
-    using System.Text;
     using System.Xml;
     using System.Xml.Linq;
     using Microsoft.CodeAnalysis;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1505OpeningBracesMustNotBeFollowedByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1505OpeningBracesMustNotBeFollowedByBlankLine.cs
@@ -10,7 +10,6 @@ namespace StyleCop.Analyzers.LayoutRules
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.Helpers;
-    using StyleCop.Analyzers.SpacingRules;
 
     /// <summary>
     /// An opening brace within a C# element, statement, or expression is followed by a blank line.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1509OpeningBracesMustNotBePrecededByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1509OpeningBracesMustNotBePrecededByBlankLine.cs
@@ -5,10 +5,8 @@ namespace StyleCop.Analyzers.LayoutRules
 {
     using System;
     using System.Collections.Immutable;
-    using System.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
-    using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.Helpers;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/JsonValue.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LightJson/JsonValue.cs
@@ -453,7 +453,7 @@ namespace LightJson
         /// Gets or sets the value associated with the specified key.
         /// </summary>
         /// <param name="key">The key of the value to get or set.</param>
-        /// <exception cref="System.InvalidOperationException">
+        /// <exception cref="InvalidOperationException">
         /// Thrown when this JsonValue is not a JsonObject.
         /// </exception>
         public JsonValue this[string key]
@@ -600,7 +600,7 @@ namespace LightJson
         /// Converts the given JsonValue into a nullable Int.
         /// </summary>
         /// <param name="jsonValue">The JsonValue to be converted.</param>
-        /// <exception cref="System.InvalidCastException">
+        /// <exception cref="InvalidCastException">
         /// Throws System.InvalidCastException when the inner value type of the
         /// JsonValue is not the desired type of the conversion.
         /// </exception>
@@ -638,7 +638,7 @@ namespace LightJson
         /// Converts the given JsonValue into a nullable Bool.
         /// </summary>
         /// <param name="jsonValue">The JsonValue to be converted.</param>
-        /// <exception cref="System.InvalidCastException">
+        /// <exception cref="InvalidCastException">
         /// Throws System.InvalidCastException when the inner value type of the
         /// JsonValue is not the desired type of the conversion.
         /// </exception>
@@ -676,7 +676,7 @@ namespace LightJson
         /// Converts the given JsonValue into a nullable Double.
         /// </summary>
         /// <param name="jsonValue">The JsonValue to be converted.</param>
-        /// <exception cref="System.InvalidCastException">
+        /// <exception cref="InvalidCastException">
         /// Throws System.InvalidCastException when the inner value type of the
         /// JsonValue is not the desired type of the conversion.
         /// </exception>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1413UseTrailingCommasInMultiLineInitializers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1413UseTrailingCommasInMultiLineInitializers.cs
@@ -5,7 +5,6 @@ namespace StyleCop.Analyzers.MaintainabilityRules
 {
     using System;
     using System.Collections.Immutable;
-    using System.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1414TupleTypesInSignaturesShouldHaveElementNames.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1414TupleTypesInSignaturesShouldHaveElementNames.cs
@@ -4,9 +4,7 @@
 namespace StyleCop.Analyzers.MaintainabilityRules
 {
     using System;
-    using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.Text;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SystemDiagnosticsDebugDiagnosticBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SystemDiagnosticsDebugDiagnosticBase.cs
@@ -9,13 +9,13 @@ namespace StyleCop.Analyzers.MaintainabilityRules
     using Microsoft.CodeAnalysis.Diagnostics;
 
     /// <summary>
-    /// A base class for <see cref="System.Diagnostics.Debug"/> diagnostics.
+    /// A base class for <see cref="Debug"/> diagnostics.
     /// It is used to share code in diagnostics <see cref="SA1405DebugAssertMustProvideMessageText"/> and <see cref="SA1406DebugFailMustProvideMessageText"/>.
     /// </summary>
     internal abstract class SystemDiagnosticsDebugDiagnosticBase : DiagnosticAnalyzer
     {
         /// <summary>
-        /// Analyzes a <see cref="InvocationExpressionSyntax"/> node to add a diagnostic to static method calls in <see cref="System.Diagnostics.Debug"/>.
+        /// Analyzes a <see cref="InvocationExpressionSyntax"/> node to add a diagnostic to static method calls in <see cref="Debug"/>.
         /// The diagnostic is added if the parameter count is lower than <paramref name="parameterIndex"/> or the string given at the index can be evaluated to null, string.Empty or just whitespaces.
         /// </summary>
         /// <param name="context">The current analysis context.</param>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NoCodeFixAttribute.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NoCodeFixAttribute.cs
@@ -19,7 +19,7 @@ namespace StyleCop.Analyzers
     /// <para>The <see cref="Reason"/> should be provided.</para>
     /// </remarks>
     [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
-    internal sealed class NoCodeFixAttribute : System.Attribute
+    internal sealed class NoCodeFixAttribute : Attribute
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NoCodeFixAttribute"/> class.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NoDiagnosticAttribute.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NoDiagnosticAttribute.cs
@@ -20,7 +20,7 @@ namespace StyleCop.Analyzers
     /// <para>The <see cref="Reason"/> should be provided.</para>
     /// </remarks>
     [AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
-    internal sealed class NoDiagnosticAttribute : System.Attribute
+    internal sealed class NoDiagnosticAttribute : Attribute
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NoDiagnosticAttribute"/> class.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1210UsingDirectivesMustBeOrderedAlphabeticallyByNamespace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1210UsingDirectivesMustBeOrderedAlphabeticallyByNamespace.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.OrderingRules
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.Globalization;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1217UsingStaticDirectivesMustBeOrderedAlphabetically.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/OrderingRules/SA1217UsingStaticDirectivesMustBeOrderedAlphabetically.cs
@@ -5,7 +5,6 @@ namespace StyleCop.Analyzers.OrderingRules
 {
     using System;
     using System.Collections.Immutable;
-    using System.Globalization;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1130UseLambdaSyntax.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1130UseLambdaSyntax.cs
@@ -5,7 +5,6 @@ namespace StyleCop.Analyzers.ReadabilityRules
 {
     using System;
     using System.Collections.Immutable;
-    using System.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1132DoNotCombineFields.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1132DoNotCombineFields.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.ReadabilityRules
     using System;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.Helpers;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1141UseTupleSyntax.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1141UseTupleSyntax.cs
@@ -4,9 +4,7 @@
 namespace StyleCop.Analyzers.ReadabilityRules
 {
     using System;
-    using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.Text;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/DocumentationSettings.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/DocumentationSettings.cs
@@ -3,10 +3,8 @@
 
 namespace StyleCop.Analyzers.Settings.ObjectModel
 {
-    using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.Linq;
     using System.Text.RegularExpressions;
     using LightJson;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/OrderingSettings.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/OrderingSettings.cs
@@ -3,7 +3,6 @@
 
 namespace StyleCop.Analyzers.Settings.ObjectModel
 {
-    using System.Collections.Generic;
     using System.Collections.Immutable;
     using LightJson;
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly.cs
@@ -4,7 +4,6 @@
 namespace StyleCop.Analyzers.SpacingRules
 {
     using System;
-    using System.Collections.Generic;
     using System.Collections.Immutable;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;


### PR DESCRIPTION
IDE0001 cleanups (namespaces and `var`).

Why don't StyleCop have these rules?