### PR TITLE
Treat ';' and ',' as typos for SA1629 code fix

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1629CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1629CodeFixProvider.cs
@@ -52,7 +52,8 @@ namespace StyleCop.Analyzers.DocumentationRules
         private static async Task<Document> GetTransformedDocumentAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
         {
             var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
-            var newText = text.WithChanges(new TextChange(new TextSpan(diagnostic.Location.SourceSpan.Start, 0), "."));
+            bool replaceChar = diagnostic.Properties.ContainsKey(SA1629DocumentationTextMustEndWithAPeriod.ReplaceCharKey);
+            var newText = text.WithChanges(new TextChange(new TextSpan(diagnostic.Location.SourceSpan.Start, replaceChar ? 1 : 0), "."));
 
             return document.WithText(newText);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1629UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1629UnitTests.cs
@@ -476,6 +476,58 @@ public interface ITest
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
         }
 
+        [Theory]
+        [InlineData(",")]
+        [InlineData(";")]
+        public async Task TestSentenceEndingWithTypoAsync(string typo)
+        {
+            var testCode = $@"
+/// <summary>
+/// Summary{typo}
+/// </summary>
+public interface ITest
+{{
+}}
+";
+            var fixedTestCode = $@"
+/// <summary>
+/// Summary.
+/// </summary>
+public interface ITest
+{{
+}}
+";
+
+            DiagnosticResult expected = Diagnostic().WithLocation(3, 12);
+            await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, default).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData(",")]
+        [InlineData(";")]
+        public async Task TestSentenceEndingWithTypoAndParenthesisAsync(string typo)
+        {
+            var testCode = $@"
+/// <summary>
+/// Summary (for example{typo})
+/// </summary>
+public interface ITest
+{{
+}}
+";
+            var fixedTestCode = $@"
+/// <summary>
+/// Summary (for example.)
+/// </summary>
+public interface ITest
+{{
+}}
+";
+
+            DiagnosticResult expected = Diagnostic().WithLocation(3, 25);
+            await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, default).ConfigureAwait(false);
+        }
+
         [Fact]
         public async Task TestMultipleParagraphBlocksAsync()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1629DocumentationTextMustEndWithAPeriod.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1629DocumentationTextMustEndWithAPeriod.cs
@@ -52,6 +52,8 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// </summary>
         internal const string NoCodeFixKey = "NoCodeFix";
 
+        internal const string ReplaceCharKey = "CharToReplace";
+
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1629.md";
         private static readonly LocalizableString Title = new LocalizableResourceString(nameof(DocumentationResources.SA1629Title), DocumentationResources.ResourceManager, typeof(DocumentationResources));
         private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(DocumentationResources.SA1629MessageFormat), DocumentationResources.ResourceManager, typeof(DocumentationResources));
@@ -128,8 +130,30 @@ namespace StyleCop.Analyzers.DocumentationRules
                                 && (startingWithFinalParagraph || !textWithoutTrailingWhitespace.EndsWith(":", StringComparison.Ordinal))
                                 && !textWithoutTrailingWhitespace.EndsWith("-or-", StringComparison.Ordinal))
                             {
-                                var location = Location.Create(xmlElement.SyntaxTree, new TextSpan(textToken.SpanStart + textWithoutTrailingWhitespace.Length, 1));
-                                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));
+                                int spanStart = textToken.SpanStart + textWithoutTrailingWhitespace.Length;
+                                ImmutableDictionary<string, string> properties = null;
+                                if (textWithoutTrailingWhitespace.EndsWith(",", StringComparison.Ordinal)
+                                    || textWithoutTrailingWhitespace.EndsWith(";", StringComparison.Ordinal))
+                                {
+                                    spanStart -= 1;
+                                    SetReplaceChar();
+                                }
+                                else if (textWithoutTrailingWhitespace.EndsWith(",)", StringComparison.Ordinal)
+                                    || textWithoutTrailingWhitespace.EndsWith(";)", StringComparison.Ordinal))
+                                {
+                                    spanStart -= 2;
+                                    SetReplaceChar();
+                                }
+
+                                var location = Location.Create(xmlElement.SyntaxTree, new TextSpan(spanStart, 1));
+                                context.ReportDiagnostic(Diagnostic.Create(Descriptor, location, properties));
+
+                                void SetReplaceChar()
+                                {
+                                    var propertiesBuilder = ImmutableDictionary.CreateBuilder<string, string>();
+                                    propertiesBuilder.Add(ReplaceCharKey, string.Empty);
+                                    properties = propertiesBuilder.ToImmutable();
+                                }
                             }
 
                             currentParagraphDone = true;


### PR DESCRIPTION
Closes #2897 