### PR TITLE
Fix for reported Issue 3094

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1604UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1604UnitTests.cs
@@ -68,6 +68,21 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("class")]
         [InlineData("struct")]
         [InlineData("interface")]
+        public async Task TestTypeWithExcludedDocumentationAsync(string typeName)
+        {
+            var testCode = @"
+/// <exclude/>
+{0} TypeName
+{{
+}}";
+            await VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("enum")]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("interface")]
         public async Task TestTypeWithoutDocumentationAsync(string typeName)
         {
             var testCode = @"
@@ -130,6 +145,16 @@ void TypeName();";
         }
 
         [Fact]
+        public async Task TestDelegateWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <exclude/>
+public delegate
+void TypeName();";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestDelegateWithoutDocumentationAsync()
         {
             var testCode = @"
@@ -183,6 +208,21 @@ public class ClassName
 public class ClassName
 {
     /// <inheritdoc/>
+    public void Test() { }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMethodWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
     public void Test() { }
 }";
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
@@ -291,6 +331,21 @@ public class ClassName
         }
 
         [Fact]
+        public async Task TestConstructorWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
+    public ClassName() { }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestConstructorWithoutDocumentationAsync()
         {
             var testCode = @"
@@ -355,6 +410,21 @@ public class ClassName
         }
 
         [Fact]
+        public async Task TestDestructorWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
+    ~ClassName() { }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestDestructorWithoutDocumentationAsync()
         {
             var testCode = @"
@@ -399,6 +469,21 @@ public class ClassName
 public class ClassName
 {
     /// <inheritdoc/>
+    public ClassName Property { get; set; }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestPropertyWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
     public ClassName Property { get; set; }
 }";
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
@@ -469,6 +554,21 @@ public class ClassName
         }
 
         [Fact]
+        public async Task TestIndexerWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
+    public ClassName this[string t] { get { return null; } }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestIndexerNoDocumentationAsync()
         {
             var testCode = @"
@@ -527,6 +627,21 @@ public class ClassName
 public class ClassName
 {
     /// <inheritdoc/>
+    public ClassName Foo;
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestFieldWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
     public ClassName Foo;
 }";
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
@@ -597,6 +712,21 @@ public class ClassName
         }
 
         [Fact]
+        public async Task TestEventWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
+    public event System.Action Foo;
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestEventNoDocumentationAsync()
         {
             var testCode = @"
@@ -655,6 +785,21 @@ public class ClassName
 public class ClassName
 {
     /// <inheritdoc/>
+    event System.Action Foo { add { } remove { } }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestEventPropertyWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
     event System.Action Foo { add { } remove { } }
 }";
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1605UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1605UnitTests.cs
@@ -90,6 +90,20 @@ partial {0} TypeName
         [InlineData("class")]
         [InlineData("struct")]
         [InlineData("interface")]
+        public async Task TestTypeWithExcludedDocumentationAsync(string typeName)
+        {
+            var testCode = @"
+/// <exclude/>
+partial {0} TypeName
+{{
+}}";
+            await VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("interface")]
         public async Task TestTypeWithoutDocumentationAsync(string typeName)
         {
             var testCode = @"
@@ -179,6 +193,21 @@ public partial class ClassName
 public partial class ClassName
 {
     /// <inheritdoc/>
+    partial void Test();
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMethodWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public partial class ClassName
+{
+    /// <exclude/>
     partial void Test();
 }";
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1606UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1606UnitTests.cs
@@ -68,6 +68,21 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("class")]
         [InlineData("struct")]
         [InlineData("interface")]
+        public async Task TestTypeWithExcludedDocumentationAsync(string typeName)
+        {
+            var testCode = @"
+/// <exclude/>
+{0} TypeName
+{{
+}}";
+            await VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("enum")]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("interface")]
         public async Task TestTypeWithoutDocumentationAsync(string typeName)
         {
             var testCode = @"
@@ -134,6 +149,16 @@ void TypeName();";
         }
 
         [Fact]
+        public async Task TestDelegateWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <exclude/>
+public delegate
+void TypeName();";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestDelegateWithoutDocumentationAsync()
         {
             var testCode = @"
@@ -189,6 +214,21 @@ public class ClassName
 public class ClassName
 {
     /// <inheritdoc/>
+    public void Test() { }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMethodWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
     public void Test() { }
 }";
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
@@ -279,6 +319,21 @@ public class ClassName
         }
 
         [Fact]
+        public async Task TestConstructorWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <excluded/>
+    public ClassName() { }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestConstructorWithoutDocumentationAsync()
         {
             var testCode = @"
@@ -345,6 +400,21 @@ public class ClassName
         }
 
         [Fact]
+        public async Task TestDestructorWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
+    ~ClassName() { }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestDestructorWithoutDocumentationAsync()
         {
             var testCode = @"
@@ -391,6 +461,21 @@ public class ClassName
 public class ClassName
 {
     /// <inheritdoc/>
+    public ClassName Property { get; set; }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestPropertyWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
     public ClassName Property { get; set; }
 }";
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
@@ -463,6 +548,21 @@ public class ClassName
         }
 
         [Fact]
+        public async Task TestIndexerWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
+    public ClassName this[string t] { get { return null; } }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestIndexerNoDocumentationAsync()
         {
             var testCode = @"
@@ -523,6 +623,21 @@ public class ClassName
 public class ClassName
 {
     /// <inheritdoc/>
+    public ClassName Foo;
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestFieldWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
     public ClassName Foo;
 }";
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
@@ -595,6 +710,21 @@ public class ClassName
         }
 
         [Fact]
+        public async Task TestEventWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
+    public event System.Action Foo;
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestEventNoDocumentationAsync()
         {
             var testCode = @"
@@ -655,6 +785,21 @@ public class ClassName
 public class ClassName
 {
     /// <inheritdoc/>
+    event System.Action Foo { add { } remove { } }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestEventPropertyWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
     event System.Action Foo { add { } remove { } }
 }";
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1607UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1607UnitTests.cs
@@ -80,6 +80,20 @@ partial {0} TypeName
         [InlineData("class")]
         [InlineData("struct")]
         [InlineData("interface")]
+        public async Task TestTypeWithExcludedDocumentationAsync(string typeName)
+        {
+            var testCode = @"
+/// <exclude/>
+partial {0} TypeName
+{{
+}}";
+            await VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("interface")]
         public async Task TestTypeWithoutSummaryDocumentationAsync(string typeName)
         {
             var testCode = @"
@@ -210,6 +224,21 @@ public partial class ClassName
 public partial class ClassName
 {
     /// <inheritdoc/>
+    partial void Test();
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestMethodWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public partial class ClassName
+{
+    /// <exclude/>
     partial void Test();
 }";
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1608UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1608UnitTests.cs
@@ -80,6 +80,20 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         [InlineData("class")]
         [InlineData("struct")]
         [InlineData("interface")]
+        public async Task TestTypeWithExcludedDocumentationAsync(string typeName)
+        {
+            var testCode = @"
+/// <exclude/>
+{0} TypeName
+{{
+}}";
+            await VerifyCSharpDiagnosticAsync(string.Format(testCode, typeName), DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("class")]
+        [InlineData("struct")]
+        [InlineData("interface")]
         public async Task TestTypeWithoutSummaryDocumentationAsync(string typeName)
         {
             var testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1609UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1609UnitTests.cs
@@ -53,6 +53,21 @@ public class ClassName
         }
 
         [Fact]
+        public async Task TestPropertyWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// 
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
+    public ClassName Property { get; set; }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestPropertyNoDocumentationAsync()
         {
             var testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1610UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1610UnitTests.cs
@@ -50,6 +50,21 @@ public class ClassName
         }
 
         [Fact]
+        public async Task TestPropertyWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
+    public ClassName Property { get; set; }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestPropertyNoDocumentationAsync()
         {
             var testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1611UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1611UnitTests.cs
@@ -132,6 +132,22 @@ public class ClassName
 
         [Theory]
         [MemberData(nameof(Data))]
+        public async Task TestExcludeAsync(string p)
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
+    public ##
+}";
+            await VerifyCSharpDiagnosticAsync(testCode.Replace("##", p), DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(Data))]
         public async Task TestMissingParametersAsync(string p)
         {
             var testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1612UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1612UnitTests.cs
@@ -271,6 +271,22 @@ public class ClassName
             await VerifyCSharpDiagnosticAsync(testCode.Replace("$$", declaration), DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
+        [Theory]
+        [MemberData(nameof(Declarations))]
+        public async Task VerifyExcludedDocumentationReportsNoDiagnosticsAsync(string declaration)
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
+    $$
+}";
+            await VerifyCSharpDiagnosticAsync(testCode.Replace("$$", declaration), DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
         [Fact]
         public async Task VerifyIncludedMemberWithoutParamsIsNotReportedAsync()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1617UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1617UnitTests.cs
@@ -98,6 +98,24 @@ public class ClassName
         }
 
         [Fact]
+        public async Task TestPropertyWithExcludedDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
+    public ClassName Method() { return null; }
+
+    /// <exclude/>
+    public delegate ClassName MethodDelegate();
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestMethodWithoutReturnValueNoDocumentationAsync()
         {
             var testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1618UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1618UnitTests.cs
@@ -225,6 +225,32 @@ public ##";
 
         [Theory]
         [MemberData(nameof(Members))]
+        public async Task TestMembersExcludeAsync(string p)
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
+    public ##
+}";
+            await VerifyCSharpDiagnosticAsync(testCode.Replace("##", p), DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(Types))]
+        public async Task TestTypesExcludeAsync(string p)
+        {
+            var testCode = @"
+/// <exclude/>
+public ##";
+            await VerifyCSharpDiagnosticAsync(testCode.Replace("##", p), DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(Members))]
         public async Task TestMembersWithMissingDocumentationAsync(string p)
         {
             var testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1619UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1619UnitTests.cs
@@ -105,6 +105,16 @@ public partial ##";
 
         [Theory]
         [MemberData(nameof(Types))]
+        public async Task TestPartialTypesExcludeAsync(string p)
+        {
+            var testCode = @"
+/// <exclude/>
+public partial ##";
+            await VerifyCSharpDiagnosticAsync(testCode.Replace("##", p), DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(Types))]
         public async Task TestPartialTypesWithMissingDocumentationAsync(string p)
         {
             var testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1620UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1620UnitTests.cs
@@ -232,11 +232,36 @@ public class ClassName
         }
 
         [Theory]
+        [MemberData(nameof(Members))]
+        public async Task TestMembersExcludeAsync(string p)
+        {
+            var testCode = @"
+/// <summary>
+/// Foo
+/// </summary>
+public class ClassName
+{
+    /// <exclude/>
+    public ##
+}";
+            await VerifyCSharpDiagnosticAsync(testCode.Replace("##", p), DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
         [MemberData(nameof(Types))]
         public async Task TestTypesInheritDocAsync(string p)
         {
             var testCode = @"
 /// <inheritdoc/>
+public ##";
+            await VerifyCSharpDiagnosticAsync(testCode.Replace("##", p), DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+        [Theory]
+        [MemberData(nameof(Types))]
+        public async Task TestTypesExcludeAsync(string p)
+        {
+            var testCode = @"
+/// <exclude/>
 public ##";
             await VerifyCSharpDiagnosticAsync(testCode.Replace("##", p), DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1625UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1625UnitTests.cs
@@ -86,6 +86,20 @@ public class TestClass
 
         [Theory]
         [MemberData(nameof(Members))]
+        public async Task VerifyThatTheAnalyzerDoesNotCrashOnExcludeAsync(string member)
+        {
+            var testCode = $@"
+public class TestClass
+{{
+    /// <exclude/>
+    {member}
+}}
+";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(Members))]
         public async Task VerifyThatWhitespacesAreNormalizedForEmptyXmlElementsAsync(string member)
         {
             var testCode = $@"

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/ElementDocumentationBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/ElementDocumentationBase.cs
@@ -209,6 +209,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
+            if (documentation.Content.GetFirstXmlElement(XmlCommentHelper.ExcludeXmlTag) != null)
+            {
+                // Ignore nodes with an <exclude /> tag in the included XML
+                return;
+            }
+
             if (this.inheritDocSuppressesWarnings
                 && documentation.Content.GetFirstXmlElement(XmlCommentHelper.InheritdocXmlTag) != null)
             {
@@ -235,6 +241,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                         completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.InheritdocXmlTag))
                     {
                         // Ignore nodes with an <inheritdoc/> tag in the included XML.
+                        return;
+                    }
+
+                        if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                    {
+                        // Ignore nodes with an <exclude /> tag in the included XML
                         return;
                     }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
@@ -207,10 +207,10 @@ namespace StyleCop.Analyzers.DocumentationRules
                     if (fileHeader != null)
                     {
                         // Don't process documentation rules when an <exclude /> tag is present
-                        if (fileHeader.GetElement("exclude") != null)
+                        /*if (fileHeader.GetElement("exclude") != null)
                         {
                             return;
-                        }
+                        }*/
 
                         if (fileHeader.IsMissing)
                         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
@@ -203,6 +203,13 @@ namespace StyleCop.Analyzers.DocumentationRules
                 if (settings.DocumentationRules.XmlHeader)
                 {
                     var fileHeader = FileHeaderHelpers.ParseXmlFileHeader(root);
+
+                    /*// Don't process documentation rules when an <exclude /> tag is present
+                    if (fileHeader.GetElement("exclude") != null)
+                    {
+                        return;
+                    }*/
+
                     if (fileHeader.IsMissing)
                     {
                         context.ReportDiagnostic(Diagnostic.Create(SA1633DescriptorMissing, fileHeader.GetLocation(context.Tree)));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/FileHeaderAnalyzers.cs
@@ -204,22 +204,25 @@ namespace StyleCop.Analyzers.DocumentationRules
                 {
                     var fileHeader = FileHeaderHelpers.ParseXmlFileHeader(root);
 
-                    /*// Don't process documentation rules when an <exclude /> tag is present
-                    if (fileHeader.GetElement("exclude") != null)
+                    if (fileHeader != null)
                     {
-                        return;
-                    }*/
+                        // Don't process documentation rules when an <exclude /> tag is present
+                        if (fileHeader.GetElement("exclude") != null)
+                        {
+                            return;
+                        }
 
-                    if (fileHeader.IsMissing)
-                    {
-                        context.ReportDiagnostic(Diagnostic.Create(SA1633DescriptorMissing, fileHeader.GetLocation(context.Tree)));
-                        return;
-                    }
+                        if (fileHeader.IsMissing)
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(SA1633DescriptorMissing, fileHeader.GetLocation(context.Tree)));
+                            return;
+                        }
 
-                    if (fileHeader.IsMalformed)
-                    {
-                        context.ReportDiagnostic(Diagnostic.Create(SA1633DescriptorMalformed, fileHeader.GetLocation(context.Tree)));
-                        return;
+                        if (fileHeader.IsMalformed)
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(SA1633DescriptorMalformed, fileHeader.GetLocation(context.Tree)));
+                            return;
+                        }
                     }
 
                     if (!compilation.IsAnalyzerSuppressed(SA1634Descriptor))

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/GenericTypeParameterDocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/GenericTypeParameterDocumentationAnalyzer.cs
@@ -136,6 +136,12 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                 rawDocumentation = declaration.GetDocumentationCommentXml(expandIncludes: true, cancellationToken: context.CancellationToken);
                 var completeDocumentation = XElement.Parse(rawDocumentation, LoadOptions.None);
+                if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                {
+                    // Ignore nodes with an <exclude /> tag in the included XML
+                    return;
+                }
+
                 if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.InheritdocXmlTag))
                 {
                     // Ignore nodes with an <inheritdoc/> tag in the included XML.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PartialElementDocumentationSummaryBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PartialElementDocumentationSummaryBase.cs
@@ -119,6 +119,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
+            if (documentation.Content.GetFirstXmlElement(XmlCommentHelper.ExcludeXmlTag) != null)
+            {
+                // Ignore nodes with an <exclude/> tag.
+                return;
+            }
+
             if (documentation.Content.GetFirstXmlElement(XmlCommentHelper.InheritdocXmlTag) != null)
             {
                 // Ignore nodes with an <inheritdoc/> tag.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PartialElementDocumentationSummaryBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PartialElementDocumentationSummaryBase.cs
@@ -151,6 +151,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                     }
 
                     completeDocumentation = XElement.Parse(rawDocumentation, LoadOptions.None);
+                    if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                    {
+                        // Ignore nodes with an <exclude /> tag in the included XML.
+                        return;
+                    }
+
                     if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.InheritdocXmlTag))
                     {
                         // Ignore nodes with an <inheritdoc/> tag in the included XML.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertyDocumentationBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertyDocumentationBase.cs
@@ -83,6 +83,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
+            if (documentation.Content.GetFirstXmlElement(XmlCommentHelper.ExcludeXmlTag) != null)
+            {
+                // Ignore nodes with an <exclude/> tag.
+                return;
+            }
+
             if (documentation.Content.GetFirstXmlElement(XmlCommentHelper.InheritdocXmlTag) != null)
             {
                 // Ignore nodes with an <inheritdoc/> tag.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertyDocumentationBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertyDocumentationBase.cs
@@ -100,6 +100,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                     var declaration = context.SemanticModel.GetDeclaredSymbol(node, context.CancellationToken);
                     var rawDocumentation = declaration?.GetDocumentationCommentXml(expandIncludes: true, cancellationToken: context.CancellationToken);
                     completeDocumentation = XElement.Parse(rawDocumentation, LoadOptions.None);
+                    if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                    {
+                        // Ignore nodes with an <exclude /> tag in the included XML.
+                        return;
+                    }
+
                     if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.InheritdocXmlTag))
                     {
                         // Ignore nodes with an <inheritdoc/> tag in the included XML.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
@@ -6,6 +6,7 @@ namespace StyleCop.Analyzers.DocumentationRules
     using System;
     using System.Collections.Immutable;
     using System.Globalization;
+    using System.Linq;
     using System.Xml.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
@@ -60,6 +61,12 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// <inheritdoc/>
         protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, bool needsComment, XmlNodeSyntax syntax, XElement completeDocumentation, Location diagnosticLocation)
         {
+            if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+            {
+                // Ignore nodes with an <exclude /> tag in the included XML.
+                return;
+            }
+
             var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
             var propertyType = context.SemanticModel.GetTypeInfo(propertyDeclaration.Type.StripRefFromType());
             var settings = context.Options.GetStyleCopSettings(context.CancellationToken);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1604ElementDocumentationMustHaveSummary.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1604ElementDocumentationMustHaveSummary.cs
@@ -51,6 +51,12 @@ namespace StyleCop.Analyzers.DocumentationRules
 
             if (completeDocumentation != null)
             {
+                // This documentation rule is excluded via the <exclude /> tag
+                if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                {
+                    return;
+                }
+
                 // We are working with an <include> element
                 if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.SummaryXmlTag))
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1604ElementDocumentationMustHaveSummary.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1604ElementDocumentationMustHaveSummary.cs
@@ -81,6 +81,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                     // Ignore nodes with an <inheritdoc/> tag.
                     return;
                 }
+
+                // This documentation rule is excluded via the <exclude /> tag
+                if (documentation?.Content.GetFirstXmlElement(XmlCommentHelper.ExcludeXmlTag) != null)
+                {
+                    return;
+                }
             }
 
             foreach (var location in diagnosticLocations)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1605PartialElementDocumentationMustHaveSummary.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1605PartialElementDocumentationMustHaveSummary.cs
@@ -95,6 +95,12 @@ namespace StyleCop.Analyzers.DocumentationRules
 
             if (completeDocumentation != null)
             {
+                // This documentation rule is excluded via the <exclude /> tag
+                if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                {
+                    return;
+                }
+
                 var hasSummaryTag = completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.SummaryXmlTag);
                 var hasContentTag = completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ContentXmlTag);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1605PartialElementDocumentationMustHaveSummary.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1605PartialElementDocumentationMustHaveSummary.cs
@@ -96,15 +96,16 @@ namespace StyleCop.Analyzers.DocumentationRules
             if (completeDocumentation != null)
             {
                 // This documentation rule is excluded via the <exclude /> tag
-                if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                /*if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
                 {
                     return;
-                }
+                }*/
 
+                var hasExcludeTag = completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag);
                 var hasSummaryTag = completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.SummaryXmlTag);
                 var hasContentTag = completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ContentXmlTag);
 
-                if (hasSummaryTag || hasContentTag)
+                if (hasExcludeTag || hasSummaryTag || hasContentTag)
                 {
                     return;
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1605PartialElementDocumentationMustHaveSummary.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1605PartialElementDocumentationMustHaveSummary.cs
@@ -101,11 +101,11 @@ namespace StyleCop.Analyzers.DocumentationRules
                     return;
                 }*/
 
-                var hasExcludeTag = completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag);
+                // var hasExcludeTag = completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag);
                 var hasSummaryTag = completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.SummaryXmlTag);
                 var hasContentTag = completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ContentXmlTag);
 
-                if (hasExcludeTag || hasSummaryTag || hasContentTag)
+                if (hasSummaryTag || hasContentTag)
                 {
                     return;
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1606ElementDocumentationMustHaveSummaryText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1606ElementDocumentationMustHaveSummaryText.cs
@@ -51,6 +51,12 @@ namespace StyleCop.Analyzers.DocumentationRules
 
             if (completeDocumentation != null)
             {
+                // This documentation rule is excluded via the <exclude /> tag
+                if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                {
+                    return;
+                }
+
                 XElement summaryNode = completeDocumentation.Nodes().OfType<XElement>().FirstOrDefault(element => element.Name == XmlCommentHelper.SummaryXmlTag);
                 if (summaryNode == null)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1607PartialElementDocumentationMustHaveSummaryText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1607PartialElementDocumentationMustHaveSummaryText.cs
@@ -90,6 +90,12 @@ namespace StyleCop.Analyzers.DocumentationRules
         {
             if (completeDocumentation != null)
             {
+                // This documentation rule is excluded via the <exclude /> tag
+                if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                {
+                    return;
+                }
+
                 var summaryTag = completeDocumentation.Nodes().OfType<XElement>().FirstOrDefault(element => element.Name == XmlCommentHelper.SummaryXmlTag);
                 var contentTag = completeDocumentation.Nodes().OfType<XElement>().FirstOrDefault(element => element.Name == XmlCommentHelper.ContentXmlTag);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1608ElementDocumentationMustNotHaveDefaultSummary.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1608ElementDocumentationMustNotHaveDefaultSummary.cs
@@ -79,6 +79,12 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// <inheritdoc/>
         protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, bool needsComment, XElement completeDocumentation, params Location[] diagnosticLocations)
         {
+            // This documentation rule is excluded via the <exclude /> tag
+            if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+            {
+                return;
+            }
+
             // We are working with an <include> element
             var includedSummaryElement = completeDocumentation.Nodes().OfType<XElement>().FirstOrDefault(element => element.Name == XmlCommentHelper.SummaryXmlTag);
             if (includedSummaryElement != null)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1609PropertyDocumentationMustHaveValue.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1609PropertyDocumentationMustHaveValue.cs
@@ -59,10 +59,10 @@ namespace StyleCop.Analyzers.DocumentationRules
             if (completeDocumentation != null)
             {
                 // This documentation rule is excluded via the <exclude /> tag
-                if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                /*if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
                 {
                     return;
-                }
+                }*/
 
                 var hasValueTag = completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ValueXmlTag);
                 if (hasValueTag)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1609PropertyDocumentationMustHaveValue.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1609PropertyDocumentationMustHaveValue.cs
@@ -58,6 +58,12 @@ namespace StyleCop.Analyzers.DocumentationRules
 
             if (completeDocumentation != null)
             {
+                // This documentation rule is excluded via the <exclude /> tag
+                if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                {
+                    return;
+                }
+
                 var hasValueTag = completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ValueXmlTag);
                 if (hasValueTag)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1610PropertyDocumentationMustHaveValueText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1610PropertyDocumentationMustHaveValueText.cs
@@ -52,6 +52,12 @@ namespace StyleCop.Analyzers.DocumentationRules
 
             if (completeDocumentation != null)
             {
+                // This documentation rule is excluded via the <exclude /> tag
+                if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                {
+                    return;
+                }
+
                 var valueTag = completeDocumentation.Nodes().OfType<XElement>().FirstOrDefault(element => element.Name == XmlCommentHelper.ValueXmlTag);
                 if (valueTag == null)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1611ElementParametersMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1611ElementParametersMustBeDocumented.cs
@@ -75,6 +75,12 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// <inheritdoc/>
         protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, bool needsComment, XElement completeDocumentation, params Location[] diagnosticLocations)
         {
+            // This documentation rule is excluded via the <exclude /> tag
+            if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+            {
+                return;
+            }
+
             if (!needsComment)
             {
                 // Omitting documentation for a parameter is allowed for this element.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1612ElementParameterDocumentationMustMatchElementParameters.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1612ElementParameterDocumentationMustMatchElementParameters.cs
@@ -143,6 +143,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
+            // This documentation rule is excluded via the <exclude /> tag
+            if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+            {
+                return;
+            }
+
             // We are working with an <include> element
             var xmlParamTags = completeDocumentation.Nodes()
                 .OfType<XElement>()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1613ElementParameterDocumentationMustDeclareParameterName.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1613ElementParameterDocumentationMustDeclareParameterName.cs
@@ -72,6 +72,12 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// <inheritdoc/>
         protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, bool needsComment, XElement completeDocumentation, params Location[] diagnosticLocations)
         {
+            // This documentation rule is excluded via the <exclude /> tag
+            if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+            {
+                return;
+            }
+
             var xmlParamTags = completeDocumentation.Nodes()
                 .OfType<XElement>()
                 .Where(e => e.Name == XmlCommentHelper.ParamXmlTag);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1614ElementParameterDocumentationMustHaveText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1614ElementParameterDocumentationMustHaveText.cs
@@ -66,6 +66,12 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// <inheritdoc/>
         protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, bool needsComment, XElement completeDocumentation, params Location[] diagnosticLocations)
         {
+            // This documentation rule is excluded via the <exclude /> tag
+            if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+            {
+                return;
+            }
+
             var xmlParamTags = completeDocumentation.Nodes()
                 .OfType<XElement>()
                 .Where(e => e.Name == XmlCommentHelper.ParamXmlTag);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1615ElementReturnValueMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1615ElementReturnValueMustBeDocumented.cs
@@ -117,6 +117,13 @@ namespace StyleCop.Analyzers.DocumentationRules
                 var declaration = context.SemanticModel.GetDeclaredSymbol(context.Node, context.CancellationToken);
                 var rawDocumentation = declaration?.GetDocumentationCommentXml(expandIncludes: true, cancellationToken: context.CancellationToken);
                 XElement completeDocumentation = XElement.Parse(rawDocumentation, LoadOptions.None);
+
+                // This documentation rule is excluded via the <exclude /> tag
+                if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                {
+                    return;
+                }
+
                 if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.InheritdocXmlTag))
                 {
                     // Ignore nodes with an <inheritdoc/> tag in the included XML.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1616ElementReturnValueDocumentationMustHaveText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1616ElementReturnValueDocumentationMustHaveText.cs
@@ -64,6 +64,12 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// <inheritdoc/>
         protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, bool needsComment, XElement completeDocumentation, params Location[] diagnosticLocations)
         {
+            // This documentation rule is excluded via the <exclude /> tag
+            if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+            {
+                return;
+            }
+
             var returnsNodes = completeDocumentation.Nodes()
                 .OfType<XElement>()
                 .Where(n => n.Name == XmlCommentHelper.ReturnsXmlTag);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1617VoidReturnValueMustNotBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1617VoidReturnValueMustNotBeDocumented.cs
@@ -106,6 +106,13 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                     rawDocumentation = declaration.GetDocumentationCommentXml(expandIncludes: true, cancellationToken: context.CancellationToken);
                     var completeDocumentation = XElement.Parse(rawDocumentation, LoadOptions.None);
+
+                    // This documentation rule is excluded via the <exclude /> tag
+                    if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                    {
+                        return;
+                    }
+
                     if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.InheritdocXmlTag))
                     {
                         // Ignore nodes with an <inheritdoc/> tag in the included XML.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1618GenericTypeParametersMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1618GenericTypeParametersMustBeDocumented.cs
@@ -135,6 +135,13 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                 rawDocumentation = declaration.GetDocumentationCommentXml(expandIncludes: true, cancellationToken: context.CancellationToken);
                 var completeDocumentation = XElement.Parse(rawDocumentation, LoadOptions.None);
+
+                // This documentation rule is excluded via the <exclude /> tag
+                if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                {
+                    return;
+                }
+
                 if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.InheritdocXmlTag))
                 {
                     // Ignore nodes with an <inheritdoc/> tag in the included XML.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1618GenericTypeParametersMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1618GenericTypeParametersMustBeDocumented.cs
@@ -122,6 +122,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
+            if (documentation.Content.GetFirstXmlElement(XmlCommentHelper.ExcludeXmlTag) != null)
+            {
+                // Ignore nodes with an <exclude/> tag.
+                return;
+            }
+
             // Check if the return value is documented
             var includeElement = documentation.Content.GetFirstXmlElement(XmlCommentHelper.IncludeXmlTag);
             if (includeElement != null)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1619GenericTypeParametersMustBeDocumentedPartialClass.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1619GenericTypeParametersMustBeDocumentedPartialClass.cs
@@ -149,6 +149,13 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                 rawDocumentation = declaration.GetDocumentationCommentXml(expandIncludes: true, cancellationToken: context.CancellationToken);
                 var completeDocumentation = XElement.Parse(rawDocumentation, LoadOptions.None);
+
+                // This documentation rule is excluded via the <exclude /> tag
+                if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                {
+                    return;
+                }
+
                 if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.InheritdocXmlTag))
                 {
                     // Ignore nodes with an <inheritdoc/> tag in the included XML.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1625ElementDocumentationMustNotBeCopiedAndPasted.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1625ElementDocumentationMustNotBeCopiedAndPasted.cs
@@ -124,6 +124,12 @@ namespace StyleCop.Analyzers.DocumentationRules
             var culture = new CultureInfo(settings.DocumentationRules.DocumentationCulture);
             var resourceManager = DocumentationResources.ResourceManager;
 
+            // This documentation rule is excluded via the <exclude /> tag
+            if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+            {
+                return;
+            }
+
             // Concatenate all XML node values
             var documentationElements = completeDocumentation.Nodes()
                 .OfType<XElement>()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1627DocumentationTextMustNotBeEmpty.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1627DocumentationTextMustNotBeEmpty.cs
@@ -122,6 +122,13 @@ namespace StyleCop.Analyzers.DocumentationRules
 
             var rawDocumentation = declaration.GetDocumentationCommentXml(expandIncludes: true, cancellationToken: context.CancellationToken);
             var completeDocumentation = XElement.Parse(rawDocumentation, LoadOptions.None);
+
+            // This documentation rule is excluded via the <exclude /> tag
+            if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+            {
+                return;
+            }
+
             if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.InheritdocXmlTag))
             {
                 // Ignore nodes with an <inheritdoc/> tag in the included XML.

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1629DocumentationTextMustEndWithAPeriod.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1629DocumentationTextMustEndWithAPeriod.cs
@@ -86,6 +86,12 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// <inheritdoc/>
         protected override void HandleCompleteDocumentation(SyntaxNodeAnalysisContext context, bool needsComment, XElement completeDocumentation, params Location[] diagnosticLocations)
         {
+            // This documentation rule is excluded via the <exclude /> tag
+            if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+            {
+                return;
+            }
+
             foreach (var node in completeDocumentation.Nodes().OfType<XElement>())
             {
                 var textWithoutTrailingWhitespace = node.Value.TrimEnd(' ', '\r', '\n');

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1648InheritDocMustBeUsedWithInheritingClass.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1648InheritDocMustBeUsedWithInheritingClass.cs
@@ -95,6 +95,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                 var rawDocumentation = declaration.GetDocumentationCommentXml(expandIncludes: true, cancellationToken: context.CancellationToken);
                 var completeDocumentation = XElement.Parse(rawDocumentation, LoadOptions.None);
 
+                // This documentation rule is excluded via the <exclude /> tag
+                if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+                {
+                    return;
+                }
+
                 var inheritDocElement = completeDocumentation.Nodes().OfType<XElement>().FirstOrDefault(element => element.Name == XmlCommentHelper.InheritdocXmlTag);
                 if (inheritDocElement == null)
                 {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1651DoNotUsePlaceholderElements.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1651DoNotUsePlaceholderElements.cs
@@ -123,6 +123,13 @@ namespace StyleCop.Analyzers.DocumentationRules
 
             var rawDocumentation = declaration.GetDocumentationCommentXml(expandIncludes: true, cancellationToken: context.CancellationToken);
             var completeDocumentation = XElement.Parse(rawDocumentation, LoadOptions.None);
+
+            // This documentation rule is excluded via the <exclude /> tag
+            if (completeDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.ExcludeXmlTag))
+            {
+                return false;
+            }
+
             return completeDocumentation.DescendantNodesAndSelf().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.PlaceholderTag);
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
@@ -41,6 +41,7 @@ namespace StyleCop.Analyzers.Helpers
         internal const string PathAttributeName = "path";
         internal const string CrefArgumentName = "cref";
         internal const string NameArgumentName = "name";
+        internal const string ExcludeXmlTag = "exclude";
 
         /// <summary>
         /// The &lt;placeholder&gt; tag is a Sandcastle Help File Builder extension to the standard XML documentation

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
@@ -37,11 +37,11 @@ namespace StyleCop.Analyzers.Helpers
         internal const string PermissionXmlTag = "permission";
         internal const string ExceptionXmlTag = "exception";
         internal const string IncludeXmlTag = "include";
+        internal const string ExcludeXmlTag = "exclude";
         internal const string FileAttributeName = "file";
         internal const string PathAttributeName = "path";
         internal const string CrefArgumentName = "cref";
         internal const string NameArgumentName = "name";
-        internal const string ExcludeXmlTag = "exclude";
 
         /// <summary>
         /// The &lt;placeholder&gt; tag is a Sandcastle Help File Builder extension to the standard XML documentation


### PR DESCRIPTION
I have a fix for issue #3094 as reported in the main repository, concerning the exclusion of rule enforcement for Doc rules when `<exclude/>` is present. I have created accompanying new unit tests in the StyleCop.Analyzers.Test project, all of which have passed.