### PR TITLE
Add init script which installs the .NET SDK required by global.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,12 @@ for issues suitable if you are unfamiliar with roslyn.
 
 You can also help by filing issues, participating in discussions and doing code review.
 
+## Building prerequisites
+
+* Visual Studio 2017 (Community Edition or higher) is required for building this repository.
+* The version of the [.NET Core SDK](https://dotnet.microsoft.com/download/dotnet-core) as specified in the global.json file at the root of this repo.
+  Use the init script at the root of the repo to conveniently acquire and install the right version.
+
 ## Implementing a diagnostic
 
 1. To start working on a diagnostic, add a comment to the issue indicating you are working on implementing it.
@@ -23,7 +29,3 @@ You can also help by filing issues, participating in discussions and doing code 
    2. A new issue was created for implementing tests for the item (e.g. #176).
    3. Evidence was given that the feature is currently operational, and the code appears to be a solid starting point
       for other contributors to continue the implementation effort.
-
-## Building
-
-Visual Studio 2017 (Community Edition or higher) is required for building this repository.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ configuration:
 - Debug
 - Release
 before_build:
+- ps: .\init.ps1 -NoRestore
 - nuget restore
 skip_tags: true
 build:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,6 +20,9 @@ jobs:
         BuildConfiguration: Release
         _debugArg: ''
   steps:
+  - powershell: .\init.ps1 -NoRestore
+    displayName: Install .NET Core SDK
+
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet 5.3.1'
     inputs:

--- a/build/Install-DotNetSdk.ps1
+++ b/build/Install-DotNetSdk.ps1
@@ -1,0 +1,161 @@
+<#
+.SYNOPSIS
+Installs the .NET SDK specified in the global.json file at the root of this repository,
+along with supporting .NET Core runtimes used for testing.
+.DESCRIPTION
+This MAY not require elevation, as the SDK and runtimes are installed locally to this repo location,
+unless `-InstallLocality machine` is specified.
+.PARAMETER InstallLocality
+A value indicating whether dependencies should be installed locally to the repo or at a per-user location.
+Per-user allows sharing the installed dependencies across repositories and allows use of a shared expanded package cache.
+Visual Studio will only notice and use these SDKs/runtimes if VS is launched from the environment that runs this script.
+Per-repo allows for high isolation, allowing for a more precise recreation of the environment within an Azure Pipelines build.
+When using 'repo', environment variables are set to cause the locally installed dotnet SDK to be used.
+Per-repo can lead to file locking issues when dotnet.exe is left running as a build server and can be mitigated by running `dotnet build-server shutdown`.
+Per-machine requires elevation and will download and install all SDKs and runtimes to machine-wide locations so all applications can find it.
+#>
+[CmdletBinding(SupportsShouldProcess=$true,ConfirmImpact='Medium')]
+Param (
+    [ValidateSet('repo','user','machine')]
+    [string]$InstallLocality='user'
+)
+
+$DotNetInstallScriptRoot = "$PSScriptRoot/../obj/tools"
+if (!(Test-Path $DotNetInstallScriptRoot)) { New-Item -ItemType Directory -Path $DotNetInstallScriptRoot | Out-Null }
+$DotNetInstallScriptRoot = Resolve-Path $DotNetInstallScriptRoot
+
+# Look up actual required .NET Core SDK version from global.json
+$globalJson = Get-Content -Path "$PSScriptRoot\..\global.json" | ConvertFrom-Json
+$sdkVersion = $globalJson.sdk.version
+
+# Search for all .NET Core runtime versions referenced from MSBuild projects and arrange to install them.
+$runtimeVersions = @()
+Get-ChildItem "$PSScriptRoot\..\*.*proj" -Recurse |% {
+    $projXml = [xml](Get-Content -Path $_)
+    $targetFrameworks = $projXml.Project.PropertyGroup.TargetFramework
+    if (!$targetFrameworks) {
+        $targetFrameworks = $projXml.Project.PropertyGroup.TargetFrameworks
+        if ($targetFrameworks) {
+            $targetFrameworks = $targetFrameworks -Split ';'
+        }
+    }
+    $targetFrameworks |? { $_ -match 'netcoreapp(\d+\.\d+)' } |% {
+        $runtimeVersions += $Matches[1]
+    }
+}
+
+Function Get-FileFromWeb([Uri]$Uri, $OutDir) {
+    $OutFile = Join-Path $OutDir $Uri.Segments[-1]
+    if (!(Test-Path $OutFile)) {
+        Write-Verbose "Downloading $Uri..."
+        try {
+            (New-Object System.Net.WebClient).DownloadFile($Uri, $OutFile)
+        } finally {
+            # This try/finally causes the script to abort
+        }
+    }
+
+    $OutFile
+}
+
+Function Get-InstallerExe($Version, [switch]$Runtime) {
+    $sdkOrRuntime = 'Sdk'
+    if ($Runtime) { $sdkOrRuntime = 'Runtime' }
+
+    # Get the latest/actual version for the specified one
+    if (([Version]$Version).Build -eq -1) {
+        $versionInfo = -Split (Invoke-WebRequest -Uri "https://dotnetcli.blob.core.windows.net/dotnet/$sdkOrRuntime/$Version/latest.version" -UseBasicParsing)
+        $Version = $versionInfo[-1]
+    }
+
+    Get-FileFromWeb -Uri "https://dotnetcli.blob.core.windows.net/dotnet/$sdkOrRuntime/$Version/dotnet-$($sdkOrRuntime.ToLowerInvariant())-$Version-win-x64.exe" -OutDir "$DotNetInstallScriptRoot"
+}
+
+Function Install-DotNet($Version, [switch]$Runtime) {
+    if ($Runtime) { $sdkSubstring = '' } else { $sdkSubstring = 'SDK ' }
+    Write-Host "Downloading .NET Core $sdkSubstring$Version..."
+    $Installer = Get-InstallerExe -Version $Version -Runtime:$Runtime
+    Write-Host "Installing .NET Core $sdkSubstring$Version..."
+    cmd /c start /wait $Installer /install /quiet
+    if ($LASTEXITCODE -ne 0) {
+        throw "Failure to install .NET Core SDK"
+    }
+}
+
+if ($InstallLocality -eq 'machine') {
+    if ($IsMacOS -or $IsLinux) {
+        Write-Error "Installing the .NET Core SDK or runtime at a machine-wide location is only supported by this script on Windows."
+        exit 1
+    }
+
+    if ($PSCmdlet.ShouldProcess(".NET Core SDK $sdkVersion", "Install")) {
+        Install-DotNet -Version $sdkVersion
+    }
+
+    $runtimeVersions | Get-Unique |% {
+        if ($PSCmdlet.ShouldProcess(".NET Core runtime $_", "Install")) {
+            Install-DotNet -Version $_ -Runtime
+        }
+    }
+
+    return
+}
+
+$switches = @(
+    '-Architecture','x64'
+)
+$envVars = @{
+    # For locally installed dotnet, skip first time experience which takes a long time
+    'DOTNET_SKIP_FIRST_TIME_EXPERIENCE' = 'true';
+}
+
+if ($InstallLocality -eq 'repo') {
+    $DotNetInstallDir = "$DotNetInstallScriptRoot/.dotnet"
+} elseif ($env:AGENT_TOOLSDIRECTORY) {
+    $DotNetInstallDir = "$env:AGENT_TOOLSDIRECTORY/dotnet"
+} else {
+    $DotNetInstallDir = Join-Path $HOME .dotnet
+}
+
+Write-Host "Installing .NET Core SDK and runtimes to $DotNetInstallDir" -ForegroundColor Blue
+
+if ($DotNetInstallDir) {
+    $switches += '-InstallDir',$DotNetInstallDir
+    $envVars['DOTNET_MULTILEVEL_LOOKUP'] = '0'
+    $envVars['DOTNET_ROOT'] = $DotNetInstallDir
+}
+
+if ($IsMacOS -or $IsLinux) {
+    $DownloadUri = "https://dot.net/v1/dotnet-install.sh"
+    $DotNetInstallScriptPath = "$DotNetInstallScriptRoot/dotnet-install.sh"
+} else {
+    $DownloadUri = "https://dot.net/v1/dotnet-install.ps1"
+    $DotNetInstallScriptPath = "$DotNetInstallScriptRoot/dotnet-install.ps1"
+}
+
+if (-not (Test-Path $DotNetInstallScriptPath)) {
+    Invoke-WebRequest -Uri $DownloadUri -OutFile $DotNetInstallScriptPath -UseBasicParsing
+    if ($IsMacOS -or $IsLinux) {
+        chmod +x $DotNetInstallScriptPath
+    }
+}
+
+if ($PSCmdlet.ShouldProcess(".NET Core SDK $sdkVersion", "Install")) {
+    Invoke-Expression -Command "$DotNetInstallScriptPath -Version $sdkVersion $switches"
+} else {
+    Invoke-Expression -Command "$DotNetInstallScriptPath -Version $sdkVersion $switches -DryRun"
+}
+
+$switches += '-Runtime','dotnet'
+
+$runtimeVersions | Get-Unique |% {
+    if ($PSCmdlet.ShouldProcess(".NET Core runtime $_", "Install")) {
+        Invoke-Expression -Command "$DotNetInstallScriptPath -Channel $_ $switches"
+    } else {
+        Invoke-Expression -Command "$DotNetInstallScriptPath -Channel $_ $switches -DryRun"
+    }
+}
+
+if ($PSCmdlet.ShouldProcess("Set DOTNET environment variables to discover these installed runtimes?")) {
+    & "$PSScriptRoot/Set-EnvVars.ps1" -Variables $envVars -PrependPath $DotNetInstallDir | Out-Null
+}

--- a/build/Set-EnvVars.ps1
+++ b/build/Set-EnvVars.ps1
@@ -1,0 +1,79 @@
+<#
+.SYNOPSIS
+    Set environment variables in the environment.
+    Azure Pipeline and CMD environments are considered.
+.PARAMETER Variables
+    A hashtable of variables to be set.
+.OUTPUTS
+    A boolean indicating whether the environment variables can be expected to propagate to the caller's environment.
+#>
+[CmdletBinding(SupportsShouldProcess=$true)]
+Param(
+    [Parameter(Mandatory=$true, Position=1)]
+    $Variables,
+    [string[]]$PrependPath
+)
+
+if ($Variables.Count -eq 0) {
+    return $true
+}
+
+$cmdInstructions = !$env:TF_BUILD -and !$env:GITHUB_ACTIONS -and $env:PS1UnderCmd -eq '1'
+if ($cmdInstructions) {
+    Write-Warning "Environment variables have been set that will be lost because you're running under cmd.exe"
+    Write-Host "Environment variables that must be set manually:" -ForegroundColor Blue
+} else {
+    Write-Host "Environment variables set:" -ForegroundColor Blue
+    $envVars
+    if ($PrependPath) {
+        Write-Host "Paths prepended to PATH: $PrependPath"
+    }
+}
+
+if ($env:TF_BUILD) {
+    Write-Host "Azure Pipelines detected. Logging commands will be used to propagate environment variables and prepend path."
+}
+
+if ($env:GITHUB_ACTIONS) {
+    Write-Host "GitHub Actions detected. Logging commands will be used to propagate environment variables and prepend path."
+}
+
+$Variables.GetEnumerator() |% {
+    Set-Item -Path env:$($_.Key) -Value $_.Value
+
+    # If we're running in a cloud CI, set these environment variables so they propagate.
+    if ($env:TF_BUILD) {
+        Write-Host "##vso[task.setvariable variable=$($_.Key);]$($_.Value)"
+    }
+    if ($env:GITHUB_ACTIONS) {
+        Write-Host "::set-env name=$($_.Key)::$($_.Value)"
+    }
+
+    if ($cmdInstructions) {
+        Write-Host "SET $($_.Key)=$($_.Value)"
+    }
+}
+
+$pathDelimiter = ';'
+if ($IsMacOS -or $IsLinux) {
+    $pathDelimiter = ':'
+}
+
+if ($PrependPath) {
+    $PrependPath |% {
+        $newPathValue = "$_$pathDelimiter$env:PATH"
+        Set-Item -Path env:PATH -Value $newPathValue
+        if ($cmdInstructions) {
+            Write-Host "SET PATH=$newPathValue"
+        }
+
+        if ($env:TF_BUILD) {
+            Write-Host "##vso[task.prependpath]$_"
+        }
+        if ($env:GITHUB_ACTIONS) {
+            Write-Host "::add-path::$_"
+        }
+    }
+}
+
+return !$cmdInstructions

--- a/init.ps1
+++ b/init.ps1
@@ -1,0 +1,57 @@
+<#
+.SYNOPSIS
+Installs dependencies required to build and test the projects in this repository.
+.DESCRIPTION
+This MAY not require elevation, as the SDK and runtimes are installed to a per-user location,
+unless the `-InstallLocality` switch is specified directing to a per-repo or per-machine location.
+See detailed help on that switch for more information.
+.PARAMETER InstallLocality
+A value indicating whether dependencies should be installed locally to the repo or at a per-user location.
+Per-user allows sharing the installed dependencies across repositories and allows use of a shared expanded package cache.
+Visual Studio will only notice and use these SDKs/runtimes if VS is launched from the environment that runs this script.
+Per-repo allows for high isolation, allowing for a more precise recreation of the environment within an Azure Pipelines build.
+When using 'repo', environment variables are set to cause the locally installed dotnet SDK to be used.
+Per-repo can lead to file locking issues when dotnet.exe is left running as a build server and can be mitigated by running `dotnet build-server shutdown`.
+Per-machine requires elevation and will download and install all SDKs and runtimes to machine-wide locations so all applications can find it.
+.PARAMETER NoPrerequisites
+Skips the installation of prerequisite software (e.g. SDKs, tools).
+.PARAMETER NoRestore
+Skips the package restore step.
+#>
+[CmdletBinding(SupportsShouldProcess=$true)]
+Param (
+    [ValidateSet('repo','user','machine')]
+    [string]$InstallLocality='user',
+    [Parameter()]
+    [switch]$NoPrerequisites,
+    [Parameter()]
+    [switch]$NoRestore
+)
+
+if (!$NoPrerequisites) {
+    & "$PSScriptRoot\build\Install-DotNetSdk.ps1" -InstallLocality $InstallLocality
+}
+
+# Workaround nuget credential provider bug that causes very unreliable package restores on Azure Pipelines
+$env:NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS=20
+$env:NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS=20
+
+Push-Location $PSScriptRoot
+try {
+    $HeaderColor = 'Green'
+
+    if (!$NoRestore -and $PSCmdlet.ShouldProcess("NuGet packages", "Restore")) {
+        Write-Host "Restoring NuGet packages" -ForegroundColor $HeaderColor
+        dotnet restore
+        if ($lastexitcode -ne 0) {
+            throw "Failure while restoring packages."
+        }
+    }
+}
+catch {
+    Write-Error $error[0]
+    exit $lastexitcode
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
This simply makes it easier to get started on the repo.

The init script by default does _not_ require elevation, but for better VS interop the `-InstallLocality machine` switch can be added to require elevation and install the .NET Core SDK at a machine-wide location where VS will discover it.
Without elevation, command line build will work after running init and VS will work if launched from that same command line.