### PR TITLE
Issue 3100 - Changed SA1600 and tests to meet new documentInterfaces values

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1601UnitTests.cs
@@ -66,7 +66,7 @@ TypeName
   ""settings"": {{
     ""documentationRules"": {{
       ""documentExposedElements"": false,
-      ""{interfaceSettingName}"": false
+      ""{interfaceSettingName}"": ""false""
     }}
   }}
 }}
@@ -100,7 +100,7 @@ TypeName
   ""settings"": {{
     ""documentationRules"": {{
       ""documentExposedElements"": false,
-      ""{interfaceSettingName}"": false
+      ""{interfaceSettingName}"": ""false""
     }}
   }}
 }}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1619UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1619UnitTests.cs
@@ -140,7 +140,7 @@ public partial ##";
   ""settings"": {{
     ""documentationRules"": {{
       ""documentExposedElements"": false,
-      ""{interfaceSettingName}"": false
+      ""{interfaceSettingName}"": ""false""
     }}
   }}
 }}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Settings/SettingsUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Settings/SettingsUnitTests.cs
@@ -123,7 +123,6 @@ namespace StyleCop.Analyzers.Test.Settings
       ""documentExposedElements"": {valueText},
       ""documentInternalElements"": {valueText},
       ""documentPrivateElements"": {valueText},
-      ""documentInterfaces"": {valueText},
       ""documentPrivateFields"": {valueText}
     }}
   }}
@@ -136,8 +135,36 @@ namespace StyleCop.Analyzers.Test.Settings
             Assert.Equal(value, styleCopSettings.DocumentationRules.DocumentExposedElements);
             Assert.Equal(value, styleCopSettings.DocumentationRules.DocumentInternalElements);
             Assert.Equal(value, styleCopSettings.DocumentationRules.DocumentPrivateElements);
-            Assert.Equal(value, styleCopSettings.DocumentationRules.DocumentInterfaces);
             Assert.Equal(value, styleCopSettings.DocumentationRules.DocumentPrivateFields);
+        }
+
+        /// <summary>
+        /// Verifies that the settings are properly read.
+        /// </summary>
+        /// <param name="value">The value for testing the settings.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [InlineData("true")]
+        [InlineData("false")]
+        [InlineData("all")]
+        [InlineData("none")]
+        [InlineData("exposed")]
+        public async Task VerifyInheritanceDocumentationSettingsAsync(string value)
+        {
+            var settings = $@"
+{{
+  ""settings"": {{
+    ""documentationRules"": {{
+      ""documentInterfaces"": ""{value}""
+    }}
+  }}
+}}
+";
+            var context = await CreateAnalysisContextAsync(settings).ConfigureAwait(false);
+
+            var styleCopSettings = context.GetStyleCopSettings(CancellationToken.None);
+
+            Assert.Equal(value, styleCopSettings.DocumentationRules.DocumentInterfaces);
         }
 
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
@@ -59,11 +59,22 @@ namespace StyleCop.Analyzers.DocumentationRules
 
         public static bool NeedsComment(DocumentationSettings documentationSettings, SyntaxKind syntaxKind, SyntaxKind parentSyntaxKind, Accessibility declaredAccessibility, Accessibility effectiveAccessibility)
         {
-            if (documentationSettings.DocumentInterfaces
-                && (syntaxKind == SyntaxKind.InterfaceDeclaration || parentSyntaxKind == SyntaxKind.InterfaceDeclaration))
+            if (syntaxKind == SyntaxKind.InterfaceDeclaration || parentSyntaxKind == SyntaxKind.InterfaceDeclaration)
             {
-                // DocumentInterfaces => all interfaces should be documented
-                return true;
+                if (documentationSettings.DocumentInterfaces == "all" || documentationSettings.DocumentInterfaces == "true")
+                {
+                    // DocumentInterfaces => all interfaces should be documented
+                    return true;
+                }
+
+                if (documentationSettings.DocumentInterfaces == "exposed" && declaredAccessibility != Accessibility.Internal)
+                {
+                    // DocumentInterfaces => only externally visible (exposed) interfaces should be documented
+                    return true;
+                }
+
+                // DocumentInterfaces => no interfaces should be exposed
+                return false;
             }
 
             if (syntaxKind == SyntaxKind.FieldDeclaration && documentationSettings.DocumentPrivateFields)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/DocumentationSettings.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/DocumentationSettings.cs
@@ -75,7 +75,7 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
         /// <summary>
         /// This is the backing field for the <see cref="DocumentInterfaces"/> property.
         /// </summary>
-        private readonly bool documentInterfaces;
+        private readonly string documentInterfaces;
 
         /// <summary>
         /// This is the backing field for the <see cref="DocumentPrivateFields"/> property.
@@ -116,7 +116,7 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
             this.documentExposedElements = true;
             this.documentInternalElements = true;
             this.documentPrivateElements = false;
-            this.documentInterfaces = true;
+            this.documentInterfaces = "all";
             this.documentPrivateFields = false;
 
             this.fileNamingConvention = FileNamingConvention.StyleCop;
@@ -150,7 +150,7 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
                     break;
 
                 case "documentInterfaces":
-                    this.documentInterfaces = kvp.ToBooleanValue();
+                    this.documentInterfaces = kvp.ToStringValue();
                     break;
 
                 case "documentPrivateFields":
@@ -256,7 +256,7 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
         public bool DocumentPrivateElements =>
             this.documentPrivateElements;
 
-        public bool DocumentInterfaces =>
+        public string DocumentInterfaces =>
             this.documentInterfaces;
 
         public bool DocumentPrivateFields =>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json
@@ -221,9 +221,9 @@
               "default": false
             },
             "documentInterfaces": {
-              "type": "boolean",
+              "type": "string",
               "description": "Specifies whether interface members need to be documented. When true, all interface members require documentation, regardless of accessibility.",
-              "default": true
+              "default": "all"
             },
             "documentPrivateFields": {
               "type": "boolean",


### PR DESCRIPTION
As specified in issue #3100, the documentInterfaces setting has been modified to allow the support the new range of acceptable values - "all"/"true", "exposed", and "none"/"false". Test cases and checks have also been modified to take into account the setting now being a string instead of a bool.