### PR TITLE
Fix incorrect handling of types in SA1135

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/HelperTests/SymbolNameHelpersCSharp7Tests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/HelperTests/SymbolNameHelpersCSharp7Tests.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.HelperTests
+{
+    using System.Threading.Tasks;
+    using StyleCop.Analyzers.Test.HelperTests;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for the <see cref="StyleCop.Analyzers.Helpers.SymbolNameHelpers"/> class in the context of C# 7.x.
+    /// </summary>
+    public class SymbolNameHelpersCSharp7Tests : SymbolNameHelpersTests
+    {
+        /// <summary>
+        /// Verify the workings of <see cref="StyleCop.Analyzers.Helpers.SymbolNameHelpers.ToQualifiedString(Microsoft.CodeAnalysis.ISymbol, Microsoft.CodeAnalysis.CSharp.Syntax.NameSyntax)"/>
+        /// for standard use cases.
+        /// </summary>
+        /// <param name="inputString">A string representation of a type or namespace to process.</param>
+        /// <param name="isNamespace"><see langword="true"/> if <paramref name="inputString"/> is a namespace;
+        /// <see langword="false"/> if <paramref name="inputString"/> is a type to be used as an alias target.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [InlineData("System.ValueTuple<int, object[]>")]
+        [InlineData("System.ValueTuple<int, (int, object)>")]
+        [InlineData("System.ValueTuple<int, (int, object)?>")]
+        [InlineData("System.ValueTuple<int, (int, object[])>")]
+        [InlineData("System.Collections.Generic.KeyValuePair<int, (int, object)>")]
+        [InlineData("System.Collections.Generic.KeyValuePair<int, (int, object[])>")]
+        [InlineData("System.Nullable<(int, object)>")]
+        [WorkItem(3149, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3149")]
+        public Task VerifyToQualifiedStringTuplesAsync(string inputString, bool isNamespace = false)
+        {
+            return this.PerformTestAsync(inputString, isNamespace);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/HelperTests/SymbolNameHelpersCSharp8Tests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/HelperTests/SymbolNameHelpersCSharp8Tests.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp8.HelperTests
+{
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using StyleCop.Analyzers.Test.CSharp7.HelperTests;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for the <see cref="StyleCop.Analyzers.Helpers.SymbolNameHelpers"/> class in the context of C# 8.0.
+    /// </summary>
+    public class SymbolNameHelpersCSharp8Tests : SymbolNameHelpersCSharp7Tests
+    {
+        /// <summary>
+        /// Verify the workings of <see cref="StyleCop.Analyzers.Helpers.SymbolNameHelpers.ToQualifiedString(ISymbol, NameSyntax)"/>
+        /// for nullable reference types.
+        /// </summary>
+        /// <param name="inputString">A string representation of a type or namespace to process.</param>
+        /// <param name="isNamespace"><see langword="true"/> if <paramref name="inputString"/> is a namespace;
+        /// <see langword="false"/> if <paramref name="inputString"/> is a type to be used as an alias target.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [InlineData("System.ValueTuple<System.Int32, System.Object?>")]
+        [InlineData("System.ValueTuple<int, object?>")]
+        [InlineData("System.ValueTuple<int, object?[]>")]
+        [InlineData("System.ValueTuple<int, object[]?>")]
+        [InlineData("System.ValueTuple<int, object?[]?>")]
+        [InlineData("System.ValueTuple<int?[]?, object>")]
+        [InlineData("System.ValueTuple<int, (int, object?)>")]
+        [InlineData("System.ValueTuple<int, (int, object?)?>")]
+        [InlineData("System.ValueTuple<int, (int, object?[])>")]
+        [InlineData("System.ValueTuple<int, (int, object[]?)>")]
+        [InlineData("System.ValueTuple<int, (int, object?[]?)>")]
+        [InlineData("System.Collections.Generic.KeyValuePair<int, object?>")]
+        [InlineData("System.Collections.Generic.KeyValuePair<int, object?[]>")]
+        [InlineData("System.Collections.Generic.KeyValuePair<int, object[]?>")]
+        [InlineData("System.Collections.Generic.KeyValuePair<int, object?[]?>")]
+        [InlineData("System.Collections.Generic.KeyValuePair<int, (int, object?)>")]
+        [InlineData("System.Collections.Generic.KeyValuePair<int, (int, object?[])>")]
+        [InlineData("System.Collections.Generic.KeyValuePair<int, (int, object[]?)>")]
+        [InlineData("System.Collections.Generic.KeyValuePair<int, (int, object?[]?)>")]
+        [InlineData("System.Nullable<(int, object?)>")]
+        [WorkItem(3149, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3149")]
+        public Task VerifyToQualifiedStringNullableReferenceTypesAsync(string inputString, bool isNamespace = false)
+        {
+            return this.PerformTestAsync(inputString, isNamespace);
+        }
+
+        /// <summary>
+        /// Provides a <see cref="CSharpCompilationOptions"/> instance with enabled nullable reference types
+        /// to be used for the test project in the workspace.
+        /// </summary>
+        /// <returns>An instance of <see cref="CSharpCompilationOptions"/> describing the project compilation options.</returns>
+        protected override CSharpCompilationOptions GetCompilationOptions()
+        {
+            return new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/ReadabilityRules/SA1135CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/ReadabilityRules/SA1135CSharp8UnitTests.cs
@@ -3,9 +3,28 @@
 
 namespace StyleCop.Analyzers.Test.CSharp8.ReadabilityRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp7.ReadabilityRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.ReadabilityRules.SA1135UsingDirectivesMustBeQualified,
+        StyleCop.Analyzers.ReadabilityRules.SA1135CodeFixProvider>;
 
     public class SA1135CSharp8UnitTests : SA1135CSharp7UnitTests
     {
+        [Fact]
+        [WorkItem(3149, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3149")]
+        public async Task TestAliasTypeGenericNullableReferenceTypeAsync()
+        {
+            var testCode = @"
+namespace TestNamespace
+{
+    using KeyValue = System.Collections.Generic.KeyValuePair<string, object?>;
+}
+";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/HelperTests/SymbolNameHelpersTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/HelperTests/SymbolNameHelpersTests.cs
@@ -1,0 +1,123 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.HelperTests
+{
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Text;
+    using StyleCop.Analyzers.Helpers;
+    using StyleCop.Analyzers.Test.Verifiers;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for the <see cref="SymbolNameHelpers"/> class.
+    /// </summary>
+    public class SymbolNameHelpersTests : IAsyncLifetime
+    {
+        private const string TestProjectName = "TestProject";
+        private const string TestFilename = "Test.cs";
+
+        private Solution testSolution;
+
+        public async Task InitializeAsync()
+        {
+            var compilationOptions = this.GetCompilationOptions();
+            this.testSolution = await CreateTestSolutionAsync(compilationOptions).ConfigureAwait(false);
+        }
+
+        public Task DisposeAsync()
+        {
+            return Task.FromResult(true);
+        }
+
+        /// <summary>
+        /// Verify the workings of <see cref="SymbolNameHelpers.ToQualifiedString(ISymbol, NameSyntax)"/>
+        /// for standard use cases.
+        /// </summary>
+        /// <param name="inputString">A string representation of a type or namespace to process.</param>
+        /// <param name="isNamespace"><see langword="true"/> if <paramref name="inputString"/> is a namespace;
+        /// <see langword="false"/> if <paramref name="inputString"/> is a type to be used as an alias target.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [InlineData("System.ValueTuple<int, object>")]
+        [InlineData("System.ValueTuple<System.Int32, System.Object>")]
+        [InlineData("System.ValueTuple<System.Int32?, System.Object>")]
+        [InlineData("System.ValueTuple<int, object[]>")]
+        [InlineData("System.ValueTuple<int?, object>")]
+        [InlineData("System.ValueTuple<int[], object>")]
+        [InlineData("System.ValueTuple<int?[], object>")]
+        [InlineData("System.Collections.Generic.KeyValuePair<int, object>")]
+        [InlineData("System.Collections.Generic.KeyValuePair<int?, object>")]
+        [InlineData("System.Collections.Generic.KeyValuePair<int, object[]>")]
+        [InlineData("System.Nullable<int>")]
+        [InlineData("System", true)]
+        [InlineData("System.Collections.Generic", true)]
+        [WorkItem(3149, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3149")]
+        public Task VerifyToQualifiedStringAsync(string inputString, bool isNamespace = false)
+        {
+            return this.PerformTestAsync(inputString, isNamespace);
+        }
+
+        /// <summary>
+        /// Performs the actual testing work.
+        /// </summary>
+        /// <param name="inputString">A string representation of a type or namespace to process.</param>
+        /// <param name="isNamespace"><see langword="true"/> if <paramref name="inputString"/> is a namespace;
+        /// <see langword="false"/> if <paramref name="inputString"/> is a type to be used as an alias target.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        protected async Task PerformTestAsync(string inputString, bool isNamespace)
+        {
+            var fileContent = isNamespace ? "using " + inputString : "using AliasType = " + inputString;
+            fileContent += ";";
+
+            var document = GetDocument(this.testSolution, fileContent);
+            var syntaxRoot = await document.GetSyntaxRootAsync().ConfigureAwait(false);
+            var semanticModel = await document.GetSemanticModelAsync().ConfigureAwait(false);
+
+            var usingDirectiveSyntax = syntaxRoot.DescendantNodes().OfType<UsingDirectiveSyntax>().First();
+            var typeSymbol = semanticModel.GetSymbolInfo(usingDirectiveSyntax.Name).Symbol;
+
+            var resultString = typeSymbol.ToQualifiedString(usingDirectiveSyntax.Name);
+            Assert.Equal(inputString, resultString);
+        }
+
+        /// <summary>
+        /// When overridden in derived classes, provides a <see cref="CSharpCompilationOptions"/> instance
+        /// to be used for the test project in the workspace.
+        /// </summary>
+        /// <returns>An instance of <see cref="CSharpCompilationOptions"/> describing the project compilation options.</returns>
+        protected virtual CSharpCompilationOptions GetCompilationOptions()
+        {
+            return new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+        }
+
+        private static Document GetDocument(Solution solution, string sourceCode)
+        {
+            var projectId = solution.ProjectIds[0];
+            var documentId = DocumentId.CreateNewId(projectId);
+            solution = solution.AddDocument(documentId, TestFilename, SourceText.From(sourceCode));
+            return solution.GetDocument(documentId);
+        }
+
+        private static async Task<Solution> CreateTestSolutionAsync(CSharpCompilationOptions compilationOptions)
+        {
+            var workspace = GenericAnalyzerTest.CreateWorkspace();
+            var projectId = ProjectId.CreateNewId();
+
+            var references = await GenericAnalyzerTest.ReferenceAssemblies
+                .ResolveAsync(LanguageNames.CSharp, CancellationToken.None).ConfigureAwait(false);
+
+            var solution = workspace.CurrentSolution
+                .AddProject(projectId, TestProjectName, TestProjectName, LanguageNames.CSharp)
+                .WithProjectCompilationOptions(projectId, compilationOptions)
+                .AddMetadataReferences(projectId, references);
+
+            return solution;
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1135UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1135UnitTests.cs
@@ -415,5 +415,31 @@ namespace System
             var expected = Diagnostic(SA1135UsingDirectivesMustBeQualified.DescriptorType).WithLocation(4, 5).WithArguments("System.Collections.Generic.List<System.ValueTuple<int, int>>");
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
+
+        [Fact]
+        [WorkItem(3149, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3149")]
+        public async Task TestAliasTypeClrTypeAsync()
+        {
+            var testCode = @"
+namespace TestNamespace
+{
+    using Example = System.Collections.Generic.List<System.Object>;
+}
+";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3149, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3149")]
+        public async Task TestAliasTypeGenericNullableAsync()
+        {
+            var testCode = @"
+namespace TestNamespace
+{
+    using Example = System.Nullable<int>;
+}
+";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }


### PR DESCRIPTION
Fixes #3149

Nullable reference types (`object?`), CLR types (`System.Object`), and the generic form of nullable (`System.Nullable<int>`) leaded to false positives of the diagnostic SA1135 for type alias syntax involving those types.

The cause of the issue was the `SymbolNameHelpers.ToQualifiedString` method which produced a qualified string that didn't correspond to the actual syntax.

Additionally, implemented a couple of unit tests for various use cases of the `SymbolNameHelpers.ToQualifiedString` method.