### PR TITLE
Fix SA1008 for attributed tuple parameters

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
@@ -997,11 +997,11 @@ namespace TestNamespace
 
         void TestMethod3([NotNull][Custom] (string, string) tuple) { }
 
-        void TestMethod4([NotNull](string, string) tuple) { }
+        void TestMethod4([NotNull]{|#0:(|}string, string) tuple) { }
 
-        void TestMethod5([NotNull, Custom](string, string) tuple) { }
+        void TestMethod5([NotNull, Custom]{|#1:(|}string, string) tuple) { }
 
-        void TestMethod6([NotNull][Custom](string, string) tuple) { }
+        void TestMethod6([NotNull][Custom]{|#2:(|}string, string) tuple) { }
     }
 }
 ";
@@ -1031,9 +1031,9 @@ namespace TestNamespace
 
             DiagnosticResult[] expectedDiagnostics =
             {
-                Diagnostic(DescriptorPreceded).WithLocation(15, 35),
-                Diagnostic(DescriptorPreceded).WithLocation(17, 43),
-                Diagnostic(DescriptorPreceded).WithLocation(19, 43),
+                Diagnostic(DescriptorPreceded).WithLocation(0),
+                Diagnostic(DescriptorPreceded).WithLocation(1),
+                Diagnostic(DescriptorPreceded).WithLocation(2),
             };
 
             await VerifyCSharpFixAsync(testCode, expectedDiagnostics, fixedCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1008CSharp7UnitTests.cs
@@ -978,5 +978,65 @@ namespace TestNamespace
 
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
+
+        [Fact]
+        [WorkItem(3117, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3117")]
+        public async Task TestTupleParameterAttributesAsync()
+        {
+            var testCode = @"
+namespace TestNamespace
+{
+    class NotNullAttribute : System.Attribute { }
+    class CustomAttribute : System.Attribute { }
+
+    class TestClass
+    {
+        void TestMethod1([NotNull] (string, string) tuple) { }
+
+        void TestMethod2([NotNull, Custom] (string, string) tuple) { }
+
+        void TestMethod3([NotNull][Custom] (string, string) tuple) { }
+
+        void TestMethod4([NotNull](string, string) tuple) { }
+
+        void TestMethod5([NotNull, Custom](string, string) tuple) { }
+
+        void TestMethod6([NotNull][Custom](string, string) tuple) { }
+    }
+}
+";
+
+            var fixedCode = @"
+namespace TestNamespace
+{
+    class NotNullAttribute : System.Attribute { }
+    class CustomAttribute : System.Attribute { }
+
+    class TestClass
+    {
+        void TestMethod1([NotNull] (string, string) tuple) { }
+
+        void TestMethod2([NotNull, Custom] (string, string) tuple) { }
+
+        void TestMethod3([NotNull][Custom] (string, string) tuple) { }
+
+        void TestMethod4([NotNull] (string, string) tuple) { }
+
+        void TestMethod5([NotNull, Custom] (string, string) tuple) { }
+
+        void TestMethod6([NotNull][Custom] (string, string) tuple) { }
+    }
+}
+";
+
+            DiagnosticResult[] expectedDiagnostics =
+            {
+                Diagnostic(DescriptorPreceded).WithLocation(15, 35),
+                Diagnostic(DescriptorPreceded).WithLocation(17, 43),
+                Diagnostic(DescriptorPreceded).WithLocation(19, 43),
+            };
+
+            await VerifyCSharpFixAsync(testCode, expectedDiagnostics, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
@@ -233,9 +233,11 @@ namespace StyleCop.Analyzers.SpacingRules
             case SyntaxKindEx.TupleType:
                 // Comma covers tuple types in parameters and nested within other tuple types.
                 // 'out', 'ref', 'in', 'params' parameters are covered by IsKeywordKind.
+                // Attributes of parameters are covered by checking the previous token's parent.
                 // Return types are handled by a helper.
                 haveLeadingSpace = prevToken.IsKind(SyntaxKind.CommaToken)
                     || SyntaxFacts.IsKeywordKind(prevToken.Kind())
+                    || prevToken.Parent.IsKind(SyntaxKind.AttributeList)
                     || ((TypeSyntax)token.Parent).GetContainingNotEnclosingType().IsReturnType();
                 break;
             }


### PR DESCRIPTION
Fixes #3117 

Parameter attributes should be followed by a space. SA1008 reported this space for tuples because of missing handling of the attribute special case.