### PR TITLE
Update "LICENSE" so that it's recognized as MIT

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,8 +1,6 @@
-﻿The MIT License (MIT)
+MIT License
 
 Copyright (c) Tunnel Vision Laboratories, LLC
-
-All rights reserved.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR replicates dotnet/runtime#36744 (it also removes the All Rights Reserved).

License text is from: https://choosealicense.com/licenses/mit/