### PR TITLE
Update testing library to 1.0.1-beta1.20478.1

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" Version="1.3.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.0.1-beta1.20453.7" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.0.1-beta1.20478.1" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.1.8" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/GenericAnalyzerTest.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/GenericAnalyzerTest.cs
@@ -5,7 +5,6 @@ namespace StyleCop.Analyzers.Test.Verifiers
 {
     using System;
     using System.Collections.Immutable;
-    using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
@@ -36,9 +35,8 @@ namespace StyleCop.Analyzers.Test.Verifiers
                 new PackageIdentity("Microsoft.CodeAnalysis.CSharp", codeAnalysisTestVersion),
                 new PackageIdentity("System.ValueTuple", "4.5.0")));
 
-            ReferenceAssembliesNet50 =
-                new ReferenceAssemblies("net5.0", new PackageIdentity("Microsoft.NETCore.App.Ref", "5.0.0-rc.1.20451.14"), Path.Combine("ref", "net5.0"))
-                    .AddPackages(ImmutableArray.Create(new PackageIdentity("Microsoft.CodeAnalysis.CSharp", codeAnalysisTestVersion)));
+            ReferenceAssembliesNet50 = ReferenceAssemblies.Net.Net50.AddPackages(ImmutableArray.Create(
+                new PackageIdentity("Microsoft.CodeAnalysis.CSharp", codeAnalysisTestVersion)));
 
             ExportProviderFactory = new Lazy<IExportProviderFactory>(
                 () =>


### PR DESCRIPTION
Removes the workarounds added by #3204.