### PR TITLE
Configuration.md: Add link to rule set example file

### DIFF
--- a/documentation/Configuration.md
+++ b/documentation/Configuration.md
@@ -14,7 +14,7 @@ StyleCop Analyzers is configured using two separate mechanisms: code analysis ru
 
 Code analysis rule sets are the standard way to configure most diagnostic analyzers within Visual Studio. Information about creating and customizing these files can be found in the [Using Rule Sets to Group Code Analysis Rules](https://docs.microsoft.com/visualstudio/code-quality/using-rule-sets-to-group-code-analysis-rules) documentation on docs.microsoft.com.
 
-Here is an example `.ruleset` file from the Roslyn SDK: https://github.com/dotnet/roslyn-sdk/blob/3e94c5fe1ee981a885c34e2e39383bc4420f2557/RoslynSDK.ruleset. This file illustrates how the severities for individual rules can easily be configured as needed.
+An example rule set file containing the default StyleCop Analyzers configuration is available at <https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/rulesets/StyleCopAnalyzersDefault.ruleset>.
 
 ## Getting Started with **stylecop.json**
 

--- a/documentation/Configuration.md
+++ b/documentation/Configuration.md
@@ -14,6 +14,8 @@ StyleCop Analyzers is configured using two separate mechanisms: code analysis ru
 
 Code analysis rule sets are the standard way to configure most diagnostic analyzers within Visual Studio. Information about creating and customizing these files can be found in the [Using Rule Sets to Group Code Analysis Rules](https://docs.microsoft.com/visualstudio/code-quality/using-rule-sets-to-group-code-analysis-rules) documentation on docs.microsoft.com.
 
+Here is an example `.ruleset` file from the Roslyn SDK: https://github.com/dotnet/roslyn-sdk/blob/3e94c5fe1ee981a885c34e2e39383bc4420f2557/RoslynSDK.ruleset. This file illustrates how the severities for individual rules can easily be configured as needed.
+
 ## Getting Started with **stylecop.json**
 
 The easiest way to add a **stylecop.json** configuration file to a new project is using a code fix provided by the project. To invoke the code fix, open any file where SA1633 is reported¹ and press Ctrl+. to bring up the Quick Fix menu. From the menu, select **Add StyleCop settings file to the project**.


### PR DESCRIPTION
It might be easy to create this file from Visual Studio (?), but not all of us are using Visual Studio (using Rider myself on Linux). And in general, it doesn't hurt to provide an example that users can benefit from reading.