### PR TITLE
Use IOperation APIs for SA1129 when supported

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1129UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1129UnitTests.cs
@@ -91,9 +91,9 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 {
     public void TestMethod()
     {
-        var v1 = new TestStruct();
+        var v1 = {|#0:new TestStruct()|};
 
-        System.Console.WriteLine(new TestStruct());
+        System.Console.WriteLine({|#1:new TestStruct()|});
     }
 
     private struct TestStruct
@@ -121,8 +121,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(5, 18),
-                Diagnostic().WithLocation(7, 34),
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
@@ -139,11 +139,11 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 {
     public void TestMethod()
     {
-        var v1 = /* c1 */ new TestStruct(); // c2
+        var v1 = /* c1 */ {|#0:new TestStruct()|}; // c2
 
         var v2 =
 #if true
-            new TestStruct();
+            {|#1:new TestStruct()|};
 #else
             new TestStruct() { TestProperty = 3 };
 #endif
@@ -179,8 +179,8 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(5, 27),
-                Diagnostic().WithLocation(9, 13),
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
@@ -198,7 +198,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     public T TestMethod1<T>()
         where T : struct
     {
-        return new T();
+        return {|#0:new T()|};
     }
 
     public T TestMethod2<T>()
@@ -227,7 +227,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(6, 16),
+                Diagnostic().WithLocation(0),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
@@ -451,7 +451,7 @@ public class TestClass
 {{
     public void TestMethod()
     {{
-        var v1 = new MyEnum();
+        var v1 = {{|#0:new MyEnum()|}};
     }}
 
     private enum MyEnum {{ {declarationBody} }}
@@ -469,7 +469,7 @@ public class TestClass
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(5, 18),
+                Diagnostic().WithLocation(0),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
@@ -492,7 +492,7 @@ public class TestClass
 {{
     public void TestMethod()
     {{
-        var v1 = new MyEnum();
+        var v1 = {{|#0:new MyEnum()|}};
     }}
 
     private enum MyEnum {{ {declarationBody} }}
@@ -510,7 +510,7 @@ public class TestClass
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(5, 18),
+                Diagnostic().WithLocation(0),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/IArgumentOperationWrapper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/IArgumentOperationWrapper.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Lightup
+{
+    using System;
+    using Microsoft.CodeAnalysis;
+
+    internal readonly struct IArgumentOperationWrapper : IOperationWrapper
+    {
+        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.Operations.IArgumentOperation";
+        private static readonly Type WrappedType;
+
+        private readonly IOperation operation;
+
+        static IArgumentOperationWrapper()
+        {
+            WrappedType = WrapperHelper.GetWrappedType(typeof(IObjectCreationOperationWrapper));
+        }
+
+        private IArgumentOperationWrapper(IOperation operation)
+        {
+            this.operation = operation;
+        }
+
+        public IOperation WrappedOperation => this.operation;
+
+        public ITypeSymbol Type => this.WrappedOperation.Type;
+
+        public static IArgumentOperationWrapper FromOperation(IOperation operation)
+        {
+            if (operation == null)
+            {
+                return default;
+            }
+
+            if (!IsInstance(operation))
+            {
+                throw new InvalidCastException($"Cannot cast '{operation.GetType().FullName}' to '{WrappedTypeName}'");
+            }
+
+            return new IArgumentOperationWrapper(operation);
+        }
+
+        public static bool IsInstance(IOperation operation)
+        {
+            return operation != null && LightupHelpers.CanWrapOperation(operation, WrappedType);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/IObjectCreationOperationWrapper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/IObjectCreationOperationWrapper.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Lightup
+{
+    using System;
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+
+    internal readonly struct IObjectCreationOperationWrapper : IOperationWrapper
+    {
+        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.Operations.IObjectCreationOperation";
+        private static readonly Type WrappedType;
+
+        private static readonly Func<IOperation, IMethodSymbol> ConstructorAccessor;
+        private static readonly Func<IOperation, IOperation> InitializerAccessor;
+        private static readonly Func<IOperation, ImmutableArray<IOperation>> ArgumentsAccessor;
+
+        private readonly IOperation operation;
+
+        static IObjectCreationOperationWrapper()
+        {
+            WrappedType = WrapperHelper.GetWrappedType(typeof(IObjectCreationOperationWrapper));
+            ConstructorAccessor = LightupHelpers.CreateOperationPropertyAccessor<IOperation, IMethodSymbol>(WrappedType, nameof(Constructor));
+            InitializerAccessor = LightupHelpers.CreateOperationPropertyAccessor<IOperation, IOperation>(WrappedType, nameof(Initializer));
+            ArgumentsAccessor = LightupHelpers.CreateOperationListPropertyAccessor<IOperation>(WrappedType, nameof(Arguments));
+        }
+
+        private IObjectCreationOperationWrapper(IOperation operation)
+        {
+            this.operation = operation;
+        }
+
+        public IOperation WrappedOperation => this.operation;
+
+        public ITypeSymbol Type => this.WrappedOperation.Type;
+
+        public IMethodSymbol Constructor
+        {
+            get
+            {
+                return ConstructorAccessor(this.WrappedOperation);
+            }
+        }
+
+        public IObjectOrCollectionInitializerOperationWrapper Initializer
+        {
+            get
+            {
+                return IObjectOrCollectionInitializerOperationWrapper.FromOperation(InitializerAccessor(this.WrappedOperation));
+            }
+        }
+
+        public ImmutableArray<IOperation> Arguments
+        {
+            get
+            {
+                return ArgumentsAccessor(this.WrappedOperation);
+            }
+        }
+
+        public static IObjectCreationOperationWrapper FromOperation(IOperation operation)
+        {
+            if (operation == null)
+            {
+                return default;
+            }
+
+            if (!IsInstance(operation))
+            {
+                throw new InvalidCastException($"Cannot cast '{operation.GetType().FullName}' to '{WrappedTypeName}'");
+            }
+
+            return new IObjectCreationOperationWrapper(operation);
+        }
+
+        public static bool IsInstance(IOperation operation)
+        {
+            return operation != null && LightupHelpers.CanWrapOperation(operation, WrappedType);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/IObjectOrCollectionInitializerOperationWrapper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/IObjectOrCollectionInitializerOperationWrapper.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Lightup
+{
+    using System;
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+
+    internal readonly struct IObjectOrCollectionInitializerOperationWrapper : IOperationWrapper
+    {
+        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.Operations.IObjectOrCollectionInitializerOperation";
+        private static readonly Type WrappedType;
+
+        private static readonly Func<IOperation, ImmutableArray<IOperation>> InitializersAccessor;
+
+        private readonly IOperation operation;
+
+        static IObjectOrCollectionInitializerOperationWrapper()
+        {
+            WrappedType = WrapperHelper.GetWrappedType(typeof(IObjectOrCollectionInitializerOperationWrapper));
+            InitializersAccessor = LightupHelpers.CreateOperationPropertyAccessor<IOperation, ImmutableArray<IOperation>>(WrappedType, nameof(Initializers));
+        }
+
+        private IObjectOrCollectionInitializerOperationWrapper(IOperation operation)
+        {
+            this.operation = operation;
+        }
+
+        public IOperation WrappedOperation => this.operation;
+
+        public ITypeSymbol Type => this.WrappedOperation.Type;
+
+        public ImmutableArray<IOperation> Initializers
+        {
+            get
+            {
+                return InitializersAccessor(this.WrappedOperation);
+            }
+        }
+
+        public static IObjectOrCollectionInitializerOperationWrapper FromOperation(IOperation operation)
+        {
+            if (operation == null)
+            {
+                return default;
+            }
+
+            if (!IsInstance(operation))
+            {
+                throw new InvalidCastException($"Cannot cast '{operation.GetType().FullName}' to '{WrappedTypeName}'");
+            }
+
+            return new IObjectOrCollectionInitializerOperationWrapper(operation);
+        }
+
+        public static bool IsInstance(IOperation operation)
+        {
+            return operation != null && LightupHelpers.CanWrapOperation(operation, WrappedType);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/IOperationWrapper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/IOperationWrapper.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#nullable enable
+
+namespace StyleCop.Analyzers.Lightup
+{
+    using Microsoft.CodeAnalysis;
+
+    internal interface IOperationWrapper
+    {
+        IOperation? WrappedOperation { get; }
+
+        ////IOperationWrapper Parent { get; }
+
+        ////OperationKind Kind { get; }
+
+        ////SyntaxNode Syntax { get; }
+
+        ITypeSymbol? Type { get; }
+
+        ////Optional<object> ConstantValue { get; }
+
+        ////IEnumerable<IOperationWrapper> Children { get; }
+
+        ////string Language { get; }
+
+        ////bool IsImplicit { get; }
+
+        ////SemanticModel SemanticModel { get; }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/ITypeParameterObjectCreationOperationWrapper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/ITypeParameterObjectCreationOperationWrapper.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Lightup
+{
+    using System;
+    using Microsoft.CodeAnalysis;
+
+    internal readonly struct ITypeParameterObjectCreationOperationWrapper : IOperationWrapper
+    {
+        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.Operations.ITypeParameterObjectCreationOperation";
+        private static readonly Type WrappedType;
+
+        private static readonly Func<IOperation, IOperation> InitializerAccessor;
+
+        private readonly IOperation operation;
+
+        static ITypeParameterObjectCreationOperationWrapper()
+        {
+            WrappedType = WrapperHelper.GetWrappedType(typeof(ITypeParameterObjectCreationOperationWrapper));
+            InitializerAccessor = LightupHelpers.CreateOperationPropertyAccessor<IOperation, IOperation>(WrappedType, nameof(Initializer));
+        }
+
+        private ITypeParameterObjectCreationOperationWrapper(IOperation operation)
+        {
+            this.operation = operation;
+        }
+
+        public IOperation WrappedOperation => this.operation;
+
+        public ITypeSymbol Type => this.WrappedOperation.Type;
+
+        public IObjectOrCollectionInitializerOperationWrapper Initializer
+        {
+            get
+            {
+                return IObjectOrCollectionInitializerOperationWrapper.FromOperation(InitializerAccessor(this.WrappedOperation));
+            }
+        }
+
+        public static ITypeParameterObjectCreationOperationWrapper FromOperation(IOperation operation)
+        {
+            if (operation == null)
+            {
+                return default;
+            }
+
+            if (!IsInstance(operation))
+            {
+                throw new InvalidCastException($"Cannot cast '{operation.GetType().FullName}' to '{WrappedTypeName}'");
+            }
+
+            return new ITypeParameterObjectCreationOperationWrapper(operation);
+        }
+
+        public static bool IsInstance(IOperation operation)
+        {
+            return operation != null && LightupHelpers.CanWrapOperation(operation, WrappedType);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LanguageVersionEx.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LanguageVersionEx.cs
@@ -15,6 +15,7 @@ namespace StyleCop.Analyzers.Lightup
         public const LanguageVersion CSharp7_2 = (LanguageVersion)702;
         public const LanguageVersion CSharp7_3 = (LanguageVersion)703;
         public const LanguageVersion CSharp8 = (LanguageVersion)800;
+        public const LanguageVersion CSharp9 = (LanguageVersion)900;
         public const LanguageVersion LatestMajor = (LanguageVersion)int.MaxValue - 2;
         public const LanguageVersion Preview = (LanguageVersion)int.MaxValue - 1;
         public const LanguageVersion Latest = (LanguageVersion)int.MaxValue;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/OperationKindEx.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/OperationKindEx.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Lightup
+{
+    using Microsoft.CodeAnalysis;
+
+    internal static class OperationKindEx
+    {
+        /// <summary>
+        /// Indicates an <see cref="T:Microsoft.CodeAnalysis.Operations.IObjectCreationOperation"/>.
+        /// </summary>
+        public const OperationKind ObjectCreation = (OperationKind)36;
+
+        /// <summary>
+        /// Indicates an <see cref="T:Microsoft.CodeAnalysis.Operations.ITypeParameterObjectCreationOperation"/>.
+        /// </summary>
+        public const OperationKind TypeParameterObjectCreation = (OperationKind)37;
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/WrapperHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/WrapperHelper.cs
@@ -6,6 +6,7 @@ namespace StyleCop.Analyzers.Lightup
     using System;
     using System.Collections.Immutable;
     using System.Reflection;
+    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
 
     internal static class WrapperHelper
@@ -14,45 +15,51 @@ namespace StyleCop.Analyzers.Lightup
 
         static WrapperHelper()
         {
-            var codeAnalysisAssembly = typeof(CSharpSyntaxNode).GetTypeInfo().Assembly;
+            var csharpCodeAnalysisAssembly = typeof(CSharpSyntaxNode).GetTypeInfo().Assembly;
+            var codeAnalysisAssembly = typeof(SyntaxNode).GetTypeInfo().Assembly;
             var builder = ImmutableDictionary.CreateBuilder<Type, Type>();
 
-            builder.Add(typeof(CasePatternSwitchLabelSyntaxWrapper), codeAnalysisAssembly.GetType(CasePatternSwitchLabelSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(CasePatternSwitchLabelSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(CasePatternSwitchLabelSyntaxWrapper.WrappedTypeName));
 
             // Prior to C# 7, ForEachStatementSyntax was the base type for all foreach statements. If
             // the CommonForEachStatementSyntax type isn't found at runtime, we fall back to using this type instead.
-            var forEachStatementSyntaxType = codeAnalysisAssembly.GetType(CommonForEachStatementSyntaxWrapper.WrappedTypeName)
-                ?? codeAnalysisAssembly.GetType(CommonForEachStatementSyntaxWrapper.FallbackWrappedTypeName);
+            var forEachStatementSyntaxType = csharpCodeAnalysisAssembly.GetType(CommonForEachStatementSyntaxWrapper.WrappedTypeName)
+                ?? csharpCodeAnalysisAssembly.GetType(CommonForEachStatementSyntaxWrapper.FallbackWrappedTypeName);
             builder.Add(typeof(CommonForEachStatementSyntaxWrapper), forEachStatementSyntaxType);
 
-            builder.Add(typeof(ConstantPatternSyntaxWrapper), codeAnalysisAssembly.GetType(ConstantPatternSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(DeclarationExpressionSyntaxWrapper), codeAnalysisAssembly.GetType(DeclarationExpressionSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(DeclarationPatternSyntaxWrapper), codeAnalysisAssembly.GetType(DeclarationPatternSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(DiscardDesignationSyntaxWrapper), codeAnalysisAssembly.GetType(DiscardDesignationSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(DiscardPatternSyntaxWrapper), codeAnalysisAssembly.GetType(DiscardPatternSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(ForEachVariableStatementSyntaxWrapper), codeAnalysisAssembly.GetType(ForEachVariableStatementSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(IsPatternExpressionSyntaxWrapper), codeAnalysisAssembly.GetType(IsPatternExpressionSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(ImplicitStackAllocArrayCreationExpressionSyntaxWrapper), codeAnalysisAssembly.GetType(ImplicitStackAllocArrayCreationExpressionSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(LocalFunctionStatementSyntaxWrapper), codeAnalysisAssembly.GetType(LocalFunctionStatementSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(ParenthesizedVariableDesignationSyntaxWrapper), codeAnalysisAssembly.GetType(ParenthesizedVariableDesignationSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(PatternSyntaxWrapper), codeAnalysisAssembly.GetType(PatternSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(PositionalPatternClauseSyntaxWrapper), codeAnalysisAssembly.GetType(PositionalPatternClauseSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(PropertyPatternClauseSyntaxWrapper), codeAnalysisAssembly.GetType(PropertyPatternClauseSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(RangeExpressionSyntaxWrapper), codeAnalysisAssembly.GetType(RangeExpressionSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(RecursivePatternSyntaxWrapper), codeAnalysisAssembly.GetType(RecursivePatternSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(RefExpressionSyntaxWrapper), codeAnalysisAssembly.GetType(RefExpressionSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(RefTypeSyntaxWrapper), codeAnalysisAssembly.GetType(RefTypeSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(SingleVariableDesignationSyntaxWrapper), codeAnalysisAssembly.GetType(SingleVariableDesignationSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(SubpatternSyntaxWrapper), codeAnalysisAssembly.GetType(SubpatternSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(SwitchExpressionArmSyntaxWrapper), codeAnalysisAssembly.GetType(SwitchExpressionArmSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(SwitchExpressionSyntaxWrapper), codeAnalysisAssembly.GetType(SwitchExpressionSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(ThrowExpressionSyntaxWrapper), codeAnalysisAssembly.GetType(ThrowExpressionSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(TupleElementSyntaxWrapper), codeAnalysisAssembly.GetType(TupleElementSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(TupleExpressionSyntaxWrapper), codeAnalysisAssembly.GetType(TupleExpressionSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(TupleTypeSyntaxWrapper), codeAnalysisAssembly.GetType(TupleTypeSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(VarPatternSyntaxWrapper), codeAnalysisAssembly.GetType(VarPatternSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(VariableDesignationSyntaxWrapper), codeAnalysisAssembly.GetType(VariableDesignationSyntaxWrapper.WrappedTypeName));
-            builder.Add(typeof(WhenClauseSyntaxWrapper), codeAnalysisAssembly.GetType(WhenClauseSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(ConstantPatternSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(ConstantPatternSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(DeclarationExpressionSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(DeclarationExpressionSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(DeclarationPatternSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(DeclarationPatternSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(DiscardDesignationSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(DiscardDesignationSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(DiscardPatternSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(DiscardPatternSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(ForEachVariableStatementSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(ForEachVariableStatementSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(IsPatternExpressionSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(IsPatternExpressionSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(ImplicitStackAllocArrayCreationExpressionSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(ImplicitStackAllocArrayCreationExpressionSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(LocalFunctionStatementSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(LocalFunctionStatementSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(ParenthesizedVariableDesignationSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(ParenthesizedVariableDesignationSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(PatternSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(PatternSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(PositionalPatternClauseSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(PositionalPatternClauseSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(PropertyPatternClauseSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(PropertyPatternClauseSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(RangeExpressionSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(RangeExpressionSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(RecursivePatternSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(RecursivePatternSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(RefExpressionSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(RefExpressionSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(RefTypeSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(RefTypeSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(SingleVariableDesignationSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(SingleVariableDesignationSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(SubpatternSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(SubpatternSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(SwitchExpressionArmSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(SwitchExpressionArmSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(SwitchExpressionSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(SwitchExpressionSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(ThrowExpressionSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(ThrowExpressionSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(TupleElementSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(TupleElementSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(TupleExpressionSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(TupleExpressionSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(TupleTypeSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(TupleTypeSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(VarPatternSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(VarPatternSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(VariableDesignationSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(VariableDesignationSyntaxWrapper.WrappedTypeName));
+            builder.Add(typeof(WhenClauseSyntaxWrapper), csharpCodeAnalysisAssembly.GetType(WhenClauseSyntaxWrapper.WrappedTypeName));
+
+            builder.Add(typeof(IArgumentOperationWrapper), codeAnalysisAssembly.GetType(IArgumentOperationWrapper.WrappedTypeName));
+            builder.Add(typeof(IObjectCreationOperationWrapper), codeAnalysisAssembly.GetType(IObjectCreationOperationWrapper.WrappedTypeName));
+            builder.Add(typeof(IObjectOrCollectionInitializerOperationWrapper), codeAnalysisAssembly.GetType(IObjectOrCollectionInitializerOperationWrapper.WrappedTypeName));
+            builder.Add(typeof(ITypeParameterObjectCreationOperationWrapper), codeAnalysisAssembly.GetType(ITypeParameterObjectCreationOperationWrapper.WrappedTypeName));
 
             WrappedTypes = builder.ToImmutable();
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1129DoNotUseDefaultValueTypeConstructor.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1129DoNotUseDefaultValueTypeConstructor.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Lightup;
 
     /// <summary>
     /// A value type was constructed using the syntax <c>new T()</c>.
@@ -28,6 +29,8 @@ namespace StyleCop.Analyzers.ReadabilityRules
         private static readonly DiagnosticDescriptor Descriptor =
             new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.ReadabilityRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
 
+        private static readonly Action<OperationAnalysisContext> ObjectCreationOperationAction = HandleObjectCreationOperation;
+        private static readonly Action<OperationAnalysisContext> TypeParameterObjectCreationOperationAction = HandleTypeParameterObjectCreationOperation;
         private static readonly Action<SyntaxNodeAnalysisContext> ObjectCreationExpressionAction = HandleObjectCreationExpression;
 
         /// <inheritdoc/>
@@ -40,7 +43,57 @@ namespace StyleCop.Analyzers.ReadabilityRules
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
 
-            context.RegisterSyntaxNodeAction(ObjectCreationExpressionAction, SyntaxKind.ObjectCreationExpression);
+            if (LightupHelpers.SupportsIOperation)
+            {
+                context.RegisterOperationAction(ObjectCreationOperationAction, OperationKindEx.ObjectCreation);
+                context.RegisterOperationAction(TypeParameterObjectCreationOperationAction, OperationKindEx.TypeParameterObjectCreation);
+            }
+            else
+            {
+                context.RegisterSyntaxNodeAction(ObjectCreationExpressionAction, SyntaxKind.ObjectCreationExpression);
+            }
+        }
+
+        private static void HandleObjectCreationOperation(OperationAnalysisContext context)
+        {
+            var objectCreation = IObjectCreationOperationWrapper.FromOperation(context.Operation);
+
+            var typeToCreate = objectCreation.Constructor.ContainingType;
+            if ((typeToCreate == null) || typeToCreate.IsReferenceType || IsReferenceTypeParameter(typeToCreate))
+            {
+                return;
+            }
+
+            if (!objectCreation.Arguments.IsEmpty)
+            {
+                // Not a use of the default constructor
+                return;
+            }
+
+            if (objectCreation.Initializer.WrappedOperation != null)
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, objectCreation.WrappedOperation.Syntax.GetLocation()));
+        }
+
+        private static void HandleTypeParameterObjectCreationOperation(OperationAnalysisContext context)
+        {
+            var objectCreation = ITypeParameterObjectCreationOperationWrapper.FromOperation(context.Operation);
+
+            var typeToCreate = objectCreation.Type;
+            if ((typeToCreate == null) || typeToCreate.IsReferenceType || IsReferenceTypeParameter(typeToCreate))
+            {
+                return;
+            }
+
+            if (objectCreation.Initializer.WrappedOperation != null)
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, objectCreation.WrappedOperation.Syntax.GetLocation()));
         }
 
         private static void HandleObjectCreationExpression(SyntaxNodeAnalysisContext context)


### PR DESCRIPTION
Eliminates performance overhead associated with `GetSymbolInfo` calls when `IOperation` APIs are supported.