### PR TITLE
Update references

### DIFF
--- a/StyleCop.Analyzers/Directory.Build.props
+++ b/StyleCop.Analyzers/Directory.Build.props
@@ -45,7 +45,7 @@
   <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.46" PrivateAssets="all" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205" PrivateAssets="all" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.304" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.8.0" PrivateAssets="all" />
   </ItemGroup>

--- a/StyleCop.Analyzers/Directory.Build.props
+++ b/StyleCop.Analyzers/Directory.Build.props
@@ -47,12 +47,12 @@
     <PackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.46" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.205" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.8.0-5.final" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeStyle" Version="3.8.0" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- C# Compiler -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.8.0-5.final" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.8.0" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- Public API -->

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/FixAllContextHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/FixAllContextHelper.cs
@@ -55,7 +55,8 @@ namespace StyleCop.Analyzers.Helpers
                         {
                             var projectDiagnostics = await GetAllDiagnosticsAsync(fixAllContext, projectToFix).ConfigureAwait(false);
                             diagnostics.TryAdd(projectToFix.Id, projectDiagnostics);
-                        }, fixAllContext.CancellationToken);
+                        },
+                        fixAllContext.CancellationToken);
                 }
 
                 await Task.WhenAll(tasks).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/MaintainabilityRules/SA1404CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/MaintainabilityRules/SA1404CodeFixProvider.cs
@@ -50,7 +50,8 @@ namespace StyleCop.Analyzers.MaintainabilityRules
                         CodeAction.Create(
                             MaintainabilityResources.SA1404CodeFix,
                             token => AddJustificationToAttributeAsync(context.Document, root, attribute),
-                            nameof(SA1404CodeFixProvider) + "-Add"), diagnostic);
+                            nameof(SA1404CodeFixProvider) + "-Add"),
+                        diagnostic);
                     return;
                 }
 
@@ -60,7 +61,8 @@ namespace StyleCop.Analyzers.MaintainabilityRules
                         CodeAction.Create(
                             MaintainabilityResources.SA1404CodeFix,
                             token => UpdateValueOfArgumentAsync(context.Document, root, argument),
-                            nameof(SA1404CodeFixProvider) + "-Update"), diagnostic);
+                            nameof(SA1404CodeFixProvider) + "-Update"),
+                        diagnostic);
                     return;
                 }
             }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/SA1206CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/SA1206CodeFixProvider.cs
@@ -95,7 +95,8 @@ namespace StyleCop.Analyzers.OrderingRules
             return AdjustTrivia(
                 accessModifiers
                     .Concat(staticModifiers)
-                    .Concat(otherModifiers), modifiers);
+                    .Concat(otherModifiers),
+                modifiers);
         }
 
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeGeneration/StyleCop.Analyzers.CodeGeneration.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeGeneration/StyleCop.Analyzers.CodeGeneration.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0-5.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
     <PackageReference Include="TunnelVisionLabs.ReferenceAssemblyAnnotator" Version="1.0.0-alpha.160" PrivateAssets="all" />
     <PackageDownload Include="Microsoft.NETCore.App.Ref" Version="[3.1.0]" />
   </ItemGroup>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/StyleCop.Analyzers.Test.CSharp7.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/StyleCop.Analyzers.Test.CSharp7.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.8.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.8.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="all" />
   </ItemGroup>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/StyleCop.Analyzers.Test.CSharp8.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/StyleCop.Analyzers.Test.CSharp8.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.6.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.6.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="all" />
   </ItemGroup>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/StyleCop.Analyzers.Test.CSharp9.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/StyleCop.Analyzers.Test.CSharp9.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.8.0-5.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0-5.final" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="all" />
   </ItemGroup>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/StyleCop.Analyzers.Test.CSharp9.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/StyleCop.Analyzers.Test.CSharp9.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0-5.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="all" />
   </ItemGroup>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1011UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1011UnitTests.cs
@@ -259,7 +259,8 @@ public class ClassName
         {
             string validStatament = string.Format(
                 @"var i = new int[1];
-            i[0]{0};", operatorText);
+            i[0]{0};",
+                operatorText);
 
             await this.TestWhitespaceInStatementOrDeclAsync(validStatament, null, DiagnosticResult.EmptyDiagnosticResults).ConfigureAwait(false);
         }
@@ -271,11 +272,13 @@ public class ClassName
         {
             string invalidStatament = string.Format(
                 @"var i = new int[1];
-            i[0] {0};", operatorText);
+            i[0] {0};",
+                operatorText);
 
             string fixedStatament = string.Format(
                 @"var i = new int[1];
-            i[0]{0};", operatorText);
+            i[0]{0};",
+                operatorText);
 
             DiagnosticResult expected = Diagnostic().WithLocation(8, 16).WithArguments(" not", "followed");
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/StyleCop.Analyzers.Test.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="1.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.3.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.0.1-beta1.20559.1" />
     <PackageReference Include="Microsoft.VisualStudio.Composition" Version="16.1.8" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />


### PR DESCRIPTION
* Remove references to Visual Basic compiler assemblies
* Update to the stable release of Roslyn 3.8.0
* Update to StyleCop.Analyzers 1.2.0-beta.304