### PR TITLE
SA1130: Handle optional named arguments correctly

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1130CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1130CodeFixProvider.cs
@@ -174,7 +174,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
             var originalInvocableExpression = argumentListSyntax.Parent;
 
             var originalSymbolInfo = semanticModel.GetSymbolInfo(originalInvocableExpression);
-            var argumentIndex = argumentListSyntax.Arguments.IndexOf(argumentSyntax);
+            var argumentIndex = SA1130UseLambdaSyntax.FindArgumentIndex(originalSymbolInfo, argumentSyntax, argumentListSyntax);
             var parameterList = SA1130UseLambdaSyntax.GetDelegateParameterList(originalSymbolInfo.Symbol, argumentIndex);
             return parameterList.Parameters.Select(p => p.Identifier.ToString()).ToImmutableArray();
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1130UseLambdaSyntax.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1130UseLambdaSyntax.cs
@@ -98,8 +98,10 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
         internal static int FindArgumentIndex(SymbolInfo originalSymbolInfo, ArgumentSyntax argumentSyntax, BaseArgumentListSyntax argumentListSyntax)
         {
+            // if delegate is passed as named argument of method try to find its position by argument name
             if (originalSymbolInfo.Symbol.Kind == SymbolKind.Method
-                && originalSymbolInfo.Symbol is IMethodSymbol methodSymbol)
+                && originalSymbolInfo.Symbol is IMethodSymbol methodSymbol
+                && argumentSyntax.NameColon != null)
             {
                 var calledMethodParameters = methodSymbol.Parameters;
                 var argumentIdentifier = argumentSyntax.NameColon.Name.Identifier.ValueText;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1130UseLambdaSyntax.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1130UseLambdaSyntax.cs
@@ -96,6 +96,26 @@ namespace StyleCop.Analyzers.ReadabilityRules
             return SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(syntaxParameters));
         }
 
+        internal static int FindArgumentIndex(SymbolInfo originalSymbolInfo, ArgumentSyntax argumentSyntax, BaseArgumentListSyntax argumentListSyntax)
+        {
+            if (originalSymbolInfo.Symbol.Kind == SymbolKind.Method
+                && originalSymbolInfo.Symbol is IMethodSymbol methodSymbol)
+            {
+                var calledMethodParameters = methodSymbol.Parameters;
+                var argumentIdentifier = argumentSyntax.NameColon.Name.Identifier.ValueText;
+
+                for (var i = 0; i < calledMethodParameters.Length; ++i)
+                {
+                    if (string.Equals(calledMethodParameters[i].Name, argumentIdentifier))
+                    {
+                        return i;
+                    }
+                }
+            }
+
+            return argumentListSyntax.Arguments.IndexOf(argumentSyntax);
+        }
+
         private static void HandleAnonymousMethodExpression(SyntaxNodeAnalysisContext context)
         {
             bool reportDiagnostic = true;
@@ -138,7 +158,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
                     return false;
                 }
 
-                var argumentIndex = argumentListSyntax.Arguments.IndexOf(argumentSyntax);
+                var argumentIndex = FindArgumentIndex(originalSymbolInfo, argumentSyntax, argumentListSyntax);
 
                 // Determine the parameter list from the method that is invoked, as delegates without parameters are allowed, but they cannot be replaced by a lambda without parameters.
                 var parameterList = GetDelegateParameterList(originalSymbolInfo.Symbol, argumentIndex);


### PR DESCRIPTION
Fixes #3279, `NullReferenceException` is thrown when delegate is used as (optional) named parameter and argument index doesn't match method signature.

Fix is handling special case when argument is used with name, e.g. `F(argName: delegate { ... })`, otherwise everything works as before.