### PR TITLE
SA1648 throws an exception on delegates that use the <include> tag

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1648UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1648UnitTests.cs
@@ -305,6 +305,53 @@ public class TestClass : ITest
             await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
+        /// <summary>
+        /// Verifies that a delegate declaration that includes the inheritdoc will produce diagnostics.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestIncorrectDocumentedDelegateInheritDocAsync()
+        {
+            var testCode = @"
+/// <summary>Foo</summary>
+/// <param name=""value"">some param</param>
+/// <returns>something</returns>
+public delegate bool TestDelegate(int value);
+
+/// <summary>Test class</summary>
+public class TestClass
+{
+  /// <include file='DelegateInheritDoc.xml' path='/TestDelegate/*'/>
+  public delegate bool TestDelegate(int value);
+}
+";
+
+            var expected = Diagnostic().WithLocation(10, 7);
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that a delegate declaration that includes the inheritdoc will produce diagnostics.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task TestIncorrectDelegateInheritDocAsync()
+        {
+            var testCode = @"
+public delegate bool TestDelegate(int value);
+
+/// <summary>Test class</summary>
+public class TestClass
+{
+  /// <include file='DelegateInheritDoc.xml' path='/TestDelegate/*'/>
+  public delegate bool TestDelegate(int value);
+}
+";
+
+            var expected = Diagnostic().WithLocation(7, 7);
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
         private static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken)
             => VerifyCSharpDiagnosticAsync(source, new[] { expected }, cancellationToken);
 
@@ -330,6 +377,11 @@ public class TestClass : ITest
   </TestMethod>
 </TestClass>
 ";
+            string contentDelegateInheritDoc = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
+<TestDelegate>
+    <inheritdoc/>
+</TestDelegate>
+";
 
             var test = new StyleCopDiagnosticVerifier<SA1648InheritDocMustBeUsedWithInheritingClass>.CSharpTest
             {
@@ -337,6 +389,7 @@ public class TestClass : ITest
                 {
                     { "ClassInheritDoc.xml", contentClassInheritDoc },
                     { "MethodInheritDoc.xml", contentMethodInheritDoc },
+                    { "DelegateInheritDoc.xml", contentDelegateInheritDoc },
                 },
             };
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1648UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1648UnitTests.cs
@@ -311,6 +311,7 @@ public class TestClass : ITest
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
         [WorkItem(3291, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3291")]
+        [WorkItem(3291, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3291")]
         public async Task TestIncorrectDocumentedDelegateInheritDocAsync()
         {
             var testCode = @"
@@ -336,6 +337,7 @@ public class TestClass
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
+        [WorkItem(3291, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3291")]
         [WorkItem(3291, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3291")]
         public async Task TestIncorrectDelegateInheritDocAsync()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1648UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1648UnitTests.cs
@@ -310,6 +310,7 @@ public class TestClass : ITest
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
+        [WorkItem(3291, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3291")]
         public async Task TestIncorrectDocumentedDelegateInheritDocAsync()
         {
             var testCode = @"
@@ -321,12 +322,12 @@ public delegate bool TestDelegate(int value);
 /// <summary>Test class</summary>
 public class TestClass
 {
-  /// <include file='DelegateInheritDoc.xml' path='/TestDelegate/*'/>
+  /// {|#0:<include file='DelegateInheritDoc.xml' path='/TestDelegate/*'/>|}
   public delegate bool TestDelegate(int value);
 }
 ";
 
-            var expected = Diagnostic().WithLocation(10, 7);
+            var expected = Diagnostic().WithLocation(0);
             await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
@@ -335,6 +336,7 @@ public class TestClass
         /// </summary>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Fact]
+        [WorkItem(3291, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3291")]
         public async Task TestIncorrectDelegateInheritDocAsync()
         {
             var testCode = @"
@@ -343,12 +345,12 @@ public delegate bool TestDelegate(int value);
 /// <summary>Test class</summary>
 public class TestClass
 {
-  /// <include file='DelegateInheritDoc.xml' path='/TestDelegate/*'/>
+  /// {|#0:<include file='DelegateInheritDoc.xml' path='/TestDelegate/*'/>|}
   public delegate bool TestDelegate(int value);
 }
 ";
 
-            var expected = Diagnostic().WithLocation(7, 7);
+            var expected = Diagnostic().WithLocation(0);
             await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1648InheritDocMustBeUsedWithInheritingClass.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1648InheritDocMustBeUsedWithInheritingClass.cs
@@ -86,7 +86,7 @@ namespace StyleCop.Analyzers.DocumentationRules
 
             if (documentation.Content.GetFirstXmlElement(XmlCommentHelper.IncludeXmlTag) is XmlEmptyElementSyntax includeElement)
             {
-                var declaration = baseType is null ? context.ContainingSymbol : context.SemanticModel.GetDeclaredSymbol(baseType, context.CancellationToken);
+                var declaration = context.SemanticModel.GetDeclaredSymbol(context.Node, context.CancellationToken);
                 if (declaration == null)
                 {
                     return;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1648InheritDocMustBeUsedWithInheritingClass.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1648InheritDocMustBeUsedWithInheritingClass.cs
@@ -86,7 +86,7 @@ namespace StyleCop.Analyzers.DocumentationRules
 
             if (documentation.Content.GetFirstXmlElement(XmlCommentHelper.IncludeXmlTag) is XmlEmptyElementSyntax includeElement)
             {
-                var declaration = context.SemanticModel.GetDeclaredSymbol(baseType, context.CancellationToken);
+                var declaration = baseType is null ? context.ContainingSymbol : context.SemanticModel.GetDeclaredSymbol(baseType, context.CancellationToken);
                 if (declaration == null)
                 {
                     return;


### PR DESCRIPTION
Tracking issue: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3291

This PR includes the following changes:
- Fix #3291 
- Add two tests