### PR TITLE
[New analyzer] SA1143 Use implicitly assignable foreach variable type

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1143UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1143UnitTests.cs
@@ -1,0 +1,616 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.ReadabilityRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.ReadabilityRules.SA1143UseImplicitlyAssignableForeachVariableType>;
+
+    /// <summary>
+    /// This class contains the unit tests for SA1141.
+    /// </summary>
+    /// <seealso cref="SA1143UseImplicitlyAssignableForeachVariableType"/>
+    public class SA1143UnitTests
+    {
+        [Fact]
+        public async Task NonGenericIComparableCollectionAsync()
+        {
+            var test = @"
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            {|#0:foreach|} (string item in new A())
+            {
+            }
+        }
+    }
+
+    struct A
+    {
+        public Enumerator GetEnumerator() =>  new Enumerator();
+
+        public struct Enumerator
+        {
+            public System.IComparable Current => 42;
+
+            public bool MoveNext() => true;
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, GetResultAt(0).WithArguments("IComparable", "String"), CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task GenericObjectCollectionAsync()
+        {
+            var test = @"
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<object>();
+            {|#0:foreach|} (string item in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, GetResultAt(0).WithArguments("Object", "String"), CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task NongenericObjectCollectionAsync()
+        {
+            var test = @"
+using System.Collections;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new ArrayList();
+            foreach (string item in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task SameTypeAsync()
+        {
+            var test = @"
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<string>();
+            foreach (string item in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task CastBaseToChildAsync()
+        {
+            var test = @"
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<A>();
+            {|#0:foreach|} (B item in x)
+            {
+            }
+        }
+    }
+
+    class A { }
+    class B : A { }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, GetResultAt(0).WithArguments("A", "B"), CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task ImplicitConversionAsync()
+        {
+            var test = @"
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<int>();
+            foreach (long item in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task UserDefinedImplicitConversionAsync()
+        {
+            var test = @"
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<A>();
+            foreach (B item in x)
+            {
+            }
+        }
+    }
+
+    class A { }
+    class B 
+    { 
+        public static implicit operator B(A a) => new B();
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task ExplicitConversionAsync()
+        {
+            var test = @"
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<long>();
+            {|#0:foreach|} (int item in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, GetResultAt(0).WithArguments("Int64", "Int32"), CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task UserDefinedExplicitConversionAsync()
+        {
+            var test = @"
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<A>();
+            {|#0:foreach|} (B item in x)
+            {
+            }
+        }
+    }
+
+    class A { }
+    class B 
+    { 
+        public static explicit operator B(A a) => new B();
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, GetResultAt(0).WithArguments("A", "B"), CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task CastChildToBaseAsync()
+        {
+            var test = @"
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<B>();
+            foreach (A item in x)
+            {
+            }
+        }
+    }
+
+    class A { }
+    class B : A { }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task InterfaceToClassAsync()
+        {
+            var test = @"
+using System;
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<IComparable>();
+            {|#0:foreach|} (string s in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, GetResultAt(0).WithArguments("IComparable", "String"), CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task ClassToInterfaseAsync()
+        {
+            var test = @"
+using System;
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<string>();
+            foreach (IComparable s in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task GenericTypes_UnrelatedAsync()
+        {
+            var test = @"
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main<A, B>()
+        {
+            var x = new List<A>();
+            {|#0:foreach|} (B s in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, DiagnosticResult.CompilerError("CS0030").WithLocation(0).WithArguments("A", "B"), CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task GenericTypes_Valid_RelationshipAsync()
+        {
+            var test = @"
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main<A, B>() where A : B
+        {
+            var x = new List<A>();
+            foreach (B s in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task GenericTypes_Invalid_RelationshipAsync()
+        {
+            var test = @"
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main<A, B>() where B : A
+        {
+            var x = new List<A>();
+            {|#0:foreach|} (B s in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, GetResultAt(0).WithArguments("A", "B"), CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task CollectionFromMethodResult_InvalidAsync()
+        {
+            var test = @"
+using System;
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            {|#0:foreach|} (string item in GenerateSequence())
+            {
+            }
+
+            IEnumerable<IComparable> GenerateSequence()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, GetResultAt(0).WithArguments("IComparable", "String"), CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task CollectionFromMethodResult_ValidAsync()
+        {
+            var test = @"
+using System;
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            foreach (IComparable item in GenerateSequence())
+            {
+            }
+
+            IEnumerable<IComparable> GenerateSequence()
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task DynamicSameTypeAsync()
+        {
+            var test = @"
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<dynamic>();
+            foreach (dynamic s in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task DynamicToObjectAsync()
+        {
+            var test = @"
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<dynamic>();
+            foreach (object s in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task DynamicToStringAsync()
+        {
+            var test = @"
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<dynamic>();
+            {|#0:foreach|} (string s in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, GetResultAt(0).WithArguments("dynamic", "String"), CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task DynamicToVarAsync()
+        {
+            var test = @"
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<dynamic>();
+            foreach (var s in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TupleToVarTupleAsync()
+        {
+            var test = @"
+using System;
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<(int, IComparable)>();
+            foreach (var (i, j) in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TupleToSameTupleAsync()
+        {
+            var test = @"
+using System;
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<(int, IComparable)>();
+            foreach ((int i,  IComparable j) in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TupleToChildTupleAsync()
+        {
+            var test = @"
+using System;
+using System.Collections.Generic;
+
+namespace ConsoleApplication1
+{
+    class Program
+    {   
+        void Main()
+        {
+            var x = new List<(int, IComparable)>();
+            foreach ((int i,  {|#0:int j|}) in x)
+            {
+            }
+        }
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(test, DiagnosticResult.CompilerError("CS0266").WithLocation(0).WithArguments("System.IComparable", "int"), CancellationToken.None).ConfigureAwait(false);
+        }
+
+        private static DiagnosticResult GetResultAt(int markupKey) =>
+            Diagnostic().WithLocation(markupKey);
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.Designer.cs
@@ -1394,6 +1394,33 @@ namespace StyleCop.Analyzers.ReadabilityRules {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to There is no implicit conversion between collection element and iterator variable, this can result in runtime exception..
+        /// </summary>
+        internal static string SA1143Description {
+            get {
+                return ResourceManager.GetString("SA1143Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot implicitly convert type &apos;{0}&apos; to &apos;{1}&apos;.
+        /// </summary>
+        internal static string SA1143MessageFormat {
+            get {
+                return ResourceManager.GetString("SA1143MessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Use implicitly assignable foreach variable type.
+        /// </summary>
+        internal static string SA1143Title {
+            get {
+                return ResourceManager.GetString("SA1143Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Remove &apos;this.&apos; prefix.
         /// </summary>
         internal static string SX1101CodeFix {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.resx
@@ -561,6 +561,15 @@
   <data name="SA1142Title" xml:space="preserve">
     <value>Refer to tuple fields by name</value>
   </data>
+  <data name="SA1143Description" xml:space="preserve">
+    <value>There is no implicit conversion between collection element and iterator variable, this can result in runtime exception.</value>
+  </data>
+  <data name="SA1143MessageFormat" xml:space="preserve">
+    <value>Cannot implicitly convert type '{0}' to '{1}'</value>
+  </data>
+  <data name="SA1143Title" xml:space="preserve">
+    <value>Use implicitly assignable foreach variable type</value>
+  </data>
   <data name="SX1101CodeFix" xml:space="preserve">
     <value>Remove 'this.' prefix</value>
   </data>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1143UseImplicitlyAssignableForeachVariableType.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1143UseImplicitlyAssignableForeachVariableType.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.ReadabilityRules
+{
+    using System;
+    using System.Collections.Immutable;
+    using System.Linq;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
+    using StyleCop.Analyzers.Lightup;
+
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal class SA1143UseImplicitlyAssignableForeachVariableType : DiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = "SA1143";
+
+        private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1143.md";
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(ReadabilityResources.SA1143Title), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(ReadabilityResources.SA1143MessageFormat), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(ReadabilityResources.SA1143Description), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
+
+        private static readonly DiagnosticDescriptor Descriptor = new(DiagnosticId, Title, MessageFormat, AnalyzerCategory.ReadabilityRules, DiagnosticSeverity.Warning, AnalyzerConstants.EnabledByDefault, Description, HelpLink);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Descriptor);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.RegisterCompilationStartAction(context =>
+            {
+                var wellKnownTypeProvider = WellKnownTypeProvider.GetOrCreate(context.Compilation);
+
+                INamedTypeSymbol? genericIEnumerableType = wellKnownTypeProvider.GetOrCreateTypeByMetadataName(WellKnownTypeNames.SystemCollectionsGenericIEnumerable1);
+                if (genericIEnumerableType == null)
+                {
+                    return;
+                }
+
+                context.RegisterOperationAction(context => AnalyzeLoop(context, genericIEnumerableType), OperationKind.LoopStatement);
+            });
+        }
+
+        private void AnalyzeLoop(OperationAnalysisContext context, INamedTypeSymbol genericIEnumerableType)
+        {
+            if (context.Operation is not IForEachLoopOperation loop ||
+                loop.Syntax is not ForEachStatementSyntax syntax)
+            {
+                return;
+            }
+
+            ForEachStatementInfo loopInfo = loop.SemanticModel.GetForEachStatementInfo(syntax);
+            if (!loopInfo.CurrentConversion.Exists ||
+                !loopInfo.CurrentConversion.IsImplicit ||
+                !loopInfo.CurrentConversion.IsIdentity)
+            {
+                return;
+            }
+
+            ITypeSymbol collectionElementType = loopInfo.ElementType;
+            if (collectionElementType.SpecialType == SpecialType.System_Object &&
+                !loop.Collection.Type.DerivesFrom(genericIEnumerableType))
+            {
+                return;
+            }
+
+            ITypeSymbol variableType = (loop.LoopControlVariable as IVariableDeclaratorOperation)?.Symbol?.Type;
+            if (variableType == null)
+            {
+                return;
+            }
+
+            CommonConversion conversion = context.Compilation.ClassifyCommonConversion(collectionElementType, variableType);
+            if (!conversion.Exists || conversion.IsImplicit)
+            {
+                return;
+            }
+
+            context.ReportDiagnostic(Diagnostic.Create(Descriptor, syntax.ForEachKeyword.GetLocation(), collectionElementType.Name, variableType.Name));
+        }
+    }
+}


### PR DESCRIPTION
Port of PR from roslyn analyzers: https://github.com/dotnet/roslyn-analyzers/issues/4479

Fixes: #3307 

![image](https://user-images.githubusercontent.com/6609929/108436184-a6218a00-7253-11eb-9c20-431ce8db4b72.png)

This analyzer reports on unobvious explicit conversion done under the hood by `foreach` loop. This conversion can result in runtime exception, but it's not guaranteed.