### PR TITLE
Create markdown-links-verifier.yml

### DIFF
--- a/.github/workflows/markdown-links-verifier.yml
+++ b/.github/workflows/markdown-links-verifier.yml
@@ -1,0 +1,14 @@
+name: Markdown links verifier
+on: [push, pull_request]
+
+jobs:
+  validate_links:
+    name: Markdown links verifier
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v1
+
+    - name: Validate links
+      uses: Youssef1313/markdown-links-verifier@v0.0.7

--- a/documentation/SA1305.md
+++ b/documentation/SA1305.md
@@ -29,9 +29,17 @@ In addition, modern code editors such as Visual Studio make it easy to identify 
 
 StyleCop assumes that any variable name that begins with one or two lower-case letters followed by an upper-case letter is making use of Hungarian notation, and will flag a violation of this rule in each case. It is possible to declare certain prefixes as legal, in which case they will be ignored. For example, a variable named *onExecute* will appear to StyleCop to be using Hungarian notation, when in reality it is not. Thus, the *on* prefix should be flagged as an allowed prefix.
 
-To configure the list of allowed prefixes, bring up the StyleCop settings for a project, and navigate to the Hungarian tab, as shown below:
+To configure the list of allowed prefixes, use *stylecop.json* like the following:
 
-![](Images/HungarianSettings.JPG)
+```json
+{
+  "settings": {
+    "namingRules": {
+      "allowedHungarianPrefixes": [ "aa", "bb" ],
+    },
+  }
+}
+```
 
 Adding a one or two letter prefix to this list will cause StyleCop to ignore variables or fields which begin with this prefix.
 


### PR DESCRIPTION
Results:

```
2021-03-14T08:50:50.5687158Z Validating links in: /github/workspace/documentation/SA1305.md.
2021-03-14T08:50:50.5694186Z ##[error]Invalid link: 'Images/HungarianSettings.JPG' relative to '/github/workspace/documentation'.
```

The GitHub Action wasn't run in the PR, only in my fork. This is probably due GitHub Actions being disabled in the repository?
If you don't want to enable this GH Action, let's fix the broken image only.