### PR TITLE
Correct property standard text for ru-RU culture

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.ru-RU.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/DocumentationResources.ru-RU.resx
@@ -139,16 +139,16 @@
     <value />
   </data>
   <data name="StartingTextGets" xml:space="preserve">
-    <value>Получает</value>
+    <value>Возвращает</value>
   </data>
   <data name="StartingTextGetsOrSets" xml:space="preserve">
-    <value>Получает или задает</value>
+    <value>Возвращает или задает</value>
   </data>
   <data name="StartingTextGetsOrSetsWhether" xml:space="preserve">
-    <value>Получает или задает значение, показывающее,</value>
+    <value>Возвращает или задает значение, показывающее,</value>
   </data>
   <data name="StartingTextGetsWhether" xml:space="preserve">
-    <value>Получает значение, показывающее,</value>
+    <value>Возвращает значение, показывающее,</value>
   </data>
   <data name="StartingTextSets" xml:space="preserve">
     <value>Задает</value>


### PR DESCRIPTION
#3334
Corrected properties starting text for ru-RU culture:
`Получает` => `Возвращает`
`Получает или задает` => `Возвращает или задает`
`Получает или задает значение, показывающее,` => `Возвращает или задает значение, показывающее,`
`Получает значение, показывающее,` => `Возвращает значение, показывающее,`.