### PR TITLE
Update System.Collections.Immutable in the status generator

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Status.Generator/StyleCop.Analyzers.Status.Generator.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Status.Generator/StyleCop.Analyzers.Status.Generator.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.2" />
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.7.0" />


### PR DESCRIPTION
Fixes an argument exception caused by newer MSBuild installations.