### PR TITLE
SA1629 should allow full-sentence links instead of forcing the period to glow white

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1629UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1629UnitTests.cs
@@ -545,15 +545,15 @@ public interface ITest
         }
 
         [Theory]
-        [InlineData("a")]
-        [InlineData("see")]
-        [InlineData("seealso")]
-        public async Task TestFullSentenceLinkAsync(string tag)
+        [InlineData("a", true)]
+        [InlineData("see", true)]
+        [InlineData("seealso", false)]
+        public async Task TestFullSentenceLinkAsync(string tag, bool insideSummary)
         {
+            var surrounding = insideSummary ? (Start: "<summary>", End: "<summary>") : (Start: string.Empty, End: string.Empty);
+
             var testCode = $@"
-/// <summary>
-/// <{tag} href=""someurl"">Periods aren't required to glow white at the end of a full-sentence link.</{tag}>
-/// </summary>
+/// {surrounding.Start}<{tag} href=""someurl"">Periods aren't required to glow white at the end of a full-sentence link.</{tag}>{surrounding.End}
 public interface ITest
 {{
 }}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1629UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1629UnitTests.cs
@@ -545,6 +545,23 @@ public interface ITest
         }
 
         [Theory]
+        [InlineData("a")]
+        [InlineData("see")]
+        [InlineData("seealso")]
+        public async Task TestFullSentenceLinkAsync(string tag)
+        {
+            var testCode = $@"
+/// <summary>
+/// <{tag} href=""someurl"">Periods aren't required to glow white at the end of a full-sentence link.</{tag}>
+/// </summary>
+public interface ITest
+{{
+}}
+";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, default).ConfigureAwait(false);
+        }
+
+        [Theory]
         [InlineData(",")]
         [InlineData(";")]
         public async Task TestSentenceEndingWithTypoAndParenthesisAsync(string typo)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
@@ -192,6 +192,37 @@ namespace StyleCop.Analyzers.Helpers
         }
 
         /// <summary>
+        /// Returns the last <see cref="XmlTextSyntax"/> which is not simply empty or whitespace.
+        /// </summary>
+        /// <param name="node">The XML content to search.</param>
+        /// <returns>The last <see cref="XmlTextSyntax"/> which is not simply empty or whitespace, or
+        /// <see langword="null"/> if no such element exists.</returns>
+        internal static XmlTextSyntax TryGetLastTextElementWithContent(XmlNodeSyntax node)
+        {
+            if (node is XmlEmptyElementSyntax)
+            {
+                return null;
+            }
+            else if (node is XmlTextSyntax xmlText)
+            {
+                return !IsConsideredEmpty(node) ? xmlText : null;
+            }
+            else if (node is XmlElementSyntax xmlElement)
+            {
+                for (var i = xmlElement.Content.Count - 1; i >= 0; i--)
+                {
+                    var nestedContent = TryGetFirstTextElementWithContent(xmlElement.Content[i]);
+                    if (nestedContent != null)
+                    {
+                        return nestedContent;
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Checks if a <see cref="SyntaxTrivia"/> contains a <see cref="DocumentationCommentTriviaSyntax"/> and returns
         /// <see langword="true"/> if it is considered empty.
         /// </summary>


### PR DESCRIPTION
This looks ugly to me, and SA1629 should not force it:

![image](https://user-images.githubusercontent.com/8040367/126090151-ab90f21e-718b-4b74-a8ec-f1bcb4354f7b.png)

The same affordance should be given for wrapping a whole sentence with `<a>`, `<see>`, and `<seealso>` which is currently given for wrapping a whole sentence with parentheses.