### PR TITLE
Fix ignored Namespace attribute in OperationLightupGenerator

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeGeneration/OperationLightupGenerator.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeGeneration/OperationLightupGenerator.cs
@@ -69,7 +69,7 @@ namespace StyleCop.Analyzers.CodeGeneration
                     variables: SyntaxFactory.SingletonSeparatedList(SyntaxFactory.VariableDeclarator(
                         identifier: SyntaxFactory.Identifier("WrappedTypeName"),
                         argumentList: null,
-                        initializer: SyntaxFactory.EqualsValueClause(SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal("Microsoft.CodeAnalysis.Operations." + node.InterfaceName))))))));
+                        initializer: SyntaxFactory.EqualsValueClause(SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal($"Microsoft.CodeAnalysis.{node.Namespace}.{node.InterfaceName}"))))))));
 
             // private static readonly Type WrappedType;
             members = members.Add(SyntaxFactory.FieldDeclaration(
@@ -988,6 +988,7 @@ namespace StyleCop.Analyzers.CodeGeneration
 
                 this.OperationKinds = operationKinds;
                 this.InterfaceName = node.Attribute("Name").Value;
+                this.Namespace = node.Attribute("Namespace")?.Value ?? "Operations";
                 this.Name = this.InterfaceName.Substring("I".Length, this.InterfaceName.Length - "I".Length - "Operation".Length);
                 this.WrapperName = this.InterfaceName + "Wrapper";
                 this.BaseInterfaceName = node.Attribute("Base").Value;
@@ -998,6 +999,8 @@ namespace StyleCop.Analyzers.CodeGeneration
             public ImmutableArray<(string name, int value, string? extraDescription)> OperationKinds { get; }
 
             public string InterfaceName { get; }
+
+            public string Namespace { get; }
 
             public string Name { get; }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/StyleCop.Analyzers.CodeGeneration/StyleCop.Analyzers.CodeGeneration.OperationLightupGenerator/ICaughtExceptionOperationWrapper.g.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/StyleCop.Analyzers.CodeGeneration/StyleCop.Analyzers.CodeGeneration.OperationLightupGenerator/ICaughtExceptionOperationWrapper.g.cs
@@ -9,7 +9,7 @@ namespace StyleCop.Analyzers.Lightup
 
     internal readonly struct ICaughtExceptionOperationWrapper : IOperationWrapper
     {
-        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.Operations.ICaughtExceptionOperation";
+        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.FlowAnalysis.ICaughtExceptionOperation";
         private static readonly Type WrappedType;
         private readonly IOperation operation;
         static ICaughtExceptionOperationWrapper()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/StyleCop.Analyzers.CodeGeneration/StyleCop.Analyzers.CodeGeneration.OperationLightupGenerator/IFlowAnonymousFunctionOperationWrapper.g.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/StyleCop.Analyzers.CodeGeneration/StyleCop.Analyzers.CodeGeneration.OperationLightupGenerator/IFlowAnonymousFunctionOperationWrapper.g.cs
@@ -9,7 +9,7 @@ namespace StyleCop.Analyzers.Lightup
 
     internal readonly struct IFlowAnonymousFunctionOperationWrapper : IOperationWrapper
     {
-        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.Operations.IFlowAnonymousFunctionOperation";
+        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.FlowAnalysis.IFlowAnonymousFunctionOperation";
         private static readonly Type WrappedType;
         private static readonly Func<IOperation, IMethodSymbol> SymbolAccessor;
         private readonly IOperation operation;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/StyleCop.Analyzers.CodeGeneration/StyleCop.Analyzers.CodeGeneration.OperationLightupGenerator/IFlowCaptureOperationWrapper.g.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/StyleCop.Analyzers.CodeGeneration/StyleCop.Analyzers.CodeGeneration.OperationLightupGenerator/IFlowCaptureOperationWrapper.g.cs
@@ -9,7 +9,7 @@ namespace StyleCop.Analyzers.Lightup
 
     internal readonly struct IFlowCaptureOperationWrapper : IOperationWrapper
     {
-        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.Operations.IFlowCaptureOperation";
+        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.FlowAnalysis.IFlowCaptureOperation";
         private static readonly Type WrappedType;
         private static readonly Func<IOperation, IOperation> ValueAccessor;
         private readonly IOperation operation;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/StyleCop.Analyzers.CodeGeneration/StyleCop.Analyzers.CodeGeneration.OperationLightupGenerator/IFlowCaptureReferenceOperationWrapper.g.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/StyleCop.Analyzers.CodeGeneration/StyleCop.Analyzers.CodeGeneration.OperationLightupGenerator/IFlowCaptureReferenceOperationWrapper.g.cs
@@ -9,7 +9,7 @@ namespace StyleCop.Analyzers.Lightup
 
     internal readonly struct IFlowCaptureReferenceOperationWrapper : IOperationWrapper
     {
-        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.Operations.IFlowCaptureReferenceOperation";
+        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.FlowAnalysis.IFlowCaptureReferenceOperation";
         private static readonly Type WrappedType;
         private readonly IOperation operation;
         static IFlowCaptureReferenceOperationWrapper()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/StyleCop.Analyzers.CodeGeneration/StyleCop.Analyzers.CodeGeneration.OperationLightupGenerator/IIsNullOperationWrapper.g.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/StyleCop.Analyzers.CodeGeneration/StyleCop.Analyzers.CodeGeneration.OperationLightupGenerator/IIsNullOperationWrapper.g.cs
@@ -9,7 +9,7 @@ namespace StyleCop.Analyzers.Lightup
 
     internal readonly struct IIsNullOperationWrapper : IOperationWrapper
     {
-        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.Operations.IIsNullOperation";
+        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.FlowAnalysis.IIsNullOperation";
         private static readonly Type WrappedType;
         private static readonly Func<IOperation, IOperation> OperandAccessor;
         private readonly IOperation operation;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/StyleCop.Analyzers.CodeGeneration/StyleCop.Analyzers.CodeGeneration.OperationLightupGenerator/IStaticLocalInitializationSemaphoreOperationWrapper.g.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/StyleCop.Analyzers.CodeGeneration/StyleCop.Analyzers.CodeGeneration.OperationLightupGenerator/IStaticLocalInitializationSemaphoreOperationWrapper.g.cs
@@ -9,7 +9,7 @@ namespace StyleCop.Analyzers.Lightup
 
     internal readonly struct IStaticLocalInitializationSemaphoreOperationWrapper : IOperationWrapper
     {
-        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.Operations.IStaticLocalInitializationSemaphoreOperation";
+        internal const string WrappedTypeName = "Microsoft.CodeAnalysis.FlowAnalysis.IStaticLocalInitializationSemaphoreOperation";
         private static readonly Type WrappedType;
         private static readonly Func<IOperation, ILocalSymbol> LocalAccessor;
         private readonly IOperation operation;


### PR DESCRIPTION
Most of the wrapped `IOperation`s are in `Microsoft.CodeAnalysis.Operations` namespace and there are 6 more of them in `FlowAnalysis` namespace:
```
Microsoft.CodeAnalysis.FlowAnalysis.ICaughtExceptionOperation
Microsoft.CodeAnalysis.FlowAnalysis.IFlowAnonymousFunctionOperation
Microsoft.CodeAnalysis.FlowAnalysis.IFlowCaptureOperation
Microsoft.CodeAnalysis.FlowAnalysis.IFlowCaptureReferenceOperation
Microsoft.CodeAnalysis.FlowAnalysis.IIsNullOperation
Microsoft.CodeAnalysis.FlowAnalysis.IStaticLocalInitializationSemaphoreOperation
```
This alternation is already configured in the `OperationInterfaces.xml` file, but the `Namespace` attribute was ignored in the code.
https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/a559b3e58af09387aadc1372a504f9208bce4909/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/OperationInterfaces.xml#L2542


Current behavior:
Using `IFlowAnonymousFunctionOperationWrapper.FromOperation(anonymousFunction)` throws cast exception, because `IsInstance` and `LightupHelpers.CanWrapOperation` finds the key, but returns `null` value for the type.