### PR TITLE
Issue #3402: Removed creation of CultureInfo with arbitrary names

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -83,7 +83,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         {
             bool isStruct = typeDeclaration.IsKind(SyntaxKind.StructDeclaration);
             var settings = document.Project.AnalyzerOptions.GetStyleCopSettings(methodDeclaration.SyntaxTree, cancellationToken);
-            var culture = new CultureInfo(settings.DocumentationRules.DocumentationCulture);
+            var culture = ResourceManagerHelper.GetCultureInfo(settings.DocumentationRules.DocumentationCulture);
             var resourceManager = DocumentationResources.ResourceManager;
 
             if (methodDeclaration is ConstructorDeclarationSyntax)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
@@ -5,7 +5,6 @@ namespace StyleCop.Analyzers.DocumentationRules
 {
     using System;
     using System.Collections.Immutable;
-    using System.Globalization;
     using System.Xml.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
@@ -62,7 +61,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
             var propertyType = context.SemanticModel.GetTypeInfo(propertyDeclaration.Type.StripRefFromType());
             var settings = context.GetStyleCopSettings(context.CancellationToken);
-            var culture = new CultureInfo(settings.DocumentationRules.DocumentationCulture);
+            var culture = ResourceManagerHelper.GetCultureInfo(settings.DocumentationRules.DocumentationCulture);
             var resourceManager = DocumentationResources.ResourceManager;
 
             if (propertyType.Type.SpecialType == SpecialType.System_Boolean)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1625ElementDocumentationMustNotBeCopiedAndPasted.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1625ElementDocumentationMustNotBeCopiedAndPasted.cs
@@ -6,7 +6,6 @@ namespace StyleCop.Analyzers.DocumentationRules
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.Globalization;
     using System.Linq;
     using System.Xml.Linq;
     using Microsoft.CodeAnalysis;
@@ -88,7 +87,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         {
             var objectPool = SharedPools.Default<HashSet<string>>();
             HashSet<string> documentationTexts = objectPool.Allocate();
-            var culture = new CultureInfo(settings.DocumentationRules.DocumentationCulture);
+            var culture = ResourceManagerHelper.GetCultureInfo(settings.DocumentationRules.DocumentationCulture);
             var resourceManager = DocumentationResources.ResourceManager;
 
             foreach (var documentationSyntax in syntaxList)
@@ -120,7 +119,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             var objectPool = SharedPools.Default<HashSet<string>>();
             HashSet<string> documentationTexts = objectPool.Allocate();
             var settings = context.GetStyleCopSettings(context.CancellationToken);
-            var culture = new CultureInfo(settings.DocumentationRules.DocumentationCulture);
+            var culture = ResourceManagerHelper.GetCultureInfo(settings.DocumentationRules.DocumentationCulture);
             var resourceManager = DocumentationResources.ResourceManager;
 
             // Concatenate all XML node values

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -5,12 +5,12 @@ namespace StyleCop.Analyzers.DocumentationRules
 {
     using System;
     using System.Collections.Immutable;
-    using System.Globalization;
     using System.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// The XML documentation header for a C# constructor does not contain the appropriate summary text.
@@ -125,7 +125,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             var constructorDeclarationSyntax = (ConstructorDeclarationSyntax)context.Node;
 
             var settings = context.GetStyleCopSettings(context.CancellationToken);
-            var culture = new CultureInfo(settings.DocumentationRules.DocumentationCulture);
+            var culture = ResourceManagerHelper.GetCultureInfo(settings.DocumentationRules.DocumentationCulture);
             var resourceManager = DocumentationResources.ResourceManager;
 
             bool isStruct = constructorDeclarationSyntax.Parent?.IsKind(SyntaxKind.StructDeclaration) ?? false;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1643DestructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1643DestructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -5,10 +5,10 @@ namespace StyleCop.Analyzers.DocumentationRules
 {
     using System;
     using System.Collections.Immutable;
-    using System.Globalization;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
 
     /// <summary>
     /// The XML documentation header for a C# finalizer does not contain the appropriate summary text.
@@ -78,7 +78,7 @@ namespace StyleCop.Analyzers.DocumentationRules
         private static void HandleDestructor(SyntaxNodeAnalysisContext context)
         {
             var settings = context.GetStyleCopSettings(context.CancellationToken);
-            var culture = new CultureInfo(settings.DocumentationRules.DocumentationCulture);
+            var culture = ResourceManagerHelper.GetCultureInfo(settings.DocumentationRules.DocumentationCulture);
             var resourceManager = DocumentationResources.ResourceManager;
 
             HandleDeclaration(

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/ResourceManagerHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/ResourceManagerHelper.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Helpers
+{
+    using System;
+    using System.Globalization;
+
+    /// <summary>
+    /// Provides helper methods related to ResourceManager.
+    /// </summary>
+    internal static class ResourceManagerHelper
+    {
+        /// <summary>
+        /// Returns a CultureInfo instance specified by the given name. Only to be passed to ResourceManager.
+        /// </summary>
+        /// <param name="name">The culture name.</param>
+        /// <returns>The created CultureInfo instance.</returns>
+        public static CultureInfo GetCultureInfo(string name)
+        {
+            return new ResourceManagerCultureInfo(name);
+        }
+
+        /// <summary>
+        /// Sub class of CultureInfo, used only to get strings from ResourceManager.
+        /// Makes it possible to create a CultureInfo with an arbitrary name even in globalization invariant mode in .NET 6,
+        /// unlike when using the normal CultureInfo class.
+        ///
+        /// The only thing necessary for the ResourceManager seeems to be the Name property.
+        /// Fortunately, almost all of CultureInfo's members are virtual, so this implementation creates
+        /// an invariant culture instance and overrides the Name property.
+        ///
+        /// Overrides all other members as well in debug builds, just to make sure that they are not used.
+        /// </summary>
+        private class ResourceManagerCultureInfo : CultureInfo
+        {
+            public ResourceManagerCultureInfo(string name)
+                : base(string.Empty) // Creates an instance of the invariant culture, which is always ok.
+            {
+                this.Name = name; // Sets the correct name, so that resource string lookups will work.
+            }
+
+            public override string Name { get; }
+
+#if DEBUG
+            public override string EnglishName => throw new NotImplementedException();
+
+            public override CultureInfo Parent => throw new NotImplementedException();
+
+            public override Calendar[] OptionalCalendars => throw new NotImplementedException();
+
+            public override NumberFormatInfo NumberFormat => throw new NotImplementedException();
+
+            public override string NativeName => throw new NotImplementedException();
+
+            public override bool IsNeutralCulture => throw new NotImplementedException();
+
+            public override string TwoLetterISOLanguageName => throw new NotImplementedException();
+
+            public override TextInfo TextInfo => throw new NotImplementedException();
+
+            public override DateTimeFormatInfo DateTimeFormat => throw new NotImplementedException();
+
+            public override CompareInfo CompareInfo => throw new NotImplementedException();
+
+            public override Calendar Calendar => throw new NotImplementedException();
+
+            public override string DisplayName => throw new NotImplementedException();
+
+            public override object Clone() => throw new NotImplementedException();
+
+            public override bool Equals(object value) => throw new NotImplementedException();
+
+            public override object GetFormat(Type formatType) => throw new NotImplementedException();
+
+            public override int GetHashCode() => throw new NotImplementedException();
+
+            public override string ToString() => throw new NotImplementedException();
+#endif
+        }
+    }
+}


### PR DESCRIPTION
Attempted fix for #3402. A bit of a hack :-), but should hopefully work.

Note: I haven't been able to verify this fix on my machine, due to not understanding how, but the problematic calls to the CultureInfo constructor with a culture name are gone. I can try again if someone can explain what to do.