### PR TITLE
Allow direct use of explicit parameterless constructors

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/ReadabilityRules/SA1129CSharp10UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/ReadabilityRules/SA1129CSharp10UnitTests.cs
@@ -3,9 +3,89 @@
 
 namespace StyleCop.Analyzers.Test.CSharp10.ReadabilityRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp9.ReadabilityRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.ReadabilityRules.SA1129DoNotUseDefaultValueTypeConstructor,
+        StyleCop.Analyzers.ReadabilityRules.SA1129CodeFixProvider>;
 
     public class SA1129CSharp10UnitTests : SA1129CSharp9UnitTests
     {
+        [Fact]
+        [WorkItem(3430, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3430")]
+        public async Task VerifyParameterlessStructConstructorAsync()
+        {
+            var testCode = @"struct S
+{
+    public S() { }
+
+    internal static S F1()
+    {
+        S s = new S();
+        return s;
+    }
+
+    internal static S F2()
+    {
+        S s = new();
+        return s;
+    }
+
+    internal static S F3() => new S();
+
+    internal static S F4() => new();
+}
+";
+
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3430, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3430")]
+        public async Task VerifyParameterlessStructConstructorInMetadataAsync()
+        {
+            await new CSharpTest
+            {
+                TestState =
+                {
+                    Sources =
+                    {
+                        @"class B
+{
+    internal static S F1()
+    {
+        S s = new S();
+        return s;
+    }
+
+    internal static S F2()
+    {
+        S s = new();
+        return s;
+    }
+
+    internal static S F3() => new S();
+
+    internal static S F4() => new();
+}
+",
+                    },
+                    AdditionalProjects =
+                    {
+                        ["Reference"] =
+                        {
+                            Sources =
+                            {
+                                @"public struct S { public S() { } }",
+                            },
+                        },
+                    },
+                    AdditionalProjectReferences = { "Reference" },
+                },
+            }.RunAsync(CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1129UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1129UnitTests.cs
@@ -127,6 +127,61 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
         }
 
+        [Fact]
+        public async Task VerifyInvalidValueTypeCreationFromMetadataAsync()
+        {
+            var testCode = @"public class TestClass
+{
+    public void TestMethod()
+    {
+        var v1 = [|new TestStruct()|];
+
+        System.Console.WriteLine([|new TestStruct()|]);
+    }
+}
+";
+
+            var fixedTestCode = @"public class TestClass
+{
+    public void TestMethod()
+    {
+        var v1 = default(TestStruct);
+
+        System.Console.WriteLine(default(TestStruct));
+    }
+}
+";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
+            };
+
+            await new CSharpTest
+            {
+                TestState =
+                {
+                    Sources = { testCode },
+                    AdditionalProjects =
+                    {
+                        ["Reference"] =
+                        {
+                            Sources =
+                            {
+                                @"public struct TestStruct { public int TestProperty { get; set; } }",
+                            },
+                        },
+                    },
+                    AdditionalProjectReferences = { "Reference" },
+                },
+                FixedState =
+                {
+                    Sources = { fixedTestCode },
+                },
+            }.RunAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Verifies that the codefix will preserve surrounding trivia.
         /// </summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1129DoNotUseDefaultValueTypeConstructor.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1129DoNotUseDefaultValueTypeConstructor.cs
@@ -70,6 +70,12 @@ namespace StyleCop.Analyzers.ReadabilityRules
                 return;
             }
 
+            if (!objectCreation.Constructor.IsImplicitlyDeclared)
+            {
+                // The value type includes an explicit parameterless constructor
+                return;
+            }
+
             if (objectCreation.Initializer.WrappedOperation != null)
             {
                 return;


### PR DESCRIPTION
Fixes #3430