### PR TITLE
Map dotnet_separate_import_directive_groups=false to OptionSetting.Allow

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/Settings/SettingsCSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/Settings/SettingsCSharp8UnitTests.cs
@@ -66,7 +66,7 @@ stylecop.unrecognizedValue = 3
 
             Assert.NotNull(styleCopSettings.OrderingRules);
             Assert.Equal(UsingDirectivesPlacement.OutsideNamespace, styleCopSettings.OrderingRules.UsingDirectivesPlacement);
-            Assert.Equal(OptionSetting.Omit, styleCopSettings.OrderingRules.BlankLinesBetweenUsingGroups);
+            Assert.Equal(OptionSetting.Allow, styleCopSettings.OrderingRules.BlankLinesBetweenUsingGroups);
         }
 
         [Theory]

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/OrderingSettings.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/OrderingSettings.cs
@@ -105,7 +105,7 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
             blankLinesBetweenUsingGroups ??= AnalyzerConfigHelper.TryGetBooleanValue(analyzerConfigOptions, "dotnet_separate_import_directive_groups") switch
             {
                 true => OptionSetting.Require,
-                false => OptionSetting.Omit,
+                false => OptionSetting.Allow,
                 _ => null,
             };
 


### PR DESCRIPTION
Roslyn does not remove blank lines when `dotnet_separate_import_directive_groups` is false.