### PR TITLE
Updated SA1009 to forbid space after a closing parenthesis in a method reference contained in single quotes

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1009UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1009UnitTests.cs
@@ -86,6 +86,33 @@ public class Foo
         }
 
         [Fact]
+        [WorkItem(2985, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2985")]
+        public async Task TestDocumentationMethodReferenceInSingleQuotesWithWhitespaceAfterClosingParenthesisAsync()
+        {
+            const string testCode = @"
+public class Foo
+{
+    /// <see cref='Method({|#0:)|} '/>
+    public void Method()
+    {
+    }
+}";
+
+            const string fixedCode = @"
+public class Foo
+{
+    /// <see cref='Method()'/>
+    public void Method()
+    {
+    }
+}";
+
+            DiagnosticResult expected = Diagnostic(DescriptorNotFollowed).WithLocation(0);
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestMethodWith2CorrectlySpacedParametersAsync()
         {
             const string testCode = @"using System;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
@@ -118,6 +118,7 @@ namespace StyleCop.Analyzers.SpacingRules
             case SyntaxKind.SemicolonToken:
             case SyntaxKind.CommaToken:
             case SyntaxKind.DoubleQuoteToken:
+            case SyntaxKind.SingleQuoteToken:
             case SyntaxKindEx.DotDotToken:
                 precedesStickyCharacter = true;
                 break;


### PR DESCRIPTION
Fixes #2985