### PR TITLE
Configure some code quality diagnostics (IDExxxx) as warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -102,3 +102,4 @@ csharp_style_conditional_delegate_call = true:suggestion
 dotnet_diagnostic.IDE0005.severity = warning      # Remove unnecessary import
 dotnet_diagnostic.IDE0051.severity = warning      # Remove unused private member
 dotnet_diagnostic.IDE0052.severity = warning      # Remove unread private member
+dotnet_diagnostic.IDE0059.severity = warning      # Remove unnecessary value assignment

--- a/.editorconfig
+++ b/.editorconfig
@@ -100,4 +100,5 @@ csharp_style_conditional_delegate_call = true:suggestion
 
 # Prefer generally simpler code
 dotnet_diagnostic.IDE0005.severity = warning      # Remove unnecessary import
+dotnet_diagnostic.IDE0051.severity = warning      # Remove unused private member
 dotnet_diagnostic.IDE0052.severity = warning      # Remove unread private member

--- a/.editorconfig
+++ b/.editorconfig
@@ -97,3 +97,6 @@ csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
 csharp_style_inlined_variable_declaration = true:none
 csharp_style_throw_expression = true:none
 csharp_style_conditional_delegate_call = true:suggestion
+
+# Prefer generally simpler code
+dotnet_diagnostic.IDE0005.severity = warning      # Remove unnecessary import

--- a/.editorconfig
+++ b/.editorconfig
@@ -100,3 +100,4 @@ csharp_style_conditional_delegate_call = true:suggestion
 
 # Prefer generally simpler code
 dotnet_diagnostic.IDE0005.severity = warning      # Remove unnecessary import
+dotnet_diagnostic.IDE0052.severity = warning      # Remove unread private member

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1642SA1643CodeFixProvider.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.DocumentationRules
     using System;
     using System.Collections.Immutable;
     using System.Composition;
-    using System.Globalization;
     using System.Linq;
     using System.Text.RegularExpressions;
     using System.Threading;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeGeneration/SyntaxLightupGenerator.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeGeneration/SyntaxLightupGenerator.cs
@@ -4,7 +4,6 @@
 namespace StyleCop.Analyzers.CodeGeneration
 {
     using System;
-    using System.Collections;
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Diagnostics;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/OrderingRules/SA1210CSharp10UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/OrderingRules/SA1210CSharp10UnitTests.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Test.CSharp10.OrderingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp9.OrderingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1009CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1009CSharp8UnitTests.cs
@@ -10,7 +10,6 @@ namespace StyleCop.Analyzers.Test.CSharp8.SpacingRules
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp7.SpacingRules;
-    using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1009ClosingParenthesisMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/SpacingRules/SA1023CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/SpacingRules/SA1023CSharp9UnitTests.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.Test.CSharp9.SpacingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.CSharp;
-    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp8.SpacingRules;
     using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402ForDelegateUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402ForDelegateUnitTests.cs
@@ -11,7 +11,6 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Settings.ObjectModel;
     using Xunit;
-    using Xunit.Sdk;
 
     public class SA1402ForDelegateUnitTests : SA1402ForNonBlockDeclarationUnitTestsBase
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1129UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1129UnitTests.cs
@@ -154,12 +154,6 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 }
 ";
 
-            DiagnosticResult[] expected =
-            {
-                Diagnostic().WithLocation(0),
-                Diagnostic().WithLocation(1),
-            };
-
             await new CSharpTest
             {
                 TestState =

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.DocumentationRules
 {
     using System;
     using System.Collections.Immutable;
-    using System.Globalization;
     using System.Xml.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1625ElementDocumentationMustNotBeCopiedAndPasted.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1625ElementDocumentationMustNotBeCopiedAndPasted.cs
@@ -8,7 +8,6 @@ namespace StyleCop.Analyzers.DocumentationRules
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
-    using System.Globalization;
     using System.Linq;
     using System.Xml.Linq;
     using Microsoft.CodeAnalysis;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1642ConstructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.DocumentationRules
 {
     using System;
     using System.Collections.Immutable;
-    using System.Globalization;
     using System.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1643DestructorSummaryDocumentationMustBeginWithStandardText.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1643DestructorSummaryDocumentationMustBeginWithStandardText.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.DocumentationRules
 {
     using System;
     using System.Collections.Immutable;
-    using System.Globalization;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Diagnostics;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/AnalyzerConfigOptionsProviderWrapper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/AnalyzerConfigOptionsProviderWrapper.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Lightup
 {
     using System;
     using Microsoft.CodeAnalysis;
-    using Microsoft.CodeAnalysis.Diagnostics;
 
     internal readonly struct AnalyzerConfigOptionsProviderWrapper
     {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/SettingsHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/SettingsHelper.cs
@@ -25,10 +25,6 @@ namespace StyleCop.Analyzers
         internal const string SettingsFileName = "stylecop.json";
         internal const string AltSettingsFileName = ".stylecop.json";
 
-        private static SourceTextValueProvider<StyleCopSettings> SettingsValueProvider { get; } =
-            new SourceTextValueProvider<StyleCopSettings>(
-                text => GetStyleCopSettings(options: null, tree: null, SettingsFileName, text, DeserializationFailureBehavior.ReturnDefaultSettings));
-
         /// <summary>
         /// Gets the StyleCop settings.
         /// </summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1024ColonsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1024ColonsMustBeSpacedCorrectly.cs
@@ -67,7 +67,6 @@ namespace StyleCop.Analyzers.SpacingRules
         public const string DiagnosticId = "SA1024";
         private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1024.md";
         private static readonly LocalizableString Title = new LocalizableResourceString(nameof(SpacingResources.SA1024Title), SpacingResources.ResourceManager, typeof(SpacingResources));
-        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(SpacingResources.SA1024MessageNotPreceded), SpacingResources.ResourceManager, typeof(SpacingResources));
         private static readonly LocalizableString Description = new LocalizableResourceString(nameof(SpacingResources.SA1024Description), SpacingResources.ResourceManager, typeof(SpacingResources));
 
         private static readonly LocalizableString MessageNotPreceded = new LocalizableResourceString(nameof(SpacingResources.SA1024MessageNotPreceded), SpacingResources.ResourceManager, typeof(SpacingResources));


### PR DESCRIPTION
I have gotten comments on pull requests regarding unnecessary using statements, so I thought it would be better to configure it as a warning instead, so it is caught automatically. Also did the same with some more IDE diagnostics that I think will be uncontroversial and had violations in the repository.