### PR TITLE
Update SA1012 to expect no space between a property pattern's opening brace and an enclosing list pattern's opening bracket

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/SpacingRules/SA1012CSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/SpacingRules/SA1012CSharp11UnitTests.cs
@@ -5,9 +5,57 @@
 
 namespace StyleCop.Analyzers.Test.CSharp11.SpacingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using StyleCop.Analyzers.Test.CSharp10.SpacingRules;
+    using StyleCop.Analyzers.Test.Verifiers;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1012OpeningBracesMustBeSpacedCorrectly,
+        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1012CSharp11UnitTests : SA1012CSharp10UnitTests
     {
+        [Fact]
+        [WorkItem(3509, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3509")]
+        public async Task TestPropertyPatternInsideListPatternAsync()
+        {
+            var testCode = @"
+class C
+{
+    void M(string[] a)
+    {
+        _ = a is [ {|#0:{|} Length: 1 }];
+        _ = a is [{ Length: 0 },{|#1:{|} Length: 1 }];
+    }
+}
+";
+
+            var fixedCode = @"
+class C
+{
+    void M(string[] a)
+    {
+        _ = a is [{ Length: 1 }];
+        _ = a is [{ Length: 0 }, { Length: 1 }];
+    }
+}
+";
+
+            await new CSharpTest()
+            {
+                ReferenceAssemblies = GenericAnalyzerTest.ReferenceAssembliesNet50,
+                TestCode = testCode,
+                ExpectedDiagnostics =
+                {
+                    // Opening brace should not be preceded by a space
+                    Diagnostic().WithLocation(0).WithArguments(" not", "preceded"),
+
+                    // Opening brace should be preceded by a space
+                    Diagnostic().WithLocation(1).WithArguments(string.Empty, "preceded"),
+                },
+                FixedCode = fixedCode,
+            }.RunAsync(CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1012OpeningBracesMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1012OpeningBracesMustBeSpacedCorrectly.cs
@@ -92,11 +92,19 @@ namespace StyleCop.Analyzers.SpacingRules
             }
 
             bool expectPrecedingSpace = true;
-            if (token.Parent.IsKind(SyntaxKindEx.PropertyPatternClause)
-                && token.GetPreviousToken() is { RawKind: (int)SyntaxKind.OpenParenToken, Parent: { RawKind: (int)SyntaxKindEx.PositionalPatternClause } })
+            if (token.Parent.IsKind(SyntaxKindEx.PropertyPatternClause))
             {
-                // value is ({ P: 0 }, { P: 0 })
-                expectPrecedingSpace = false;
+                var prevToken = token.GetPreviousToken();
+                if (prevToken is { RawKind: (int)SyntaxKind.OpenParenToken, Parent: { RawKind: (int)SyntaxKindEx.PositionalPatternClause } })
+                {
+                    // value is ({ P: 0 }, { P: 0 })
+                    expectPrecedingSpace = false;
+                }
+                else if (prevToken is { RawKind: (int)SyntaxKind.OpenBracketToken, Parent: { RawKind: (int)SyntaxKindEx.ListPattern } })
+                {
+                    // value is [{ P: 0 }, { P: 0 }]
+                    expectPrecedingSpace = false;
+                }
             }
 
             bool precededBySpace = token.IsFirstInLine() || token.IsPrecededByWhitespace(context.CancellationToken);


### PR DESCRIPTION
Fixes #3509