### PR TITLE
Performance improvement: Reduce time spent reading settings file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ OpenCover.Symbols/
 .nuget/NuGet.exe
 build/nuget/
 *.log
+*.binlog
 
 # Visual Studio performance tools
 *.psess

--- a/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerExtensions.cs
@@ -26,10 +26,10 @@ namespace StyleCop.Analyzers
         public static void RegisterSyntaxTreeAction(this AnalysisContext context, Action<SyntaxTreeAnalysisContext, StyleCopSettings> action)
         {
             context.RegisterSyntaxTreeAction(
-                context =>
+                c =>
                 {
-                    StyleCopSettings settings = context.GetStyleCopSettings(context.CancellationToken);
-                    action(context, settings);
+                    StyleCopSettings settings = c.GetStyleCopSettings(c.CancellationToken);
+                    action(c, settings);
                 });
         }
 
@@ -42,10 +42,10 @@ namespace StyleCop.Analyzers
         public static void RegisterSyntaxTreeAction(this CompilationStartAnalysisContext context, Action<SyntaxTreeAnalysisContext, StyleCopSettings> action)
         {
             context.RegisterSyntaxTreeAction(
-                context =>
+                c =>
                 {
-                    StyleCopSettings settings = context.GetStyleCopSettings(context.CancellationToken);
-                    action(context, settings);
+                    StyleCopSettings settings = c.GetStyleCopSettings(c.CancellationToken);
+                    action(c, settings);
                 });
         }
 
@@ -81,10 +81,10 @@ namespace StyleCop.Analyzers
             where TLanguageKindEnum : struct
         {
             context.RegisterSyntaxNodeAction(
-                context =>
+                c =>
                 {
-                    StyleCopSettings settings = context.GetStyleCopSettings(context.CancellationToken);
-                    action(context, settings);
+                    StyleCopSettings settings = c.GetStyleCopSettings(c.CancellationToken);
+                    action(c, settings);
                 },
                 syntaxKinds);
         }
@@ -121,10 +121,10 @@ namespace StyleCop.Analyzers
             where TLanguageKindEnum : struct
         {
             context.RegisterSyntaxNodeAction(
-                context =>
+                c =>
                 {
-                    StyleCopSettings settings = context.GetStyleCopSettings(context.CancellationToken);
-                    action(context, settings);
+                    StyleCopSettings settings = c.GetStyleCopSettings(c.CancellationToken);
+                    action(c, settings);
                 },
                 syntaxKinds);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerExtensions.cs
@@ -28,7 +28,7 @@ namespace StyleCop.Analyzers
             context.RegisterSyntaxTreeAction(
                 c =>
                 {
-                    StyleCopSettings settings = c.GetStyleCopSettings(c.CancellationToken);
+                    StyleCopSettings settings = context.GetStyleCopSettings(c.Options, c.Tree, c.CancellationToken);
                     action(c, settings);
                 });
         }
@@ -44,7 +44,7 @@ namespace StyleCop.Analyzers
             context.RegisterSyntaxTreeAction(
                 c =>
                 {
-                    StyleCopSettings settings = c.GetStyleCopSettings(c.CancellationToken);
+                    StyleCopSettings settings = context.GetStyleCopSettings(c.Options, c.Tree, c.CancellationToken);
                     action(c, settings);
                 });
         }
@@ -83,7 +83,7 @@ namespace StyleCop.Analyzers
             context.RegisterSyntaxNodeAction(
                 c =>
                 {
-                    StyleCopSettings settings = c.GetStyleCopSettings(c.CancellationToken);
+                    StyleCopSettings settings = context.GetStyleCopSettings(c.Options, c.Node.SyntaxTree, c.CancellationToken);
                     action(c, settings);
                 },
                 syntaxKinds);
@@ -123,7 +123,7 @@ namespace StyleCop.Analyzers
             context.RegisterSyntaxNodeAction(
                 c =>
                 {
-                    StyleCopSettings settings = c.GetStyleCopSettings(c.CancellationToken);
+                    StyleCopSettings settings = context.GetStyleCopSettings(c.Options, c.Node.SyntaxTree, c.CancellationToken);
                     action(c, settings);
                 },
                 syntaxKinds);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/SettingsHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/SettingsHelper.cs
@@ -108,6 +108,26 @@ namespace StyleCop.Analyzers
                 || string.Equals(fileName, AltSettingsFileName, StringComparison.OrdinalIgnoreCase);
         }
 
+        private static StyleCopSettings GetStyleCopSettings(AnalyzerOptions options, SyntaxTree tree, ImmutableArray<AdditionalText> additionalFiles, DeserializationFailureBehavior failureBehavior, CancellationToken cancellationToken)
+        {
+            foreach (var additionalFile in additionalFiles)
+            {
+                if (IsStyleCopSettingsFile(additionalFile.Path))
+                {
+                    SourceText additionalTextContent = additionalFile.GetText(cancellationToken);
+                    return GetStyleCopSettings(options, tree, additionalFile.Path, additionalTextContent, failureBehavior);
+                }
+            }
+
+            if (tree != null)
+            {
+                var optionsProvider = options.AnalyzerConfigOptionsProvider().GetOptions(tree);
+                return new StyleCopSettings(new JsonObject(), optionsProvider);
+            }
+
+            return new StyleCopSettings();
+        }
+
         private static StyleCopSettings GetStyleCopSettings(AnalyzerOptions options, SyntaxTree tree, string path, SourceText text, DeserializationFailureBehavior failureBehavior)
         {
             var optionsProvider = options.AnalyzerConfigOptionsProvider().GetOptions(tree);
@@ -142,26 +162,6 @@ namespace StyleCop.Analyzers
             catch (JsonParseException) when (failureBehavior == DeserializationFailureBehavior.ReturnDefaultSettings)
             {
                 // The settings file is invalid -> return the default settings.
-            }
-
-            return new StyleCopSettings();
-        }
-
-        private static StyleCopSettings GetStyleCopSettings(AnalyzerOptions options, SyntaxTree tree, ImmutableArray<AdditionalText> additionalFiles, DeserializationFailureBehavior failureBehavior, CancellationToken cancellationToken)
-        {
-            foreach (var additionalFile in additionalFiles)
-            {
-                if (IsStyleCopSettingsFile(additionalFile.Path))
-                {
-                    SourceText additionalTextContent = additionalFile.GetText(cancellationToken);
-                    return GetStyleCopSettings(options, tree, additionalFile.Path, additionalTextContent, failureBehavior);
-                }
-            }
-
-            if (tree != null)
-            {
-                var optionsProvider = options.AnalyzerConfigOptionsProvider().GetOptions(tree);
-                return new StyleCopSettings(new JsonObject(), optionsProvider);
             }
 
             return new StyleCopSettings();

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/SettingsHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/SettingsHelper.cs
@@ -7,6 +7,7 @@ namespace StyleCop.Analyzers
 {
     using System;
     using System.Collections.Immutable;
+    using System.Diagnostics;
     using System.IO;
     using System.Threading;
     using LightJson;
@@ -25,9 +26,70 @@ namespace StyleCop.Analyzers
         internal const string SettingsFileName = "stylecop.json";
         internal const string AltSettingsFileName = ".stylecop.json";
 
-        private static SourceTextValueProvider<StyleCopSettings> SettingsValueProvider { get; } =
-            new SourceTextValueProvider<StyleCopSettings>(
-                text => GetStyleCopSettings(options: null, tree: null, SettingsFileName, text, DeserializationFailureBehavior.ReturnDefaultSettings));
+        private static SourceTextValueProvider<JsonValue> SettingsValueProvider { get; } =
+            new SourceTextValueProvider<JsonValue>(
+                text => JsonReader.Parse(text.ToString()));
+
+        /// <summary>
+        /// Gets the StyleCop settings.
+        /// </summary>
+        /// <remarks>
+        /// <para>If a <see cref="JsonParseException"/> or <see cref="InvalidSettingsException"/> occurs while
+        /// deserializing the settings file, a default settings instance is returned.</para>
+        /// </remarks>
+        /// <param name="context">The context that will be used to determine the StyleCop settings.</param>
+        /// <param name="options">The analyzer options that will be used to determine the StyleCop settings.</param>
+        /// <param name="tree">The syntax tree.</param>
+        /// <param name="cancellationToken">The cancellation token that the operation will observe.</param>
+        /// <returns>A <see cref="StyleCopSettings"/> instance that represents the StyleCop settings for the given context.</returns>
+        internal static StyleCopSettings GetStyleCopSettings(this AnalysisContext context, AnalyzerOptions options, SyntaxTree tree, CancellationToken cancellationToken)
+        {
+            return GetStyleCopSettings(options, tree, GetSettingsJson, cancellationToken);
+
+            JsonValue? GetSettingsJson(SourceText text)
+            {
+                if (context.TryGetValue(text, SettingsValueProvider, out var json))
+                {
+                    return json;
+                }
+                else
+                {
+                    // The provider threw an exception, i.e. the json file could not be parsed
+                    return null;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Gets the StyleCop settings.
+        /// </summary>
+        /// <remarks>
+        /// <para>If a <see cref="JsonParseException"/> or <see cref="InvalidSettingsException"/> occurs while
+        /// deserializing the settings file, a default settings instance is returned.</para>
+        /// </remarks>
+        /// <param name="context">The context that will be used to determine the StyleCop settings.</param>
+        /// <param name="options">The analyzer options that will be used to determine the StyleCop settings.</param>
+        /// <param name="tree">The syntax tree.</param>
+        /// <param name="cancellationToken">The cancellation token that the operation will observe.</param>
+        /// <returns>A <see cref="StyleCopSettings"/> instance that represents the StyleCop settings for the given context.</returns>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("MicrosoftCodeAnalysisPerformance", "RS1012:Start action has no registered actions", Justification = "This is not a start action")]
+        internal static StyleCopSettings GetStyleCopSettings(this CompilationStartAnalysisContext context, AnalyzerOptions options, SyntaxTree tree, CancellationToken cancellationToken)
+        {
+            return GetStyleCopSettings(options, tree, GetSettingsJson, cancellationToken);
+
+            JsonValue? GetSettingsJson(SourceText text)
+            {
+                if (context.TryGetValue(text, SettingsValueProvider, out var json))
+                {
+                    return json;
+                }
+                else
+                {
+                    // The provider threw an exception, i.e. the json file could not be parsed
+                    return null;
+                }
+            }
+        }
 
         /// <summary>
         /// Gets the StyleCop settings.
@@ -86,7 +148,14 @@ namespace StyleCop.Analyzers
         /// <returns>A <see cref="StyleCopSettings"/> instance that represents the StyleCop settings for the given context.</returns>
         internal static StyleCopSettings GetStyleCopSettings(this AnalyzerOptions options, SyntaxTree tree, DeserializationFailureBehavior failureBehavior, CancellationToken cancellationToken)
         {
-            return GetStyleCopSettings(options, tree, options != null ? options.AdditionalFiles : ImmutableArray.Create<AdditionalText>(), failureBehavior, cancellationToken);
+            var additionalFiles = options != null ? options.AdditionalFiles : ImmutableArray.Create<AdditionalText>();
+            return GetStyleCopSettings(options, tree, additionalFiles, failureBehavior, GetSettingsJson, cancellationToken);
+
+            JsonValue? GetSettingsJson(SourceText text)
+            {
+                // Note: Null is never returned here.
+                return JsonReader.Parse(text.ToString());
+            }
         }
 
         /// <summary>
@@ -108,14 +177,20 @@ namespace StyleCop.Analyzers
                 || string.Equals(fileName, AltSettingsFileName, StringComparison.OrdinalIgnoreCase);
         }
 
-        private static StyleCopSettings GetStyleCopSettings(AnalyzerOptions options, SyntaxTree tree, ImmutableArray<AdditionalText> additionalFiles, DeserializationFailureBehavior failureBehavior, CancellationToken cancellationToken)
+        private static StyleCopSettings GetStyleCopSettings(AnalyzerOptions options, SyntaxTree tree, Func<SourceText, JsonValue?> getSettingsJson, CancellationToken cancellationToken)
+        {
+            var additionalTexts = options != null ? options.AdditionalFiles : ImmutableArray.Create<AdditionalText>();
+            return GetStyleCopSettings(options, tree, additionalTexts, DeserializationFailureBehavior.ReturnDefaultSettings, getSettingsJson, cancellationToken);
+        }
+
+        private static StyleCopSettings GetStyleCopSettings(AnalyzerOptions options, SyntaxTree tree, ImmutableArray<AdditionalText> additionalFiles, DeserializationFailureBehavior failureBehavior, Func<SourceText, JsonValue?> getSettingsJson, CancellationToken cancellationToken)
         {
             foreach (var additionalFile in additionalFiles)
             {
                 if (IsStyleCopSettingsFile(additionalFile.Path))
                 {
                     SourceText additionalTextContent = additionalFile.GetText(cancellationToken);
-                    return GetStyleCopSettings(options, tree, additionalFile.Path, additionalTextContent, failureBehavior);
+                    return GetStyleCopSettings(options, tree, additionalFile.Path, additionalTextContent, failureBehavior, getSettingsJson);
                 }
             }
 
@@ -128,13 +203,24 @@ namespace StyleCop.Analyzers
             return new StyleCopSettings();
         }
 
-        private static StyleCopSettings GetStyleCopSettings(AnalyzerOptions options, SyntaxTree tree, string path, SourceText text, DeserializationFailureBehavior failureBehavior)
+        private static StyleCopSettings GetStyleCopSettings(AnalyzerOptions options, SyntaxTree tree, string path, SourceText text, DeserializationFailureBehavior failureBehavior, Func<SourceText, JsonValue?> getSettingsJson)
         {
             var optionsProvider = options.AnalyzerConfigOptionsProvider().GetOptions(tree);
 
             try
             {
-                var rootValue = JsonReader.Parse(text.ToString());
+                var nullableRootValue = getSettingsJson(text);
+                if (nullableRootValue == null)
+                {
+                    // The settings file is invalid -> return the default settings.
+                    //
+                    // Note: We will only get here when reading using the provider.
+                    // If we don't, the called method will throw an exception instead of returning null.
+                    Debug.Assert(failureBehavior == DeserializationFailureBehavior.ReturnDefaultSettings, "Unexpected failure behaviour. Original exception is lost when reading from the provider.");
+                    return new StyleCopSettings();
+                }
+
+                var rootValue = nullableRootValue.Value;
                 if (!rootValue.IsJsonObject)
                 {
                     throw new JsonParseException(

--- a/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
+++ b/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
 
     <!-- Automatically generate the necessary assembly binding redirects -->
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -24,10 +24,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="2.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.2.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I profiled using StyleCopTester and noticed that a lot of time was spent reading the settings file. Previously a SourceTextValueProvider was used to cache the parsed json data, but that was no longer used. Updating SettingsHelper to again use a SourceTextValueProvider improved the time needed to retrieve the diagnostics in StyleCopTester by around 15% on my machine, when running on StyleCop.Analyzers.sln.