### PR TITLE
Keep tracked nodes in a list

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1133CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1133CodeFixProvider.cs
@@ -116,7 +116,9 @@ namespace StyleCop.Analyzers.ReadabilityRules
                 var syntaxRoot = await document.GetSyntaxRootAsync(fixAllContext.CancellationToken).ConfigureAwait(false);
                 var settings = SettingsHelper.GetStyleCopSettings(document.Project.AnalyzerOptions, syntaxRoot.SyntaxTree, fixAllContext.CancellationToken);
 
-                var nodes = diagnostics.Select(diagnostic => syntaxRoot.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true).FirstAncestorOrSelf<AttributeListSyntax>());
+                // 🐉 Need to eagerly evaluate this with ToList() to ensure nodes are not garbage collected between the
+                // call to TrackNodes and subsequent enumeration.
+                var nodes = diagnostics.Select(diagnostic => syntaxRoot.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true).FirstAncestorOrSelf<AttributeListSyntax>()).ToList();
 
                 var newRoot = syntaxRoot.TrackNodes(nodes);
 


### PR DESCRIPTION
Lazily-enumerated nodes which are passed to `TrackNodes` and then enumerated a second time can be garbage collected between the two passes. If this occurs, the node tracking will fail. We resolve the issue by ensuring the nodes are held in an eagerly-evaluated list.

See https://github.com/dotnet/roslyn/pull/61958