### PR TITLE
Update SA1515 to not let one range of trivia affect another

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1515UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1515UnitTests.cs
@@ -243,5 +243,31 @@ public class TestConstants
 
             await VerifyCSharpFixAsync(testCode, expectedDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
         }
+
+        /// <summary>
+        /// Verifies that the analyzer will properly handle documentation followed by a comment,
+        /// even if there is another non-adjacent comment earlier.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        [WorkItem(3481, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3481")]
+        public async Task TestDocumentationFollowedByCommentWhenThereIsAlsoAnEarlierCommentAsync()
+        {
+            var testCode = @"
+public class Class1 // Comment 1
+{
+    public Class1()
+    {
+    }
+
+    /// <summary>
+    /// Gets value.
+    /// </summary>
+    // Comment 2
+    public double Value { get; }
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515SingleLineCommentMustBePrecededByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515SingleLineCommentMustBePrecededByBlankLine.cs
@@ -108,21 +108,18 @@ namespace StyleCop.Analyzers.LayoutRules
         private static void HandleSyntaxTree(SyntaxTreeAnalysisContext context)
         {
             var syntaxRoot = context.Tree.GetRoot(context.CancellationToken);
-            var previousCommentNotOnOwnLine = false;
 
             foreach (var trivia in syntaxRoot.DescendantTrivia().Where(trivia => trivia.IsKind(SyntaxKind.SingleLineCommentTrivia)))
             {
                 if (trivia.FullSpan.Start == 0)
                 {
                     // skip the trivia if it is at the start of the file
-                    previousCommentNotOnOwnLine = false;
                     continue;
                 }
 
                 if (trivia.ToString().StartsWith("////", StringComparison.Ordinal))
                 {
                     // ignore commented out code
-                    previousCommentNotOnOwnLine = false;
                     continue;
                 }
 
@@ -132,25 +129,20 @@ namespace StyleCop.Analyzers.LayoutRules
                 if (!IsOnOwnLine(triviaList, triviaIndex))
                 {
                     // ignore comments after other code elements.
-                    previousCommentNotOnOwnLine = true;
                     continue;
                 }
 
                 if (IsPrecededByBlankLine(triviaList, triviaIndex))
                 {
                     // allow properly formatted blank line comments.
-                    previousCommentNotOnOwnLine = false;
                     continue;
                 }
 
-                if (!previousCommentNotOnOwnLine && IsPrecededBySingleLineCommentOrDocumentation(triviaList, triviaIndex))
+                if (IsPrecededBySingleLineCommentOnOwnLineOrDocumentation(triviaList, triviaIndex))
                 {
                     // allow consecutive single line comments.
-                    previousCommentNotOnOwnLine = false;
                     continue;
                 }
-
-                previousCommentNotOnOwnLine = false;
 
                 if (IsAtStartOfScope(trivia))
                 {
@@ -185,7 +177,7 @@ namespace StyleCop.Analyzers.LayoutRules
             return false;
         }
 
-        private static bool IsPrecededBySingleLineCommentOrDocumentation<T>(T triviaList, int triviaIndex)
+        private static bool IsPrecededBySingleLineCommentOnOwnLineOrDocumentation<T>(T triviaList, int triviaIndex)
             where T : IReadOnlyList<SyntaxTrivia>
         {
             var eolCount = 0;
@@ -206,6 +198,8 @@ namespace StyleCop.Analyzers.LayoutRules
                     break;
 
                 case SyntaxKind.SingleLineCommentTrivia:
+                    return IsOnOwnLine(triviaList, triviaIndex);
+
                 case SyntaxKind.SingleLineDocumentationCommentTrivia:
                     return true;
 


### PR DESCRIPTION
Fixes #3481

The problem as I see it was that the previous code kept state to be able to trigger on the following code:
```
a(); // Some comment
// Diagnostic wanted here
```
without triggering on this:
```
// Some comment
// Diagnostic not wanted here
```

But this state also leaked over to unrelated chunks of trivia. I replaced the state with more digging in the current trivia, to avoid the reported false positive.