### PR TITLE
Remove byte order mark from schema file

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "$schema": "http://json-schema.org/draft-04/schema#",
   "id": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "title": "StyleCop Analyzers Configuration",


### PR DESCRIPTION
Remove the byte order mark from the schema file to fix Visual Studio Code parse error.

![image](https://user-images.githubusercontent.com/1439341/193446925-cbdda26f-50ff-4e2f-b60b-430d84176f76.png)
