### PR TITLE
Update SA1313 to also allow incorrect names in explicitly implemented methods from interfaces

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
@@ -278,6 +278,57 @@ public class Test : ITest
         }
 
         [Fact]
+        [WorkItem(3555, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3555")]
+        public async Task TestNoViolationOnExplicitlyImplementedInterfaceParameterNameAsync()
+        {
+            var testCode = @"
+public interface ITest
+{
+    void Method(int param1, int {|#0:Param2|});
+}
+
+public class Test : ITest
+{
+    void ITest.Method(int param1, int Param2)
+    {
+    }
+}";
+
+            var expected = new[]
+            {
+                Diagnostic().WithLocation(0).WithArguments("Param2"),
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3555, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3555")]
+        public async Task TestViolationOnRenamedExplicitlyImplementedInterfaceParameterNameAsync()
+        {
+            var testCode = @"
+public interface ITest
+{
+    void Method(int param1, int {|#0:Param2|});
+}
+
+public class Test : ITest
+{
+    public void Method(int param1, int {|#1:Other|})
+    {
+    }
+}";
+
+            var expected = new[]
+            {
+                Diagnostic().WithLocation(0).WithArguments("Param2"),
+                Diagnostic().WithLocation(1).WithArguments("Other"),
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestNoViolationOnAbstractParameterNameAsync()
         {
             var testCode = @"

--- a/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1313ParameterNamesMustBeginWithLowerCaseLetter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/NamingRules/SA1313ParameterNamesMustBeginWithLowerCaseLetter.cs
@@ -137,10 +137,21 @@ namespace StyleCop.Analyzers.NamingRules
 
             if (methodSymbol.IsOverride)
             {
-                // OverridenMethod can be null in case of an invalid method declaration -> exit because there is no meaningful analysis to be done.
+                // OverriddenMethod can be null in case of an invalid method declaration -> exit because there is no meaningful analysis to be done.
                 if ((methodSymbol.OverriddenMethod == null) || (methodSymbol.OverriddenMethod.Parameters[index].Name == syntax.Identifier.ValueText))
                 {
                     return true;
+                }
+            }
+            else if (methodSymbol.ExplicitInterfaceImplementations.Length > 0)
+            {
+                // Checking explicitly implemented interface members here because the code below will not handle them correctly
+                foreach (var interfaceMethod in methodSymbol.ExplicitInterfaceImplementations)
+                {
+                    if (interfaceMethod.Parameters[index].Name == syntax.Identifier.ValueText)
+                    {
+                        return true;
+                    }
                 }
             }
             else


### PR DESCRIPTION
Fixes #3555