### PR TITLE
Update Microsoft.CodeAnalysis.CSharp.Workspaces to version 4.4.0 for the c# 11 test project

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/StyleCop.Analyzers.Test.CSharp11.csproj
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/StyleCop.Analyzers.Test.CSharp11.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0-4.final" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" PrivateAssets="all" />
   </ItemGroup>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/StyleCopCodeFixVerifier`2.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/StyleCopCodeFixVerifier`2.cs
@@ -5,6 +5,7 @@
 
 namespace StyleCop.Analyzers.Test.Verifiers
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
@@ -94,6 +95,10 @@ namespace StyleCop.Analyzers.Test.Verifiers
             private const int DefaultIndentationSize = 4;
             private const int DefaultTabSize = 4;
             private const bool DefaultUseTabs = false;
+
+            private int indentationSize = DefaultIndentationSize;
+            private bool useTabs = DefaultUseTabs;
+            private int tabSize = DefaultTabSize;
 
             static CSharpTest()
             {
@@ -200,7 +205,24 @@ namespace StyleCop.Analyzers.Test.Verifiers
             /// <value>
             /// The value of the <see cref="FormattingOptions.IndentationSize"/> to apply to the test workspace.
             /// </value>
-            public int IndentationSize { get; set; } = DefaultIndentationSize;
+            public int IndentationSize
+            {
+                get
+                {
+                    return this.indentationSize;
+                }
+
+                set
+                {
+                    if (this.indentationSize == value)
+                    {
+                        return;
+                    }
+
+                    this.indentationSize = value;
+                    this.UpdateGlobalAnalyzerConfig();
+                }
+            }
 
             /// <summary>
             /// Gets or sets a value indicating whether the <see cref="FormattingOptions.UseTabs"/> option is applied to the
@@ -209,7 +231,24 @@ namespace StyleCop.Analyzers.Test.Verifiers
             /// <value>
             /// The value of the <see cref="FormattingOptions.UseTabs"/> to apply to the test workspace.
             /// </value>
-            public bool UseTabs { get; set; } = DefaultUseTabs;
+            public bool UseTabs
+            {
+                get
+                {
+                    return this.useTabs;
+                }
+
+                set
+                {
+                    if (this.useTabs == value)
+                    {
+                        return;
+                    }
+
+                    this.useTabs = value;
+                    this.UpdateGlobalAnalyzerConfig();
+                }
+            }
 
             /// <summary>
             /// Gets or sets the value of the <see cref="FormattingOptions.TabSize"/> to apply to the test workspace.
@@ -217,7 +256,24 @@ namespace StyleCop.Analyzers.Test.Verifiers
             /// <value>
             /// The value of the <see cref="FormattingOptions.TabSize"/> to apply to the test workspace.
             /// </value>
-            public int TabSize { get; set; } = DefaultTabSize;
+            public int TabSize
+            {
+                get
+                {
+                    return this.tabSize;
+                }
+
+                set
+                {
+                    if (this.tabSize == value)
+                    {
+                        return;
+                    }
+
+                    this.tabSize = value;
+                    this.UpdateGlobalAnalyzerConfig();
+                }
+            }
 
             /// <summary>
             /// Gets or sets the content of the settings file to use.
@@ -274,6 +330,34 @@ namespace StyleCop.Analyzers.Test.Verifiers
                 var codeFixProvider = new TCodeFix();
                 Assert.NotSame(WellKnownFixAllProviders.BatchFixer, codeFixProvider.GetFixAllProvider());
                 return new[] { codeFixProvider };
+            }
+
+            private void UpdateGlobalAnalyzerConfig()
+            {
+                if (!LightupHelpers.SupportsCSharp11)
+                {
+                    // Options support workspace options in this version
+                    // https://github.com/dotnet/roslyn/issues/66779
+                    return;
+                }
+
+                if (this.TestState.AnalyzerConfigFiles.Count == 1
+                    && this.TestState.AnalyzerConfigFiles[0].filename == "/.globalconfig")
+                {
+                    this.TestState.AnalyzerConfigFiles.RemoveAt(0);
+                }
+                else if (this.TestState.AnalyzerConfigFiles.Count > 1
+                    || (this.TestState.AnalyzerConfigFiles.Count > 0 && this.TestState.AnalyzerConfigFiles[0].filename != "/.globalconfig"))
+                {
+                    throw new NotSupportedException("Additional configuration files are not currently supported by the test");
+                }
+
+                this.TestState.AnalyzerConfigFiles.Add(("/.globalconfig", $@"is_global = true
+
+indent_size = {this.IndentationSize}
+indent_style = {(this.UseTabs ? "tab" : "space")}
+tab_width = {this.TabSize}
+"));
             }
 
             // NOTE: If needed, this method can be temporarily updated to default to a preview version

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/StyleCopCodeFixVerifier`2.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/StyleCopCodeFixVerifier`2.cs
@@ -276,16 +276,9 @@ namespace StyleCop.Analyzers.Test.Verifiers
                 return new[] { codeFixProvider };
             }
 
-            // TODO: Remove when c# 11 is a supported language version
+            // NOTE: If needed, this method can be temporarily updated to default to a preview version
             private LanguageVersion? GetDefaultLanguageVersion()
             {
-                // Temporary fix since c# 11 is not yet the default language version
-                // in the c# 11 test project.
-                if (LightupHelpers.SupportsCSharp11)
-                {
-                    return LanguageVersionEx.Preview;
-                }
-
                 return null;
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/StyleCopDiagnosticVerifier`1.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Verifiers/StyleCopDiagnosticVerifier`1.cs
@@ -81,16 +81,9 @@ namespace StyleCop.Analyzers.Test.Verifiers
                 return parseOptions;
             }
 
-            // TODO: Remove when c# 11 is a supported language version
+            // NOTE: If needed, this method can be temporarily updated to default to a preview version
             private LanguageVersion? GetDefaultLanguageVersion()
             {
-                // Temporary fix since c# 11 is not yet the default language version
-                // in the c# 11 test project.
-                if (LightupHelpers.SupportsCSharp11)
-                {
-                    return LanguageVersionEx.Preview;
-                }
-
                 return null;
             }
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LanguageVersionEx.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LanguageVersionEx.cs
@@ -19,6 +19,7 @@ namespace StyleCop.Analyzers.Lightup
         public const LanguageVersion CSharp8 = (LanguageVersion)800;
         public const LanguageVersion CSharp9 = (LanguageVersion)900;
         public const LanguageVersion CSharp10 = (LanguageVersion)1000;
+        public const LanguageVersion CSharp11 = (LanguageVersion)1100;
         public const LanguageVersion LatestMajor = (LanguageVersion)int.MaxValue - 2;
         public const LanguageVersion Preview = (LanguageVersion)int.MaxValue - 1;
         public const LanguageVersion Latest = (LanguageVersion)int.MaxValue;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LightupHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LightupHelpers.cs
@@ -46,10 +46,8 @@ namespace StyleCop.Analyzers.Lightup
         public static bool SupportsCSharp10 { get; }
             = Enum.GetNames(typeof(LanguageVersion)).Contains(nameof(LanguageVersionEx.CSharp10));
 
-        // NOTE: Since c# is only in preview yet, we need to check something else than available language versions. Picked a new syntax kind temporarily.
-        // TODO: Update when c# 11 is available as a language version.
         public static bool SupportsCSharp11 { get; }
-            = Enum.GetNames(typeof(SyntaxKind)).Contains(nameof(SyntaxKindEx.SlicePattern));
+            = Enum.GetNames(typeof(LanguageVersion)).Contains(nameof(LanguageVersionEx.CSharp11));
 
         public static bool SupportsIOperation => SupportsCSharp73;
 


### PR DESCRIPTION
This is the Roslyn version used in Visual Studio 17.4, with official support for c# 11.