### PR TITLE
Update SA1000 to trigger after keywords is, or, and, not

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/SpacingRules/SA1000CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/SpacingRules/SA1000CSharp9UnitTests.cs
@@ -10,6 +10,10 @@ namespace StyleCop.Analyzers.Test.CSharp9.SpacingRules
     using StyleCop.Analyzers.Test.CSharp8.SpacingRules;
     using Xunit;
 
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1000KeywordsMustBeSpacedCorrectly,
+        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
+
     public class SA1000CSharp9UnitTests : SA1000CSharp8UnitTests
     {
         [Fact]
@@ -18,6 +22,50 @@ namespace StyleCop.Analyzers.Test.CSharp9.SpacingRules
             string statementWithoutSpace = "int a = new();";
 
             await this.TestKeywordStatementAsync(statementWithoutSpace, DiagnosticResult.EmptyDiagnosticResults, statementWithoutSpace).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3508, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3508")]
+        public async Task TestIsBeforeRelationalPatternAsync()
+        {
+            var statementWithoutSpace = "_ = 1 {|#0:is|}>1;";
+            var statementWithSpace = "_ = 1 is >1;";
+
+            var expected = Diagnostic().WithArguments("is", string.Empty, "followed").WithLocation(0);
+            await this.TestKeywordStatementAsync(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3508, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3508")]
+        public async Task TestNotBeforeRelationalPatternAsync()
+        {
+            var statementWithoutSpace = "_ = 1 is {|#0:not|}>1;";
+            var statementWithSpace = "_ = 1 is not >1;";
+
+            var expected = Diagnostic().WithArguments("not", string.Empty, "followed").WithLocation(0);
+            await this.TestKeywordStatementAsync(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3508, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3508")]
+        public async Task TestAndBeforeRelationalPatternAsync()
+        {
+            var statementWithoutSpace = "_ = 1 is 1 {|#0:and|}>0;";
+            var statementWithSpace = "_ = 1 is 1 and >0;";
+
+            var expected = Diagnostic().WithArguments("and", string.Empty, "followed").WithLocation(0);
+            await this.TestKeywordStatementAsync(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3508, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3508")]
+        public async Task TestOrBeforeRelationalPatternAsync()
+        {
+            var statementWithoutSpace = "_ = 1 is 1 {|#0:or|}>1;";
+            var statementWithSpace = "_ = 1 is 1 or >1;";
+
+            var expected = Diagnostic().WithArguments("or", string.Empty, "followed").WithLocation(0);
+            await this.TestKeywordStatementAsync(statementWithoutSpace, expected, statementWithSpace).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1000KeywordsMustBeSpacedCorrectly.cs
@@ -87,6 +87,7 @@ namespace StyleCop.Analyzers.SpacingRules
             {
                 switch (token.Kind())
                 {
+                case SyntaxKindEx.AndKeyword:
                 case SyntaxKind.AwaitKeyword:
                 case SyntaxKind.CaseKeyword:
                 case SyntaxKind.CatchKeyword:
@@ -98,9 +99,12 @@ namespace StyleCop.Analyzers.SpacingRules
                 case SyntaxKind.IfKeyword:
                 case SyntaxKind.InKeyword:
                 case SyntaxKind.IntoKeyword:
+                case SyntaxKind.IsKeyword:
                 case SyntaxKind.JoinKeyword:
                 case SyntaxKind.LetKeyword:
                 case SyntaxKind.LockKeyword:
+                case SyntaxKindEx.NotKeyword:
+                case SyntaxKindEx.OrKeyword:
                 case SyntaxKind.OrderByKeyword:
                 case SyntaxKind.OutKeyword:
                 case SyntaxKind.RefKeyword:

--- a/documentation/SA1000.md
+++ b/documentation/SA1000.md
@@ -23,11 +23,11 @@ The spacing around a C# keyword is incorrect.
 
 A violation of this rule occurs when the spacing around a keyword is incorrect.
 
-The following C# keywords should always be followed by a single space: `await`, `case`, `catch`, `fixed`, `for`,
-`foreach`, `from`, `group`, `if`, `in`, `into`, `join`, `let`, `lock`, `orderby`, `out`, `ref`, `return`, `select`,
+The following C# keywords should always be followed by a single space: `and`, `await`, `case`, `catch`, `fixed`, `for`,
+`foreach`, `from`, `group`, `if`, `in`, `is`, `into`, `join`, `let`, `lock`, `not`, `orderby`, `or`, `out`, `ref`, `return`, `select`,
 `switch`, `using`, `var`, `where`, `while`, `yield`.
 
-The following keywords should not be followed by any space: `checked`, `default`, `sizeof`, `typeof`, `unchecked`.
+The following keywords should not be followed by any space: `checked`, `default`, `nameof`, `sizeof`, `typeof`, `unchecked`.
 
 The `new` and `stackalloc` keywords should always be followed by a space, except in the following cases:
 


### PR DESCRIPTION
Fixes #3508