### PR TITLE
Optimize SA1141

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/ReadabilityRules/SA1141CSharp10UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/ReadabilityRules/SA1141CSharp10UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp10.ReadabilityRules
+{
+    using StyleCop.Analyzers.Test.CSharp9.ReadabilityRules;
+
+    public class SA1141CSharp10UnitTests : SA1141CSharp9UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/ReadabilityRules/SA1142CSharp10UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/ReadabilityRules/SA1142CSharp10UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp10.ReadabilityRules
+{
+    using StyleCop.Analyzers.Test.CSharp9.ReadabilityRules;
+
+    public class SA1142CSharp10UnitTests : SA1142CSharp9UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/ReadabilityRules/SA1141CSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/ReadabilityRules/SA1141CSharp11UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp11.ReadabilityRules
+{
+    using StyleCop.Analyzers.Test.CSharp10.ReadabilityRules;
+
+    public class SA1141CSharp11UnitTests : SA1141CSharp10UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/ReadabilityRules/SA1142CSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/ReadabilityRules/SA1142CSharp11UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp11.ReadabilityRules
+{
+    using StyleCop.Analyzers.Test.CSharp10.ReadabilityRules;
+
+    public class SA1142CSharp11UnitTests : SA1142CSharp10UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1141CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1141CSharp7UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
+    using StyleCop.Analyzers.Test.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1141UseTupleSyntax,
@@ -19,7 +18,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     /// </summary>
     /// <seealso cref="SA1141UseTupleSyntax"/>
     /// <seealso cref="SA1141CodeFixProvider"/>
-    public class SA1141CSharp7UnitTests
+    public class SA1141CSharp7UnitTests : SA1141UnitTests
     {
         /// <summary>
         /// Verifies that member declarations containing ValueTuple will result in the proper diagnostics and fixes.
@@ -32,28 +31,28 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
 
 public class TestClass
 {
-    public ValueTuple<int, int> TestMethod(ValueTuple<double, double> value)
+    public [|ValueTuple<int, int>|] TestMethod([|ValueTuple<double, double>|] value)
     {
         throw new NotImplementedException();
     }
 
-    public System.ValueTuple<(int, int), int> TestMethod2(int p1, ValueTuple<System.ValueTuple<long, long>, long> p2, (ValueTuple<string, string>, string) p3)
+    public [|System.ValueTuple<(int, int), int>|] TestMethod2(int p1, [|ValueTuple<System.ValueTuple<long, long>, long>|] p2, ([|ValueTuple<string, string>|], string) p3)
     {
         throw new NotImplementedException();
     }
 
-    public System.ValueTuple<int, int> TestProperty1 { get; set; }
+    public [|System.ValueTuple<int, int>|] TestProperty1 { get; set; }
 
-    public System.Collections.Generic.List<ValueTuple<int, int>> TestProperty2 { get; set; }
+    public System.Collections.Generic.List<[|ValueTuple<int, int>|]> TestProperty2 { get; set; }
 
-    public System.ValueTuple<int, long> this[int i] { get { return (1, 1l); } set { } }
+    public [|System.ValueTuple<int, long>|] this[int i] { get { return (1, 1l); } set { } }
 
-    public static explicit operator TestClass(System.ValueTuple<int, int> p1)
+    public static explicit operator TestClass([|System.ValueTuple<int, int>|] p1)
     {
         throw new NotImplementedException();
     }
 
-    public static implicit operator System.ValueTuple<int, int>(TestClass p1)
+    public static implicit operator [|System.ValueTuple<int, int>|](TestClass p1)
     {
         throw new NotImplementedException();
     }
@@ -92,21 +91,7 @@ public class TestClass
 }
 ";
 
-            DiagnosticResult[] expectedDiagnostics =
-            {
-                Diagnostic().WithLocation(5, 12),
-                Diagnostic().WithLocation(5, 44),
-                Diagnostic().WithLocation(10, 12),
-                Diagnostic().WithLocation(10, 67),
-                Diagnostic().WithLocation(10, 120),
-                Diagnostic().WithLocation(15, 12),
-                Diagnostic().WithLocation(17, 44),
-                Diagnostic().WithLocation(19, 12),
-                Diagnostic().WithLocation(21, 47),
-                Diagnostic().WithLocation(26, 37),
-            };
-
-            await VerifyCSharpFixAsync(testCode, expectedDiagnostics, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -122,18 +107,18 @@ public class TestClass
 {
     public void TestMethod()
     {
-        var test1 = new ValueTuple<int, int>(1, 2);
-        var test2 = new System.ValueTuple<int, int>(1, 2);
-        var test3 = new ValueTuple<ValueTuple<int, int>, int>(new ValueTuple<int, int>(3, 4), 2);
-        var test4 = new System.ValueTuple<int, System.ValueTuple<int, int>>(1, new System.ValueTuple<int, int>(2, 3));
-        var test5 = (new ValueTuple<int, int>(3, 4), 2);
-        var test6 = new System.ValueTuple<int, System.ValueTuple<int, int>>(1, (2, 3));
-        var test7 = ValueTuple.Create(1, 2);
-        var test8 = ValueTuple.Create<int, double>(1, 2);
-        var test9 = System.ValueTuple.Create(1, new ValueTuple<int, double>(2, 3));
-        var test10 = ValueTuple.Create(ValueTuple.Create(1, 2, 3), 4);
-        var test11 = new ValueTuple<int, ValueTuple<int, int>>(1, ValueTuple.Create(2, 3));
-        var test12 = new System.ValueTuple<byte, int>(1, 2);
+        var test1 = [|new ValueTuple<int, int>(1, 2)|];
+        var test2 = [|new System.ValueTuple<int, int>(1, 2)|];
+        var test3 = [|new ValueTuple<ValueTuple<int, int>, int>([|new ValueTuple<int, int>(3, 4)|], 2)|];
+        var test4 = [|new System.ValueTuple<int, System.ValueTuple<int, int>>(1, [|new System.ValueTuple<int, int>(2, 3)|])|];
+        var test5 = ([|new ValueTuple<int, int>(3, 4)|], 2);
+        var test6 = [|new System.ValueTuple<int, System.ValueTuple<int, int>>(1, (2, 3))|];
+        var test7 = [|ValueTuple.Create|](1, 2);
+        var test8 = [|ValueTuple.Create<int, double>|](1, 2);
+        var test9 = [|System.ValueTuple.Create|](1, [|new ValueTuple<int, double>(2, 3)|]);
+        var test10 = [|ValueTuple.Create|]([|ValueTuple.Create|](1, 2, 3), 4);
+        var test11 = [|new ValueTuple<int, ValueTuple<int, int>>(1, [|ValueTuple.Create|](2, 3))|];
+        var test12 = [|new System.ValueTuple<byte, int>(1, 2)|];
     }
 }
 ";
@@ -160,28 +145,7 @@ public class TestClass
 }
 ";
 
-            DiagnosticResult[] expectedDiagnostics =
-            {
-                Diagnostic().WithLocation(7, 21),
-                Diagnostic().WithLocation(8, 21),
-                Diagnostic().WithLocation(9, 21),
-                Diagnostic().WithLocation(9, 63),
-                Diagnostic().WithLocation(10, 21),
-                Diagnostic().WithLocation(10, 80),
-                Diagnostic().WithLocation(11, 22),
-                Diagnostic().WithLocation(12, 21),
-                Diagnostic().WithLocation(13, 21),
-                Diagnostic().WithLocation(14, 21),
-                Diagnostic().WithLocation(15, 21),
-                Diagnostic().WithLocation(15, 49),
-                Diagnostic().WithLocation(16, 22),
-                Diagnostic().WithLocation(16, 40),
-                Diagnostic().WithLocation(17, 22),
-                Diagnostic().WithLocation(17, 67),
-                Diagnostic().WithLocation(18, 22),
-            };
-
-            await VerifyCSharpFixAsync(testCode, expectedDiagnostics, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -329,8 +293,8 @@ public class TestClass
 {
     public void TestMethod(object input)
     {
-        var test1 = (ValueTuple<int, int>)input;
-        var test2 = (System.ValueTuple<System.ValueTuple<int, long>, byte>)input;
+        var test1 = ([|ValueTuple<int, int>|])input;
+        var test2 = ([|System.ValueTuple<System.ValueTuple<int, long>, byte>|])input;
     }
 }
 ";
@@ -347,13 +311,7 @@ public class TestClass
 }
 ";
 
-            DiagnosticResult[] expectedDiagnostics =
-            {
-                Diagnostic().WithLocation(7, 22),
-                Diagnostic().WithLocation(8, 22),
-            };
-
-            await VerifyCSharpFixAsync(testCode, expectedDiagnostics, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -369,8 +327,8 @@ public class TestClass
 {
     public void TestMethod()
     {
-        var test1 = default(ValueTuple<int, int>);
-        var test2 = default(System.ValueTuple<System.ValueTuple<int, long>, byte>);
+        var test1 = default([|ValueTuple<int, int>|]);
+        var test2 = default([|System.ValueTuple<System.ValueTuple<int, long>, byte>|]);
     }
 }
 ";
@@ -387,13 +345,7 @@ public class TestClass
 }
 ";
 
-            DiagnosticResult[] expectedDiagnostics =
-            {
-                Diagnostic().WithLocation(7, 29),
-                Diagnostic().WithLocation(8, 29),
-            };
-
-            await VerifyCSharpFixAsync(testCode, expectedDiagnostics, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -407,7 +359,7 @@ public class TestClass
 
 public class TestClass
 {
-    public delegate System.ValueTuple<int, bool> TestDelegate(ValueTuple<int, ValueTuple<int, long>> arg1, (long, double) arg2, (long, System.ValueTuple<bool, bool>) arg3);
+    public delegate [|System.ValueTuple<int, bool>|] TestDelegate([|ValueTuple<int, ValueTuple<int, long>>|] arg1, (long, double) arg2, (long, [|System.ValueTuple<bool, bool>|]) arg3);
 }
 ";
 
@@ -419,14 +371,7 @@ public class TestClass
 }
 ";
 
-            DiagnosticResult[] expectedDiagnostics =
-            {
-                Diagnostic().WithLocation(5, 21),
-                Diagnostic().WithLocation(5, 63),
-                Diagnostic().WithLocation(5, 136),
-            };
-
-            await VerifyCSharpFixAsync(testCode, expectedDiagnostics, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1142CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1142CSharp7UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
+    using StyleCop.Analyzers.Test.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1142ReferToTupleElementsByName,
@@ -19,7 +18,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     /// </summary>
     /// <seealso cref="SA1142ReferToTupleElementsByName"/>
     /// <seealso cref="SA1142CodeFixProvider"/>
-    public class SA1142CSharp7UnitTests
+    public class SA1142CSharp7UnitTests : SA1142UnitTests
     {
         /// <summary>
         /// Validate that tuple fields that are referenced by their name will not produce any diagnostics.
@@ -78,12 +77,7 @@ public class TestClass
 }
 ";
 
-            DiagnosticResult[] expectedDiagnostics =
-            {
-                // diagnostics are specified inline
-            };
-
-            await VerifyCSharpFixAsync(testCode, expectedDiagnostics, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/ReadabilityRules/SA1141CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/ReadabilityRules/SA1141CSharp8UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp8.ReadabilityRules
+{
+    using StyleCop.Analyzers.Test.CSharp7.ReadabilityRules;
+
+    public class SA1141CSharp8UnitTests : SA1141CSharp7UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/ReadabilityRules/SA1142CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/ReadabilityRules/SA1142CSharp8UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp8.ReadabilityRules
+{
+    using StyleCop.Analyzers.Test.CSharp7.ReadabilityRules;
+
+    public class SA1142CSharp8UnitTests : SA1142CSharp7UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/ReadabilityRules/SA1141CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/ReadabilityRules/SA1141CSharp9UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp9.ReadabilityRules
+{
+    using StyleCop.Analyzers.Test.CSharp8.ReadabilityRules;
+
+    public class SA1141CSharp9UnitTests : SA1141CSharp8UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/ReadabilityRules/SA1142CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/ReadabilityRules/SA1142CSharp9UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp9.ReadabilityRules
+{
+    using StyleCop.Analyzers.Test.CSharp8.ReadabilityRules;
+
+    public class SA1142CSharp9UnitTests : SA1142CSharp8UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1141UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1141UnitTests.cs
@@ -1,14 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.ReadabilityRules
 {
     using System;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.CodeAnalysis.Testing;
+    using Microsoft.CodeAnalysis.CSharp;
     using StyleCop.Analyzers.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
@@ -42,9 +40,10 @@ public class TestClass
 }
 ";
 
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await new CSharpTest(LanguageVersion.CSharp6)
+            {
+                TestCode = testCode,
+            }.RunAsync(CancellationToken.None).ConfigureAwait(false);
         }
-
-        //// TODO: Make sure that all paths are covered!
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1142UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1142UnitTests.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.ReadabilityRules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.ReadabilityRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.ReadabilityRules.SA1142ReferToTupleElementsByName,
+        StyleCop.Analyzers.ReadabilityRules.SA1142CodeFixProvider>;
+
+    /// <summary>
+    /// This class contains the unit tests for SA1142.
+    /// </summary>
+    /// <seealso cref="SA1142ReferToTupleElementsByName"/>
+    /// <seealso cref="SA1142CodeFixProvider"/>
+    public class SA1142UnitTests
+    {
+        /// <summary>
+        /// Verify that ValueTuple names referenced by their metadata name will not produce diagnostics when no other
+        /// name is available.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact]
+        public async Task ValidateFieldNameReferencesWithoutReplacementAsync()
+        {
+            var testCode = @"using System;
+
+public class TestClass
+{
+    public int TestMethod1(ValueTuple<int, int> p1)
+    {
+        return p1.Item1 + p1.Item2 + p1.ToString().Length;
+    }
+
+    public int TestMethod2(ValueTuple<int, ValueTuple<int, int>> p1)
+    {
+        return p1.Item1 + p1.Item2.Item1 + p1.Item2.Item2;
+    }
+}
+";
+
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/LanguageFeatureHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/LanguageFeatureHelpers.cs
@@ -5,6 +5,7 @@
 
 namespace StyleCop.Analyzers.Helpers
 {
+    using System.Diagnostics.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.Lightup;
@@ -14,6 +15,17 @@ namespace StyleCop.Analyzers.Helpers
     /// </summary>
     internal static class LanguageFeatureHelpers
     {
+        /// <summary>
+        /// Checks if the tuple language feature is supported.
+        /// </summary>
+        /// <param name="context">The analysis context that will be checked.</param>
+        /// <returns>True if tuples are supported by the compiler.</returns>
+        [SuppressMessage("MicrosoftCodeAnalysisPerformance", "RS1012:Start action has no registered actions", Justification = "This is not a start action method.")]
+        internal static bool SupportsTuples(this CompilationStartAnalysisContext context)
+        {
+            return context.Compilation is CSharpCompilation { LanguageVersion: >= LanguageVersionEx.CSharp7 };
+        }
+
         /// <summary>
         /// Checks if the tuple language feature is supported.
         /// </summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1141UseTupleSyntax.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1141UseTupleSyntax.cs
@@ -50,6 +50,14 @@ namespace StyleCop.Analyzers.ReadabilityRules
             context.EnableConcurrentExecution();
 
             context.RegisterCompilationStartAction(CompilationStartAction);
+        }
+
+        private static void HandleCompilationStart(CompilationStartAnalysisContext context)
+        {
+            if (!context.SupportsTuples())
+            {
+                return;
+            }
 
             context.RegisterSyntaxNodeAction(MethodDeclarationAction, SyntaxKind.MethodDeclaration);
             context.RegisterSyntaxNodeAction(ConversionOperatorAction, SyntaxKind.ConversionOperatorDeclaration);
@@ -59,10 +67,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
             context.RegisterSyntaxNodeAction(DelegateDeclarationAction, SyntaxKind.DelegateDeclaration);
             context.RegisterSyntaxNodeAction(LambdaExpressionAction, SyntaxKinds.LambdaExpression);
-        }
 
-        private static void HandleCompilationStart(CompilationStartAnalysisContext context)
-        {
             var expressionType = context.Compilation.GetTypeByMetadataName("System.Linq.Expressions.Expression`1");
 
             context.RegisterSyntaxNodeAction(context => HandleObjectCreationExpression(context, expressionType), SyntaxKind.ObjectCreationExpression);
@@ -75,11 +80,6 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
         private static void HandleMethodDeclaration(SyntaxNodeAnalysisContext context)
         {
-            if (!context.SupportsTuples())
-            {
-                return;
-            }
-
             var methodDeclaration = (MethodDeclarationSyntax)context.Node;
 
             CheckType(context, expressionType: null, methodDeclaration.ReturnType);
@@ -88,11 +88,6 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
         private static void HandleConversionOperator(SyntaxNodeAnalysisContext context)
         {
-            if (!context.SupportsTuples())
-            {
-                return;
-            }
-
             var conversionOperatorDeclaration = (ConversionOperatorDeclarationSyntax)context.Node;
 
             CheckType(context, expressionType: null, conversionOperatorDeclaration.Type);
@@ -101,33 +96,18 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
         private static void HandleBasePropertyDeclaration(SyntaxNodeAnalysisContext context)
         {
-            if (!context.SupportsTuples())
-            {
-                return;
-            }
-
             var propertyDeclaration = (BasePropertyDeclarationSyntax)context.Node;
             CheckType(context, expressionType: null, propertyDeclaration.Type);
         }
 
         private static void HandleFieldDeclaration(SyntaxNodeAnalysisContext context)
         {
-            if (!context.SupportsTuples())
-            {
-                return;
-            }
-
             var fieldDeclaration = (BaseFieldDeclarationSyntax)context.Node;
             CheckType(context, expressionType: null, fieldDeclaration.Declaration.Type);
         }
 
         private static void HandleLambdaExpression(SyntaxNodeAnalysisContext context)
         {
-            if (!context.SupportsTuples())
-            {
-                return;
-            }
-
             var lambdaExpression = (LambdaExpressionSyntax)context.Node;
             if (lambdaExpression is ParenthesizedLambdaExpressionSyntax parenthesizedLambdaExpression)
             {
@@ -137,22 +117,12 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
         private static void HandleObjectCreationExpression(SyntaxNodeAnalysisContext context, INamedTypeSymbol expressionType)
         {
-            if (!context.SupportsTuples())
-            {
-                return;
-            }
-
             var objectCreationExpression = (ObjectCreationExpressionSyntax)context.Node;
             CheckType(context, expressionType, objectCreationExpression.Type, objectCreationExpression.GetLocation());
         }
 
         private static void HandleInvocationExpression(SyntaxNodeAnalysisContext context, INamedTypeSymbol expressionType)
         {
-            if (!context.SupportsTuples())
-            {
-                return;
-            }
-
             var invocationExpression = (InvocationExpressionSyntax)context.Node;
             if (invocationExpression.ArgumentList.Arguments.Count < 2)
             {
@@ -181,22 +151,12 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
         private static void HandleDefaultExpression(SyntaxNodeAnalysisContext context, INamedTypeSymbol expressionType)
         {
-            if (!context.SupportsTuples())
-            {
-                return;
-            }
-
             var defaultExpression = (DefaultExpressionSyntax)context.Node;
             CheckType(context, expressionType, defaultExpression.Type);
         }
 
         private static void HandleDelegateDeclaration(SyntaxNodeAnalysisContext context)
         {
-            if (!context.SupportsTuples())
-            {
-                return;
-            }
-
             var delegateDeclaration = (DelegateDeclarationSyntax)context.Node;
             CheckType(context, expressionType: null, delegateDeclaration.ReturnType);
             CheckParameterList(context, delegateDeclaration.ParameterList);
@@ -204,11 +164,6 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
         private static void HandleCastExpression(SyntaxNodeAnalysisContext context, INamedTypeSymbol expressionType)
         {
-            if (!context.SupportsTuples())
-            {
-                return;
-            }
-
             var castExpression = (CastExpressionSyntax)context.Node;
             CheckType(context, expressionType, castExpression.Type);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1141UseTupleSyntax.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1141UseTupleSyntax.cs
@@ -136,13 +136,12 @@ namespace StyleCop.Analyzers.ReadabilityRules
             }
 
             var memberAccessExpression = (MemberAccessExpressionSyntax)invocationExpression.Expression;
-
-            var symbolInfo = context.SemanticModel.GetSymbolInfo(memberAccessExpression.Expression);
-            if (symbolInfo.Symbol is INamedTypeSymbol namedTypeSymbol
-                && namedTypeSymbol.ToDisplayString(DisplayFormat) == "System.ValueTuple"
-                && !context.Node.IsInExpressionTree(context.SemanticModel, expressionType, context.CancellationToken))
+            if (memberAccessExpression.Name.Identifier.ValueText == "Create")
             {
-                if (memberAccessExpression.Name.Identifier.ValueText == "Create")
+                var symbolInfo = context.SemanticModel.GetSymbolInfo(memberAccessExpression.Expression);
+                if (symbolInfo.Symbol is INamedTypeSymbol namedTypeSymbol
+                    && namedTypeSymbol.ToDisplayString(DisplayFormat) == "System.ValueTuple"
+                    && !context.Node.IsInExpressionTree(context.SemanticModel, expressionType, context.CancellationToken))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(Descriptor, memberAccessExpression.GetLocation()));
                 }
@@ -209,7 +208,8 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
         private static void CheckGenericName(SyntaxNodeAnalysisContext context, INamedTypeSymbol expressionType, GenericNameSyntax genericNameSyntax, Location reportLocation)
         {
-            if (IsValueTupleWithLanguageRepresentation(context, expressionType, genericNameSyntax))
+            if (genericNameSyntax.Identifier.ValueText == "ValueTuple"
+                && IsValueTupleWithLanguageRepresentation(context, expressionType, genericNameSyntax))
             {
                 var location = reportLocation ?? genericNameSyntax.GetLocation();
                 context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));


### PR DESCRIPTION
* Avoid all work on compilations that don't support tuples (not a common case)
* Check identifier names before calling `GetSymbolInfo`

This is a partial resolution of the issue that led to #3609. Note that the new behavior for handling `ValueTuple.Create` will not work correctly in cases where users have a using alias directive like the following:

```cs
using VT = System.ValueTuple;
```