### PR TITLE
Update so that SA1600 tests will be run with the expected language version in test projects for c# 8 and above

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/DocumentationRules/SA1600CSharp10UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/DocumentationRules/SA1600CSharp10UnitTests.cs
@@ -22,9 +22,6 @@ namespace StyleCop.Analyzers.Test.CSharp10.DocumentationRules
                     // /0/Test0.cs(4,1): error CS0106: The modifier 'public' is not valid for this item
                     DiagnosticResult.CompilerError("CS0106").WithSpan(4, 1, 4, 7).WithArguments("public"),
 
-                    // /0/Test0.cs(4,1): error CS8320: Feature 'top-level statements' is not available in C# 7.2. Please use language version 9.0 or greater.
-                    DiagnosticResult.CompilerError("CS8320").WithSpan(4, 1, 4, 29).WithArguments("top-level statements", "9.0"),
-
                     // /0/Test0.cs(4,1): error CS8805: Program using top-level statements must be an executable.
                     DiagnosticResult.CompilerError("CS8805").WithSpan(4, 1, 4, 29),
                 };

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/DocumentationRules/SA1600CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/DocumentationRules/SA1600CSharp8UnitTests.cs
@@ -3,9 +3,12 @@
 
 namespace StyleCop.Analyzers.Test.CSharp8.DocumentationRules
 {
+    using Microsoft.CodeAnalysis.CSharp;
     using StyleCop.Analyzers.Test.CSharp7.DocumentationRules;
 
     public class SA1600CSharp8UnitTests : SA1600CSharp7UnitTests
     {
+        // Using 'Default' here makes sure that later test projects also run these tests with their own language version, without having to override this property
+        protected override LanguageVersion LanguageVersion => LanguageVersion.Default;
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/DocumentationRules/SA1600CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/DocumentationRules/SA1600CSharp9UnitTests.cs
@@ -21,9 +21,6 @@ namespace StyleCop.Analyzers.Test.CSharp9.DocumentationRules
 
                     // /0/Test0.cs(4,1): error CS0106: The modifier 'public' is not valid for this item
                     DiagnosticResult.CompilerError("CS0106").WithSpan(4, 1, 4, 7).WithArguments("public"),
-
-                    // /0/Test0.cs(4,1): error CS8320: Feature 'top-level statements' is not available in C# 7.2. Please use language version 9.0 or greater.
-                    DiagnosticResult.CompilerError("CS8320").WithSpan(4, 1, 4, 29).WithArguments("top-level statements", "9.0"),
                 };
             }
 


### PR DESCRIPTION
Another partial fix for #3493.

Test projects for c# 8 and above were using c# 7.2 when running the SA1600 tests.