### PR TITLE
Update SA1015 to require trailing space after an explicit generic return type in a lambda expression

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/SpacingRules/SA1015CSharp10UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/SpacingRules/SA1015CSharp10UnitTests.cs
@@ -3,9 +3,42 @@
 
 namespace StyleCop.Analyzers.Test.CSharp10.SpacingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp9.SpacingRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1015ClosingGenericBracketsMustBeSpacedCorrectly,
+        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1015CSharp10UnitTests : SA1015CSharp9UnitTests
     {
+        [Fact]
+        [WorkItem(3624, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3624")]
+        public async Task TestLambdaWithExplicitGenericReturnTypeAsync()
+        {
+            const string testCode = @"using System.Threading.Tasks;
+
+public class TestClass
+{
+    public void TestMethod()
+    {
+        var _ = Task<int[|>|](int x) => Task.FromResult(x);
+    }
+}";
+
+            const string fixedCode = @"using System.Threading.Tasks;
+
+public class TestClass
+{
+    public void TestMethod()
+    {
+        var _ = Task<int> (int x) => Task.FromResult(x);
+    }
+}";
+
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }


### PR DESCRIPTION
Fixes #3624