### PR TITLE
Update StyleCopTester project so it is able to load this solution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ OpenCover.Symbols/
 .nuget/NuGet.exe
 build/nuget/
 *.log
+*.binlog
 
 # Visual Studio performance tools
 *.psess

--- a/StyleCop.Analyzers/StyleCopTester/Properties/launchSettings.json
+++ b/StyleCop.Analyzers/StyleCopTester/Properties/launchSettings.json
@@ -1,5 +1,12 @@
 {
   "profiles": {
+    "StyleCopAnalyzers.sln": {
+      "commandName": "Project",
+      "commandLineArgs": "..\\..\\StyleCopAnalyzers.sln",
+      "workingDirectory": "$(MSBuildProjectDirectory)",
+      "environmentVariables": {
+      }
+    },
     "StyleCopAnalyzers.sln /stats": {
       "commandName": "Project",
       "commandLineArgs": "..\\..\\StyleCopAnalyzers.sln /stats",

--- a/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
+++ b/StyleCop.Analyzers/StyleCopTester/StyleCopTester.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net46</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
 
     <!-- Automatically generate the necessary assembly binding redirects -->
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
@@ -24,10 +24,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Locator" Version="1.2.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="2.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="2.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.9.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="2.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.5.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
It did not start before due to assembly load exceptions. Unsure of what caused this.
I actually still get load exceptions occasionally, even with these changes, but a rebuild usually fixes it again.

I also added anther launch profile without the `/stats` option.