### PR TITLE
Correct SA1515 to not fire on the second line of a file header

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1515UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/LayoutRules/SA1515UnitTests.cs
@@ -5,6 +5,7 @@
 
 namespace StyleCop.Analyzers.Test.LayoutRules
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
@@ -266,6 +267,37 @@ public class Class1 // Comment 1
     // Comment 2
     public double Value { get; }
 }";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Verifies that the analyzer does not fire in file headers (i.e. one line comments at the start of the file).
+        /// </summary>
+        /// <param name="startWithPragma"><see langword="true"/> if the source code should start with a pragma; otherwise, <see langword="false"/>.</param>
+        /// <param name="numberOfHeaderLines">The number of lines in the header.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Theory]
+        [CombinatorialData]
+        [WorkItem(3630, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3630")]
+        public async Task TestFileHeaderAsync(
+            bool startWithPragma,
+            [CombinatorialValues(1, 2, 3)] int numberOfHeaderLines)
+        {
+            var testCode = @"
+class TestClass
+{
+}";
+
+            for (var i = 0; i < numberOfHeaderLines; i++)
+            {
+                testCode = "// A comment line." + Environment.NewLine + testCode;
+            }
+
+            if (startWithPragma)
+            {
+                testCode = "#pragma warning disable CS1591" + Environment.NewLine + testCode;
+            }
 
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515SingleLineCommentMustBePrecededByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515SingleLineCommentMustBePrecededByBlankLine.cs
@@ -164,8 +164,19 @@ namespace StyleCop.Analyzers.LayoutRules
         private static bool IsOnOwnLine<T>(T triviaList, int triviaIndex)
             where T : IReadOnlyList<SyntaxTrivia>
         {
+            if (triviaList[triviaIndex].Span.Start == 0)
+            {
+                return true;
+            }
+
             while (triviaIndex >= 0)
             {
+                if (triviaList[triviaIndex].IsDirective)
+                {
+                    // directive trivia are special, as they have a 'built-in' end-of-line.
+                    return true;
+                }
+
                 if (triviaList[triviaIndex].IsKind(SyntaxKind.EndOfLineTrivia))
                 {
                     return true;
@@ -275,6 +286,7 @@ namespace StyleCop.Analyzers.LayoutRules
                 case SyntaxKind.IfDirectiveTrivia:
                 case SyntaxKind.ElifDirectiveTrivia:
                 case SyntaxKind.ElseDirectiveTrivia:
+                case SyntaxKind.PragmaWarningDirectiveTrivia:
                     return true;
 
                 default:


### PR DESCRIPTION
Fixes #3630