### PR TITLE
Update RenameToUpperCaseCodeFixProvider to not offer a code fix if the identifier only consists of underscores

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/NamingRules/RenameToUpperCaseCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/NamingRules/RenameToUpperCaseCodeFixProvider.cs
@@ -59,6 +59,12 @@ namespace StyleCop.Analyzers.NamingRules
             {
                 var token = root.FindToken(diagnostic.Location.SourceSpan.Start);
                 var tokenText = token.ValueText.TrimStart('_');
+                if (tokenText == string.Empty)
+                {
+                    // Skip this one, since we can't create a new identifier from this
+                    continue;
+                }
+
                 var baseName = char.ToUpper(tokenText[0]) + tokenText.Substring(1);
                 var newName = baseName;
                 var memberSyntax = RenameHelper.GetParentDeclaration(token);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
@@ -982,5 +982,30 @@ public interface IInterface
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
+
+        [Theory]
+        [InlineData("_")]
+        [InlineData("__")]
+        [WorkItem(3636, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3636")]
+        public async Task TestUnderscoreMethodAsync(string name)
+        {
+            var testCode = $@"
+public class TestClass
+{{
+    public void [|{name}|]()
+    {{
+    }}
+}}";
+
+            var fixedCode = $@"
+public class TestClass
+{{
+    public void [|{name}|]()
+    {{
+    }}
+}}";
+
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }


### PR DESCRIPTION
Fixes #3636.

Updated so the diagnostic is still reported, but no code fix is offered.
This code fix provider can handle a bunch of diagnostics, but I could only trigger the problem with SA1300, so that's the only test I added.