### PR TITLE
Don't emit SA1414 for interface implementations

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1414CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1414CSharp7UnitTests.cs
@@ -5,6 +5,7 @@
 
 namespace StyleCop.Analyzers.Test.CSharp7.MaintainabilityRules
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
@@ -119,7 +120,7 @@ public class TestClass
         }
 
         [Fact]
-        public Task ValidateTuplesFromInheritedTypeAsync()
+        public Task ValidateTuplesFromInterfaceAsync()
         {
             const string testCode = @"
 using System.Collections.Generic;
@@ -131,9 +132,53 @@ namespace Test {
 
 	    public int GetHashCode((string, string) obj) => throw null;
     }
-}
-";
+}";
             return VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, default);
+        }
+
+        [Fact]
+        public Task ValidateTuplesFromExplicitInterfaceImplementationAsync()
+        {
+            const string testCode = @"
+using System.Collections.Generic;
+
+namespace Test {
+    class StringTupleComparer : IEqualityComparer<(string, string)>
+    {
+	    bool IEqualityComparer<(string, string)>.Equals((string, string) x, (string, string) y) => throw null;
+
+	    int IEqualityComparer<(string, string)>.GetHashCode((string, string) obj) => throw null;
+    }
+}";
+            return VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, default);
+        }
+
+        [Fact]
+        public Task ValidateTuplesFromBaseClassAsync()
+        {
+            const string testCode = @"
+namespace Test {
+    class A : B
+	{
+		public override void Run((string, string) x)
+		{
+		}
+
+		public override void Run((int, int) y)
+		{
+		}
+	}
+
+	abstract class B
+	{
+		public abstract void Run(([|string|], [|string|]) x);
+
+		public virtual void Run(([|int|], [|int|]) y)
+		{
+		}
+	}
+}";
+            return VerifyCSharpDiagnosticAsync(testCode, Array.Empty<DiagnosticResult>(), default);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1414CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1414CSharp7UnitTests.cs
@@ -178,7 +178,7 @@ namespace Test {
 		}
 	}
 }";
-            return VerifyCSharpDiagnosticAsync(testCode, Array.Empty<DiagnosticResult>(), default);
+            return VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, default);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1414CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1414CSharp7UnitTests.cs
@@ -117,5 +117,23 @@ public class TestClass
 
             await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
+
+        [Fact]
+        public Task ValidateTuplesFromInheritedTypeAsync()
+        {
+            const string testCode = @"
+using System.Collections.Generic;
+
+namespace Test {
+    class StringTupleComparer : IEqualityComparer<(string, string)>
+    {
+	    public bool Equals((string, string) x, (string, string) y) => throw null;
+
+	    public int GetHashCode((string, string) obj) => throw null;
+    }
+}
+";
+            return VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, default);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1414CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1414CSharp7UnitTests.cs
@@ -160,22 +160,16 @@ namespace Test {
 namespace Test {
     class A : B
 	{
-		public override void Run((string, string) x)
-		{
-		}
+		public override (string, string) Run((string, string) x) => throw null;
 
-		public override void Run((int, int) y)
-		{
-		}
+		public override (int, int) Run((int, int) y) => throw null;
 	}
 
 	abstract class B
 	{
-		public abstract void Run(([|string|], [|string|]) x);
+		public abstract ([|string|], [|string|]) Run(([|string|], [|string|]) x);
 
-		public virtual void Run(([|int|], [|int|]) y)
-		{
-		}
+		public virtual ([|int|], [|int|]) Run(([|int|], [|int|]) y) => throw null;
 	}
 }";
             return VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, default);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1414CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/MaintainabilityRules/SA1414CSharp7UnitTests.cs
@@ -120,7 +120,7 @@ public class TestClass
         }
 
         [Fact]
-        public Task ValidateTuplesFromInterfaceAsync()
+        public async Task ValidateTuplesFromInterfaceAsync()
         {
             const string testCode = @"
 using System.Collections.Generic;
@@ -133,11 +133,11 @@ namespace Test {
 	    public int GetHashCode((string, string) obj) => throw null;
     }
 }";
-            return VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, default);
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
-        public Task ValidateTuplesFromExplicitInterfaceImplementationAsync()
+        public async Task ValidateTuplesFromExplicitInterfaceImplementationAsync()
         {
             const string testCode = @"
 using System.Collections.Generic;
@@ -150,11 +150,11 @@ namespace Test {
 	    int IEqualityComparer<(string, string)>.GetHashCode((string, string) obj) => throw null;
     }
 }";
-            return VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, default);
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
-        public Task ValidateTuplesFromBaseClassAsync()
+        public async Task ValidateTuplesFromBaseClassAsync()
         {
             const string testCode = @"
 namespace Test {
@@ -172,7 +172,7 @@ namespace Test {
 		public virtual ([|int|], [|int|]) Run(([|int|], [|int|]) y) => throw null;
 	}
 }";
-            return VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, default);
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1414TupleTypesInSignaturesShouldHaveElementNames.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1414TupleTypesInSignaturesShouldHaveElementNames.cs
@@ -68,21 +68,6 @@ namespace StyleCop.Analyzers.MaintainabilityRules
                 return;
             }
 
-            var methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodDeclaration);
-            var containingType = methodSymbol.ContainingType;
-            if (containingType is null || methodSymbol.ExplicitInterfaceImplementations.Length > 0)
-            {
-                return;
-            }
-
-            foreach (var member in containingType.AllInterfaces.SelectMany(i => i.GetMembers(methodSymbol.Name).OfType<IMethodSymbol>()))
-            {
-                if (methodSymbol.Equals(containingType.FindImplementationForInterfaceMember(member)))
-                {
-                    return;
-                }
-            }
-
             CheckType(context, methodDeclaration.ReturnType);
             CheckParameterList(context, methodDeclaration.ParameterList);
         }
@@ -181,7 +166,7 @@ namespace StyleCop.Analyzers.MaintainabilityRules
             {
                 CheckType(context, tupleElementSyntax.Type);
 
-                if (tupleElementSyntax.Identifier.IsKind(SyntaxKind.None))
+                if (tupleElementSyntax.Identifier.IsKind(SyntaxKind.None) && !NamedTypeHelpers.IsImplementingAnInterfaceMember(context.SemanticModel.GetDeclaredSymbol(context.Node)))
                 {
                     var location = tupleElementSyntax.SyntaxNode.GetLocation();
                     context.ReportDiagnostic(Diagnostic.Create(Descriptor, location));

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1414TupleTypesInSignaturesShouldHaveElementNames.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1414TupleTypesInSignaturesShouldHaveElementNames.cs
@@ -63,9 +63,14 @@ namespace StyleCop.Analyzers.MaintainabilityRules
             }
 
             var methodDeclaration = (MethodDeclarationSyntax)context.Node;
+            if (methodDeclaration.Modifiers.Any(SyntaxKind.OverrideKeyword))
+            {
+                return;
+            }
+
             var methodSymbol = context.SemanticModel.GetDeclaredSymbol(methodDeclaration);
             var containingType = methodSymbol.ContainingType;
-            if (containingType == null)
+            if (containingType is null || methodSymbol.ExplicitInterfaceImplementations.Length > 0)
             {
                 return;
             }


### PR DESCRIPTION
When implementing an interface whose members contain tuples, the implementations must exactly match the interface's definition, hence in the case of tuples, no names are permitted. Otherwise the compiler emits a [CS8141](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/cs8141) error.

This PR checks if a method implements an interface before checking for nameless tuples.