### PR TITLE
Make XmlCommentHelper faster

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1625ElementDocumentationMustNotBeCopiedAndPasted.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1625ElementDocumentationMustNotBeCopiedAndPasted.cs
@@ -101,14 +101,10 @@ namespace StyleCop.Analyzers.DocumentationRules
                     continue;
                 }
 
-                if (documentationTexts.Contains(documentation))
+                if (!documentationTexts.Add(documentation))
                 {
                     // Add violation
                     context.ReportDiagnostic(Diagnostic.Create(Descriptor, documentationSyntax.GetLocation()));
-                }
-                else
-                {
-                    documentationTexts.Add(documentation);
                 }
             }
 
@@ -148,14 +144,10 @@ namespace StyleCop.Analyzers.DocumentationRules
                     continue;
                 }
 
-                if (documentationTexts.Contains(documentation))
+                if (!documentationTexts.Add(documentation))
                 {
                     // Add violation
                     context.ReportDiagnostic(Diagnostic.Create(Descriptor, diagnosticLocations.First()));
-                }
-                else
-                {
-                    documentationTexts.Add(documentation);
                 }
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/ObjectPools/StringBuilderPool.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/ObjectPools/StringBuilderPool.cs
@@ -22,8 +22,11 @@ namespace StyleCop.Analyzers.Helpers.ObjectPools
 
         public static string ReturnAndFree(StringBuilder builder)
         {
-            SharedPools.Default<StringBuilder>();
-            return builder.ToString();
+            string result = builder.ToString();
+
+            StringBuilderPool.Free(builder);
+
+            return result;
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
@@ -317,6 +317,10 @@ namespace StyleCop.Analyzers.Helpers
         /// <summary>
         /// Append to StringBuilder and perform white space normalization.
         /// </summary>
+        /// <param name="builder">StringBuilder to append to.</param>
+        /// <param name="text">String to append.</param>
+        /// <param name="normalizeWhitespace">Normalize flag.</param>
+        /// <param name="lastWhitespace">last char is white space flag.</param>
         /// <returns>True if output is different.</returns>
         internal static bool AppendNormalize(this StringBuilder builder, string text, bool normalizeWhitespace, ref bool lastWhitespace)
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
@@ -301,6 +301,7 @@ namespace StyleCop.Analyzers.Helpers
                     {
                         StringBuilderPool.Free(stringBuilder);
 
+                        // No change is needed, return original string.
                         return single;
                     }
                 }
@@ -313,6 +314,10 @@ namespace StyleCop.Analyzers.Helpers
             return StringBuilderPool.ReturnAndFree(stringBuilder);
         }
 
+        /// <summary>
+        /// Append to StringBuilder and perform white space normalization.
+        /// </summary>
+        /// <returns>True if output is different.</returns>
         internal static bool AppendNormalize(this StringBuilder builder, string text, bool normalizeWhitespace, ref bool lastWhitespace)
         {
             bool diff = false;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
@@ -319,7 +319,7 @@ namespace StyleCop.Analyzers.Helpers
 
             bool lastSpace = false;
 
-            bool diff = true;
+            bool diff = false;
 
             foreach (char ch in text)
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/XmlCommentHelper.cs
@@ -7,7 +7,6 @@ namespace StyleCop.Analyzers.Helpers
 {
     using System.Linq;
     using System.Text;
-    using System.Text.RegularExpressions;
     using System.Xml.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -311,11 +310,6 @@ namespace StyleCop.Analyzers.Helpers
             }
 
             int length = text.Length;
-
-            if (length == 0)
-            {
-                return string.Empty;
-            }
 
             bool lastSpace = false;
 


### PR DESCRIPTION
1) Use StringBuilder only when there are multiple lines
2) In white space normalization, return original string when no change is needed.
3) When changes are really needed, calculate exact size, allocate a char buffer for the changed text, then allocate string.