### PR TITLE
Update SA1011 to forbid trailing space before the end of a switch case

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/SpacingRules/SA1011CSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/SpacingRules/SA1011CSharp11UnitTests.cs
@@ -3,9 +3,55 @@
 
 namespace StyleCop.Analyzers.Test.CSharp11.SpacingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp10.SpacingRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1011ClosingSquareBracketsMustBeSpacedCorrectly,
+        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public class SA1011CSharp11UnitTests : SA1011CSharp10UnitTests
     {
+        [Fact]
+        [WorkItem(3673, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3673")]
+        public async Task TestListPatternInSwitchCaseAsync()
+        {
+            var testCode = @"public class TestClass
+{
+    public void TestMethod(object[] arg)
+    {
+        switch (arg)
+        {
+            case [string s{|#0:]|} :
+                break;
+        }
+    }}
+";
+
+            var fixedCode = @"public class TestClass
+{
+    public void TestMethod(object[] arg)
+    {
+        switch (arg)
+        {
+            case [string s]:
+                break;
+        }
+    }}
+";
+
+            await new CSharpTest
+            {
+                ReferenceAssemblies = ReferenceAssemblies.Net.Net70,
+                TestCode = testCode,
+                ExpectedDiagnostics =
+                {
+                    Diagnostic().WithLocation(0).WithArguments(" not", "followed"),
+                },
+                FixedCode = fixedCode,
+            }.RunAsync(CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011ClosingSquareBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1011ClosingSquareBracketsMustBeSpacedCorrectly.cs
@@ -135,7 +135,9 @@ namespace StyleCop.Analyzers.SpacingRules
                     break;
 
                 case SyntaxKind.ColonToken:
-                    precedesSpecialCharacter = nextToken.Parent.IsKind(SyntaxKind.InterpolationFormatClause);
+                    precedesSpecialCharacter =
+                        nextToken.Parent.IsKind(SyntaxKind.InterpolationFormatClause) ||
+                        nextToken.Parent.IsKind(SyntaxKindEx.CasePatternSwitchLabel);
                     suppressFollowingSpaceError = false;
                     break;
 


### PR DESCRIPTION
Fixes #3673