### PR TITLE
Avoid allocations in CanWrap... methods

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LightupHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LightupHelpers.cs
@@ -65,11 +65,7 @@ namespace StyleCop.Analyzers.Lightup
                 return false;
             }
 
-            // Avoid creating the delegate if the value already exists
-            if (!SupportedObjectWrappers.TryGetValue(underlyingType, out var wrappedObject))
-            {
-                wrappedObject = SupportedObjectWrappers.GetOrAdd(underlyingType, static _ => new ConcurrentDictionary<Type, bool>());
-            }
+            ConcurrentDictionary<Type, bool> wrappedObject = SupportedObjectWrappers.GetOrAdd(underlyingType, static _ => new ConcurrentDictionary<Type, bool>());
 
             // Avoid creating the delegate and capture class
             if (!wrappedObject.TryGetValue(obj.GetType(), out var canCast))
@@ -95,11 +91,7 @@ namespace StyleCop.Analyzers.Lightup
                 return false;
             }
 
-            // Avoid creating the delegate if the value already exists
-            if (!SupportedSyntaxWrappers.TryGetValue(underlyingType, out var wrappedSyntax))
-            {
-                wrappedSyntax = SupportedSyntaxWrappers.GetOrAdd(underlyingType, static _ => new ConcurrentDictionary<SyntaxKind, bool>());
-            }
+            ConcurrentDictionary<SyntaxKind, bool> wrappedSyntax = SupportedSyntaxWrappers.GetOrAdd(underlyingType, static _ => new ConcurrentDictionary<SyntaxKind, bool>());
 
             // Avoid creating the delegate and capture class
             if (!wrappedSyntax.TryGetValue(node.Kind(), out var canCast))
@@ -125,11 +117,7 @@ namespace StyleCop.Analyzers.Lightup
                 return false;
             }
 
-            // Avoid creating the delegate if the value already exists
-            if (!SupportedOperationWrappers.TryGetValue(underlyingType, out var wrappedSyntax))
-            {
-                wrappedSyntax = SupportedOperationWrappers.GetOrAdd(underlyingType, static _ => new ConcurrentDictionary<OperationKind, bool>());
-            }
+            ConcurrentDictionary<OperationKind, bool> wrappedSyntax = SupportedOperationWrappers.GetOrAdd(underlyingType, static _ => new ConcurrentDictionary<OperationKind, bool>());
 
             // Avoid creating the delegate and capture class
             if (!wrappedSyntax.TryGetValue(operation.Kind, out var canCast))

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LightupHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LightupHelpers.cs
@@ -65,18 +65,22 @@ namespace StyleCop.Analyzers.Lightup
                 return false;
             }
 
-            ConcurrentDictionary<Type, bool> wrappedObject = SupportedObjectWrappers.GetOrAdd(underlyingType, _ => new ConcurrentDictionary<Type, bool>());
-
             // Avoid creating the delegate if the value already exists
-            bool canCast;
-            if (!wrappedObject.TryGetValue(obj.GetType(), out canCast))
+            if (!SupportedObjectWrappers.TryGetValue(underlyingType, out var wrappedObject))
             {
-                canCast = wrappedObject.GetOrAdd(
-                    obj.GetType(),
-                    kind => underlyingType.GetTypeInfo().IsAssignableFrom(obj.GetType().GetTypeInfo()));
+                wrappedObject = SupportedObjectWrappers.GetOrAdd(underlyingType, static _ => new ConcurrentDictionary<Type, bool>());
             }
 
-            return canCast;
+            // Avoid creating the delegate and capture class if the value already exists
+            return wrappedObject.TryGetValue(obj.GetType(), out var canCast)
+                ? canCast
+                : GetOrAdd(obj, underlyingType, wrappedObject);
+
+            // Don't inline this method. Otherwise a capture class is generated on each call to CanWrapObject.
+            static bool GetOrAdd(object obj, Type underlyingType, ConcurrentDictionary<Type, bool> wrappedObject)
+                => wrappedObject.GetOrAdd(
+                    obj.GetType(),
+                    kind => underlyingType.GetTypeInfo().IsAssignableFrom(obj.GetType().GetTypeInfo()));
         }
 
         internal static bool CanWrapNode(SyntaxNode node, Type underlyingType)
@@ -93,18 +97,22 @@ namespace StyleCop.Analyzers.Lightup
                 return false;
             }
 
-            ConcurrentDictionary<SyntaxKind, bool> wrappedSyntax = SupportedSyntaxWrappers.GetOrAdd(underlyingType, _ => new ConcurrentDictionary<SyntaxKind, bool>());
-
             // Avoid creating the delegate if the value already exists
-            bool canCast;
-            if (!wrappedSyntax.TryGetValue(node.Kind(), out canCast))
+            if (!SupportedSyntaxWrappers.TryGetValue(underlyingType, out var wrappedSyntax))
             {
-                canCast = wrappedSyntax.GetOrAdd(
-                    node.Kind(),
-                    kind => underlyingType.GetTypeInfo().IsAssignableFrom(node.GetType().GetTypeInfo()));
+                wrappedSyntax = SupportedSyntaxWrappers.GetOrAdd(underlyingType, static _ => new ConcurrentDictionary<SyntaxKind, bool>());
             }
 
-            return canCast;
+            // Avoid creating the delegate and capture class if the value already exists
+            return wrappedSyntax.TryGetValue(node.Kind(), out var canCast)
+                ? canCast
+                : GetOrAdd(node, underlyingType, wrappedSyntax);
+
+            // Don't inline this method. Otherwise a capture class is generated on each call to CanWrapNode.
+            static bool GetOrAdd(SyntaxNode node, Type underlyingType, ConcurrentDictionary<SyntaxKind, bool> wrappedSyntax) =>
+                wrappedSyntax.GetOrAdd(
+                    node.Kind(),
+                    kind => underlyingType.GetTypeInfo().IsAssignableFrom(node.GetType().GetTypeInfo()));
         }
 
         internal static bool CanWrapOperation(IOperation operation, Type underlyingType)
@@ -121,18 +129,22 @@ namespace StyleCop.Analyzers.Lightup
                 return false;
             }
 
-            ConcurrentDictionary<OperationKind, bool> wrappedSyntax = SupportedOperationWrappers.GetOrAdd(underlyingType, _ => new ConcurrentDictionary<OperationKind, bool>());
-
             // Avoid creating the delegate if the value already exists
-            bool canCast;
-            if (!wrappedSyntax.TryGetValue(operation.Kind, out canCast))
+            if (!SupportedOperationWrappers.TryGetValue(underlyingType, out var wrappedSyntax))
             {
-                canCast = wrappedSyntax.GetOrAdd(
-                    operation.Kind,
-                    kind => underlyingType.GetTypeInfo().IsAssignableFrom(operation.GetType().GetTypeInfo()));
+                wrappedSyntax = SupportedOperationWrappers.GetOrAdd(underlyingType, static _ => new ConcurrentDictionary<OperationKind, bool>());
             }
 
-            return canCast;
+            // Avoid creating the delegate if the value already exists
+            return wrappedSyntax.TryGetValue(operation.Kind, out var canCast)
+                ? canCast
+                : GetOrAdd(operation, underlyingType, wrappedSyntax);
+
+            // Don't inline this method. Otherwise a capture class is generated on each call to CanWrapOperation.
+            static bool GetOrAdd(IOperation operation, Type underlyingType, ConcurrentDictionary<OperationKind, bool> wrappedSyntax) =>
+                wrappedSyntax.GetOrAdd(
+                    operation.Kind,
+                    kind => underlyingType.GetTypeInfo().IsAssignableFrom(operation.GetType().GetTypeInfo()));
         }
 
         internal static Func<TOperation, TProperty> CreateOperationPropertyAccessor<TOperation, TProperty>(Type type, string propertyName)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LightupHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LightupHelpers.cs
@@ -71,16 +71,14 @@ namespace StyleCop.Analyzers.Lightup
                 wrappedObject = SupportedObjectWrappers.GetOrAdd(underlyingType, static _ => new ConcurrentDictionary<Type, bool>());
             }
 
-            // Avoid creating the delegate and capture class if the value already exists
-            return wrappedObject.TryGetValue(obj.GetType(), out var canCast)
-                ? canCast
-                : GetOrAdd(obj, underlyingType, wrappedObject);
+            // Avoid creating the delegate and capture class
+            if (!wrappedObject.TryGetValue(obj.GetType(), out var canCast))
+            {
+                canCast = underlyingType.GetTypeInfo().IsAssignableFrom(obj.GetType().GetTypeInfo());
+                wrappedObject.TryAdd(obj.GetType(), canCast);
+            }
 
-            // Don't inline this method. Otherwise a capture class is generated on each call to CanWrapObject.
-            static bool GetOrAdd(object obj, Type underlyingType, ConcurrentDictionary<Type, bool> wrappedObject)
-                => wrappedObject.GetOrAdd(
-                    obj.GetType(),
-                    kind => underlyingType.GetTypeInfo().IsAssignableFrom(obj.GetType().GetTypeInfo()));
+            return canCast;
         }
 
         internal static bool CanWrapNode(SyntaxNode node, Type underlyingType)
@@ -103,16 +101,14 @@ namespace StyleCop.Analyzers.Lightup
                 wrappedSyntax = SupportedSyntaxWrappers.GetOrAdd(underlyingType, static _ => new ConcurrentDictionary<SyntaxKind, bool>());
             }
 
-            // Avoid creating the delegate and capture class if the value already exists
-            return wrappedSyntax.TryGetValue(node.Kind(), out var canCast)
-                ? canCast
-                : GetOrAdd(node, underlyingType, wrappedSyntax);
+            // Avoid creating the delegate and capture class
+            if (!wrappedSyntax.TryGetValue(node.Kind(), out var canCast))
+            {
+                canCast = underlyingType.GetTypeInfo().IsAssignableFrom(node.GetType().GetTypeInfo());
+                wrappedSyntax.TryAdd(node.Kind(), canCast);
+            }
 
-            // Don't inline this method. Otherwise a capture class is generated on each call to CanWrapNode.
-            static bool GetOrAdd(SyntaxNode node, Type underlyingType, ConcurrentDictionary<SyntaxKind, bool> wrappedSyntax) =>
-                wrappedSyntax.GetOrAdd(
-                    node.Kind(),
-                    kind => underlyingType.GetTypeInfo().IsAssignableFrom(node.GetType().GetTypeInfo()));
+            return canCast;
         }
 
         internal static bool CanWrapOperation(IOperation operation, Type underlyingType)
@@ -135,16 +131,14 @@ namespace StyleCop.Analyzers.Lightup
                 wrappedSyntax = SupportedOperationWrappers.GetOrAdd(underlyingType, static _ => new ConcurrentDictionary<OperationKind, bool>());
             }
 
-            // Avoid creating the delegate if the value already exists
-            return wrappedSyntax.TryGetValue(operation.Kind, out var canCast)
-                ? canCast
-                : GetOrAdd(operation, underlyingType, wrappedSyntax);
+            // Avoid creating the delegate and capture class
+            if (!wrappedSyntax.TryGetValue(operation.Kind, out var canCast))
+            {
+                canCast = underlyingType.GetTypeInfo().IsAssignableFrom(operation.GetType().GetTypeInfo());
+                wrappedSyntax.TryAdd(operation.Kind, canCast);
+            }
 
-            // Don't inline this method. Otherwise a capture class is generated on each call to CanWrapOperation.
-            static bool GetOrAdd(IOperation operation, Type underlyingType, ConcurrentDictionary<OperationKind, bool> wrappedSyntax) =>
-                wrappedSyntax.GetOrAdd(
-                    operation.Kind,
-                    kind => underlyingType.GetTypeInfo().IsAssignableFrom(operation.GetType().GetTypeInfo()));
+            return canCast;
         }
 
         internal static Func<TOperation, TProperty> CreateOperationPropertyAccessor<TOperation, TProperty>(Type type, string propertyName)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LightupHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/LightupHelpers.cs
@@ -67,7 +67,7 @@ namespace StyleCop.Analyzers.Lightup
 
             ConcurrentDictionary<Type, bool> wrappedObject = SupportedObjectWrappers.GetOrAdd(underlyingType, static _ => new ConcurrentDictionary<Type, bool>());
 
-            // Avoid creating the delegate and capture class
+            // Avoid creating a delegate and capture class
             if (!wrappedObject.TryGetValue(obj.GetType(), out var canCast))
             {
                 canCast = underlyingType.GetTypeInfo().IsAssignableFrom(obj.GetType().GetTypeInfo());
@@ -93,7 +93,7 @@ namespace StyleCop.Analyzers.Lightup
 
             ConcurrentDictionary<SyntaxKind, bool> wrappedSyntax = SupportedSyntaxWrappers.GetOrAdd(underlyingType, static _ => new ConcurrentDictionary<SyntaxKind, bool>());
 
-            // Avoid creating the delegate and capture class
+            // Avoid creating a delegate and capture class
             if (!wrappedSyntax.TryGetValue(node.Kind(), out var canCast))
             {
                 canCast = underlyingType.GetTypeInfo().IsAssignableFrom(node.GetType().GetTypeInfo());
@@ -119,7 +119,7 @@ namespace StyleCop.Analyzers.Lightup
 
             ConcurrentDictionary<OperationKind, bool> wrappedSyntax = SupportedOperationWrappers.GetOrAdd(underlyingType, static _ => new ConcurrentDictionary<OperationKind, bool>());
 
-            // Avoid creating the delegate and capture class
+            // Avoid creating a delegate and capture class
             if (!wrappedSyntax.TryGetValue(operation.Kind, out var canCast))
             {
                 canCast = underlyingType.GetTypeInfo().IsAssignableFrom(operation.GetType().GetTypeInfo());


### PR DESCRIPTION
The "CanWrap.." methods are in the hot path in our repository (see SonarSource/sonar-dotnet/issues/8106). It is likely that the methods are on the hot path in your analyzer as well (they are called by each ...Wrapper.IsInstance implementation).

The following improvements can be validated by the generated IL:
* Capture class creation is removed: `IL_00000` creates a capture class for the whole method. In the new version, no capture class is created.
* ~`Func<,>` delegate instantiation for `_ => new ConcurrentDictionary<Type, bool>()` is deferred for sure. The function delegate in `IL_0047`  seems to be stored in a hidden static field and reused in the old version. The new version makes sure that the delegate is not instantiated on the happy path for sure. `IL_0033` in the new version is only conditional executed after the branch after the `SupportedSyntaxWrappers.TryGetValue` (`IL_0017`) and a second branch after the static field lookup (`IL_0025`).~
* If `wrappedSyntax.TryGetValue` is not successful `canCast` is calculated and added to the `ConcurrentDictionary` without a delegate. This is possible because `canCast` is a value type. Unlike with reference types, the created value doesn't suffer from concurrency issues if `TryAdd` fails.

The allocation saving for the capture class was measured in this SonarSource/sonar-dotnet/pull/8107 on our side with the similar changes in place.

The IL for the old version of `CanWrapNode` looks like so (3 times `newobj`):

```
  .method assembly hidebysig static bool
    CanWrapNode(
      class [Microsoft.CodeAnalysis]Microsoft.CodeAnalysis.SyntaxNode node,
      class [System.Runtime]System.Type underlyingType
    ) cil managed
  {
    .maxstack 4
    .locals init (
      [0] class StyleCop.Analyzers.Lightup.LightupHelpers/'<>c__DisplayClass30_0' 'CS$<>8__locals0',
      [1] class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool> wrappedSyntax,
      [2] bool canCast
    )

    IL_0000: newobj       instance void StyleCop.Analyzers.Lightup.LightupHelpers/'<>c__DisplayClass30_0'::.ctor()
    IL_0005: stloc.0      // 'CS$<>8__locals0'
    IL_0006: ldloc.0      // 'CS$<>8__locals0'
    IL_0007: ldarg.1      // underlyingType
    IL_0008: stfld        class [System.Runtime]System.Type StyleCop.Analyzers.Lightup.LightupHelpers/'<>c__DisplayClass30_0'::underlyingType
    IL_000d: ldloc.0      // 'CS$<>8__locals0'
    IL_000e: ldarg.0      // node
    IL_000f: stfld        class [Microsoft.CodeAnalysis]Microsoft.CodeAnalysis.SyntaxNode StyleCop.Analyzers.Lightup.LightupHelpers/'<>c__DisplayClass30_0'::node

    // [84 13 - 84 30]
    IL_0014: ldloc.0      // 'CS$<>8__locals0'
    IL_0015: ldfld        class [Microsoft.CodeAnalysis]Microsoft.CodeAnalysis.SyntaxNode StyleCop.Analyzers.Lightup.LightupHelpers/'<>c__DisplayClass30_0'::node
    IL_001a: brtrue.s     IL_001e

    // [87 17 - 87 29]
    IL_001c: ldc.i4.1
    IL_001d: ret

    // [90 13 - 90 40]
    IL_001e: ldloc.0      // 'CS$<>8__locals0'
    IL_001f: ldfld        class [System.Runtime]System.Type StyleCop.Analyzers.Lightup.LightupHelpers/'<>c__DisplayClass30_0'::underlyingType
    IL_0024: brtrue.s     IL_0028

    // [93 17 - 93 30]
    IL_0026: ldc.i4.0
    IL_0027: ret

    // [96 13 - 96 168]
    IL_0028: ldsfld       class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<class [System.Runtime]System.Type, class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>> StyleCop.Analyzers.Lightup.LightupHelpers::SupportedSyntaxWrappers
    IL_002d: ldloc.0      // 'CS$<>8__locals0'
    IL_002e: ldfld        class [System.Runtime]System.Type StyleCop.Analyzers.Lightup.LightupHelpers/'<>c__DisplayClass30_0'::underlyingType
    IL_0033: ldsfld       class [System.Runtime]System.Func`2<class [System.Runtime]System.Type, class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>> StyleCop.Analyzers.Lightup.LightupHelpers/'<>c'::'<>9__30_0'
    IL_0038: dup
    IL_0039: brtrue.s     IL_0052
    IL_003b: pop
    IL_003c: ldsfld       class StyleCop.Analyzers.Lightup.LightupHelpers/'<>c' StyleCop.Analyzers.Lightup.LightupHelpers/'<>c'::'<>9'
    IL_0041: ldftn        instance class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool> StyleCop.Analyzers.Lightup.LightupHelpers/'<>c'::'<CanWrapNode>b__30_0'(class [System.Runtime]System.Type)
    IL_0047: newobj       instance void class [System.Runtime]System.Func`2<class [System.Runtime]System.Type, class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>>::.ctor(object, native int)
    IL_004c: dup
    IL_004d: stsfld       class [System.Runtime]System.Func`2<class [System.Runtime]System.Type, class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>> StyleCop.Analyzers.Lightup.LightupHelpers/'<>c'::'<>9__30_0'
    IL_0052: callvirt     instance !1/*class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>*/ class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<class [System.Runtime]System.Type, class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>>::GetOrAdd(!0/*class [System.Runtime]System.Type*/, class [System.Runtime]System.Func`2<!0/*class [System.Runtime]System.Type*/, !1/*class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>*/>)
    IL_0057: stloc.1      // wrappedSyntax

    // [100 13 - 100 70]
    IL_0058: ldloc.1      // wrappedSyntax
    IL_0059: ldloc.0      // 'CS$<>8__locals0'
    IL_005a: ldfld        class [Microsoft.CodeAnalysis]Microsoft.CodeAnalysis.SyntaxNode StyleCop.Analyzers.Lightup.LightupHelpers/'<>c__DisplayClass30_0'::node
    IL_005f: call         valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.CSharpExtensions::Kind(class [Microsoft.CodeAnalysis]Microsoft.CodeAnalysis.SyntaxNode)
    IL_0064: ldloca.s     canCast
    IL_0066: callvirt     instance bool class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>::TryGetValue(!0/*valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind*/, !1/*bool*/&)
    IL_006b: brtrue.s     IL_008b

    // [102 17 - 104 106]
    IL_006d: ldloc.1      // wrappedSyntax
    IL_006e: ldloc.0      // 'CS$<>8__locals0'
    IL_006f: ldfld        class [Microsoft.CodeAnalysis]Microsoft.CodeAnalysis.SyntaxNode StyleCop.Analyzers.Lightup.LightupHelpers/'<>c__DisplayClass30_0'::node
    IL_0074: call         valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.CSharpExtensions::Kind(class [Microsoft.CodeAnalysis]Microsoft.CodeAnalysis.SyntaxNode)
    IL_0079: ldloc.0      // 'CS$<>8__locals0'
    IL_007a: ldftn        instance bool StyleCop.Analyzers.Lightup.LightupHelpers/'<>c__DisplayClass30_0'::'<CanWrapNode>b__1'(valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind)
    IL_0080: newobj       instance void class [System.Runtime]System.Func`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>::.ctor(object, native int)
    IL_0085: callvirt     instance !1/*bool*/ class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>::GetOrAdd(!0/*valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind*/, class [System.Runtime]System.Func`2<!0/*valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind*/, !1/*bool*/>)
    IL_008a: stloc.2      // canCast

    // [107 13 - 107 28]
    IL_008b: ldloc.2      // canCast
    IL_008c: ret

  } // end of method LightupHelpers::CanWrapNode
```

The IL for the new version looks like so (1 time `newobj`):

```
  .method assembly hidebysig static bool
    CanWrapNode(
      class [Microsoft.CodeAnalysis]Microsoft.CodeAnalysis.SyntaxNode node,
      class [System.Runtime]System.Type underlyingType
    ) cil managed
  {
    .maxstack 4
    .locals init (
      [0] class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool> wrappedSyntax,
      [1] bool canCast
    )

    // [82 13 - 82 30]
    IL_0000: ldarg.0      // node
    IL_0001: brtrue.s     IL_0005

    // [85 17 - 85 29]
    IL_0003: ldc.i4.1
    IL_0004: ret

    // [88 13 - 88 40]
    IL_0005: ldarg.1      // underlyingType
    IL_0006: brtrue.s     IL_000a

    // [91 17 - 91 30]
    IL_0008: ldc.i4.0
    IL_0009: ret

    // [94 13 - 94 175]
    IL_000a: ldsfld       class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<class [System.Runtime]System.Type, class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>> StyleCop.Analyzers.Lightup.LightupHelpers::SupportedSyntaxWrappers
    IL_000f: ldarg.1      // underlyingType
    IL_0010: ldsfld       class [System.Runtime]System.Func`2<class [System.Runtime]System.Type, class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>> StyleCop.Analyzers.Lightup.LightupHelpers/'<>c'::'<>9__30_0'
    IL_0015: dup
    IL_0016: brtrue.s     IL_002f
    IL_0018: pop
    IL_0019: ldsfld       class StyleCop.Analyzers.Lightup.LightupHelpers/'<>c' StyleCop.Analyzers.Lightup.LightupHelpers/'<>c'::'<>9'
    IL_001e: ldftn        instance class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool> StyleCop.Analyzers.Lightup.LightupHelpers/'<>c'::'<CanWrapNode>b__30_0'(class [System.Runtime]System.Type)
    IL_0024: newobj       instance void class [System.Runtime]System.Func`2<class [System.Runtime]System.Type, class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>>::.ctor(object, native int)
    IL_0029: dup
    IL_002a: stsfld       class [System.Runtime]System.Func`2<class [System.Runtime]System.Type, class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>> StyleCop.Analyzers.Lightup.LightupHelpers/'<>c'::'<>9__30_0'
    IL_002f: callvirt     instance !1/*class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>*/ class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<class [System.Runtime]System.Type, class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>>::GetOrAdd(!0/*class [System.Runtime]System.Type*/, class [System.Runtime]System.Func`2<!0/*class [System.Runtime]System.Type*/, !1/*class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>*/>)
    IL_0034: stloc.0      // wrappedSyntax

    // [97 13 - 97 74]
    IL_0035: ldloc.0      // wrappedSyntax
    IL_0036: ldarg.0      // node
    IL_0037: call         valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.CSharpExtensions::Kind(class [Microsoft.CodeAnalysis]Microsoft.CodeAnalysis.SyntaxNode)
    IL_003c: ldloca.s     canCast
    IL_003e: callvirt     instance bool class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>::TryGetValue(!0/*valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind*/, !1/*bool*/&)
    IL_0043: brtrue.s     IL_006a

    // [99 17 - 99 103]
    IL_0045: ldarg.1      // underlyingType
    IL_0046: call         class [System.Reflection]System.Reflection.TypeInfo [System.Reflection]System.Reflection.IntrospectionExtensions::GetTypeInfo(class [System.Runtime]System.Type)
    IL_004b: ldarg.0      // node
    IL_004c: callvirt     instance class [System.Runtime]System.Type [System.Runtime]System.Object::GetType()
    IL_0051: call         class [System.Reflection]System.Reflection.TypeInfo [System.Reflection]System.Reflection.IntrospectionExtensions::GetTypeInfo(class [System.Runtime]System.Type)
    IL_0056: callvirt     instance bool [System.Reflection]System.Reflection.TypeInfo::IsAssignableFrom(class [System.Reflection]System.Reflection.TypeInfo)
    IL_005b: stloc.1      // canCast

    // [100 17 - 100 60]
    IL_005c: ldloc.0      // wrappedSyntax
    IL_005d: ldarg.0      // node
    IL_005e: call         valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.CSharpExtensions::Kind(class [Microsoft.CodeAnalysis]Microsoft.CodeAnalysis.SyntaxNode)
    IL_0063: ldloc.1      // canCast
    IL_0064: callvirt     instance bool class [System.Collections.Concurrent]System.Collections.Concurrent.ConcurrentDictionary`2<valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind, bool>::TryAdd(!0/*valuetype [Microsoft.CodeAnalysis.CSharp]Microsoft.CodeAnalysis.CSharp.SyntaxKind*/, !1/*bool*/)
    IL_0069: pop

    // [103 13 - 103 28]
    IL_006a: ldloc.1      // canCast
    IL_006b: ret

  } // end of method LightupHelpers::CanWrapNode
```