### PR TITLE
Temporary workaround for unstable SA1134 code fix

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1134UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1134UnitTests.cs
@@ -319,7 +319,16 @@ namespace TestNamespace
                 Diagnostic().WithLocation(23, 54),
             };
 
-            await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+            // TODO: Revert after fixing issue 2438 (https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2438)
+            var test = new CSharpTest
+            {
+                TestCode = testCode,
+                FixedCode = fixedTestCode,
+                NumberOfIncrementalIterations = int.MinValue,
+                NumberOfFixAllIterations = int.MinValue,
+            };
+            test.ExpectedDiagnostics.AddRange(expected);
+            await test.RunAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
Would this be ok to get rid on random failures of the test VerifyMultipleAttributesOnSameLineForMembersAsync?
This happens quite often unfortunately. Unsure if this helps, but I interpret the documentation like it should.