### PR TITLE
Update SA1648 to accept inheritdoc on members implemented from static abstract/virtual interface members

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/DocumentationRules/SA1648CSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/DocumentationRules/SA1648CSharp11UnitTests.cs
@@ -3,9 +3,46 @@
 
 namespace StyleCop.Analyzers.Test.CSharp11.DocumentationRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp10.DocumentationRules;
+    using Xunit;
 
     public partial class SA1648CSharp11UnitTests : SA1648CSharp10UnitTests
     {
+        [WorkItem(3595, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3595")]
+        [Theory]
+        [InlineData("abstract void TestMethod();", "public void TestMethod() {}")]
+        [InlineData("abstract void TestMethod();", "void TestInterface.TestMethod() {}")]
+        [InlineData("virtual void TestMethod() {}", "public void TestMethod() {}")]
+        [InlineData("virtual void TestMethod() {}", "void TestInterface.TestMethod() {}")]
+        [InlineData("abstract int TestProperty { get; set; }", "public int TestProperty { get; set; }")]
+        [InlineData("abstract int TestProperty { get; set; }", "int TestInterface.TestProperty { get; set; }")]
+        [InlineData("virtual int TestProperty { get; set; }", "public int TestProperty { get; set; }")]
+        [InlineData("virtual int TestProperty { get; set; }", "int TestInterface.TestProperty { get; set; }")]
+        [InlineData("abstract event System.Action TestEvent;", "public event System.Action TestEvent;")]
+        [InlineData("abstract event System.Action TestEvent;", "event System.Action TestInterface.TestEvent { add {} remove {} }")]
+        [InlineData("virtual event System.Action TestEvent;", "public event System.Action TestEvent;")]
+        [InlineData("virtual event System.Action TestEvent;", "event System.Action TestInterface.TestEvent { add {} remove {} }")]
+        public async Task TestCorrectMemberInheritDocFromStaticAbstractOrVirtualMemberInInterfaceAsync(string interfaceMember, string classMember)
+        {
+            var testCode = $@"
+public interface TestInterface
+{{
+    /// <summary>
+    /// A summary text.
+    /// </summary>
+    static {interfaceMember}
+}}
+
+public class TestClass : TestInterface
+{{
+    /// <inheritdoc />
+    static {classMember}
+}}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/DocumentationRules/SA1648CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/DocumentationRules/SA1648CSharp8UnitTests.cs
@@ -3,9 +3,37 @@
 
 namespace StyleCop.Analyzers.Test.CSharp8.DocumentationRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp7.DocumentationRules;
+    using Xunit;
 
     public partial class SA1648CSharp8UnitTests : SA1648CSharp7UnitTests
     {
+        [WorkItem(3595, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3595")]
+        [Theory]
+        [InlineData("void TestMethod() {}")]
+        [InlineData("int TestProperty { get; set; }")]
+        [InlineData("event System.Action TestEvent;")]
+        public async Task TestIncorrectMemberInheritDocFromStaticMemberInInterfaceAsync(string member)
+        {
+            var testCode = $@"
+public interface TestInterface
+{{
+    /// <summary>
+    /// A summary text.
+    /// </summary>
+    static {member}
+}}
+
+public class TestClass : TestInterface
+{{
+    /// [|<inheritdoc />|]
+    public static {member}
+}}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1648UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1648UnitTests.cs
@@ -323,10 +323,10 @@ public delegate bool TestDelegate(int value);
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        private static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken)
+        protected static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken)
             => VerifyCSharpDiagnosticAsync(source, new[] { expected }, cancellationToken);
 
-        private static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken)
+        protected static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken)
         {
             var test = CreateTest(expected);
             test.TestCode = source;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/NamedTypeHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/NamedTypeHelpers.cs
@@ -145,11 +145,6 @@ namespace StyleCop.Analyzers.Helpers
         /// <returns>true if the member is implementing an interface member, otherwise false.</returns>
         internal static bool IsImplementingAnInterfaceMember(ISymbol memberSymbol)
         {
-            if (memberSymbol.IsStatic)
-            {
-                return false;
-            }
-
             bool isImplementingExplicitly;
 
             // Only methods, properties and events can implement an interface member


### PR DESCRIPTION
Fixes #3595.
Also added tests for non-abstract/virtual static interface members to make sure that case wasn't affected.