### PR TITLE
Update SA1119 to allow parenthesized switch expressions followed by an invocation

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/MaintainabilityRules/SA1119CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/MaintainabilityRules/SA1119CSharp8UnitTests.cs
@@ -220,6 +220,25 @@ public class Foo
         }
 
         [Fact]
+        [WorkItem(3730, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3730")]
+        public async Task TestSwitchExpressionFollowedByInvocationAsync()
+        {
+            string testCode = @"
+using System;
+
+public class Foo
+{
+    public string TestMethod(int n, Func<string> a, Func<string> b)
+    {
+        return (n switch { 1 => a, 2 => b })();
+    }
+}
+";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
         public async Task TestStackAllocExpressionInExpressionAsync()
         {
             const string testCode = @"public class TestClass

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119StatementMustNotUseUnnecessaryParenthesis.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119StatementMustNotUseUnnecessaryParenthesis.cs
@@ -230,6 +230,7 @@ namespace StyleCop.Analyzers.MaintainabilityRules
                 MemberAccessExpressionSyntax memberAccessExpression => memberAccessExpression.Expression == outerExpression,
                 ConditionalAccessExpressionSyntax conditionalAccessExpression => conditionalAccessExpression.Expression == outerExpression,
                 ElementAccessExpressionSyntax elementAccessExpression => elementAccessExpression.Expression == outerExpression,
+                InvocationExpressionSyntax invocationExpression => invocationExpression.Expression == outerExpression,
                 _ => false,
             };
         }


### PR DESCRIPTION
Fixes #3730