### PR TITLE
Update SA1119 to allow parenthesis around a ref ternary conditional expression when it is the left-hand side of an assigment

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119StatementMustNotUseUnnecessaryParenthesis.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1119StatementMustNotUseUnnecessaryParenthesis.cs
@@ -153,6 +153,15 @@ namespace StyleCop.Analyzers.MaintainabilityRules
                         return;
                     }
 
+                    if (node.Parent is AssignmentExpressionSyntax assignmentExpression
+                        && node.Expression.IsKind(SyntaxKind.ConditionalExpression)
+                        && assignmentExpression.Left == node)
+                    {
+                        // NOTE: This is only valid syntax if the conditional expression is a ref expression
+                        // Parenthesis can't be removed here
+                        return;
+                    }
+
                     if (!(node.Parent is ExpressionSyntax)
                         || node.Parent is CheckedExpressionSyntax
                         || node.Parent is MemberAccessExpressionSyntax)


### PR DESCRIPTION
Fixes #3712