### PR TITLE
Update SA1008 to not crash if there is no previous token

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/SpacingRules/SA1008CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/SpacingRules/SA1008CSharp9UnitTests.cs
@@ -5,8 +5,10 @@
 
 namespace StyleCop.Analyzers.Test.CSharp9.SpacingRules
 {
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp8.SpacingRules;
     using Xunit;
@@ -80,6 +82,33 @@ class C
 }";
 
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData(" ")]
+        [InlineData("\n")]
+        [InlineData("\n ")]
+        [WorkItem(2354, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2354")]
+        public async Task TestDeconstructionInTopLevelProgramAsync(string prefix)
+        {
+            var testCode = $@"{prefix}{{|#0:(|}} var a, var b) = (1, 2);";
+            var fixedCode = $@"{prefix}(var a, var b) = (1, 2);";
+
+            await new CSharpTest()
+            {
+                TestState =
+                {
+                    OutputKind = OutputKind.ConsoleApplication,
+                    Sources = { testCode },
+                },
+                ExpectedDiagnostics =
+                {
+                    // /0/Test0.cs(1,1): warning SA1008: Opening parenthesis should not be followed by a space.
+                    Diagnostic(DescriptorNotFollowed).WithLocation(0),
+                },
+                FixedCode = fixedCode,
+            }.RunAsync(CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1008UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1008UnitTests.cs
@@ -2158,5 +2158,22 @@ class ClassName
 
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
+
+        [Fact]
+        [WorkItem(2354, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2354")]
+        public async Task TestNoPreviousTokenAsync()
+        {
+            var testCode = "(";
+
+            var test = new CSharpTest()
+            {
+                TestCode = testCode,
+
+                // Compiler diagnostics differ between Roslyn versions. The main thing is that the analyzer doesn't throw an exception.
+                CompilerDiagnostics = CompilerDiagnostics.None,
+            };
+
+            await test.RunAsync(CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
@@ -142,7 +142,11 @@ namespace StyleCop.Analyzers.SpacingRules
             var leadingTriviaList = TriviaHelper.MergeTriviaLists(prevToken.TrailingTrivia, token.LeadingTrivia);
 
             var isFirstOnLine = false;
-            if (prevToken.GetLineSpan().EndLinePosition.Line < token.GetLineSpan().StartLinePosition.Line)
+            if (prevToken.IsKind(SyntaxKind.None))
+            {
+                isFirstOnLine = true; // This means that it doesn't matter if there are spaces before or not
+            }
+            else if (prevToken.GetLineSpan().EndLinePosition.Line < token.GetLineSpan().StartLinePosition.Line)
             {
                 var done = false;
                 for (var i = leadingTriviaList.Count - 1; !done && (i >= 0); i--)


### PR DESCRIPTION
Fixes #2354

Protected all similar methods in LocationHelpers against null reference exception.
I found one situation where this happens in SA1008 so I added a unit test for that as well.

I also went through all uses of the SyntaxTree properties in SyntaxToken, SyntaxTrivia and SyntaxNodeOrToken and tried to make sure that they could not cause a null reference exceptions.