### PR TITLE
Update SA1513 to not require a blank line if the closing brace is at the end of a collection expression

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/LayoutRules/SA1513CSharp12UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/LayoutRules/SA1513CSharp12UnitTests.cs
@@ -3,9 +3,34 @@
 
 namespace StyleCop.Analyzers.Test.CSharp12.LayoutRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp11.LayoutRules;
+    using Xunit;
+
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.LayoutRules.SA1513ClosingBraceMustBeFollowedByBlankLine,
+        StyleCop.Analyzers.LayoutRules.SA1513CodeFixProvider>;
 
     public partial class SA1513CSharp12UnitTests : SA1513CSharp11UnitTests
     {
+        [Fact]
+        [WorkItem(3720, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3720")]
+        public async Task TestObjectInitializerInCollectionExpressionAsync()
+        {
+            var testCode = @"
+public class Foo
+{
+    public Foo[] TestMethod() =>
+    [
+        new Foo
+        {
+        }
+    ];
+}";
+
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513ClosingBraceMustBeFollowedByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513ClosingBraceMustBeFollowedByBlankLine.cs
@@ -272,6 +272,12 @@ namespace StyleCop.Analyzers.LayoutRules
                         return;
                     }
 
+                    if (nextToken.IsKind(SyntaxKind.CloseBracketToken))
+                    {
+                        // the close brace is for example in an object initializer at the end of a collection expression.
+                        return;
+                    }
+
                     if (nextToken.IsKind(SyntaxKind.AddKeyword)
                         || nextToken.IsKind(SyntaxKind.RemoveKeyword)
                         || nextToken.IsKind(SyntaxKind.GetKeyword)


### PR DESCRIPTION
Fixes #3720