### PR TITLE
Update SA1008 to allow space before the opening parenthesis of a using alias definition of a tuple type

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/SpacingRules/SA1008CSharp12UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/SpacingRules/SA1008CSharp12UnitTests.cs
@@ -3,9 +3,30 @@
 
 namespace StyleCop.Analyzers.Test.CSharp12.SpacingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using StyleCop.Analyzers.Test.CSharp11.SpacingRules;
+    using Xunit;
+
+    using static StyleCop.Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly,
+        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public partial class SA1008CSharp12UnitTests : SA1008CSharp11UnitTests
     {
+        [Fact]
+        [WorkItem(3743, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3743")]
+        public async Task TestTupleUsingAliasAsync()
+        {
+            const string testCode = @"
+using TestAlias ={|#0:(|}string X, bool Y);";
+
+            const string fixedCode = @"
+using TestAlias = (string X, bool Y);";
+
+            var expected = Diagnostic(DescriptorPreceded).WithLocation(0);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
@@ -249,10 +249,12 @@ namespace StyleCop.Analyzers.SpacingRules
 
             case SyntaxKindEx.TupleType:
                 // Comma covers tuple types in parameters and nested within other tuple types.
+                // Equals covers definition of a tuple type alias.
                 // 'out', 'ref', 'in', 'params' parameters are covered by IsKeywordKind.
                 // Attributes of parameters are covered by checking the previous token's parent.
                 // Return types are handled by a helper.
                 haveLeadingSpace = prevToken.IsKind(SyntaxKind.CommaToken)
+                    || prevToken.IsKind(SyntaxKind.EqualsToken)
                     || SyntaxFacts.IsKeywordKind(prevToken.Kind())
                     || prevToken.Parent.IsKind(SyntaxKind.AttributeList)
                     || ((TypeSyntax)token.Parent).GetContainingNotEnclosingType().IsReturnType();


### PR DESCRIPTION
Fixes #3743