### PR TITLE
Update SA1009 to require a space after the closing parenthesis if it is followed by ++ or -- from a prefix unary expression

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1009ClosingParenthesisMustBeSpacedCorrectly.cs
@@ -181,7 +181,9 @@ namespace StyleCop.Analyzers.SpacingRules
 
             case SyntaxKind.PlusPlusToken:
             case SyntaxKind.MinusMinusToken:
-                precedesStickyCharacter = true;
+                precedesStickyCharacter =
+                    !nextToken.Parent.IsKind(SyntaxKind.PreIncrementExpression)
+                    && !nextToken.Parent.IsKind(SyntaxKind.PreDecrementExpression);
                 suppressFollowingSpaceError = false;
                 break;
 


### PR DESCRIPTION
Fixes #3731