### PR TITLE
[WIP] Update SA1600 to not require documentation for explicitly implemented members

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1600UnitTests.cs
@@ -90,7 +90,7 @@ using System;
         public async Task TestMethodWithoutDocumentationAsync()
         {
             await this.TestMethodDeclarationDocumentationAsync(string.Empty, false, false, false).ConfigureAwait(false);
-            await this.TestMethodDeclarationDocumentationAsync(string.Empty, true, true, false).ConfigureAwait(false);
+            await this.TestMethodDeclarationDocumentationAsync(string.Empty, true, false, false).ConfigureAwait(false);
             await this.TestMethodDeclarationDocumentationAsync("private", false, false, false).ConfigureAwait(false);
             await this.TestMethodDeclarationDocumentationAsync("protected", false, true, false).ConfigureAwait(false);
             await this.TestMethodDeclarationDocumentationAsync("internal", false, true, false).ConfigureAwait(false);
@@ -282,7 +282,7 @@ using System;
         public async Task TestPropertyWithoutDocumentationAsync()
         {
             await this.TestPropertyDeclarationDocumentationAsync(string.Empty, false, false, false).ConfigureAwait(false);
-            await this.TestPropertyDeclarationDocumentationAsync(string.Empty, true, true, false).ConfigureAwait(false);
+            await this.TestPropertyDeclarationDocumentationAsync(string.Empty, true, false, false).ConfigureAwait(false);
             await this.TestPropertyDeclarationDocumentationAsync("private", false, false, false).ConfigureAwait(false);
             await this.TestPropertyDeclarationDocumentationAsync("protected", false, true, false).ConfigureAwait(false);
             await this.TestPropertyDeclarationDocumentationAsync("internal", false, true, false).ConfigureAwait(false);
@@ -310,7 +310,7 @@ using System;
         public async Task TestIndexerWithoutDocumentationAsync()
         {
             await this.TestIndexerDeclarationDocumentationAsync(string.Empty, false, false, false).ConfigureAwait(false);
-            await this.TestIndexerDeclarationDocumentationAsync(string.Empty, true, true, false).ConfigureAwait(false);
+            await this.TestIndexerDeclarationDocumentationAsync(string.Empty, true, false, false).ConfigureAwait(false);
             await this.TestIndexerDeclarationDocumentationAsync("private", false, false, false).ConfigureAwait(false);
             await this.TestIndexerDeclarationDocumentationAsync("protected", false, true, false).ConfigureAwait(false);
             await this.TestIndexerDeclarationDocumentationAsync("internal", false, true, false).ConfigureAwait(false);
@@ -338,7 +338,7 @@ using System;
         public async Task TestEventWithoutDocumentationAsync()
         {
             await this.TestEventDeclarationDocumentationAsync(string.Empty, false, false, false).ConfigureAwait(false);
-            await this.TestEventDeclarationDocumentationAsync(string.Empty, true, true, false).ConfigureAwait(false);
+            await this.TestEventDeclarationDocumentationAsync(string.Empty, true, false, false).ConfigureAwait(false);
             await this.TestEventDeclarationDocumentationAsync("private", false, false, false).ConfigureAwait(false);
             await this.TestEventDeclarationDocumentationAsync("protected", false, true, false).ConfigureAwait(false);
             await this.TestEventDeclarationDocumentationAsync("internal", false, true, false).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
@@ -13,7 +13,6 @@ namespace StyleCop.Analyzers.DocumentationRules
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.Helpers;
-    using StyleCop.Analyzers.Lightup;
     using StyleCop.Analyzers.Settings.ObjectModel;
 
     /// <summary>
@@ -161,6 +160,12 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                 MethodDeclarationSyntax declaration = (MethodDeclarationSyntax)context.Node;
 
+                if (declaration.ExplicitInterfaceSpecifier != null)
+                {
+                    // Skipping since explicitly implemented members can't be used through the implementing type
+                    return;
+                }
+
                 Accessibility declaredAccessibility = declaration.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
                 Accessibility effectiveAccessibility = declaration.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
                 if (NeedsComment(settings.DocumentationRules, declaration.Kind(), declaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility))
@@ -221,6 +226,12 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                 PropertyDeclarationSyntax declaration = (PropertyDeclarationSyntax)context.Node;
 
+                if (declaration.ExplicitInterfaceSpecifier != null)
+                {
+                    // Skipping since explicitly implemented members can't be used through the implementing type
+                    return;
+                }
+
                 Accessibility declaredAccessibility = declaration.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
                 Accessibility effectiveAccessibility = declaration.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
                 if (NeedsComment(settings.DocumentationRules, declaration.Kind(), declaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility))
@@ -240,6 +251,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                 }
 
                 IndexerDeclarationSyntax declaration = (IndexerDeclarationSyntax)context.Node;
+
+                if (declaration.ExplicitInterfaceSpecifier != null)
+                {
+                    // Skipping since explicitly implemented members can't be used through the implementing type
+                    return;
+                }
 
                 Accessibility declaredAccessibility = declaration.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
                 Accessibility effectiveAccessibility = declaration.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
@@ -305,6 +322,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                 }
 
                 EventDeclarationSyntax declaration = (EventDeclarationSyntax)context.Node;
+
+                if (declaration.ExplicitInterfaceSpecifier != null)
+                {
+                    // Skipping since explicitly implemented members can't be used through the implementing type
+                    return;
+                }
 
                 Accessibility declaredAccessibility = declaration.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
                 Accessibility effectiveAccessibility = declaration.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);


### PR DESCRIPTION
Fixes #3717.

Good thing: Only the SA1600 code is touched.

Bad thing: This change leaves some old code uncovered by tests. The code is regarding ExplicitInterfaceSpecifier and is located inside the various GetDeclaredAccessibility methods in AccessLevelHelper. Could be because of missing tests for some other analyzers, or that the now uncovered code was actually unnecessary for all other analyzers that call these methods, however strange that sounds. If this change is accepted I can write another issue to investigating what to do about it.