### PR TITLE
Fix csharp_using_directive_placement setting retrieval

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/Settings/SettingsCSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/Settings/SettingsCSharp8UnitTests.cs
@@ -172,6 +172,22 @@ file_header_template = {variable}
             Assert.Equal("[InvalidReference]", styleCopSettings.DocumentationRules.GetCopyrightText("unused"));
         }
 
+        [Fact]
+        public async Task VerifyEditorConfigSettingsReadCorrectlyDirectivePlacementWithoutSeverityLevelAsync()
+        {
+            var settings = @"root = true
+
+[*]
+csharp_using_directive_placement = outside_namespace
+";
+            var context = await this.CreateAnalysisContextFromEditorConfigAsync(settings).ConfigureAwait(false);
+
+            var styleCopSettings = context.GetStyleCopSettings(CancellationToken.None);
+
+            Assert.NotNull(styleCopSettings.OrderingRules);
+            Assert.Equal(UsingDirectivesPlacement.OutsideNamespace, styleCopSettings.OrderingRules.UsingDirectivesPlacement);
+        }
+
         protected virtual AnalyzerConfigOptionsProvider CreateAnalyzerConfigOptionsProvider(AnalyzerConfigSet analyzerConfigSet)
             => new TestAnalyzerConfigOptionsProvider(analyzerConfigSet);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/AnalyzerConfigHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/AnalyzerConfigHelper.cs
@@ -71,6 +71,8 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
                 {
                     return new KeyValuePair<string, string>(value.Substring(0, colonIndex), value.Substring(colonIndex + 1));
                 }
+
+                return new KeyValuePair<string, string>(value, string.Empty);
             }
 
             return null;


### PR DESCRIPTION
Hi,

I use this setting in my editorconfig file
> csharp_using_directive_placement = outside_namespace

But the StyleCop Analyzer was not using it.

So I analyzed the source code and found that the method that read the setting expects that the setting is followed by the severity level.
This is not the case for me and so the setting is not retrieved.

Currently the code that set the setting not use the severity level so I just return an empty string in this case.