### PR TITLE
Update SA1025 documentation to reflect handling of multiple spaces preceding a symbol

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1025CodeMustNotContainMultipleWhitespaceInARow.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1025CodeMustNotContainMultipleWhitespaceInARow.cs
@@ -17,8 +17,7 @@ namespace StyleCop.Analyzers.SpacingRules
     /// </summary>
     /// <remarks>
     /// <para>A violation of this rule occurs whenever the code contains multiple whitespace characters in a row, unless
-    /// the characters come at the beginning or end of a line of code, following a comma or semicolon or preceding a
-    /// symbol.</para>
+    /// the characters come at the beginning or end of a line of code, or following a comma or semicolon.</para>
     /// </remarks>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     internal class SA1025CodeMustNotContainMultipleWhitespaceInARow : DiagnosticAnalyzer

--- a/documentation/KnownChanges.md
+++ b/documentation/KnownChanges.md
@@ -123,8 +123,14 @@ StyleCop Classic allowed multiple spaces to precede a comment placed at the end 
 int x;    // comment
 ```
 
-StyleCop Analyzers does not currently make an exception to the SA1025 rule for this case, although this decision is
-still under review.
+It also allowed multiple spaces preceding a symbol, such as in the second line of the following code:
+
+```csharp
+int xyz = 1;
+int w   = 1;
+```
+
+StyleCop Analyzers does not currently make an exception to the SA1025 rule for these cases.
 
 ## Readability Rules
 

--- a/documentation/SA1025.md
+++ b/documentation/SA1025.md
@@ -22,7 +22,7 @@ The code contains multiple whitespace characters in a row.
 ## Rule description
 
 A violation of this rule occurs whenever the code contains multiple whitespace characters in a row, unless the
-characters come at the beginning or end of a line of code, following a comma or semicolon or preceding a symbol.
+characters come at the beginning or end of a line of code, or following a comma or semicolon.
 
 ## How to fix violations
 


### PR DESCRIPTION
Fixes #3684 by updating documentation.