### PR TITLE
Update SA1515 to not require a blank line before a comment at the start of a collection expression

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/LayoutRules/SA1515CSharp12UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/LayoutRules/SA1515CSharp12UnitTests.cs
@@ -3,9 +3,37 @@
 
 namespace StyleCop.Analyzers.Test.CSharp12.LayoutRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp11.LayoutRules;
+    using Xunit;
+
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.LayoutRules.SA1515SingleLineCommentMustBePrecededByBlankLine,
+        StyleCop.Analyzers.LayoutRules.SA1515CodeFixProvider>;
 
     public partial class SA1515CSharp12UnitTests : SA1515CSharp11UnitTests
     {
+        [Fact]
+        [WorkItem(3766, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3766")]
+        public async Task TestFirstInCollectionExpressionAsync()
+        {
+            var testCode = @"
+public class TestClass
+{
+    private string[] elements =
+    [
+      // Hydrogen
+      ""H"",
+
+      // Helium
+      ""He"",
+    ];
+}
+";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515SingleLineCommentMustBePrecededByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1515SingleLineCommentMustBePrecededByBlankLine.cs
@@ -266,9 +266,10 @@ namespace StyleCop.Analyzers.LayoutRules
 
             var prevToken = token.GetPreviousToken();
             return prevToken.IsKind(SyntaxKind.OpenBraceToken)
-                   || prevToken.Parent.IsKind(SyntaxKind.CaseSwitchLabel)
-                   || prevToken.Parent.IsKind(SyntaxKindEx.CasePatternSwitchLabel)
-                   || prevToken.Parent.IsKind(SyntaxKind.DefaultSwitchLabel);
+                || (prevToken.IsKind(SyntaxKind.OpenBracketToken) && prevToken.Parent.IsKind(SyntaxKindEx.CollectionExpression))
+                || prevToken.Parent.IsKind(SyntaxKind.CaseSwitchLabel)
+                || prevToken.Parent.IsKind(SyntaxKindEx.CasePatternSwitchLabel)
+                || prevToken.Parent.IsKind(SyntaxKind.DefaultSwitchLabel);
         }
 
         private static bool IsPrecededByDirectiveTrivia<T>(T triviaList, int triviaIndex)


### PR DESCRIPTION
Fixes #3766