### PR TITLE
Draft: Make SA1600 trigger on undocumented record primary ctor parameters

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/DocumentationRules/SA1600CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/DocumentationRules/SA1600CSharp9UnitTests.cs
@@ -5,11 +5,205 @@
 
 namespace StyleCop.Analyzers.Test.CSharp9.DocumentationRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.DocumentationRules;
     using StyleCop.Analyzers.Test.CSharp8.DocumentationRules;
+    using StyleCop.Analyzers.Test.Helpers;
+    using StyleCop.Analyzers.Test.Verifiers;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<
+        StyleCop.Analyzers.DocumentationRules.SA1600ElementsMustBeDocumented>;
 
     public partial class SA1600CSharp9UnitTests : SA1600CSharp8UnitTests
     {
+        [Theory]
+        [MemberData(nameof(CommonMemberData.RecordTypeDeclarationKeywords), MemberType = typeof(CommonMemberData))]
+        [WorkItem(3780, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3780")]
+        public async Task TestRecordPrimaryConstructorNoParameterDocumentationAsync(string keyword)
+        {
+            string testCode = $@"
+/// <summary>
+/// Record.
+/// </summary>
+public {keyword} MyRecord(int {{|#0:Param1|}}, string {{|#1:Param2|}});";
+
+            DiagnosticResult[] expectedResults = new[]
+            {
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
+                Diagnostic().WithLocation(1),
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expectedResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(CommonMemberData.RecordTypeDeclarationKeywords), MemberType = typeof(CommonMemberData))]
+        [WorkItem(3780, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3780")]
+        public async Task TestRecordPrimaryConstructorNoDocumentationAsync(string keyword)
+        {
+            string testCode = $@"
+public {keyword} {{|#0:MyRecord|}}(int {{|#1:Param1|}});";
+
+            DiagnosticResult[] expectedResults = new[]
+            {
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
+                Diagnostic().WithLocation(1),
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expectedResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(CommonMemberData.RecordTypeDeclarationKeywords), MemberType = typeof(CommonMemberData))]
+        [WorkItem(3780, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3780")]
+        public async Task TestRecordPrimaryConstructorCompleteParameterDocumentationAsync(string keyword)
+        {
+            string testCode = $@"
+/// <summary>
+/// Record.
+/// </summary>
+/// <param name=""Param1"">Parameter one.</param>
+/// <param name=""Param2"">Parameter two.</param>
+public {keyword} MyRecord(int Param1, string Param2);";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(CommonMemberData.RecordTypeDeclarationKeywords), MemberType = typeof(CommonMemberData))]
+        [WorkItem(3780, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3780")]
+        public async Task TestRecordPrimaryConstructorPartialParameterDocumentationAsync(string keyword)
+        {
+            string testCode = $@"
+/// <summary>
+/// Record.
+/// </summary>
+/// <param name=""Param1"">Parameter one.</param>
+public {keyword} MyRecord(int Param1, string {{|#0:Param2|}});";
+
+            DiagnosticResult[] expectedResults = new[]
+            {
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(0),
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expectedResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(CommonMemberData.RecordTypeDeclarationKeywords), MemberType = typeof(CommonMemberData))]
+        [WorkItem(3780, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3780")]
+        public async Task TestRecordPrimaryConstructorInheritdocAsync(string keyword)
+        {
+            string testCode = $@"
+/// <inheritdoc />
+public {keyword} MyRecord(int Param1, string Param2);";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(CommonMemberData.RecordTypeDeclarationKeywords), MemberType = typeof(CommonMemberData))]
+        [WorkItem(3780, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3780")]
+        public async Task TestRecordPrimaryConstructorIncludeParameterDocumentationAsync(string keyword)
+        {
+            string testCode = $@"
+/// <include file='WithParameterDocumentation.xml' path='/TestType/*' />
+public {keyword} MyRecord(int Param1, string Param2, bool Param3);";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(CommonMemberData.RecordTypeDeclarationKeywords), MemberType = typeof(CommonMemberData))]
+        [WorkItem(3780, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3780")]
+        public async Task TestRecordPrimaryConstructorIncludePartialParameterDocumentationAsync(string keyword)
+        {
+            string testCode = $@"
+/// <include file='WithPartialParameterDocumentation.xml' path='/TestType/*' />
+public {keyword} MyRecord(int {{|#0:Param1|}}, string Param2, bool Param3);";
+
+            DiagnosticResult[] expectedResults = new[]
+            {
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(0),
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expectedResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(CommonMemberData.RecordTypeDeclarationKeywords), MemberType = typeof(CommonMemberData))]
+        [WorkItem(3780, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3780")]
+        public async Task TestRecordPrimaryConstructorIncludeMissingParameterDocumentationAsync(string keyword)
+        {
+            string testCode = $@"
+/// <include file='MissingParameterDocumentation.xml' path='/TestType/*' />
+public {keyword} MyRecord(int {{|#0:Param1|}}, string {{|#1:Param2|}}, bool {{|#2:Param3|}});";
+
+            DiagnosticResult[] expectedResults = new[]
+            {
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
+                Diagnostic().WithLocation(1),
+                Diagnostic().WithLocation(2),
+                Diagnostic().WithLocation(2),
+            };
+
+            await VerifyCSharpDiagnosticAsync(testCode, expectedResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken)
+        {
+            string typeWithoutParameterDocumentation = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
+        <TestType>
+            <summary>
+                Foo
+            </summary>
+        </TestType>
+        ";
+            string typeWithPartialParameterDocumentation = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
+        <TestType>
+            <summary>
+                Foo
+            </summary>
+            <param name=""Param2"">Param 2.</param>
+            <param name=""Param3"">Param 3.</param>
+        </TestType>
+        ";
+            string typeWithParameterDocumentation = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
+        <TestType>
+            <summary>
+                Foo
+            </summary>
+            <param name=""Param1"">Param 1.</param>
+            <param name=""Param2"">Param 2.</param>
+            <param name=""Param3"">Param 3.</param>
+        </TestType>
+        ";
+
+            var test = new CSharpTest
+            {
+                TestCode = source,
+                XmlReferences =
+                        {
+                            { "MissingParameterDocumentation.xml", typeWithoutParameterDocumentation },
+                            { "WithParameterDocumentation.xml", typeWithParameterDocumentation },
+                            { "WithPartialParameterDocumentation.xml", typeWithPartialParameterDocumentation },
+                        },
+            };
+
+            test.ExpectedDiagnostics.AddRange(expected);
+            return test.RunAsync(cancellationToken);
+        }
+
         protected override DiagnosticResult[] GetExpectedResultTestRegressionMethodGlobalNamespace(string code)
         {
             if (code == "public void {|#0:TestMember|}() { }")

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/SA1600ElementsMustBeDocumented.cs
@@ -6,8 +6,12 @@
 namespace StyleCop.Analyzers.DocumentationRules
 {
     using System;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Linq;
+    using System.Reflection.Metadata;
+    using System.Xml.Linq;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -143,11 +147,29 @@ namespace StyleCop.Analyzers.DocumentationRules
 
                 Accessibility declaredAccessibility = declaration.GetDeclaredAccessibility(context.SemanticModel, context.CancellationToken);
                 Accessibility effectiveAccessibility = declaration.GetEffectiveAccessibility(context.SemanticModel, context.CancellationToken);
-                if (NeedsComment(settings.DocumentationRules, declaration.Kind(), declaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility))
+                if (!NeedsComment(settings.DocumentationRules, declaration.Kind(), declaration.Parent.Kind(), declaredAccessibility, effectiveAccessibility))
                 {
-                    if (!XmlCommentHelper.HasDocumentation(declaration))
+                    return;
+                }
+
+                if (!XmlCommentHelper.HasDocumentation(declaration))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, declaration.Identifier.GetLocation()));
+                }
+
+                if (context.Node is TypeDeclarationSyntax typeDeclaration && RecordDeclarationSyntaxWrapper.IsInstance(typeDeclaration))
+                {
+                    RecordDeclarationSyntaxWrapper recordDeclaration = typeDeclaration;
+
+                    string[] documentedParameterNames = GetDocumentedParameters(context, typeDeclaration, out bool hasInheritdoc);
+                    IEnumerable<ParameterSyntax> parameters = recordDeclaration.ParameterList?.Parameters ?? Enumerable.Empty<ParameterSyntax>();
+
+                    foreach (var parameter in parameters)
                     {
-                        context.ReportDiagnostic(Diagnostic.Create(Descriptor, declaration.Identifier.GetLocation()));
+                        if (!hasInheritdoc && !documentedParameterNames.Contains(parameter.Identifier.ValueText))
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptor, parameter.Identifier.GetLocation()));
+                        }
                     }
                 }
             }
@@ -340,6 +362,61 @@ namespace StyleCop.Analyzers.DocumentationRules
                         }
                     }
                 }
+            }
+
+            private static string[] GetDocumentedParameters(SyntaxNodeAnalysisContext context, RecordDeclarationSyntaxWrapper typeDeclarationSyntax, out bool hasInheritdoc)
+            {
+                hasInheritdoc = false;
+
+                var documentation = context.Node.GetDocumentationCommentTriviaSyntax();
+                if (documentation == null)
+                {
+                    return EmptyArray<string>.Instance;
+                }
+
+                if (documentation.Content.GetFirstXmlElement(XmlCommentHelper.InheritdocXmlTag) != null)
+                {
+                    hasInheritdoc = true;
+                    return EmptyArray<string>.Instance;
+                }
+
+                var hasIncludedDocumentation =
+                    documentation.Content.GetFirstXmlElement(XmlCommentHelper.IncludeXmlTag) != null;
+
+                if (hasIncludedDocumentation)
+                {
+                    var declaredSymbol = context.SemanticModel.GetDeclaredSymbol(typeDeclarationSyntax, context.CancellationToken);
+                    var rawDocumentation = declaredSymbol?.GetDocumentationCommentXml(expandIncludes: true, cancellationToken: context.CancellationToken);
+                    var includedDocumentation = XElement.Parse(rawDocumentation ?? "<doc></doc>", LoadOptions.None);
+
+                    if (includedDocumentation.Nodes().OfType<XElement>().Any(element => element.Name == XmlCommentHelper.InheritdocXmlTag))
+                    {
+                        hasInheritdoc = true;
+                        return EmptyArray<string>.Instance;
+                    }
+
+                    IEnumerable<XElement> paramElements = includedDocumentation.Nodes()
+                        .OfType<XElement>()
+                        .Where(x => x.Name == XmlCommentHelper.ParamXmlTag);
+
+                    return paramElements
+                        .SelectMany(x => x.Attributes().Where(y => y.Name == XmlCommentHelper.NameArgumentName))
+                        .Select(x => x.Value)
+                        .ToArray();
+                }
+                else
+                {
+                    IEnumerable<XmlNodeSyntax> xmlNodes = documentation.Content.GetXmlElements(XmlCommentHelper.ParamXmlTag);
+                    return xmlNodes.Select(XmlCommentHelper.GetFirstAttributeOrDefault<XmlNameAttributeSyntax>)
+                        .Where(x => x != null)
+                        .Select(x => x.Identifier.Identifier.ValueText)
+                        .ToArray();
+                }
+            }
+
+            private static class EmptyArray<T>
+            {
+                public static T[] Instance { get; } = new T[0];
             }
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/RecordDeclarationSyntaxWrapper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/RecordDeclarationSyntaxWrapper.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Lightup;
+
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+internal partial struct RecordDeclarationSyntaxWrapper : ISyntaxWrapper<TypeDeclarationSyntax>
+{
+    public static implicit operator RecordDeclarationSyntaxWrapper(TypeDeclarationSyntax node)
+    {
+        return new RecordDeclarationSyntaxWrapper(node);
+    }
+}


### PR DESCRIPTION
Add analysis of XML <param> tags to SA1600 so that it is raised on record primary constructor parameters. Closes https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3780.

This is in draft as I had a few questions:

- All of my diagnostics are being reported twice in the C# 9 unit tests. I've baked these into the expectation, which is fine for C# 9 and C# 10, but causes C# 11 and C# 12 to fail after reporting the correct number of diagnostics.
- I've added a diagnostic verifier method that passes custom XML files to the C# 9 unit test file, rather than the base unit tests, because the base SA1600 tests pass in `this.LanguageVersion` to the verification. I wasn't quite sure how (or if) I should adapt the custom verifier method to accept this.
- The logic in `SA1600ElementsMustBeDocumented.GetDocumentedParameters` is more or less entirely copied from `ElementDocumentationBase.HandleDeclaration`. Would it be worth extracting this into a common helper, or are they sufficiently unique to leave separate?