### PR TITLE
Update SA1012 to forbid space before a property pattern, when it is preceeded by an opening parenthesis. Previously only handled positional patterns correctly.

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/SpacingRules/SA1012CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/SpacingRules/SA1012CSharp9UnitTests.cs
@@ -3,9 +3,135 @@
 
 namespace StyleCop.Analyzers.Test.CSharp9.SpacingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp8.SpacingRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1012OpeningBracesMustBeSpacedCorrectly,
+        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public partial class SA1012CSharp9UnitTests : SA1012CSharp8UnitTests
     {
+        [Fact]
+        [WorkItem(3812, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3812")]
+        public async Task TestInAndPropertyPatternsAsync()
+        {
+            var testCode = @"
+class C
+{
+    public static bool HasValidLength(string s)
+    {
+        return s is ( {|#0:{|}Length: < 5 } and { Length: < 5 });
+    }
+}
+";
+
+            var fixedCode = @"
+class C
+{
+    public static bool HasValidLength(string s)
+    {
+        return s is ({ Length: < 5 } and { Length: < 5 });
+    }
+}
+";
+
+            DiagnosticResult[] expectedResults =
+            {
+                // SA1012: Opening brace should be followed by a space
+                Diagnostic().WithLocation(0).WithArguments(string.Empty, "followed"),
+
+                // SA1012: Opening brace should not be preceded by a space
+                Diagnostic().WithLocation(0).WithArguments(" not", "preceded"),
+            };
+
+            await VerifyCSharpFixAsync(
+                testCode,
+                expectedResults,
+                fixedCode,
+                CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3812, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3812")]
+        public async Task TestInOrPropertyPatternsAsync()
+        {
+            var testCode = @"
+class C
+{
+    public static bool HasValidLength(string s)
+    {
+        return s is ( {|#0:{|}Length: < 5 } or { Length: < 5 });
+    }
+}
+";
+
+            var fixedCode = @"
+class C
+{
+    public static bool HasValidLength(string s)
+    {
+        return s is ({ Length: < 5 } or { Length: < 5 });
+    }
+}
+";
+
+            DiagnosticResult[] expectedResults =
+            {
+                // SA1012: Opening brace should be followed by a space
+                Diagnostic().WithLocation(0).WithArguments(string.Empty, "followed"),
+
+                // SA1012: Opening brace should not be preceded by a space
+                Diagnostic().WithLocation(0).WithArguments(" not", "preceded"),
+            };
+
+            await VerifyCSharpFixAsync(
+                testCode,
+                expectedResults,
+                fixedCode,
+                CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3812, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3812")]
+        public async Task TestInParenthesizedPropertyPatternsAsync()
+        {
+            var testCode = @"
+class C
+{
+    public static bool HasValidLength(string s)
+    {
+        return s is ( {|#0:{|}Length: < 5 });
+    }
+}
+";
+
+            var fixedCode = @"
+class C
+{
+    public static bool HasValidLength(string s)
+    {
+        return s is ({ Length: < 5 });
+    }
+}
+";
+
+            DiagnosticResult[] expectedResults =
+            {
+                // SA1012: Opening brace should be followed by a space
+                Diagnostic().WithLocation(0).WithArguments(string.Empty, "followed"),
+
+                // SA1012: Opening brace should not be preceded by a space
+                Diagnostic().WithLocation(0).WithArguments(" not", "preceded"),
+            };
+
+            await VerifyCSharpFixAsync(
+                testCode,
+                expectedResults,
+                fixedCode,
+                CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1012OpeningBracesMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1012OpeningBracesMustBeSpacedCorrectly.cs
@@ -95,9 +95,12 @@ namespace StyleCop.Analyzers.SpacingRules
             if (token.Parent.IsKind(SyntaxKindEx.PropertyPatternClause))
             {
                 var prevToken = token.GetPreviousToken();
-                if (prevToken is { RawKind: (int)SyntaxKind.OpenParenToken, Parent: { RawKind: (int)SyntaxKindEx.PositionalPatternClause } })
+                if (prevToken.IsKind(SyntaxKind.OpenParenToken))
                 {
                     // value is ({ P: 0 }, { P: 0 })
+                    // value is ({ P: 0 } and { P: 0 })
+                    // value is ({ P: 0 } or { P: 0 })
+                    // value is ({ P: 0 })
                     expectPrecedingSpace = false;
                 }
                 else if (prevToken is { RawKind: (int)SyntaxKind.OpenBracketToken, Parent: { RawKind: (int)SyntaxKindEx.ListPattern } })


### PR DESCRIPTION
Fixes #3812

Removed a condition which made us forbid a blank before a property pattern only in the case of a positional pattern.