### PR TITLE
Update SA1513 to not require a blank line before linq 'into' keyword

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/LayoutRules/SA1513CSharp12UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/LayoutRules/SA1513CSharp12UnitTests.cs
@@ -32,5 +32,76 @@ public class Foo
 
             await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
         }
+
+        [Fact]
+        public async Task TestJoinIntoClauseSyntaxQueryExpressionAsync()
+        {
+            var testCode = @"
+using System.Collections.Generic;
+using System.Linq;
+
+public class JoinIntoClauseSyntaxQueryExpressionTest
+{
+    public JoinIntoClauseSyntaxQueryExpressionTest()
+    {
+        List<Foo> fooList =
+        [
+            new(1, ""First""),
+            new(2, ""Second""),
+            new(3, ""Third""),
+            new(1, ""Fourth"")
+        ];
+
+        List<Bar> barList =
+        [
+            new(1, ""First""),
+            new(2, ""Second""),
+            new(3, ""Third"")
+        ];
+
+        var query =
+            from foo in fooList
+            join bar in barList
+                on new
+                {
+                    foo.Id,
+                    foo.Name
+                }
+                equals new
+                {
+                    bar.Id,
+                    bar.Name
+                }
+            into grouping
+            from joined in grouping.DefaultIfEmpty()
+            select new
+            {
+                joined.Id,
+                BarName = joined.Name,
+                FooName = foo.Name
+            };
+    }
+
+    private class Foo(
+        int id,
+        string name)
+    {
+        public int Id { get; } = id;
+
+        public string Name { get; } = name;
+    }
+
+    private class Bar(
+        int id,
+        string name)
+    {
+        public int Id { get; } = id;
+
+        public string Name { get; } = name;
+    }
+}";
+
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, testCode, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513ClosingBraceMustBeFollowedByBlankLine.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/LayoutRules/SA1513ClosingBraceMustBeFollowedByBlankLine.cs
@@ -238,7 +238,8 @@ namespace StyleCop.Analyzers.LayoutRules
                     {
                         if (nextToken.Parent is QueryClauseSyntax
                             || nextToken.Parent is SelectOrGroupClauseSyntax
-                            || nextToken.Parent is QueryContinuationSyntax)
+                            || nextToken.Parent is QueryContinuationSyntax
+                            || nextToken.Parent is JoinIntoClauseSyntax)
                         {
                             // the close brace is part of a query expression
                             return;


### PR DESCRIPTION
No blank line needed before LINQ 'into' keyword when using anonymous object creation syntax. This PR fixes the issue.