### PR TITLE
Update SA1003 to handle the null-coalescing assignment operator, the unsigned right-shift operator, the unsigned right-shift assignment operator and the null-forgiving operator

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/SpacingRules/SA1003CSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/SpacingRules/SA1003CSharp11UnitTests.cs
@@ -3,9 +3,92 @@
 
 namespace StyleCop.Analyzers.Test.CSharp11.SpacingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using StyleCop.Analyzers.Test.CSharp10.SpacingRules;
+    using Xunit;
+
+    using static StyleCop.Analyzers.SpacingRules.SA1003SymbolsMustBeSpacedCorrectly;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1003SymbolsMustBeSpacedCorrectly,
+        StyleCop.Analyzers.SpacingRules.SA1003CodeFixProvider>;
 
     public partial class SA1003CSharp11UnitTests : SA1003CSharp10UnitTests
     {
+        [Fact]
+        [WorkItem(3822, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3822")]
+        public async Task TestUnsignedRightShiftAssignmentOperatorAsync()
+        {
+            var testCode = @"
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod(int x)
+        {
+            x{|#0:>>>=|}0;
+        }
+    }
+}
+";
+
+            var fixedCode = @"
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod(int x)
+        {
+            x >>>= 0;
+        }
+    }
+}
+";
+
+            var expected = new[]
+            {
+                    Diagnostic(DescriptorPrecededByWhitespace).WithLocation(0).WithArguments(">>>="),
+                    Diagnostic(DescriptorFollowedByWhitespace).WithLocation(0).WithArguments(">>>="),
+            };
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3822, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3822")]
+        public async Task TestUnsignedRightShiftOperatorAsync()
+        {
+            var testCode = @"
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public int TestMethod(int x)
+        {
+            return x{|#0:>>>|}0;
+        }
+    }
+}
+";
+
+            var fixedCode = @"
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public int TestMethod(int x)
+        {
+            return x >>> 0;
+        }
+    }
+}
+";
+
+            var expected = new[]
+            {
+                    Diagnostic(DescriptorPrecededByWhitespace).WithLocation(0).WithArguments(">>>"),
+                    Diagnostic(DescriptorFollowedByWhitespace).WithLocation(0).WithArguments(">>>"),
+            };
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1003CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1003CSharp8UnitTests.cs
@@ -66,5 +66,81 @@ namespace TestNamespace
                 FixedCode = fixedCode,
             }.RunAsync(CancellationToken.None).ConfigureAwait(false);
         }
+
+        [Fact]
+        [WorkItem(3822, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3822")]
+        public async Task TestNullCoalescingAssignmentOperatorAsync()
+        {
+            var testCode = @"
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod(int? x)
+        {
+            x{|#0:??=|}0;
+        }
+    }
+}
+";
+
+            var fixedCode = @"
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public void TestMethod(int? x)
+        {
+            x ??= 0;
+        }
+    }
+}
+";
+
+            var expected = new[]
+            {
+                    Diagnostic(DescriptorPrecededByWhitespace).WithLocation(0).WithArguments("??="),
+                    Diagnostic(DescriptorFollowedByWhitespace).WithLocation(0).WithArguments("??="),
+            };
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3822, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3822")]
+        public async Task TestNullForgivingOperatorAsync()
+        {
+            var testCode = @"
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public string TestMethod(string? x)
+        {
+            return x {|#0:!|} ;
+        }
+    }
+}
+";
+
+            var fixedCode = @"
+namespace TestNamespace
+{
+    public class TestClass
+    {
+        public string TestMethod(string? x)
+        {
+            return x!;
+        }
+    }
+}
+";
+
+            var expected = new[]
+            {
+                    Diagnostic(DescriptorNotPrecededByWhitespace).WithLocation(0).WithArguments("!"),
+                    Diagnostic(DescriptorNotFollowedByWhitespace).WithLocation(0).WithArguments("!"),
+            };
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/SyntaxKindEx.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/SyntaxKindEx.cs
@@ -27,7 +27,9 @@ namespace StyleCop.Analyzers.Lightup
         public const SyntaxKind IsPatternExpression = (SyntaxKind)8657;
         public const SyntaxKind RangeExpression = (SyntaxKind)8658;
         public const SyntaxKind ImplicitObjectCreationExpression = (SyntaxKind)8659;
+        public const SyntaxKind UnsignedRightShiftExpression = (SyntaxKind)8692;
         public const SyntaxKind CoalesceAssignmentExpression = (SyntaxKind)8725;
+        public const SyntaxKind UnsignedRightShiftAssignmentExpression = (SyntaxKind)8726;
         public const SyntaxKind IndexExpression = (SyntaxKind)8741;
         public const SyntaxKind DefaultLiteralExpression = (SyntaxKind)8755;
         public const SyntaxKind LocalFunctionStatement = (SyntaxKind)8830;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003SymbolsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1003SymbolsMustBeSpacedCorrectly.cs
@@ -86,6 +86,7 @@ namespace StyleCop.Analyzers.SpacingRules
                 SyntaxKind.GreaterThanOrEqualExpression,
                 SyntaxKind.LeftShiftExpression,
                 SyntaxKind.RightShiftExpression,
+                SyntaxKindEx.UnsignedRightShiftExpression,
                 SyntaxKind.AddExpression,
                 SyntaxKind.SubtractExpression,
                 SyntaxKind.MultiplyExpression,
@@ -105,7 +106,10 @@ namespace StyleCop.Analyzers.SpacingRules
                 SyntaxKind.AddressOfExpression);
 
         private static readonly ImmutableArray<SyntaxKind> PostfixUnaryExpressionKinds =
-            ImmutableArray.Create(SyntaxKind.PostIncrementExpression, SyntaxKind.PostDecrementExpression);
+            ImmutableArray.Create(
+                SyntaxKind.PostIncrementExpression,
+                SyntaxKind.PostDecrementExpression,
+                SyntaxKindEx.SuppressNullableWarningExpression);
 
         private static readonly ImmutableArray<SyntaxKind> AssignmentExpressionKinds =
             ImmutableArray.Create(
@@ -114,11 +118,13 @@ namespace StyleCop.Analyzers.SpacingRules
                 SyntaxKind.ExclusiveOrAssignmentExpression,
                 SyntaxKind.LeftShiftAssignmentExpression,
                 SyntaxKind.RightShiftAssignmentExpression,
+                SyntaxKindEx.UnsignedRightShiftAssignmentExpression,
                 SyntaxKind.AddAssignmentExpression,
                 SyntaxKind.SubtractAssignmentExpression,
                 SyntaxKind.MultiplyAssignmentExpression,
                 SyntaxKind.DivideAssignmentExpression,
                 SyntaxKind.ModuloAssignmentExpression,
+                SyntaxKindEx.CoalesceAssignmentExpression,
                 SyntaxKind.SimpleAssignmentExpression);
 
         private static readonly Action<SyntaxNodeAnalysisContext> ConstructorDeclarationAction = HandleConstructorDeclaration;


### PR DESCRIPTION
Fixes #3822. Also found some more operators that were not being handled by SA1003.