### PR TITLE
Update SA1404 to not crash when attribute uses a namespace alias

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1404UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1404UnitTests.cs
@@ -426,5 +426,23 @@ public class Foo
 
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
+
+        [Theory]
+        [InlineData("global::System.Obsolete")]
+        [InlineData("global::My")]
+        [WorkItem(3829, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3829")]
+        public async Task TestGlobalOtherAttributeAsync(string name)
+        {
+            var testCode = $@"public class MyAttribute : System.Attribute
+{{
+}}
+
+[{name}]
+public class Foo
+{{
+}}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1404CodeAnalysisSuppressionMustHaveJustification.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/MaintainabilityRules/SA1404CodeAnalysisSuppressionMustHaveJustification.cs
@@ -100,8 +100,15 @@ namespace StyleCop.Analyzers.MaintainabilityRules
                 {
                     if (!(attribute.Name is SimpleNameSyntax simpleNameSyntax))
                     {
-                        QualifiedNameSyntax qualifiedNameSyntax = attribute.Name as QualifiedNameSyntax;
-                        simpleNameSyntax = qualifiedNameSyntax.Right;
+                        if (attribute.Name is AliasQualifiedNameSyntax aliasQualifiedNameSyntax)
+                        {
+                            simpleNameSyntax = aliasQualifiedNameSyntax.Name;
+                        }
+                        else
+                        {
+                            QualifiedNameSyntax qualifiedNameSyntax = attribute.Name as QualifiedNameSyntax;
+                            simpleNameSyntax = qualifiedNameSyntax.Right;
+                        }
                     }
 
                     if (simpleNameSyntax.Identifier.ValueText != nameof(SuppressMessageAttribute)


### PR DESCRIPTION
Fixes #3829