### PR TITLE
Update SA1004 to allow doc comments to start with the in, out and ref keywords

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/SpacingRules/SA1004CSharp12UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/SpacingRules/SA1004CSharp12UnitTests.cs
@@ -3,9 +3,35 @@
 
 namespace StyleCop.Analyzers.Test.CSharp12.SpacingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp11.SpacingRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1004DocumentationLinesMustBeginWithSingleSpace,
+        StyleCop.Analyzers.SpacingRules.SA1004CodeFixProvider>;
 
     public partial class SA1004CSharp12UnitTests : SA1004CSharp11UnitTests
     {
+        [Fact]
+        [WorkItem(3817, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3817")]
+        public async Task TestParameterModifierReadOnlyFirstOnLineAsync()
+        {
+            string testCode = $@"
+/// <summary>
+/// Description of some remarks that refer to a method: <see cref=""SomeMethod(int, int, ref
+/// readonly string)""/>.
+/// </summary>
+public class TypeName
+{{
+    public void SomeMethod(int x, int y, ref readonly string z)
+    {{
+        throw new System.Exception();
+    }}
+}}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1004UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1004UnitTests.cs
@@ -1,13 +1,14 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Lightup;
     using StyleCop.Analyzers.SpacingRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
@@ -19,6 +20,20 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     /// </summary>
     public class SA1004UnitTests
     {
+        public static IEnumerable<object[]> ParameterModifiers
+        {
+            get
+            {
+                yield return new[] { "out" };
+                yield return new[] { "ref" };
+
+                if (LightupHelpers.SupportsCSharp72)
+                {
+                    yield return new[] { "in" };
+                }
+            }
+        }
+
         [Fact]
         public async Task TestFixedExampleAsync()
         {
@@ -212,6 +227,34 @@ public class TypeName
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(ParameterModifiers))]
+        [WorkItem(3817, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3817")]
+        public async Task TestParameterModifierFirstOnLineAsync(string keyword)
+        {
+            string testCode = $@"
+/// <summary>
+/// Description of some remarks that refer to a method: <see cref=""SomeMethod(int, int,
+/// {keyword} string)""/>.
+/// </summary>
+public class TypeName
+{{
+    public void SomeMethod(int x, int y, {keyword} string z)
+    {{
+        throw new System.Exception();
+    }}
+}}";
+
+            var languageVersion = (LightupHelpers.SupportsCSharp8, LightupHelpers.SupportsCSharp72) switch
+            {
+                // Make sure to use C# 7.2 if supported, unless we are going to default to something greater
+                (false, true) => LanguageVersionEx.CSharp7_2,
+                _ => (LanguageVersion?)null,
+            };
+
+            await VerifyCSharpDiagnosticAsync(languageVersion, testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1004DocumentationLinesMustBeginWithSingleSpace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1004DocumentationLinesMustBeginWithSingleSpace.cs
@@ -113,6 +113,7 @@ namespace StyleCop.Analyzers.SpacingRules
             case SyntaxKind.InKeyword:
             case SyntaxKind.OutKeyword:
             case SyntaxKind.RefKeyword:
+            case SyntaxKind.ReadOnlyKeyword:
                 if (!token.HasLeadingTrivia)
                 {
                     break;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1004DocumentationLinesMustBeginWithSingleSpace.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1004DocumentationLinesMustBeginWithSingleSpace.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.SpacingRules
 {
     using System;
@@ -112,6 +110,9 @@ namespace StyleCop.Analyzers.SpacingRules
             case SyntaxKind.XmlCommentEndToken:
             case SyntaxKind.XmlCDataStartToken:
             case SyntaxKind.XmlCDataEndToken:
+            case SyntaxKind.InKeyword:
+            case SyntaxKind.OutKeyword:
+            case SyntaxKind.RefKeyword:
                 if (!token.HasLeadingTrivia)
                 {
                     break;


### PR DESCRIPTION
Fixes #3817