### PR TITLE
Update `stylecop.json` schema to have correct default for `headerDecoration`.

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/DocumentationSettings.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/DocumentationSettings.cs
@@ -116,7 +116,7 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
         {
             this.companyName = DefaultCompanyName;
             this.copyrightText = DefaultCopyrightText;
-            this.headerDecoration = null;
+            this.headerDecoration = string.Empty;
             this.variables = ImmutableDictionary<string, string>.Empty;
             this.xmlHeader = true;
 
@@ -267,7 +267,7 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
             this.documentPrivateFields = documentPrivateFields.GetValueOrDefault(false);
             this.companyName = companyName ?? DefaultCompanyName;
             this.copyrightText = copyrightText ?? DefaultCopyrightText;
-            this.headerDecoration = headerDecoration;
+            this.headerDecoration = headerDecoration ?? string.Empty;
             this.variables = variables?.ToImmutable() ?? ImmutableDictionary<string, string>.Empty;
             this.xmlHeader = xmlHeader.GetValueOrDefault(true);
             this.fileNamingConvention = fileNamingConvention.GetValueOrDefault(FileNamingConvention.StyleCop);

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json
@@ -263,7 +263,7 @@
             "headerDecoration": {
               "type": "string",
               "description": "The text used as decoration for the copyright header comment.",
-              "default": null
+              "default": ""
             },
             "fileNamingConvention": {
               "type": "string",


### PR DESCRIPTION
The default is documented to be the empty string, and since it's typed as `string`, `null` is not actually a valid value and will fail to validate.