### PR TITLE
Update SA1015 to not care about trailing spaces in a number of cases: typically last in dictionary initializer items, collection initializers and collection expressions. #3856

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/SpacingRules/SA1015CSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/SpacingRules/SA1015CSharp11UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.CSharp11.SpacingRules
 {
     using System.Threading;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/SpacingRules/SA1015CSharp12UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/SpacingRules/SA1015CSharp12UnitTests.cs
@@ -3,11 +3,40 @@
 
 namespace StyleCop.Analyzers.Test.CSharp12.SpacingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp11.SpacingRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.SpacingRules.SA1015ClosingGenericBracketsMustBeSpacedCorrectly,
+        StyleCop.Analyzers.SpacingRules.TokenSpacingCodeFixProvider>;
 
     public partial class SA1015CSharp12UnitTests : SA1015CSharp11UnitTests
     {
+        [Theory]
+        [InlineData(" M<int> ")]
+        [InlineData("M<int>")]
+        [WorkItem(3856, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3856")]
+        public async Task TestSpacingAfterGenericMethodGroupInCollectionExpressionAsync(string item)
+        {
+            var testCode = $@"
+using System;
+using System.Collections.Generic;
+
+public class TestClass
+{{
+    private List<Action> values = [{item}];
+    
+    private static void M<T>()
+    {{
+    }}
+}}
+";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
         protected override DiagnosticResult[] GetExpectedResultMissingToken()
         {
             return new[]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1015CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/SpacingRules/SA1015CSharp7UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.CSharp7.SpacingRules
 {
     using System.Threading;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1015CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/SpacingRules/SA1015CSharp8UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.CSharp8.SpacingRules
 {
     using System.Threading;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1015UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1015UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
@@ -428,6 +426,55 @@ public class TestClass
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData(" M<int> ")]
+        [InlineData("M<int>")]
+        [WorkItem(3856, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3856")]
+        public async Task TestSpacingAfterGenericMethodGroupInCollectionInitializerAsync(string item)
+        {
+            var testCode = $@"
+using System;
+using System.Collections.Generic;
+
+public class TestClass
+{{
+    private List<Action> values = new List<Action> {{{item}}};
+    
+    private static void M<T>()
+    {{
+    }}
+}}
+";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData(" 1, M<int> ")]
+        [InlineData("1, M<int>")]
+        [WorkItem(3856, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3856")]
+        public async Task TestSpacingAfterGenericMethodGroupInDictionaryInitializerItemAsync(string item)
+        {
+            var testCode = $@"
+using System;
+using System.Collections.Generic;
+
+public class TestClass
+{{
+    private Dictionary<int, Action> values = new Dictionary<int, Action>
+    {{
+        {{{item}}}
+    }};
+    
+    private static void M<T>()
+    {{
+    }}
+}}
+";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         protected virtual DiagnosticResult[] GetExpectedResultMissingToken()

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1015ClosingGenericBracketsMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1015ClosingGenericBracketsMustBeSpacedCorrectly.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.SpacingRules
 {
     using System;
@@ -127,6 +125,8 @@ namespace StyleCop.Analyzers.SpacingRules
 
                 case SyntaxKind.CloseParenToken:
                 case SyntaxKind.GreaterThanToken:
+                case SyntaxKind.CloseBraceToken:
+                case SyntaxKind.CloseBracketToken when nextToken.Parent.IsKind(SyntaxKindEx.CollectionExpression):
                     allowTrailingNoSpace = true;
                     allowTrailingSpace = true;
                     break;


### PR DESCRIPTION
Fixes #3856 by ignoring trailing space in the reported case and letting it be handled by SA1013.
Also found some other cases that I think should also be handled in the same way.