### PR TITLE
Update SA1649CodeFixProvider to fix problems related to linked files

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1649CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/DocumentationRules/SA1649CodeFixProvider.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.DocumentationRules
 {
     using System.Collections.Immutable;
@@ -14,6 +12,7 @@ namespace StyleCop.Analyzers.DocumentationRules
     using Microsoft.CodeAnalysis.CodeActions;
     using Microsoft.CodeAnalysis.CodeFixes;
     using StyleCop.Analyzers.Helpers;
+    using StyleCop.Analyzers.Lightup;
 
     /// <summary>
     /// Implements a code fix for <see cref="SA1649FileNameMustMatchTypeName"/>.
@@ -27,7 +26,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             ImmutableArray.Create(SA1649FileNameMustMatchTypeName.DiagnosticId);
 
         /// <inheritdoc/>
-        public override FixAllProvider GetFixAllProvider()
+        public override FixAllProvider? GetFixAllProvider()
         {
             // The batch fixer can't handle code fixes that create new files
             return null;
@@ -55,25 +54,32 @@ namespace StyleCop.Analyzers.DocumentationRules
             var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
             var expectedFileName = diagnostic.Properties[SA1649FileNameMustMatchTypeName.ExpectedFileNameKey];
 
-            var newSolution = ReplaceDocument(solution, document, document.Id, syntaxRoot, expectedFileName);
+            var newSolution = RenameDocument(solution, document, document.Id, syntaxRoot, expectedFileName);
 
             // Make sure to also update other projects which reference the same file
             foreach (var linkedDocumentId in document.GetLinkedDocumentIds())
             {
-                newSolution = ReplaceDocument(newSolution, null, linkedDocumentId, syntaxRoot, expectedFileName);
+                newSolution = RenameDocument(newSolution, null, linkedDocumentId, syntaxRoot, expectedFileName);
             }
 
             return newSolution;
         }
 
-        private static Solution ReplaceDocument(Solution solution, Document document, DocumentId documentId, SyntaxNode syntaxRoot, string expectedFileName)
+        private static Solution RenameDocument(Solution solution, Document? document, DocumentId documentId, SyntaxNode syntaxRoot, string expectedFileName)
         {
-            document ??= solution.GetDocument(documentId);
+            // First try to use the "new" WithDocumentName method. This will return null if it is not available in the current Roslyn version.
+            var newSolution = solution.WithDocumentName(documentId, expectedFileName);
+            if (newSolution != null)
+            {
+                return newSolution;
+            }
 
+            // Continue by instead removing and re-adding the file again
+            document ??= solution.GetDocument(documentId);
             var newDocumentFilePath = document.FilePath != null ? Path.Combine(Path.GetDirectoryName(document.FilePath), expectedFileName) : null;
             var newDocumentId = DocumentId.CreateNewId(documentId.ProjectId);
 
-            var newSolution = solution
+            newSolution = solution
                 .RemoveDocument(documentId)
                 .AddDocument(newDocumentId, expectedFileName, syntaxRoot, document.Folders, newDocumentFilePath);
             return newSolution;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Lightup/SolutionExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Lightup/SolutionExtensions.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Lightup
+{
+    using System;
+    using Microsoft.CodeAnalysis;
+
+    internal static class SolutionExtensions
+    {
+        private static readonly Func<Solution, DocumentId, string, Solution> WithDocumentNameAccessor;
+
+        static SolutionExtensions()
+        {
+            WithDocumentNameAccessor = LightupHelpers.CreateSyntaxPropertyAccessor<Solution, DocumentId, string, Solution>(typeof(Solution), typeof(DocumentId), typeof(string), nameof(WithDocumentName));
+        }
+
+        public static Solution WithDocumentName(this Solution solution, DocumentId documentId, string name)
+        {
+            return WithDocumentNameAccessor(solution, documentId, name);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1693 
Fixes #3866
Fixes #2277

Unsure how to unit test this properly, but I have also used the code fix "live" in this repository with good success:
https://github.com/bjornhellander/SA1649CodeFixProblem
Shared Projects still doesn't work, with exceptions being thrown and the fix messing up the projects, but it does not seem to behave worse than before. (The built-in rename refactoring MoveTypeCodeRefactoringProvider also throws exception on this, but handles files and projects better.) But normal linked files between projects seem to be handled correctly with these changes.

I have started looking at the new APIs to rename files, but since these issues seems to be solvable without them I didn't add those part in this PR.