### PR TITLE
Add a setting to enable stricter handling of multiline parameters in SA1116 and SA1117

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1116CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1116CSharp7UnitTests.cs
@@ -16,9 +16,13 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
 
     public partial class SA1116CSharp7UnitTests : SA1116UnitTests
     {
-        [Fact]
-        public async Task TestValidLocalFunctionAsync()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TestValidLocalFunctionAsync(bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = @"
 class Foo
 {
@@ -27,12 +31,16 @@ class Foo
         object LocalFunction(int a, string s) => null;
     }
 }";
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpDiagnosticAsync(testCode, settings, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestInvalidLocalFunctionsAsync()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TestInvalidLocalFunctionsAsync(bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = @"
 class Foo
 {
@@ -52,8 +60,8 @@ class Foo
  string s) => null;
     }
 }";
-            DiagnosticResult expected = Diagnostic().WithLocation(6, 30);
-            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            DiagnosticResult[] expected = new[] { Diagnostic().WithLocation(6, 30) };
+            await VerifyCSharpFixAsync(testCode, settings, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1117CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1117CSharp7UnitTests.cs
@@ -14,9 +14,13 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
 
     public partial class SA1117CSharp7UnitTests : SA1117UnitTests
     {
-        [Fact]
-        public async Task TestValidLocalFunctionsAsync()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TestValidLocalFunctionsAsync(bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = @"
 class Foo
 {
@@ -33,12 +37,16 @@ class Foo
         object LocalFunction3(int a, int b, string s) => null;
     }
 }";
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpDiagnosticAsync(null, testCode, settings, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestInvalidLocalFunctionsAsync()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TestInvalidLocalFunctionsAsync(bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = @"
 class Foo
 {
@@ -59,10 +67,9 @@ class Foo
  string s) => null;
     }
 }";
-            DiagnosticResult expected = Diagnostic().WithLocation(7, 2);
-            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
-            await VerifyCSharpDiagnosticAsync(fixedCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
-            ////await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            DiagnosticResult[] expected = new[] { Diagnostic().WithLocation(7, 2) };
+            await VerifyCSharpDiagnosticAsync(null, testCode, settings, expected, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpDiagnosticAsync(null, fixedCode, settings, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/ReadabilityRules/SA1116CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/ReadabilityRules/SA1116CSharp9UnitTests.cs
@@ -16,9 +16,13 @@ namespace StyleCop.Analyzers.Test.CSharp9.ReadabilityRules
 
     public partial class SA1116CSharp9UnitTests : SA1116CSharp8UnitTests
     {
-        [Fact]
-        public async Task TestTargetTypedNewExpressionnAsync()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TestTargetTypedNewExpressionnAsync(bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = @"
 class Foo
 {
@@ -48,8 +52,8 @@ class Foo
     }
 }";
 
-            DiagnosticResult expected = Diagnostic().WithLocation(10, 21);
-            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            DiagnosticResult[] expected = new[] { Diagnostic().WithLocation(10, 21) };
+            await VerifyCSharpFixAsync(testCode, settings, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/ReadabilityRules/SA1117CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/ReadabilityRules/SA1117CSharp9UnitTests.cs
@@ -14,9 +14,13 @@ namespace StyleCop.Analyzers.Test.CSharp9.ReadabilityRules
 
     public partial class SA1117CSharp9UnitTests : SA1117CSharp8UnitTests
     {
-        [Fact]
-        public async Task TestValidTargetTypedNewExpressionAsync()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TestValidTargetTypedNewExpressionAsync(bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = @"
 class Foo
 {
@@ -33,12 +37,16 @@ class Foo
     }
 }";
 
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpDiagnosticAsync(null, testCode, settings, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestInvalidTargetTypedNewExpressionAsync()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TestInvalidTargetTypedNewExpressionAsync(bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = @"
 class Foo
 {
@@ -53,8 +61,8 @@ class Foo
     }
 }";
 
-            DiagnosticResult expected = Diagnostic().WithLocation(11, 16);
-            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            DiagnosticResult[] expected = new[] { Diagnostic().WithLocation(11, 16) };
+            await VerifyCSharpDiagnosticAsync(null, testCode, settings, expected, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1116UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1116UnitTests.cs
@@ -20,60 +20,78 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 
     public class SA1116UnitTests
     {
-        public static IEnumerable<object[]> GetTestDeclarations(string delimiter, string fixDelimiter)
+        public static IEnumerable<object[]> GetTestDeclarations(string delimiter, string fixDelimiter, bool treatMultilineParametersAsSplit)
         {
-            yield return new object[] { $"public Foo(int a,{delimiter} string s) {{ }}", $"public Foo({fixDelimiter}int a,{delimiter} string s) {{ }}", 16 };
-            yield return new object[] { $"public object Bar(int a,{delimiter} string s) => null;", $"public object Bar({fixDelimiter}int a,{delimiter} string s) => null;", 23 };
-            yield return new object[] { $"public static Foo operator + (Foo a,{delimiter} Foo b) => null;", $"public static Foo operator + ({fixDelimiter}Foo a,{delimiter} Foo b) => null;", 35 };
-            yield return new object[] { $"public object this[int a,{delimiter} string s] => null;", $"public object this[{fixDelimiter}int a,{delimiter} string s] => null;", 24 };
-            yield return new object[] { $"public delegate void Bar(int a,{delimiter} string s);", $"public delegate void Bar({fixDelimiter}int a,{delimiter} string s);", 30 };
+            yield return new object[] { $"public Foo(int a,{delimiter} string s) {{ }}", $"public Foo({fixDelimiter}int a,{delimiter} string s) {{ }}", 16, treatMultilineParametersAsSplit };
+            yield return new object[] { $"public object Bar(int a,{delimiter} string s) => null;", $"public object Bar({fixDelimiter}int a,{delimiter} string s) => null;", 23, treatMultilineParametersAsSplit };
+            yield return new object[] { $"public static Foo operator + (Foo a,{delimiter} Foo b) => null;", $"public static Foo operator + ({fixDelimiter}Foo a,{delimiter} Foo b) => null;", 35, treatMultilineParametersAsSplit };
+            yield return new object[] { $"public object this[int a,{delimiter} string s] => null;", $"public object this[{fixDelimiter}int a,{delimiter} string s] => null;", 24, treatMultilineParametersAsSplit };
+            yield return new object[] { $"public delegate void Bar(int a,{delimiter} string s);", $"public delegate void Bar({fixDelimiter}int a,{delimiter} string s);", 30, treatMultilineParametersAsSplit };
         }
 
-        public static IEnumerable<object[]> GetTestConstructorInitializers(string delimiter, string fixDelimiter)
+        public static IEnumerable<object[]> GetTestConstructorInitializers(string delimiter, string fixDelimiter, bool treatMultilineParametersAsSplit)
         {
-            yield return new object[] { $"this(42,{delimiter} \"hello\")", $"this({fixDelimiter}42,{delimiter} \"hello\")" };
-            yield return new object[] { $"base(42,{delimiter} \"hello\")", $"base({fixDelimiter}42,{delimiter} \"hello\")" };
+            yield return new object[] { $"this(42,{delimiter} \"hello\")", $"this({fixDelimiter}42,{delimiter} \"hello\")", treatMultilineParametersAsSplit };
+            yield return new object[] { $"base(42,{delimiter} \"hello\")", $"base({fixDelimiter}42,{delimiter} \"hello\")", treatMultilineParametersAsSplit };
         }
 
-        public static IEnumerable<object[]> GetTestExpressions(string delimiter, string fixDelimiter)
+        public static IEnumerable<object[]> GetTrailingMultilineTestConstructorInitializers(string delimiter, string fixDelimiter, bool treatMultilineParametersAsSplit)
         {
-            yield return new object[] { $"Bar(1,{delimiter} 2)", $"Bar({fixDelimiter}1,{delimiter} 2)", 13 };
-            yield return new object[] { $"System.Action<int, int> func = (int x,{delimiter} int y) => Bar(x, y)", $"System.Action<int, int> func = ({fixDelimiter}int x,{delimiter} int y) => Bar(x, y)", 41 };
-            yield return new object[] { $"System.Action<int, int> func = delegate(int x,{delimiter} int y) {{ Bar(x, y); }}", $"System.Action<int, int> func = delegate({fixDelimiter}int x,{delimiter} int y) {{ Bar(x, y); }}", 49 };
-            yield return new object[] { $"new string('a',{delimiter} 2)", $"new string({fixDelimiter}'a',{delimiter} 2)", 20 };
-            yield return new object[] { $"var arr = new string[2,{delimiter} 2];", $"var arr = new string[{fixDelimiter}2,{delimiter} 2];", 30 };
-            yield return new object[] { $"char cc = (new char[3, 3])[2,{delimiter} 2];", $"char cc = (new char[3, 3])[{fixDelimiter}2,{delimiter} 2];", 36 };
-            yield return new object[] { $"char? c = (new char[3, 3])?[2,{delimiter} 2];", $"char? c = (new char[3, 3])?[{fixDelimiter}2,{delimiter} 2];", 37 };
-            yield return new object[] { $"long ll = this[2,{delimiter} 2];", $"long ll = this[{fixDelimiter}2,{delimiter} 2];", 24 };
+            yield return new object[] { $"this(42,{delimiter} () =>\r\n{{\r\n}})", $"this({fixDelimiter}42,{delimiter} () =>\r\n{{\r\n}})", treatMultilineParametersAsSplit };
+            yield return new object[] { $"base(42,{delimiter} () =>\r\n{{\r\n}})", $"base({fixDelimiter}42,{delimiter} () =>\r\n{{\r\n}})", treatMultilineParametersAsSplit };
         }
 
-        public static IEnumerable<object[]> ValidTestExpressions()
+        public static IEnumerable<object[]> GetTestExpressions(string delimiter, string fixDelimiter, bool treatMultilineParametersAsSplit)
         {
-            yield return new object[] { $"System.Action func = () => Bar(0, 3)", null, 0 };
-            yield return new object[] { $"System.Action<int> func = x => Bar(x, 3)", null, 0 };
-            yield return new object[] { $"System.Action func = delegate {{ Bar(0, 0); }}", null, 0 };
+            yield return new object[] { $"Bar(1,{delimiter} 2)", $"Bar({fixDelimiter}1,{delimiter} 2)", 13, treatMultilineParametersAsSplit };
+            yield return new object[] { $"System.Action<int, int> func = (int x,{delimiter} int y) => Bar(x, y)", $"System.Action<int, int> func = ({fixDelimiter}int x,{delimiter} int y) => Bar(x, y)", 41, treatMultilineParametersAsSplit };
+            yield return new object[] { $"System.Action<int, int> func = delegate(int x,{delimiter} int y) {{ Bar(x, y); }}", $"System.Action<int, int> func = delegate({fixDelimiter}int x,{delimiter} int y) {{ Bar(x, y); }}", 49, treatMultilineParametersAsSplit };
+            yield return new object[] { $"new string('a',{delimiter} 2)", $"new string({fixDelimiter}'a',{delimiter} 2)", 20, treatMultilineParametersAsSplit };
+            yield return new object[] { $"var arr = new string[2,{delimiter} 2];", $"var arr = new string[{fixDelimiter}2,{delimiter} 2];", 30, treatMultilineParametersAsSplit };
+            yield return new object[] { $"char cc = (new char[3, 3])[2,{delimiter} 2];", $"char cc = (new char[3, 3])[{fixDelimiter}2,{delimiter} 2];", 36, treatMultilineParametersAsSplit };
+            yield return new object[] { $"char? c = (new char[3, 3])?[2,{delimiter} 2];", $"char? c = (new char[3, 3])?[{fixDelimiter}2,{delimiter} 2];", 37, treatMultilineParametersAsSplit };
+            yield return new object[] { $"long ll = this[2,{delimiter} 2];", $"long ll = this[{fixDelimiter}2,{delimiter} 2];", 24, treatMultilineParametersAsSplit };
+        }
+
+        public static IEnumerable<object[]> GetLambdaTestExpressions(string delimiter, string fixDelimiter, bool treatMultilineParametersAsSplit)
+        {
+            yield return new object[] { $"Buz(() => {{ }}, () =>{delimiter} {{{delimiter} }})", $"Buz({fixDelimiter}() => {{ }}, () =>{delimiter} {{{delimiter} }})", 13, treatMultilineParametersAsSplit };
+            yield return new object[] { $"new System.Lazy<int>(() =>{delimiter} {{{delimiter} return 1;{delimiter} }})", $"new System.Lazy<int>({fixDelimiter}() =>{delimiter} {{{delimiter} return 1;{delimiter} }})", 30, treatMultilineParametersAsSplit };
+        }
+
+        public static IEnumerable<object[]> ValidTestExpressions(bool treatMultilineParametersAsSplit)
+        {
+            yield return new object[] { $"System.Action func = () => Bar(0, 3)", null, 0, treatMultilineParametersAsSplit };
+            yield return new object[] { $"System.Action<int> func = x => Bar(x, 3)", null, 0, treatMultilineParametersAsSplit };
+            yield return new object[] { $"System.Action func = delegate {{ Bar(0, 0); }}", null, 0, treatMultilineParametersAsSplit };
         }
 
         [Theory]
-        [MemberData(nameof(GetTestDeclarations), "", "")]
-        public async Task TestValidDeclarationAsync(string declaration, string fixedDeclaration, int column)
+        [MemberData(nameof(GetTestDeclarations), "", "", false)]
+        [MemberData(nameof(GetTestDeclarations), "", "", true)]
+        public async Task TestValidDeclarationAsync(string declaration, string fixedDeclaration, int column, bool treatMultilineParametersAsSplit)
         {
             // Not needed for this test
             _ = fixedDeclaration;
             _ = column;
+
+            var settings = GetSettings(treatMultilineParametersAsSplit);
 
             var testCode = $@"
 class Foo
 {{
     {declaration}
 }}";
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpDiagnosticAsync(testCode, settings, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
-        [MemberData(nameof(GetTestDeclarations), "\r\n", "\r\n        ")]
-        public async Task TestInvalidDeclarationAsync(string declaration, string fixedDeclaration, int column)
+        [MemberData(nameof(GetTestDeclarations), "\r\n", "\r\n        ", false)]
+        [MemberData(nameof(GetTestDeclarations), "\r\n", "\r\n        ", true)]
+        public async Task TestInvalidDeclarationAsync(string declaration, string fixedDeclaration, int column, bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = $@"
 class Foo
 {{
@@ -84,21 +102,29 @@ class Foo
 {{
     {fixedDeclaration}
 }}";
-            DiagnosticResult expected = Diagnostic().WithLocation(4, column);
-            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            DiagnosticResult[] expected = new[] { Diagnostic().WithLocation(4, column) };
+            await VerifyCSharpFixAsync(testCode, settings, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
-        [MemberData(nameof(GetTestConstructorInitializers), "", "")]
-        public async Task TestValidConstructorInitializerAsync(string initializer, string fixedInitializer)
+        [MemberData(nameof(GetTestConstructorInitializers), "", "", false)]
+        [MemberData(nameof(GetTestConstructorInitializers), "", "", true)]
+        [MemberData(nameof(GetTrailingMultilineTestConstructorInitializers), "", "", false)]
+        public async Task TestValidConstructorInitializerAsync(string initializer, string fixedInitializer, bool treatMultilineParametersAsSplit)
         {
             // Not needed for this test
             _ = fixedInitializer;
 
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = $@"
 class Base
 {{
-    public Base(int a, string s)
+    public Base(int a, string b)
+    {{
+    }}
+
+    public Base(int c, System.Action d)
     {{
     }}
 }}
@@ -110,23 +136,38 @@ class Derived : Base
     {{
     }}
 
-    public Derived(int i, string z)
-        : base(i, z)
+    public Derived(int w, string x)
+        : base(w, x)
+    {{
+    }}
+
+    public Derived(int y, System.Action z)
+        : base(y, z)
     {{
     }}
 }}";
 
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpDiagnosticAsync(testCode, settings, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
-        [MemberData(nameof(GetTestConstructorInitializers), "\r\n", "\r\n            ")]
-        public async Task TestInvalidConstructorInitializerAsync(string initializer, string fixedInitializer)
+        [MemberData(nameof(GetTestConstructorInitializers), "\r\n", "\r\n            ", false)]
+        [MemberData(nameof(GetTestConstructorInitializers), "\r\n", "\r\n            ", true)]
+        [MemberData(nameof(GetTrailingMultilineTestConstructorInitializers), "", "\r\n            ", true)]
+        [MemberData(nameof(GetTrailingMultilineTestConstructorInitializers), "\r\n", "\r\n            ", false)]
+        [MemberData(nameof(GetTrailingMultilineTestConstructorInitializers), "\r\n", "\r\n            ", true)]
+        public async Task TestInvalidConstructorInitializerAsync(string initializer, string fixedInitializer, bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = $@"
 class Base
 {{
-    public Base(int a, string s)
+    public Base(int a, string b)
+    {{
+    }}
+
+    public Base(int c, System.Action d)
     {{
     }}
 }}
@@ -138,15 +179,24 @@ class Derived : Base
     {{
     }}
 
-    public Derived(int i, string z)
-        : base(i, z)
+    public Derived(int w, string x)
+        : base(w, x)
+    {{
+    }}
+
+    public Derived(int y, System.Action z)
+        : base(y, z)
     {{
     }}
 }}";
             var fixedCode = $@"
 class Base
 {{
-    public Base(int a, string s)
+    public Base(int a, string b)
+    {{
+    }}
+
+    public Base(int c, System.Action d)
     {{
     }}
 }}
@@ -158,29 +208,45 @@ class Derived : Base
     {{
     }}
 
-    public Derived(int i, string z)
-        : base(i, z)
+    public Derived(int w, string x)
+        : base(w, x)
+    {{
+    }}
+
+    public Derived(int y, System.Action z)
+        : base(y, z)
     {{
     }}
 }}";
 
-            DiagnosticResult expected = Diagnostic().WithLocation(12, 16);
-            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            DiagnosticResult[] expected = new[] { Diagnostic().WithLocation(16, 16) };
+            await VerifyCSharpFixAsync(testCode, settings, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
-        [MemberData(nameof(GetTestExpressions), "", "")]
-        [MemberData(nameof(ValidTestExpressions))]
-        public async Task TestValidExpressionAsync(string expression, string fixedExpression, int column)
+        [MemberData(nameof(GetTestExpressions), "", "", false)]
+        [MemberData(nameof(GetTestExpressions), "", "", true)]
+        [MemberData(nameof(GetLambdaTestExpressions), "", "", false)]
+        [MemberData(nameof(GetLambdaTestExpressions), "", "", true)]
+        [MemberData(nameof(GetLambdaTestExpressions), "\r\n", "", false)]
+        [MemberData(nameof(ValidTestExpressions), false)]
+        [MemberData(nameof(ValidTestExpressions), true)]
+        public async Task TestValidExpressionAsync(string expression, string fixedExpression, int column, bool treatMultilineParametersAsSplit)
         {
             // Not needed for this test
             _ = fixedExpression;
             _ = column;
 
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = $@"
 class Foo
 {{
-    public void Bar(int i, int z)
+    public void Bar(int a, int b)
+    {{
+    }}
+
+    public void Buz(System.Action c, System.Action d)
     {{
     }}
 
@@ -189,20 +255,28 @@ class Foo
         {expression};
     }}
 
-    public long this[int a, int s] => a + s;
+    public long this[int e, int f] => e + f;
 }}";
 
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpDiagnosticAsync(testCode, settings, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
-        [MemberData(nameof(GetTestExpressions), "\r\n", "\r\n            ")]
-        public async Task TestInvalidExpressionAsync(string expression, string fixedExpression, int column)
+        [MemberData(nameof(GetTestExpressions), "\r\n", "\r\n            ", false)]
+        [MemberData(nameof(GetTestExpressions), "\r\n", "\r\n            ", true)]
+        [MemberData(nameof(GetLambdaTestExpressions), "\r\n", "\r\n            ", true)]
+        public async Task TestInvalidExpressionAsync(string expression, string fixedExpression, int column, bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = $@"
 class Foo
 {{
-    public void Bar(int i, int z)
+    public void Bar(int a, int b)
+    {{
+    }}
+
+    public void Buz(System.Action c, System.Action d)
     {{
     }}
 
@@ -211,12 +285,16 @@ class Foo
         {expression};
     }}
 
-    public long this[int a, int s] => a + s;
+    public long this[int e, int f] => e + f;
 }}";
             var fixedCode = $@"
 class Foo
 {{
-    public void Bar(int i, int z)
+    public void Bar(int a, int b)
+    {{
+    }}
+
+    public void Buz(System.Action c, System.Action d)
     {{
     }}
 
@@ -225,16 +303,20 @@ class Foo
         {fixedExpression};
     }}
 
-    public long this[int a, int s] => a + s;
+    public long this[int e, int f] => e + f;
 }}";
 
-            DiagnosticResult expected = Diagnostic().WithLocation(10, column);
-            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            DiagnosticResult[] expected = new[] { Diagnostic().WithLocation(14, column) };
+            await VerifyCSharpFixAsync(testCode, settings, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestImplicitElementAccessAsync()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TestImplicitElementAccessAsync(bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = @"
 class Foo
 {
@@ -244,12 +326,16 @@ class Foo
     };
 }";
 
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpDiagnosticAsync(testCode, settings, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestValidAttributeAsync()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TestValidAttributeAsync(bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = @"
 [System.AttributeUsage(System.AttributeTargets.Class)]
 public class MyAttribute : System.Attribute
@@ -270,12 +356,16 @@ class ObsoleteType
 {
 }";
 
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpDiagnosticAsync(testCode, settings, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestInvalidAttributeAsync()
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public async Task TestInvalidAttributeAsync(bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = @"
 [System.AttributeUsage(System.AttributeTargets.Class)]
 public class MyAttribute : System.Attribute
@@ -306,8 +396,21 @@ class Foo
 {
 }";
 
-            DiagnosticResult expected = Diagnostic().WithLocation(10, 14);
-            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+            DiagnosticResult[] expected = new[] { Diagnostic().WithLocation(10, 14) };
+            await VerifyCSharpFixAsync(testCode, settings, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        protected static string GetSettings(bool treatMultilineParametersAsSplit = false)
+        {
+            return $@"
+{{
+    ""settings"": {{
+        ""readabilityRules"": {{
+            ""treatMultilineParametersAsSplit"" : {treatMultilineParametersAsSplit.ToString().ToLowerInvariant()}
+        }}
+    }}
+}}
+";
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1117UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1117UnitTests.cs
@@ -14,87 +14,101 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 
     public class SA1117UnitTests
     {
-        public static IEnumerable<object[]> GetTestDeclarations(string delimiter)
+        public static IEnumerable<object[]> GetTestDeclarations(string delimiter, bool treatMultilineParametersAsSplit)
         {
-            yield return new object[] { $"public Foo(int a, int b,{delimiter} {{|#0:string s|}}) {{ }}" };
-            yield return new object[] { $"public object Bar(int a, int b,{delimiter} {{|#0:string s|}}) => null;" };
-            yield return new object[] { $"public object this[int a, int b,{delimiter} {{|#0:string s|}}] => null;" };
-            yield return new object[] { $"public delegate void Bar(int a, int b,{delimiter} {{|#0:string s|}});" };
+            yield return new object[] { $"public Foo(int a, int b,{delimiter} {{|#0:string s|}}) {{ }}", treatMultilineParametersAsSplit };
+            yield return new object[] { $"public object Bar(int a, int b,{delimiter} {{|#0:string s|}}) => null;", treatMultilineParametersAsSplit };
+            yield return new object[] { $"public object this[int a, int b,{delimiter} {{|#0:string s|}}] => null;", treatMultilineParametersAsSplit };
+            yield return new object[] { $"public delegate void Bar(int a, int b,{delimiter} {{|#0:string s|}});", treatMultilineParametersAsSplit };
         }
 
-        public static IEnumerable<object[]> GetMultilineTestDeclarations(string delimiter)
+        public static IEnumerable<object[]> GetMultilineTestDeclarations(string delimiter, bool treatMultilineParametersAsSplit)
         {
-            yield return new object[] { $"public Foo(int a,{delimiter} string\r\ns) {{ }}" };
-            yield return new object[] { $"public object Bar(int a,{delimiter} string\r\ns) => null;" };
-            yield return new object[] { $"public object this[int a,{delimiter} string\r\ns] => null;" };
-            yield return new object[] { $"public delegate void Bar(int a,{delimiter} string\r\ns);" };
+            yield return new object[] { $"public Foo(int a,{delimiter} {{|#0:string\r\ns|}}) {{ }}", treatMultilineParametersAsSplit };
+            yield return new object[] { $"public object Bar(int a,{delimiter} {{|#0:string\r\ns|}}) => null;", treatMultilineParametersAsSplit };
+            yield return new object[] { $"public object this[int a,{delimiter} {{|#0:string\r\ns|}}] => null;", treatMultilineParametersAsSplit };
+            yield return new object[] { $"public delegate void Bar(int a,{delimiter} {{|#0:string\r\ns|}});", treatMultilineParametersAsSplit };
         }
 
-        public static IEnumerable<object[]> GetTestConstructorInitializers(string delimiter)
+        public static IEnumerable<object[]> GetTestConstructorInitializers(string delimiter, bool treatMultilineParametersAsSplit)
         {
-            yield return new object[] { $"this(42, 43, {delimiter} {{|#0:\"hello\"|}})" };
-            yield return new object[] { $"base(42, 43, {delimiter} {{|#0:\"hello\"|}})" };
+            yield return new object[] { $"this(42, 43, {delimiter} {{|#0:\"hello\"|}})", treatMultilineParametersAsSplit };
+            yield return new object[] { $"base(42, 43, {delimiter} {{|#0:\"hello\"|}})", treatMultilineParametersAsSplit };
+            yield return new object[] { $"this(42, 43, {delimiter} {{|#0:() => {{ }}|}})", treatMultilineParametersAsSplit };
+            yield return new object[] { $"base(42, 43, {delimiter} {{|#0:() => {{ }}|}})", treatMultilineParametersAsSplit };
         }
 
-        public static IEnumerable<object[]> GetMultilineTestConstructorInitializers(string delimiter)
+        public static IEnumerable<object[]> GetLeadingMultilineTestConstructorInitializers(string delimiter, bool treatMultilineParametersAsSplit)
         {
-            yield return new object[] { $"this(42\r\n+ 1, {delimiter} {{|#0:43|}}, {delimiter} \"hello\")" };
-            yield return new object[] { $"base(42\r\n+ 1, {delimiter} {{|#0:43|}}, {delimiter} \"hello\")" };
+            yield return new object[] { $"this(42\r\n+ 1, {delimiter} {{|#0:43|}}, {delimiter} \"hello\")", treatMultilineParametersAsSplit };
+            yield return new object[] { $"base(42\r\n+ 1, {delimiter} {{|#0:43|}}, {delimiter} \"hello\")", treatMultilineParametersAsSplit };
         }
 
-        public static IEnumerable<object[]> GetTestExpressions(string delimiter)
+        public static IEnumerable<object[]> GetTrailingMultilineTestConstructorInitializers(string delimiter, bool treatMultilineParametersAsSplit)
         {
-            yield return new object[] { $"Bar(1, 2, {delimiter} {{|#0:2|}})" };
-            yield return new object[] { $"System.Action<int, int, int> func = (int x, int y, {delimiter} {{|#0:int z|}}) => Bar(x, y, z)" };
-            yield return new object[] { $"System.Action<int, int, int> func = delegate(int x, int y, {delimiter} {{|#0:int z|}}) {{ Bar(x, y, z); }}" };
-            yield return new object[] { $"new System.DateTime(2015, 9, {delimiter} {{|#0:14|}})" };
-            yield return new object[] { $"var arr = new string[2, 2, {delimiter} {{|#0:2|}}];" };
-            yield return new object[] { $"char cc = (new char[3, 3, 3])[2, 2,{delimiter} {{|#0:2|}}];" };
-            yield return new object[] { $"char? c = (new char[3, 3, 3])?[2, 2,{delimiter} {{|#0:2|}}];" };
-            yield return new object[] { $"long ll = this[2, 2,{delimiter} {{|#0:2|}}];" };
+            yield return new object[] { $"this(42, {delimiter} 43, {delimiter} {{|#0:() =>\r\n{{\r\n}}|}})", treatMultilineParametersAsSplit };
+            yield return new object[] { $"base(42, {delimiter} 43, {delimiter} {{|#0:() =>\r\n{{\r\n}}|}})", treatMultilineParametersAsSplit };
         }
 
-        public static IEnumerable<object[]> GetTrailingMultilineTestExpressions(string delimiter)
+        public static IEnumerable<object[]> GetTestExpressions(string delimiter, bool treatMultilineParametersAsSplit)
         {
-            yield return new object[] { $"System.Action<int, int, int> func = (int x, {delimiter} int y, {delimiter} int\r\nz) => Bar(x, y, z)" };
-            yield return new object[] { $"System.Action<int, int, int> func = delegate(int x, {delimiter} int y, {delimiter} int\r\nz) {{ Bar(x, y, z); }}" };
-            yield return new object[] { $"var arr = new string[2, {delimiter} 2\r\n+ 2];" };
-            yield return new object[] { $"char cc = (new char[3, 3])[2, {delimiter} 2\r\n+ 2];" };
-            yield return new object[] { $"char? c = (new char[3, 3])?[2, {delimiter} 2\r\n+ 2];" };
-            yield return new object[] { $"long ll = this[2,{delimiter} 2,{delimiter} 2\r\n+ 1];" };
-            yield return new object[] { $"var str = string.Join(\r\n\"def\",{delimiter}\"abc\"\r\n + \"cba\");" };
+            yield return new object[] { $"Bar(1, 2, {delimiter} {{|#0:2|}})", treatMultilineParametersAsSplit };
+            yield return new object[] { $"System.Action<int, int, int> func = (int x, int y, {delimiter} {{|#0:int z|}}) => Bar(x, y, z)", treatMultilineParametersAsSplit };
+            yield return new object[] { $"System.Action<int, int, int> func = delegate(int x, int y, {delimiter} {{|#0:int z|}}) {{ Bar(x, y, z); }}", treatMultilineParametersAsSplit };
+            yield return new object[] { $"new System.DateTime(2015, 9, {delimiter} {{|#0:14|}})", treatMultilineParametersAsSplit };
+            yield return new object[] { $"var arr = new string[2, 2, {delimiter} {{|#0:2|}}];", treatMultilineParametersAsSplit };
+            yield return new object[] { $"char cc = (new char[3, 3, 3])[2, 2,{delimiter} {{|#0:2|}}];", treatMultilineParametersAsSplit };
+            yield return new object[] { $"char? c = (new char[3, 3, 3])?[2, 2,{delimiter} {{|#0:2|}}];", treatMultilineParametersAsSplit };
+            yield return new object[] { $"long ll = this[2, 2,{delimiter} {{|#0:2|}}];", treatMultilineParametersAsSplit };
+            yield return new object[] { $"Buz(() => {{ }}, 2,{delimiter} {{|#0:() => {{ }}|}});", treatMultilineParametersAsSplit };
         }
 
-        public static IEnumerable<object[]> GetLeadingMultilineTestExpressions(string delimiter)
+        public static IEnumerable<object[]> GetTrailingMultilineTestExpressions(string delimiter, bool treatMultilineParametersAsSplit)
         {
-            yield return new object[] { $"var str = string.Join(\r\n\"abc\"\r\n + \"cba\",{delimiter}{{|#0:\"def\"|}});" };
-            yield return new object[] { $"Bar(\r\n1\r\n + 2,{delimiter}{{|#0:3|}},\r\n 4);" };
+            yield return new object[] { $"System.Action<int, int, int> func = (int x, {delimiter} int y, {delimiter} {{|#0:int\r\nz|}}) => Bar(x, y, z)", treatMultilineParametersAsSplit };
+            yield return new object[] { $"System.Action<int, int, int> func = delegate(int x, {delimiter} int y, {delimiter} {{|#0:int\r\nz|}}) {{ Bar(x, y, z); }}", treatMultilineParametersAsSplit };
+            yield return new object[] { $"var arr = new string[2, {delimiter} {{|#0:2\r\n+ 2|}}];", treatMultilineParametersAsSplit };
+            yield return new object[] { $"char cc = (new char[3, 3])[2, {delimiter} {{|#0:2\r\n+ 2|}}];", treatMultilineParametersAsSplit };
+            yield return new object[] { $"char? c = (new char[3, 3])?[2, {delimiter} {{|#0:2\r\n+ 2|}}];", treatMultilineParametersAsSplit };
+            yield return new object[] { $"long ll = this[2,{delimiter} 2,{delimiter} {{|#0:2\r\n+ 1|}}];", treatMultilineParametersAsSplit };
+            yield return new object[] { $"var str = string.Join(\r\n\"def\",{delimiter}{{|#0:\"abc\"\r\n + \"cba\"|}});", treatMultilineParametersAsSplit };
+            yield return new object[] { $"Buz(() => {{ }},{delimiter} 2,{delimiter} {{|#0:() =>\r\n{{\r\n}}|}});", treatMultilineParametersAsSplit };
         }
 
-        public static IEnumerable<object[]> GetTestAttributes(string delimiter)
+        public static IEnumerable<object[]> GetLeadingMultilineTestExpressions(string delimiter, bool treatMultilineParametersAsSplit)
         {
-            yield return new object[] { $"[MyAttribute(1, {delimiter}2, {{|#0:3|}})]" };
+            yield return new object[] { $"var str = string.Join(\r\n\"abc\"\r\n + \"cba\",{delimiter}{{|#0:\"def\"|}});", treatMultilineParametersAsSplit };
+            yield return new object[] { $"Bar(\r\n1\r\n + 2,{delimiter}{{|#0:3|}},\r\n 4);", treatMultilineParametersAsSplit };
+            yield return new object[] { $"Buz(\r\n() =>\r\n{{\r\n}},{delimiter}{{|#0:3|}},\r\n () => {{ }});", treatMultilineParametersAsSplit };
+            yield return new object[] { $"new System.Lazy<int>(\r\n() =>\r\n{{\r\nreturn 1;\r\n}},{delimiter} {{|#0:true|}})", treatMultilineParametersAsSplit };
         }
 
-        public static IEnumerable<object[]> GetMultilineTestAttributes(string delimiter)
+        public static IEnumerable<object[]> GetTestAttributes(string delimiter, bool treatMultilineParametersAsSplit)
         {
-            yield return new object[] { $"[MyAttribute(1, {delimiter}2, {delimiter}3\r\n+ 5)]" };
+            yield return new object[] { $"[MyAttribute(1, {delimiter}2, {{|#0:3|}})]", treatMultilineParametersAsSplit };
         }
 
-        public static IEnumerable<object[]> ValidTestExpressions()
+        public static IEnumerable<object[]> GetMultilineTestAttributes(string delimiter, bool treatMultilineParametersAsSplit)
         {
-            yield return new object[] { $"System.Action func = () => Bar(0, 2, 3)" };
-            yield return new object[] { $"System.Action<int> func = x => Bar(x, 2, 3)" };
-            yield return new object[] { $"System.Action func = delegate {{ Bar(0, 0, 0); }}" };
-            yield return new object[] { "var weird = new int[10][,,,];" };
+            yield return new object[] { $"[MyAttribute(1, {delimiter}2, {delimiter}{{|#0:3\r\n+ 5|}})]", treatMultilineParametersAsSplit };
         }
 
-        public static IEnumerable<object[]> ValidTestDeclarations()
+        public static IEnumerable<object[]> ValidTestExpressions(bool treatMultilineParametersAsSplit)
+        {
+            yield return new object[] { $"System.Action func = () => Bar(0, 2, 3)", treatMultilineParametersAsSplit };
+            yield return new object[] { $"System.Action<int> func = x => Bar(x, 2, 3)", treatMultilineParametersAsSplit };
+            yield return new object[] { $"System.Action func = delegate {{ Bar(0, 0, 0); }}", treatMultilineParametersAsSplit };
+            yield return new object[] { "var weird = new int[10][,,,];", treatMultilineParametersAsSplit };
+            yield return new object[] { $"new System.Lazy<int>(() => {{ return 1; }}, true)", treatMultilineParametersAsSplit };
+        }
+
+        public static IEnumerable<object[]> ValidTestDeclarations(bool treatMultilineParametersAsSplit)
         {
             yield return new object[]
             {
                 $@"public Foo(
     int a, int b, string s) {{ }}",
+                treatMultilineParametersAsSplit,
             };
             yield return new object[]
             {
@@ -102,17 +116,19 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     int a,
     int b,
     string s) {{ }}",
+                treatMultilineParametersAsSplit,
             };
         }
 
-        public static IEnumerable<object[]> ValidTestAttribute()
+        public static IEnumerable<object[]> ValidTestAttribute(bool treatMultilineParametersAsSplit)
         {
             // This is a regression test for https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1211
-            yield return new object[] { @"[System.Obsolete]" };
+            yield return new object[] { @"[System.Obsolete]", treatMultilineParametersAsSplit };
             yield return new object[]
             {
                 @"[MyAttribute(
     1, 2, 3)]",
+                treatMultilineParametersAsSplit,
             };
             yield return new object[]
             {
@@ -120,47 +136,68 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     1,
     2,
     3)]",
+                treatMultilineParametersAsSplit,
             };
         }
 
         [Theory]
-        [MemberData(nameof(GetTestDeclarations), "")]
-        [MemberData(nameof(GetMultilineTestDeclarations), "\r\n")]
-        [MemberData(nameof(GetMultilineTestDeclarations), "")]
-        [MemberData(nameof(ValidTestDeclarations))]
-        public async Task TestValidDeclarationAsync(string declaration)
+        [MemberData(nameof(GetTestDeclarations), "", false)]
+        [MemberData(nameof(GetMultilineTestDeclarations), "\r\n", false)]
+        [MemberData(nameof(GetMultilineTestDeclarations), "", false)]
+        [MemberData(nameof(ValidTestDeclarations), false)]
+        [MemberData(nameof(GetTestDeclarations), "", true)]
+        [MemberData(nameof(GetMultilineTestDeclarations), "\r\n", true)]
+        [MemberData(nameof(ValidTestDeclarations), true)]
+        public async Task TestValidDeclarationAsync(string declaration, bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = $@"
 class Foo
 {{
     {declaration}
 }}";
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpDiagnosticAsync(null, testCode, settings, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
-        [MemberData(nameof(GetTestDeclarations), "\r\n")]
-        public async Task TestInvalidDeclarationAsync(string declaration)
+        [MemberData(nameof(GetTestDeclarations), "\r\n", false)]
+        [MemberData(nameof(GetTestDeclarations), "\r\n", true)]
+        [MemberData(nameof(GetMultilineTestDeclarations), "", true)]
+        public async Task TestInvalidDeclarationAsync(string declaration, bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = $@"
 class Foo
 {{
     {declaration}
 }}";
 
-            DiagnosticResult expected = Diagnostic().WithLocation(0);
-            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            DiagnosticResult[] expected = new[] { Diagnostic().WithLocation(0) };
+            await VerifyCSharpDiagnosticAsync(null, testCode, settings, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
-        [MemberData(nameof(GetTestConstructorInitializers), "")]
-        [MemberData(nameof(GetMultilineTestConstructorInitializers), "\r\n")]
-        public async Task TestValidConstructorInitializerAsync(string initializer)
+        [MemberData(nameof(GetTestConstructorInitializers), "", false)]
+        [MemberData(nameof(GetLeadingMultilineTestConstructorInitializers), "\r\n", false)]
+        [MemberData(nameof(GetTrailingMultilineTestConstructorInitializers), "", false)]
+        [MemberData(nameof(GetTrailingMultilineTestConstructorInitializers), "\r\n", false)]
+        [MemberData(nameof(GetTestConstructorInitializers), "", true)]
+        [MemberData(nameof(GetLeadingMultilineTestConstructorInitializers), "\r\n", true)]
+        [MemberData(nameof(GetTrailingMultilineTestConstructorInitializers), "\r\n", true)]
+        public async Task TestValidConstructorInitializerAsync(string initializer, bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = $@"
 class Base
 {{
-    public Base(int a, int b, string s)
+    public Base(int a, int b, string c)
+    {{
+    }}
+
+    public Base(int d, int e, System.Action f)
     {{
     }}
 }}
@@ -172,24 +209,38 @@ class Derived : Base
     {{
     }}
 
-    public Derived(int i, int j, string z)
-        : base(i, j, z)
+    public Derived(int u, int v, string w)
+        : base(u, v, w)
+    {{
+    }}
+
+    public Derived(int x, int y, System.Action z)
+        : base(x, y, z)
     {{
     }}
 }}";
 
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpDiagnosticAsync(null, testCode, settings, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
-        [MemberData(nameof(GetTestConstructorInitializers), "\r\n")]
-        [MemberData(nameof(GetMultilineTestConstructorInitializers), "")]
-        public async Task TestInvalidConstructorInitializerAsync(string initializer)
+        [MemberData(nameof(GetTestConstructorInitializers), "\r\n", false)]
+        [MemberData(nameof(GetLeadingMultilineTestConstructorInitializers), "", false)]
+        [MemberData(nameof(GetTestConstructorInitializers), "\r\n", true)]
+        [MemberData(nameof(GetLeadingMultilineTestConstructorInitializers), "", true)]
+        [MemberData(nameof(GetTrailingMultilineTestConstructorInitializers), "", true)]
+        public async Task TestInvalidConstructorInitializerAsync(string initializer, bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = $@"
 class Base
 {{
-    public Base(int a, int b, string s)
+    public Base(int a, int b, string c)
+    {{
+    }}
+
+    public Base(int d, int e, System.Action f)
     {{
     }}
 }}
@@ -201,28 +252,43 @@ class Derived : Base
     {{
     }}
 
-    public Derived(int i, int j, string z)
-        : base(i, j, z)
+    public Derived(int u, int v, string w)
+        : base(u, v, w)
+    {{
+    }}
+
+    public Derived(int x, int y, System.Action z)
+        : base(x, y, z)
     {{
     }}
 }}";
 
-            DiagnosticResult expected = Diagnostic().WithLocation(0);
-            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            DiagnosticResult[] expected = new[] { Diagnostic().WithLocation(0) };
+            await VerifyCSharpDiagnosticAsync(null, testCode, settings, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
-        [MemberData(nameof(GetTestExpressions), "")]
-        [MemberData(nameof(GetLeadingMultilineTestExpressions), "\r\n")]
-        [MemberData(nameof(GetTrailingMultilineTestExpressions), "\r\n")]
-        [MemberData(nameof(GetTrailingMultilineTestExpressions), "")]
-        [MemberData(nameof(ValidTestExpressions))]
-        public async Task TestValidExpressionAsync(string expression)
+        [MemberData(nameof(GetTestExpressions), "", false)]
+        [MemberData(nameof(GetLeadingMultilineTestExpressions), "\r\n", false)]
+        [MemberData(nameof(GetTrailingMultilineTestExpressions), "\r\n", false)]
+        [MemberData(nameof(GetTrailingMultilineTestExpressions), "", false)]
+        [MemberData(nameof(ValidTestExpressions), false)]
+        [MemberData(nameof(GetTestExpressions), "", true)]
+        [MemberData(nameof(GetLeadingMultilineTestExpressions), "\r\n", true)]
+        [MemberData(nameof(GetTrailingMultilineTestExpressions), "\r\n", true)]
+        [MemberData(nameof(ValidTestExpressions), true)]
+        public async Task TestValidExpressionAsync(string expression, bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = $@"
 class Foo
 {{
-    public void Bar(int i, int j, int k)
+    public void Bar(int d, int e, int f)
+    {{
+    }}
+
+    public void Buz(System.Action h, int i, System.Action j)
     {{
     }}
 
@@ -231,21 +297,30 @@ class Foo
         {expression};
     }}
 
-    public long this[int a, int b, int s] => a + b + s;
+    public long this[int a, int b, int c] => a + b + c;
 }}";
 
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpDiagnosticAsync(null, testCode, settings, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
-        [MemberData(nameof(GetTestExpressions), "\r\n")]
-        [MemberData(nameof(GetLeadingMultilineTestExpressions), "")]
-        public async Task TestInvalidExpressionAsync(string expression)
+        [MemberData(nameof(GetTestExpressions), "\r\n", false)]
+        [MemberData(nameof(GetLeadingMultilineTestExpressions), "", false)]
+        [MemberData(nameof(GetTestExpressions), "\r\n", true)]
+        [MemberData(nameof(GetLeadingMultilineTestExpressions), "", true)]
+        [MemberData(nameof(GetTrailingMultilineTestExpressions), "", true)]
+        public async Task TestInvalidExpressionAsync(string expression, bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = $@"
 class Foo
 {{
-    public void Bar(int i, int j, int k)
+    public void Bar(int d, int e, int f)
+    {{
+    }}
+
+    public void Buz(System.Action h, int i, System.Action j)
     {{
     }}
 
@@ -254,20 +329,25 @@ class Foo
         {expression};
     }}
 
-    public long this[int a, int b, int s] => a + b + s;
+    public long this[int a, int b, int c] => a + b + c;
 }}";
 
-            DiagnosticResult expected = Diagnostic().WithLocation(0);
-            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            DiagnosticResult[] expected = new[] { Diagnostic().WithLocation(0) };
+            await VerifyCSharpDiagnosticAsync(null, testCode, settings, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
-        [MemberData(nameof(GetTestAttributes), "")]
-        [MemberData(nameof(GetMultilineTestAttributes), "\r\n")]
-        [MemberData(nameof(GetMultilineTestAttributes), "")]
-        [MemberData(nameof(ValidTestAttribute))]
-        public async Task TestValidAttributeAsync(string attribute)
+        [MemberData(nameof(GetTestAttributes), "", false)]
+        [MemberData(nameof(GetMultilineTestAttributes), "\r\n", false)]
+        [MemberData(nameof(GetMultilineTestAttributes), "", false)]
+        [MemberData(nameof(ValidTestAttribute), false)]
+        [MemberData(nameof(GetTestAttributes), "", true)]
+        [MemberData(nameof(GetMultilineTestAttributes), "\r\n", true)]
+        [MemberData(nameof(ValidTestAttribute), true)]
+        public async Task TestValidAttributeAsync(string attribute, bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = $@"
 [System.AttributeUsage(System.AttributeTargets.Class)]
 public class MyAttribute : System.Attribute
@@ -282,13 +362,17 @@ class Foo
 {{
 }}";
 
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpDiagnosticAsync(null, testCode, settings, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Theory]
-        [MemberData(nameof(GetTestAttributes), "\r\n")]
-        public async Task TestInvalidAttributeAsync(string attribute)
+        [MemberData(nameof(GetTestAttributes), "\r\n", false)]
+        [MemberData(nameof(GetTestAttributes), "\r\n", true)]
+        [MemberData(nameof(GetMultilineTestAttributes), "", true)]
+        public async Task TestInvalidAttributeAsync(string attribute, bool treatMultilineParametersAsSplit)
         {
+            var settings = GetSettings(treatMultilineParametersAsSplit);
+
             var testCode = $@"
 [System.AttributeUsage(System.AttributeTargets.Class)]
 public class MyAttribute : System.Attribute
@@ -303,9 +387,21 @@ class Foo
 {{
 }}";
 
-            DiagnosticResult expected = Diagnostic().WithLocation(0);
+            DiagnosticResult[] expected = new[] { Diagnostic().WithLocation(0) };
+            await VerifyCSharpDiagnosticAsync(null, testCode, settings, expected, CancellationToken.None).ConfigureAwait(false);
+        }
 
-            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        protected static string GetSettings(bool treatMultilineParametersAsSplit = false)
+        {
+            return $@"
+{{
+    ""settings"": {{
+        ""readabilityRules"": {{
+            ""treatMultilineParametersAsSplit"" : {treatMultilineParametersAsSplit.ToString().ToLowerInvariant()}
+        }}
+    }}
+}}
+";
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1116SplitParametersMustStartOnLineAfterDeclaration.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1116SplitParametersMustStartOnLineAfterDeclaration.cs
@@ -13,6 +13,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.Helpers;
     using StyleCop.Analyzers.Lightup;
+    using StyleCop.Analyzers.Settings.ObjectModel;
 
     /// <summary>
     /// The parameters to a C# method or indexer call or declaration span across multiple lines, but the first parameter
@@ -56,21 +57,21 @@ namespace StyleCop.Analyzers.ReadabilityRules
         private static readonly ImmutableArray<SyntaxKind> BaseMethodDeclarationKinds =
             ImmutableArray.Create(SyntaxKind.ConstructorDeclaration, SyntaxKind.MethodDeclaration, SyntaxKind.OperatorDeclaration);
 
-        private static readonly Action<SyntaxNodeAnalysisContext> BaseMethodDeclarationAction = HandleBaseMethodDeclaration;
-        private static readonly Action<SyntaxNodeAnalysisContext> LocalFunctionStatementAction = HandleLocalFunctionStatement;
-        private static readonly Action<SyntaxNodeAnalysisContext> ConstructorInitializerAction = HandleConstructorInitializer;
-        private static readonly Action<SyntaxNodeAnalysisContext> DelegateDeclarationAction = HandleDelegateDeclaration;
-        private static readonly Action<SyntaxNodeAnalysisContext> IndexerDeclarationAction = HandleIndexerDeclaration;
-        private static readonly Action<SyntaxNodeAnalysisContext> InvocationExpressionAction = HandleInvocationExpression;
-        private static readonly Action<SyntaxNodeAnalysisContext> ObjectCreationExpressionAction = HandleObjectCreationExpression;
-        private static readonly Action<SyntaxNodeAnalysisContext> ImplicitObjectCreationExpressionAction = HandleImplicitObjectCreationExpression;
-        private static readonly Action<SyntaxNodeAnalysisContext> ElementAccessExpressionAction = HandleElementAccessExpression;
-        private static readonly Action<SyntaxNodeAnalysisContext> ElementBindingExpressionAction = HandleElementBindingExpression;
-        private static readonly Action<SyntaxNodeAnalysisContext> ImplicitElementAccessAction = HandleImplicitElementAccess;
-        private static readonly Action<SyntaxNodeAnalysisContext> ArrayCreationExpressionAction = HandleArrayCreationExpression;
-        private static readonly Action<SyntaxNodeAnalysisContext> AttributeAction = HandleAttribute;
-        private static readonly Action<SyntaxNodeAnalysisContext> AnonymousMethodExpressionAction = HandleAnonymousMethodExpression;
-        private static readonly Action<SyntaxNodeAnalysisContext> ParenthesizedLambdaExpressionAction = HandleParenthesizedLambdaExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> BaseMethodDeclarationAction = HandleBaseMethodDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> LocalFunctionStatementAction = HandleLocalFunctionStatement;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> ConstructorInitializerAction = HandleConstructorInitializer;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> DelegateDeclarationAction = HandleDelegateDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> IndexerDeclarationAction = HandleIndexerDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> InvocationExpressionAction = HandleInvocationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> ObjectCreationExpressionAction = HandleObjectCreationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> ImplicitObjectCreationExpressionAction = HandleImplicitObjectCreationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> ElementAccessExpressionAction = HandleElementAccessExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> ElementBindingExpressionAction = HandleElementBindingExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> ImplicitElementAccessAction = HandleImplicitElementAccess;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> ArrayCreationExpressionAction = HandleArrayCreationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> AttributeAction = HandleAttribute;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> AnonymousMethodExpressionAction = HandleAnonymousMethodExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> ParenthesizedLambdaExpressionAction = HandleParenthesizedLambdaExpression;
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
@@ -82,86 +83,82 @@ namespace StyleCop.Analyzers.ReadabilityRules
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
 
-            context.RegisterSyntaxNodeAction(BaseMethodDeclarationAction, BaseMethodDeclarationKinds);
-            context.RegisterSyntaxNodeAction(LocalFunctionStatementAction, SyntaxKindEx.LocalFunctionStatement);
-            context.RegisterSyntaxNodeAction(ConstructorInitializerAction, SyntaxKinds.ConstructorInitializer);
-            context.RegisterSyntaxNodeAction(DelegateDeclarationAction, SyntaxKind.DelegateDeclaration);
-            context.RegisterSyntaxNodeAction(IndexerDeclarationAction, SyntaxKind.IndexerDeclaration);
-            context.RegisterSyntaxNodeAction(InvocationExpressionAction, SyntaxKind.InvocationExpression);
-            context.RegisterSyntaxNodeAction(ObjectCreationExpressionAction, SyntaxKind.ObjectCreationExpression);
-            context.RegisterSyntaxNodeAction(ImplicitObjectCreationExpressionAction, SyntaxKindEx.ImplicitObjectCreationExpression);
-            context.RegisterSyntaxNodeAction(ElementAccessExpressionAction, SyntaxKind.ElementAccessExpression);
-            context.RegisterSyntaxNodeAction(ElementBindingExpressionAction, SyntaxKind.ElementBindingExpression);
-            context.RegisterSyntaxNodeAction(ImplicitElementAccessAction, SyntaxKind.ImplicitElementAccess);
-            context.RegisterSyntaxNodeAction(ArrayCreationExpressionAction, SyntaxKind.ArrayCreationExpression);
-            context.RegisterSyntaxNodeAction(AttributeAction, SyntaxKind.Attribute);
-            context.RegisterSyntaxNodeAction(AnonymousMethodExpressionAction, SyntaxKind.AnonymousMethodExpression);
-            context.RegisterSyntaxNodeAction(ParenthesizedLambdaExpressionAction, SyntaxKind.ParenthesizedLambdaExpression);
+            context.RegisterCompilationStartAction(
+                context =>
+                {
+                    context.RegisterSyntaxNodeAction(BaseMethodDeclarationAction, BaseMethodDeclarationKinds);
+                    context.RegisterSyntaxNodeAction(LocalFunctionStatementAction, SyntaxKindEx.LocalFunctionStatement);
+                    context.RegisterSyntaxNodeAction(ConstructorInitializerAction, SyntaxKinds.ConstructorInitializer);
+                    context.RegisterSyntaxNodeAction(DelegateDeclarationAction, SyntaxKind.DelegateDeclaration);
+                    context.RegisterSyntaxNodeAction(IndexerDeclarationAction, SyntaxKind.IndexerDeclaration);
+                    context.RegisterSyntaxNodeAction(InvocationExpressionAction, SyntaxKind.InvocationExpression);
+                    context.RegisterSyntaxNodeAction(ObjectCreationExpressionAction, SyntaxKind.ObjectCreationExpression);
+                    context.RegisterSyntaxNodeAction(ImplicitObjectCreationExpressionAction, SyntaxKindEx.ImplicitObjectCreationExpression);
+                    context.RegisterSyntaxNodeAction(ElementAccessExpressionAction, SyntaxKind.ElementAccessExpression);
+                    context.RegisterSyntaxNodeAction(ElementBindingExpressionAction, SyntaxKind.ElementBindingExpression);
+                    context.RegisterSyntaxNodeAction(ImplicitElementAccessAction, SyntaxKind.ImplicitElementAccess);
+                    context.RegisterSyntaxNodeAction(ArrayCreationExpressionAction, SyntaxKind.ArrayCreationExpression);
+                    context.RegisterSyntaxNodeAction(AttributeAction, SyntaxKind.Attribute);
+                    context.RegisterSyntaxNodeAction(AnonymousMethodExpressionAction, SyntaxKind.AnonymousMethodExpression);
+                    context.RegisterSyntaxNodeAction(ParenthesizedLambdaExpressionAction, SyntaxKind.ParenthesizedLambdaExpression);
+                });
         }
 
-        private static void HandleBaseMethodDeclaration(SyntaxNodeAnalysisContext context)
+        private static void HandleBaseMethodDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var declaration = (BaseMethodDeclarationSyntax)context.Node;
-            HandleParameterListSyntax(context, declaration.ParameterList);
+            HandleParameterListSyntax(context, declaration.ParameterList, settings);
         }
 
-        private static void HandleLocalFunctionStatement(SyntaxNodeAnalysisContext context)
+        private static void HandleLocalFunctionStatement(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var statement = (LocalFunctionStatementSyntaxWrapper)context.Node;
-            HandleParameterListSyntax(context, statement.ParameterList);
+            HandleParameterListSyntax(context, statement.ParameterList, settings);
         }
 
-        private static void HandleInvocationExpression(SyntaxNodeAnalysisContext context)
+        private static void HandleInvocationExpression(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
-            HandleArgumentListSyntax(context, invocation.ArgumentList);
+            HandleArgumentListSyntax(context, invocation.ArgumentList, settings);
         }
 
-        private static void HandleObjectCreationExpression(SyntaxNodeAnalysisContext context)
+        private static void HandleObjectCreationExpression(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var objectCreation = (ObjectCreationExpressionSyntax)context.Node;
-            HandleArgumentListSyntax(context, objectCreation.ArgumentList);
+            HandleArgumentListSyntax(context, objectCreation.ArgumentList, settings);
         }
 
-        private static void HandleImplicitObjectCreationExpression(SyntaxNodeAnalysisContext context)
+        private static void HandleImplicitObjectCreationExpression(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var implicitObjectCreation = (ImplicitObjectCreationExpressionSyntaxWrapper)context.Node;
-            HandleArgumentListSyntax(context, implicitObjectCreation.ArgumentList);
+            HandleArgumentListSyntax(context, implicitObjectCreation.ArgumentList, settings);
         }
 
-        private static void HandleIndexerDeclaration(SyntaxNodeAnalysisContext context)
+        private static void HandleIndexerDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var indexerDeclaration = (IndexerDeclarationSyntax)context.Node;
             BracketedParameterListSyntax argumentListSyntax = indexerDeclaration.ParameterList;
             SeparatedSyntaxList<ParameterSyntax> arguments = argumentListSyntax.Parameters;
-
-            if (arguments.Count > 1)
-            {
-                Analyze(context, argumentListSyntax.OpenBracketToken, arguments[0], arguments[1]);
-            }
+            Analyze(context, argumentListSyntax.OpenBracketToken, arguments, settings);
         }
 
-        private static void HandleElementAccessExpression(SyntaxNodeAnalysisContext context)
+        private static void HandleElementAccessExpression(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var elementAccess = (ElementAccessExpressionSyntax)context.Node;
-            HandleBracketedArgumentListSyntax(context, elementAccess.ArgumentList);
+            HandleBracketedArgumentListSyntax(context, elementAccess.ArgumentList, settings);
         }
 
-        private static void HandleArrayCreationExpression(SyntaxNodeAnalysisContext context)
+        private static void HandleArrayCreationExpression(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var arrayCreation = (ArrayCreationExpressionSyntax)context.Node;
-
             foreach (var rankSpecifier in arrayCreation.Type.RankSpecifiers)
             {
                 SeparatedSyntaxList<ExpressionSyntax> sizes = rankSpecifier.Sizes;
-                if (sizes.Count > 1)
-                {
-                    Analyze(context, rankSpecifier.OpenBracketToken, sizes[0], sizes[1]);
-                }
+                Analyze(context, rankSpecifier.OpenBracketToken, sizes, settings);
             }
         }
 
-        private static void HandleAttribute(SyntaxNodeAnalysisContext context)
+        private static void HandleAttribute(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var attribute = (AttributeSyntax)context.Node;
             AttributeArgumentListSyntax argumentListSyntax = attribute.ArgumentList;
@@ -171,49 +168,46 @@ namespace StyleCop.Analyzers.ReadabilityRules
             }
 
             SeparatedSyntaxList<AttributeArgumentSyntax> arguments = argumentListSyntax.Arguments;
-            if (arguments.Count > 1)
-            {
-                Analyze(context, argumentListSyntax.OpenParenToken, arguments[0], arguments[1]);
-            }
+            Analyze(context, argumentListSyntax.OpenParenToken, arguments, settings);
         }
 
-        private static void HandleAnonymousMethodExpression(SyntaxNodeAnalysisContext context)
+        private static void HandleAnonymousMethodExpression(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var anonymousMethod = (AnonymousMethodExpressionSyntax)context.Node;
-            HandleParameterListSyntax(context, anonymousMethod.ParameterList);
+            HandleParameterListSyntax(context, anonymousMethod.ParameterList, settings);
         }
 
-        private static void HandleParenthesizedLambdaExpression(SyntaxNodeAnalysisContext context)
+        private static void HandleParenthesizedLambdaExpression(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var parenthesizedLambda = (ParenthesizedLambdaExpressionSyntax)context.Node;
-            HandleParameterListSyntax(context, parenthesizedLambda.ParameterList);
+            HandleParameterListSyntax(context, parenthesizedLambda.ParameterList, settings);
         }
 
-        private static void HandleDelegateDeclaration(SyntaxNodeAnalysisContext context)
+        private static void HandleDelegateDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var delegateDeclaration = (DelegateDeclarationSyntax)context.Node;
-            HandleParameterListSyntax(context, delegateDeclaration.ParameterList);
+            HandleParameterListSyntax(context, delegateDeclaration.ParameterList, settings);
         }
 
-        private static void HandleConstructorInitializer(SyntaxNodeAnalysisContext context)
+        private static void HandleConstructorInitializer(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var constructorInitializer = (ConstructorInitializerSyntax)context.Node;
-            HandleArgumentListSyntax(context, constructorInitializer.ArgumentList);
+            HandleArgumentListSyntax(context, constructorInitializer.ArgumentList, settings);
         }
 
-        private static void HandleElementBindingExpression(SyntaxNodeAnalysisContext context)
+        private static void HandleElementBindingExpression(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var elementBinding = (ElementBindingExpressionSyntax)context.Node;
-            HandleBracketedArgumentListSyntax(context, elementBinding.ArgumentList);
+            HandleBracketedArgumentListSyntax(context, elementBinding.ArgumentList, settings);
         }
 
-        private static void HandleImplicitElementAccess(SyntaxNodeAnalysisContext context)
+        private static void HandleImplicitElementAccess(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var implicitElementAccess = (ImplicitElementAccessSyntax)context.Node;
-            HandleBracketedArgumentListSyntax(context, implicitElementAccess.ArgumentList);
+            HandleBracketedArgumentListSyntax(context, implicitElementAccess.ArgumentList, settings);
         }
 
-        private static void HandleArgumentListSyntax(SyntaxNodeAnalysisContext context, ArgumentListSyntax argumentList)
+        private static void HandleArgumentListSyntax(SyntaxNodeAnalysisContext context, ArgumentListSyntax argumentList, StyleCopSettings settings)
         {
             if (argumentList == null)
             {
@@ -221,14 +215,10 @@ namespace StyleCop.Analyzers.ReadabilityRules
             }
 
             SeparatedSyntaxList<ArgumentSyntax> parameters = argumentList.Arguments;
-
-            if (parameters.Count > 1)
-            {
-                Analyze(context, argumentList.OpenParenToken, parameters[0], parameters[1]);
-            }
+            Analyze(context, argumentList.OpenParenToken, parameters, settings);
         }
 
-        private static void HandleParameterListSyntax(SyntaxNodeAnalysisContext context, ParameterListSyntax parameterList)
+        private static void HandleParameterListSyntax(SyntaxNodeAnalysisContext context, ParameterListSyntax parameterList, StyleCopSettings settings)
         {
             if (parameterList == null)
             {
@@ -236,32 +226,30 @@ namespace StyleCop.Analyzers.ReadabilityRules
             }
 
             SeparatedSyntaxList<ParameterSyntax> parameters = parameterList.Parameters;
-            if (parameters.Count > 1)
-            {
-                Analyze(context, parameterList.OpenParenToken, parameters[0], parameters[1]);
-            }
+            Analyze(context, parameterList.OpenParenToken, parameters, settings);
         }
 
-        private static void HandleBracketedArgumentListSyntax(SyntaxNodeAnalysisContext context, BracketedArgumentListSyntax bracketedArgumentList)
+        private static void HandleBracketedArgumentListSyntax(SyntaxNodeAnalysisContext context, BracketedArgumentListSyntax bracketedArgumentList, StyleCopSettings settings)
         {
             SeparatedSyntaxList<ArgumentSyntax> parameters = bracketedArgumentList.Arguments;
-
-            if (parameters.Count > 1)
-            {
-                Analyze(context, bracketedArgumentList.OpenBracketToken, parameters[0], parameters[1]);
-            }
+            Analyze(context, bracketedArgumentList.OpenBracketToken, parameters, settings);
         }
 
-        private static void Analyze(
-            SyntaxNodeAnalysisContext context,
-            SyntaxToken openParenOrBracketToken,
-            SyntaxNode firstParameter,
-            SyntaxNode secondParameter)
+        private static void Analyze<T>(SyntaxNodeAnalysisContext context, SyntaxToken openParenOrBracketToken, SeparatedSyntaxList<T> arguments, StyleCopSettings settings)
+            where T : SyntaxNode
         {
-            int firstParameterLine = firstParameter.GetLineSpan().StartLinePosition.Line;
-            if (openParenOrBracketToken.GetLine() == firstParameterLine)
+            var minimumArgumentCount = settings.ReadabilityRules.TreatMultilineParametersAsSplit ? 1 : 2;
+            if (arguments.Count < minimumArgumentCount)
             {
-                if (firstParameterLine != secondParameter.GetLineSpan().StartLinePosition.Line)
+                return;
+            }
+
+            SyntaxNode firstParameter = arguments.First();
+            int startLine = firstParameter.GetLine();
+            if (startLine == openParenOrBracketToken.GetLine())
+            {
+                var endLine = settings.ReadabilityRules.TreatMultilineParametersAsSplit ? arguments.Last().GetEndLine() : arguments[1].GetLine();
+                if (startLine != endLine)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(Descriptor, firstParameter.GetLocation()));
                 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1117ParametersMustBeOnSameLineOrSeparateLines.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SA1117ParametersMustBeOnSameLineOrSeparateLines.cs
@@ -13,6 +13,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
     using Microsoft.CodeAnalysis.Diagnostics;
     using StyleCop.Analyzers.Helpers;
     using StyleCop.Analyzers.Lightup;
+    using StyleCop.Analyzers.Settings.ObjectModel;
 
     /// <summary>
     /// The parameters to a C# method or indexer call or declaration are not all on the same line or each on a separate
@@ -67,20 +68,20 @@ namespace StyleCop.Analyzers.ReadabilityRules
         private static readonly ImmutableArray<SyntaxKind> BaseMethodDeclarationKinds =
             ImmutableArray.Create(SyntaxKind.ConstructorDeclaration, SyntaxKind.MethodDeclaration);
 
-        private static readonly Action<SyntaxNodeAnalysisContext> BaseMethodDeclarationAction = HandleBaseMethodDeclaration;
-        private static readonly Action<SyntaxNodeAnalysisContext> LocalFunctionStatementAction = HandleLocalFunctionStatement;
-        private static readonly Action<SyntaxNodeAnalysisContext> ConstructorInitializerAction = HandleConstructorInitializer;
-        private static readonly Action<SyntaxNodeAnalysisContext> DelegateDeclarationAction = HandleDelegateDeclaration;
-        private static readonly Action<SyntaxNodeAnalysisContext> IndexerDeclarationAction = HandleIndexerDeclaration;
-        private static readonly Action<SyntaxNodeAnalysisContext> InvocationExpressionAction = HandleInvocationExpression;
-        private static readonly Action<SyntaxNodeAnalysisContext> ObjectCreationExpressionAction = HandleObjectCreationExpression;
-        private static readonly Action<SyntaxNodeAnalysisContext> ImplicitObjectCreationExpressionAction = HandleImplicitObjectCreationExpression;
-        private static readonly Action<SyntaxNodeAnalysisContext> ElementAccessExpressionAction = HandleElementAccessExpression;
-        private static readonly Action<SyntaxNodeAnalysisContext> ElementBindingExpressionAction = HandleElementBindingExpression;
-        private static readonly Action<SyntaxNodeAnalysisContext> ArrayCreationExpressionAction = HandleArrayCreationExpression;
-        private static readonly Action<SyntaxNodeAnalysisContext> AttributeAction = HandleAttribute;
-        private static readonly Action<SyntaxNodeAnalysisContext> AnonymousMethodExpressionAction = HandleAnonymousMethodExpression;
-        private static readonly Action<SyntaxNodeAnalysisContext> ParenthesizedLambdaExpressionAction = HandleParenthesizedLambdaExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> BaseMethodDeclarationAction = HandleBaseMethodDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> LocalFunctionStatementAction = HandleLocalFunctionStatement;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> ConstructorInitializerAction = HandleConstructorInitializer;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> DelegateDeclarationAction = HandleDelegateDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> IndexerDeclarationAction = HandleIndexerDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> InvocationExpressionAction = HandleInvocationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> ObjectCreationExpressionAction = HandleObjectCreationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> ImplicitObjectCreationExpressionAction = HandleImplicitObjectCreationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> ElementAccessExpressionAction = HandleElementAccessExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> ElementBindingExpressionAction = HandleElementBindingExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> ArrayCreationExpressionAction = HandleArrayCreationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> AttributeAction = HandleAttribute;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> AnonymousMethodExpressionAction = HandleAnonymousMethodExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext, StyleCopSettings> ParenthesizedLambdaExpressionAction = HandleParenthesizedLambdaExpression;
 
         /// <inheritdoc/>
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
@@ -92,79 +93,82 @@ namespace StyleCop.Analyzers.ReadabilityRules
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
             context.EnableConcurrentExecution();
 
-            context.RegisterSyntaxNodeAction(BaseMethodDeclarationAction, BaseMethodDeclarationKinds);
-            context.RegisterSyntaxNodeAction(LocalFunctionStatementAction, SyntaxKindEx.LocalFunctionStatement);
-            context.RegisterSyntaxNodeAction(ConstructorInitializerAction, SyntaxKinds.ConstructorInitializer);
-            context.RegisterSyntaxNodeAction(DelegateDeclarationAction, SyntaxKind.DelegateDeclaration);
-            context.RegisterSyntaxNodeAction(IndexerDeclarationAction, SyntaxKind.IndexerDeclaration);
-            context.RegisterSyntaxNodeAction(InvocationExpressionAction, SyntaxKind.InvocationExpression);
-            context.RegisterSyntaxNodeAction(ObjectCreationExpressionAction, SyntaxKind.ObjectCreationExpression);
-            context.RegisterSyntaxNodeAction(ImplicitObjectCreationExpressionAction, SyntaxKindEx.ImplicitObjectCreationExpression);
-            context.RegisterSyntaxNodeAction(ElementAccessExpressionAction, SyntaxKind.ElementAccessExpression);
-            context.RegisterSyntaxNodeAction(ElementBindingExpressionAction, SyntaxKind.ElementBindingExpression);
-            context.RegisterSyntaxNodeAction(ArrayCreationExpressionAction, SyntaxKind.ArrayCreationExpression);
-            context.RegisterSyntaxNodeAction(AttributeAction, SyntaxKind.Attribute);
-            context.RegisterSyntaxNodeAction(AnonymousMethodExpressionAction, SyntaxKind.AnonymousMethodExpression);
-            context.RegisterSyntaxNodeAction(ParenthesizedLambdaExpressionAction, SyntaxKind.ParenthesizedLambdaExpression);
+            context.RegisterCompilationStartAction(
+                context =>
+                {
+                    context.RegisterSyntaxNodeAction(BaseMethodDeclarationAction, BaseMethodDeclarationKinds);
+                    context.RegisterSyntaxNodeAction(LocalFunctionStatementAction, SyntaxKindEx.LocalFunctionStatement);
+                    context.RegisterSyntaxNodeAction(ConstructorInitializerAction, SyntaxKinds.ConstructorInitializer);
+                    context.RegisterSyntaxNodeAction(DelegateDeclarationAction, SyntaxKind.DelegateDeclaration);
+                    context.RegisterSyntaxNodeAction(IndexerDeclarationAction, SyntaxKind.IndexerDeclaration);
+                    context.RegisterSyntaxNodeAction(InvocationExpressionAction, SyntaxKind.InvocationExpression);
+                    context.RegisterSyntaxNodeAction(ObjectCreationExpressionAction, SyntaxKind.ObjectCreationExpression);
+                    context.RegisterSyntaxNodeAction(ImplicitObjectCreationExpressionAction, SyntaxKindEx.ImplicitObjectCreationExpression);
+                    context.RegisterSyntaxNodeAction(ElementAccessExpressionAction, SyntaxKind.ElementAccessExpression);
+                    context.RegisterSyntaxNodeAction(ElementBindingExpressionAction, SyntaxKind.ElementBindingExpression);
+                    context.RegisterSyntaxNodeAction(ArrayCreationExpressionAction, SyntaxKind.ArrayCreationExpression);
+                    context.RegisterSyntaxNodeAction(AttributeAction, SyntaxKind.Attribute);
+                    context.RegisterSyntaxNodeAction(AnonymousMethodExpressionAction, SyntaxKind.AnonymousMethodExpression);
+                    context.RegisterSyntaxNodeAction(ParenthesizedLambdaExpressionAction, SyntaxKind.ParenthesizedLambdaExpression);
+                });
         }
 
-        private static void HandleBaseMethodDeclaration(SyntaxNodeAnalysisContext context)
+        private static void HandleBaseMethodDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var declaration = (BaseMethodDeclarationSyntax)context.Node;
-            HandleParameterListSyntax(context, declaration.ParameterList);
+            HandleParameterListSyntax(context, declaration.ParameterList, settings);
         }
 
-        private static void HandleLocalFunctionStatement(SyntaxNodeAnalysisContext context)
+        private static void HandleLocalFunctionStatement(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var statement = (LocalFunctionStatementSyntaxWrapper)context.Node;
-            HandleParameterListSyntax(context, statement.ParameterList);
+            HandleParameterListSyntax(context, statement.ParameterList, settings);
         }
 
-        private static void HandleInvocationExpression(SyntaxNodeAnalysisContext context)
+        private static void HandleInvocationExpression(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var invocation = (InvocationExpressionSyntax)context.Node;
-            HandleArgumentListSyntax(context, invocation.ArgumentList);
+            HandleArgumentListSyntax(context, invocation.ArgumentList, settings);
         }
 
-        private static void HandleObjectCreationExpression(SyntaxNodeAnalysisContext context)
+        private static void HandleObjectCreationExpression(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var objectCreation = (ObjectCreationExpressionSyntax)context.Node;
-            HandleArgumentListSyntax(context, objectCreation.ArgumentList);
+            HandleArgumentListSyntax(context, objectCreation.ArgumentList, settings);
         }
 
-        private static void HandleImplicitObjectCreationExpression(SyntaxNodeAnalysisContext context)
+        private static void HandleImplicitObjectCreationExpression(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var implicitObjectCreation = (ImplicitObjectCreationExpressionSyntaxWrapper)context.Node;
-            HandleArgumentListSyntax(context, implicitObjectCreation.ArgumentList);
+            HandleArgumentListSyntax(context, implicitObjectCreation.ArgumentList, settings);
         }
 
-        private static void HandleIndexerDeclaration(SyntaxNodeAnalysisContext context)
+        private static void HandleIndexerDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var indexerDeclaration = (IndexerDeclarationSyntax)context.Node;
             BracketedParameterListSyntax argumentListSyntax = indexerDeclaration.ParameterList;
             SeparatedSyntaxList<ParameterSyntax> arguments = argumentListSyntax.Parameters;
-
-            Analyze(context, arguments);
+            Analyze(context, arguments, settings);
         }
 
-        private static void HandleElementAccessExpression(SyntaxNodeAnalysisContext context)
+        private static void HandleElementAccessExpression(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var elementAccess = (ElementAccessExpressionSyntax)context.Node;
-            HandleBracketedArgumentListSyntax(context, elementAccess.ArgumentList);
+            HandleBracketedArgumentListSyntax(context, elementAccess.ArgumentList, settings);
         }
 
-        private static void HandleArrayCreationExpression(SyntaxNodeAnalysisContext context)
+        private static void HandleArrayCreationExpression(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var arrayCreation = (ArrayCreationExpressionSyntax)context.Node;
 
             foreach (var rankSpecifier in arrayCreation.Type.RankSpecifiers)
             {
                 SeparatedSyntaxList<ExpressionSyntax> sizes = rankSpecifier.Sizes;
-                Analyze(context, sizes);
+                Analyze(context, sizes, settings);
             }
         }
 
-        private static void HandleAttribute(SyntaxNodeAnalysisContext context)
+        private static void HandleAttribute(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var attribute = (AttributeSyntax)context.Node;
             AttributeArgumentListSyntax argumentListSyntax = attribute.ArgumentList;
@@ -174,40 +178,40 @@ namespace StyleCop.Analyzers.ReadabilityRules
             }
 
             SeparatedSyntaxList<AttributeArgumentSyntax> arguments = argumentListSyntax.Arguments;
-            Analyze(context, arguments);
+            Analyze(context, arguments, settings);
         }
 
-        private static void HandleAnonymousMethodExpression(SyntaxNodeAnalysisContext context)
+        private static void HandleAnonymousMethodExpression(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var anonymousMethod = (AnonymousMethodExpressionSyntax)context.Node;
-            HandleParameterListSyntax(context, anonymousMethod.ParameterList);
+            HandleParameterListSyntax(context, anonymousMethod.ParameterList, settings);
         }
 
-        private static void HandleParenthesizedLambdaExpression(SyntaxNodeAnalysisContext context)
+        private static void HandleParenthesizedLambdaExpression(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var parenthesizedLambda = (ParenthesizedLambdaExpressionSyntax)context.Node;
-            HandleParameterListSyntax(context, parenthesizedLambda.ParameterList);
+            HandleParameterListSyntax(context, parenthesizedLambda.ParameterList, settings);
         }
 
-        private static void HandleDelegateDeclaration(SyntaxNodeAnalysisContext context)
+        private static void HandleDelegateDeclaration(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var delegateDeclaration = (DelegateDeclarationSyntax)context.Node;
-            HandleParameterListSyntax(context, delegateDeclaration.ParameterList);
+            HandleParameterListSyntax(context, delegateDeclaration.ParameterList, settings);
         }
 
-        private static void HandleConstructorInitializer(SyntaxNodeAnalysisContext context)
+        private static void HandleConstructorInitializer(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var constructorInitializer = (ConstructorInitializerSyntax)context.Node;
-            HandleArgumentListSyntax(context, constructorInitializer.ArgumentList);
+            HandleArgumentListSyntax(context, constructorInitializer.ArgumentList, settings);
         }
 
-        private static void HandleElementBindingExpression(SyntaxNodeAnalysisContext context)
+        private static void HandleElementBindingExpression(SyntaxNodeAnalysisContext context, StyleCopSettings settings)
         {
             var elementBinding = (ElementBindingExpressionSyntax)context.Node;
-            HandleBracketedArgumentListSyntax(context, elementBinding.ArgumentList);
+            HandleBracketedArgumentListSyntax(context, elementBinding.ArgumentList, settings);
         }
 
-        private static void HandleArgumentListSyntax(SyntaxNodeAnalysisContext context, ArgumentListSyntax argumentList)
+        private static void HandleArgumentListSyntax(SyntaxNodeAnalysisContext context, ArgumentListSyntax argumentList, StyleCopSettings settings)
         {
             if (argumentList == null)
             {
@@ -215,10 +219,10 @@ namespace StyleCop.Analyzers.ReadabilityRules
             }
 
             SeparatedSyntaxList<ArgumentSyntax> arguments = argumentList.Arguments;
-            Analyze(context, arguments);
+            Analyze(context, arguments, settings);
         }
 
-        private static void HandleParameterListSyntax(SyntaxNodeAnalysisContext context, ParameterListSyntax parameterList)
+        private static void HandleParameterListSyntax(SyntaxNodeAnalysisContext context, ParameterListSyntax parameterList, StyleCopSettings settings)
         {
             if (parameterList == null)
             {
@@ -226,16 +230,16 @@ namespace StyleCop.Analyzers.ReadabilityRules
             }
 
             SeparatedSyntaxList<ParameterSyntax> parameters = parameterList.Parameters;
-            Analyze(context, parameters);
+            Analyze(context, parameters, settings);
         }
 
-        private static void HandleBracketedArgumentListSyntax(SyntaxNodeAnalysisContext context, BracketedArgumentListSyntax bracketedArgumentList)
+        private static void HandleBracketedArgumentListSyntax(SyntaxNodeAnalysisContext context, BracketedArgumentListSyntax bracketedArgumentList, StyleCopSettings settings)
         {
             SeparatedSyntaxList<ArgumentSyntax> arguments = bracketedArgumentList.Arguments;
-            Analyze(context, arguments);
+            Analyze(context, arguments, settings);
         }
 
-        private static void Analyze<T>(SyntaxNodeAnalysisContext context, SeparatedSyntaxList<T> arguments)
+        private static void Analyze<T>(SyntaxNodeAnalysisContext context, SeparatedSyntaxList<T> arguments, StyleCopSettings settings)
             where T : SyntaxNode
         {
             if (arguments.Count < 2)
@@ -245,17 +249,19 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
             SyntaxNode firstParameter = arguments[0];
             SyntaxNode secondParameter = arguments[1];
-            Func<SyntaxNode, SyntaxNode, bool> lineCondition;
 
-            if (firstParameter.GetLine() == secondParameter.GetLine())
+            Func<SyntaxNode, SyntaxNode, bool> lineCondition;
+            if (settings.ReadabilityRules.TreatMultilineParametersAsSplit)
             {
-                // arguments should be on same line
-                lineCondition = (param1, param2) => param1.GetLine() == param2.GetLine();
+                lineCondition = firstParameter.GetLine() == secondParameter.GetEndLine()
+                    ? (param1, param2) => param1.GetLine() == param2.GetEndLine() // Arguments should be on same line.
+                    : (param1, param2) => param1.GetEndLine() != param2.GetLine(); // Each argument should be on its own line.
             }
             else
             {
-                // each argument should be on its own line
-                lineCondition = (param1, param2) => param1.GetEndLine() != param2.GetLine();
+                lineCondition = firstParameter.GetLine() == secondParameter.GetLine()
+                    ? (param1, param2) => param1.GetLine() == param2.GetLine() // Arguments should be on same line.
+                    : (param1, param2) => param1.GetEndLine() != param2.GetLine(); // Each argument should be on its own line.
             }
 
             SyntaxNode previousParameter = firstParameter;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/ReadabilitySettings.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/ReadabilitySettings.cs
@@ -16,11 +16,17 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
         private readonly bool allowBuiltInTypeAliases;
 
         /// <summary>
+        /// This is the backing field for the <see cref="TreatMultilineParametersAsSplit"/> property.
+        /// </summary>
+        private readonly bool treatMultilineParametersAsSplit;
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="ReadabilitySettings"/> class.
         /// </summary>
         protected internal ReadabilitySettings()
         {
             this.allowBuiltInTypeAliases = false;
+            this.treatMultilineParametersAsSplit = false;
         }
 
         /// <summary>
@@ -32,6 +38,7 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
         protected internal ReadabilitySettings(JsonObject readabilitySettingsObject, AnalyzerConfigOptionsWrapper analyzerConfigOptions)
         {
             bool? allowBuiltInTypeAliases = null;
+            bool? treatMultilineParametersAsSplit = null;
 
             foreach (var kvp in readabilitySettingsObject)
             {
@@ -41,17 +48,26 @@ namespace StyleCop.Analyzers.Settings.ObjectModel
                     allowBuiltInTypeAliases = kvp.ToBooleanValue();
                     break;
 
+                case "treatMultilineParametersAsSplit":
+                    treatMultilineParametersAsSplit = kvp.ToBooleanValue();
+                    break;
+
                 default:
                     break;
                 }
             }
 
             allowBuiltInTypeAliases ??= AnalyzerConfigHelper.TryGetBooleanValue(analyzerConfigOptions, "stylecop.readability.allowBuiltInTypeAliases");
+            treatMultilineParametersAsSplit ??= AnalyzerConfigHelper.TryGetBooleanValue(analyzerConfigOptions, "stylecop.readability.treatMultilineParametersAsSplit");
 
             this.allowBuiltInTypeAliases = allowBuiltInTypeAliases.GetValueOrDefault(false);
+            this.treatMultilineParametersAsSplit = treatMultilineParametersAsSplit.GetValueOrDefault(false);
         }
 
         public bool AllowBuiltInTypeAliases =>
             this.allowBuiltInTypeAliases;
+
+        public bool TreatMultilineParametersAsSplit =>
+            this.treatMultilineParametersAsSplit;
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json
@@ -50,6 +50,11 @@
               "type": "boolean",
               "description": "When true, diagnostics will not be reported for using aliases of built-in types.",
               "default": false
+            },
+            "treatMultilineParametersAsSplit": {
+              "type": "boolean",
+              "description": "When true, SA1116 and SA1117 will treat multiline parameters as split parameters, requiring them to be each on a separate line.",
+              "default": false
             }
           }
         },

--- a/documentation/Configuration.md
+++ b/documentation/Configuration.md
@@ -118,6 +118,38 @@ HRESULT hr = SomeNativeOperation(); // SA1121
 
 The `allowBuiltInTypeAliases` configuration property can be set to `true` to allow cases like this while continuing to report diagnostics for direct references to the metadata type name, `Int32`.
 
+### Treat Multiline Parameters as Split
+
+| Property | Default Value | Minimum Version | Summary |
+| --- | --- | --- | --- |
+| `treatMultilineParametersAsSplit` | **false** | 1.2.0 | Specifies whether multiline parameters are treated as split parameters. |
+
+By default, SA1116 and SA1117 will only check that parameters start on the same line. This can cause inconsistencies when multiline parameters are used:
+
+```csharp
+// Reports SA1117.
+Invoked("first argument", input =>
+{
+}, "third argument");
+
+// Does not report any violations.
+Invoked("first argument", input =>
+{
+});
+
+// Reports SA1116.
+Invoked(input =>
+{
+}, "second argument");
+
+// Does not report any violations.
+Invoked(input =>
+{
+});
+```
+
+The `treatMultilineParametersAsSplit` configuration property can be set to `true` to report diagnostics for multiline parameters as if they were split parameters, requiring them to be each on a separate line.
+
 ## Ordering Rules
 
 This section describes the features of ordering rules which can be configured in **stylecop.json**. Each of the described properties are configured in the `orderingRules` object, which is shown in the following sample file.

--- a/documentation/SA1116.md
+++ b/documentation/SA1116.md
@@ -19,6 +19,8 @@
 
 The parameters to a C# method or indexer call or declaration span across multiple lines, but the first parameter does not start on the line after the opening bracket.
 
+> :memo: The behavior of this rule can change based on the configuration of the `treatMultilineParametersAsSplit` property in **stylecop.json**. See [Configuration.md](Configuration.md) for more information.
+
 ## Rule description
 
 A violation of this rule occurs when the parameters to a method or indexer span across multiple lines, but the first parameter does not start on the line after the opening bracket. For example:

--- a/documentation/SA1117.md
+++ b/documentation/SA1117.md
@@ -19,6 +19,8 @@
 
 The parameters to a C# method or indexer call or declaration are not all on the same line or each on a separate line.
 
+> :memo: The behavior of this rule can change based on the configuration of the `treatMultilineParametersAsSplit` property in **stylecop.json**. See [Configuration.md](Configuration.md) for more information.
+
 ## Rule description
 
 A violation of this rule occurs when the parameters to a method or indexer are not all on the same line or each on its own line. For example:


### PR DESCRIPTION
Fixes #3183 by adding a new configuration setting that can be enabled to use stricter handling of multiline parameters in SA1116 and SA1117.