### PR TITLE
Add alternative rules for SA1116 and SA1117 with stricter handling of multiline parameters

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SX1116CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SX1116CodeFixProvider.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#nullable disable
+
+namespace StyleCop.Analyzers.ReadabilityRules
+{
+    using System.Collections.Immutable;
+    using System.Composition;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CodeActions;
+    using Microsoft.CodeAnalysis.CodeFixes;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.Text;
+    using StyleCop.Analyzers.Helpers;
+
+    /// <summary>
+    /// Implements a code fix for <see cref="SX1116SplitParametersMustStartOnLineAfterDeclaration"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>To fix a violation of this rule, ensure that the first parameter starts on the line after the opening
+    /// bracket, or place all parameters on the same line if the parameters are not too long.</para>
+    /// </remarks>
+    [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SX1116CodeFixProvider))]
+    [Shared]
+    internal class SX1116CodeFixProvider : CodeFixProvider
+    {
+        /// <inheritdoc/>
+        public override ImmutableArray<string> FixableDiagnosticIds { get; } =
+            ImmutableArray.Create(SX1116SplitParametersMustStartOnLineAfterDeclaration.DiagnosticId);
+
+        /// <inheritdoc/>
+        public override FixAllProvider GetFixAllProvider()
+        {
+            return CustomFixAllProviders.BatchFixer;
+        }
+
+        /// <inheritdoc/>
+        public override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            foreach (var diagnostic in context.Diagnostics)
+            {
+                context.RegisterCodeFix(
+                    CodeAction.Create(
+                        ReadabilityResources.SX1116CodeFix,
+                        cancellationToken => GetTransformedDocumentAsync(context.Document, diagnostic, cancellationToken),
+                        nameof(SX1116CodeFixProvider)),
+                    diagnostic);
+            }
+
+            return SpecializedTasks.CompletedTask;
+        }
+
+        private static async Task<Document> GetTransformedDocumentAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
+        {
+            SyntaxNode root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            SyntaxToken originalToken = root.FindToken(diagnostic.Location.SourceSpan.Start);
+
+            SyntaxTree tree = root.SyntaxTree;
+            SourceText sourceText = await tree.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            TextLine sourceLine = sourceText.Lines.GetLineFromPosition(originalToken.SpanStart);
+
+            string lineText = sourceText.ToString(sourceLine.Span);
+            int indentLength;
+            for (indentLength = 0; indentLength < lineText.Length; indentLength++)
+            {
+                if (!char.IsWhiteSpace(lineText[indentLength]))
+                {
+                    break;
+                }
+            }
+
+            var settings = SettingsHelper.GetStyleCopSettings(document.Project.AnalyzerOptions, tree, cancellationToken);
+            SyntaxTriviaList newTrivia =
+                SyntaxFactory.TriviaList(
+                    SyntaxFactory.CarriageReturnLineFeed,
+                    SyntaxFactory.Whitespace(lineText.Substring(0, indentLength) + IndentationHelper.GenerateIndentationString(settings.Indentation, 1)));
+
+            SyntaxToken updatedToken = originalToken.WithLeadingTrivia(originalToken.LeadingTrivia.AddRange(newTrivia));
+            SyntaxNode updatedRoot = root.ReplaceToken(originalToken, updatedToken);
+            return document.WithSyntaxRoot(updatedRoot);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/ReadabilityRules/SX1116CSharp10UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/ReadabilityRules/SX1116CSharp10UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp10.ReadabilityRules
+{
+    using StyleCop.Analyzers.Test.CSharp9.ReadabilityRules;
+
+    public partial class SX1116CSharp10UnitTests : SX1116CSharp9UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/ReadabilityRules/SX1117CSharp10UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp10/ReadabilityRules/SX1117CSharp10UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp10.ReadabilityRules
+{
+    using StyleCop.Analyzers.Test.CSharp9.ReadabilityRules;
+
+    public partial class SX1117CSharp10UnitTests : SX1117CSharp9UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/ReadabilityRules/SX1116CSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/ReadabilityRules/SX1116CSharp11UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp11.ReadabilityRules
+{
+    using StyleCop.Analyzers.Test.CSharp10.ReadabilityRules;
+
+    public partial class SX1116CSharp11UnitTests : SX1116CSharp10UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/ReadabilityRules/SX1117CSharp11UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp11/ReadabilityRules/SX1117CSharp11UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp11.ReadabilityRules
+{
+    using StyleCop.Analyzers.Test.CSharp10.ReadabilityRules;
+
+    public partial class SX1117CSharp11UnitTests : SX1117CSharp10UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/ReadabilityRules/SX1116CSharp12UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/ReadabilityRules/SX1116CSharp12UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp12.ReadabilityRules
+{
+    using StyleCop.Analyzers.Test.CSharp11.ReadabilityRules;
+
+    public partial class SX1116CSharp12UnitTests : SX1116CSharp11UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/ReadabilityRules/SX1117CSharp12UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/ReadabilityRules/SX1117CSharp12UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp12.ReadabilityRules
+{
+    using StyleCop.Analyzers.Test.CSharp11.ReadabilityRules;
+
+    public partial class SX1117CSharp12UnitTests : SX1117CSharp11UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SX1116CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SX1116CSharp7UnitTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#nullable disable
+
+namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.ReadabilityRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.ReadabilityRules.SX1116SplitParametersMustStartOnLineAfterDeclaration,
+        StyleCop.Analyzers.ReadabilityRules.SX1116CodeFixProvider>;
+
+    public partial class SX1116CSharp7UnitTests : SX1116UnitTests
+    {
+        [Fact]
+        public async Task TestValidLocalFunctionAsync()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Method()
+    {
+        object LocalFunction(int a, string s) => null;
+    }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInvalidLocalFunctionsAsync()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Method()
+    {
+        object LocalFunction(int a,
+ string s) => null;
+    }
+}";
+            var fixedCode = @"
+class Foo
+{
+    public void Method()
+    {
+        object LocalFunction(
+            int a,
+ string s) => null;
+    }
+}";
+            DiagnosticResult expected = Diagnostic().WithLocation(6, 30);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SX1117CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SX1117CSharp7UnitTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#nullable disable
+
+namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.ReadabilityRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.ReadabilityRules.SX1117ParametersMustBeOnSameLineOrSeparateLines>;
+
+    public partial class SX1117CSharp7UnitTests : SX1117UnitTests
+    {
+        [Fact]
+        public async Task TestValidLocalFunctionsAsync()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Method()
+    {
+        void LocalFunction1(
+            int a, int b, string s) { }
+
+        void LocalFunction2(
+            int a,
+            int b,
+            string s) { }
+
+        object LocalFunction3(int a, int b, string s) => null;
+    }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInvalidLocalFunctionsAsync()
+        {
+            var testCode = @"
+class Foo
+{
+    public void Method()
+    {
+        object LocalFunction(int a, int b,
+ string s) => null;
+    }
+}";
+            var fixedCode = @"
+class Foo
+{
+    public void Method()
+    {
+        object LocalFunction(
+            int a,
+            int b,
+ string s) => null;
+    }
+}";
+            DiagnosticResult expected = Diagnostic().WithLocation(7, 2);
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpDiagnosticAsync(fixedCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/ReadabilityRules/SX1116CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/ReadabilityRules/SX1116CSharp8UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp8.ReadabilityRules
+{
+    using StyleCop.Analyzers.Test.CSharp7.ReadabilityRules;
+
+    public partial class SX1116CSharp8UnitTests : SX1116CSharp7UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/ReadabilityRules/SX1117CSharp8UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp8/ReadabilityRules/SX1117CSharp8UnitTests.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.CSharp8.ReadabilityRules
+{
+    using StyleCop.Analyzers.Test.CSharp7.ReadabilityRules;
+
+    public partial class SX1117CSharp8UnitTests : SX1117CSharp7UnitTests
+    {
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/ReadabilityRules/SX1116CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/ReadabilityRules/SX1116CSharp9UnitTests.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#nullable disable
+
+namespace StyleCop.Analyzers.Test.CSharp9.ReadabilityRules
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.CSharp8.ReadabilityRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.ReadabilityRules.SX1116SplitParametersMustStartOnLineAfterDeclaration,
+        StyleCop.Analyzers.ReadabilityRules.SX1116CodeFixProvider>;
+
+    public partial class SX1116CSharp9UnitTests : SX1116CSharp8UnitTests
+    {
+        public static IEnumerable<object[]> GetTargetTypedNewTestExpressions(string delimiter, string fixDelimiter)
+        {
+            yield return new object[] { $"Foo x = new(1,{delimiter} 2)", $"Foo x = new({fixDelimiter}1,{delimiter} 2)", 21 };
+            yield return new object[]
+            {
+                $"System.Lazy<int> x = new(() =>{delimiter} {{{delimiter} return 1;{delimiter} }},{delimiter} true)",
+                $"System.Lazy<int> x = new({fixDelimiter}() =>{delimiter} {{{delimiter} return 1;{delimiter} }},{delimiter} true)",
+                34,
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTargetTypedNewTestExpressions), "\r\n", "\r\n            ")]
+        public async Task TestTargetTypedNewExpressionAsync(string expression, string fixedExpression, int column)
+        {
+            var testCode = $@"
+class Foo
+{{
+    public Foo(int a, int b)
+    {{
+    }}
+
+    public void Method()
+    {{
+        {expression};
+    }}
+}}";
+
+            var fixedCode = $@"
+class Foo
+{{
+    public Foo(int a, int b)
+    {{
+    }}
+
+    public void Method()
+    {{
+        {fixedExpression};
+    }}
+}}";
+
+            DiagnosticResult expected = Diagnostic().WithLocation(10, column);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/ReadabilityRules/SX1117CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/ReadabilityRules/SX1117CSharp9UnitTests.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#nullable disable
+
+namespace StyleCop.Analyzers.Test.CSharp9.ReadabilityRules
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.CSharp8.ReadabilityRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.ReadabilityRules.SX1117ParametersMustBeOnSameLineOrSeparateLines>;
+
+    public partial class SX1117CSharp9UnitTests : SX1117CSharp8UnitTests
+    {
+        [Fact]
+        public async Task TestValidTargetTypedNewExpressionAsync()
+        {
+            var testCode = @"
+class Foo
+{
+    public Foo(int a, int b, int c)
+    {
+    }
+
+    public void Method()
+    {
+        Foo x = new(
+            1,
+            2,
+            3);
+    }
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInvalidTargetTypedNewExpressionAsync()
+        {
+            var testCode = @"
+class Foo
+{
+    public Foo(int a, int b, int c)
+    {
+    }
+
+    public void Method()
+    {
+        Foo x = new(1,
+            2, 3);
+    }
+}";
+
+            DiagnosticResult expected = Diagnostic().WithLocation(11, 16);
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SX1116UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SX1116UnitTests.cs
@@ -1,0 +1,356 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#nullable disable
+
+// Several test methods in this file use the same member data, but in some cases the test does not use all of the
+// supported parameters. See https://github.com/xunit/xunit/issues/1556.
+#pragma warning disable xUnit1026 // Theory methods should use all of their parameters
+
+namespace StyleCop.Analyzers.Test.ReadabilityRules
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.ReadabilityRules.SX1116SplitParametersMustStartOnLineAfterDeclaration,
+        StyleCop.Analyzers.ReadabilityRules.SX1116CodeFixProvider>;
+
+    public class SX1116UnitTests
+    {
+        public static IEnumerable<object[]> GetTestDeclarations(string delimiter, string fixDelimiter)
+        {
+            yield return new object[] { $"public Foo(int a,{delimiter} string s) {{ }}", $"public Foo({fixDelimiter}int a,{delimiter} string s) {{ }}", 16 };
+            yield return new object[] { $"public object Bar(int a,{delimiter} string s) => null;", $"public object Bar({fixDelimiter}int a,{delimiter} string s) => null;", 23 };
+            yield return new object[] { $"public static Foo operator + (Foo a,{delimiter} Foo b) => null;", $"public static Foo operator + ({fixDelimiter}Foo a,{delimiter} Foo b) => null;", 35 };
+            yield return new object[] { $"public object this[int a,{delimiter} string s] => null;", $"public object this[{fixDelimiter}int a,{delimiter} string s] => null;", 24 };
+            yield return new object[] { $"public delegate void Bar(int a,{delimiter} string s);", $"public delegate void Bar({fixDelimiter}int a,{delimiter} string s);", 30 };
+        }
+
+        public static IEnumerable<object[]> GetTestConstructorInitializers(string delimiter, string fixDelimiter)
+        {
+            yield return new object[] { $"this(42,{delimiter} \"hello\")", $"this({fixDelimiter}42,{delimiter} \"hello\")" };
+            yield return new object[] { $"base(42,{delimiter} \"hello\")", $"base({fixDelimiter}42,{delimiter} \"hello\")" };
+            yield return new object[] { $"this(new System.UriBuilder(){delimiter} {{{delimiter} Port = 5000{delimiter} }})", $"this({fixDelimiter}new System.UriBuilder(){delimiter} {{{delimiter} Port = 5000{delimiter} }})" };
+            yield return new object[] { $"base(new System.UriBuilder(){delimiter} {{{delimiter} Port = 5000{delimiter} }})", $"base({fixDelimiter}new System.UriBuilder(){delimiter} {{{delimiter} Port = 5000{delimiter} }})" };
+        }
+
+        public static IEnumerable<object[]> GetTestExpressions(string delimiter, string fixDelimiter)
+        {
+            yield return new object[] { $"Bar(1,{delimiter} 2)", $"Bar({fixDelimiter}1,{delimiter} 2)", 13 };
+            yield return new object[] { $"System.Action<int, int> func = (int x,{delimiter} int y) => Bar(x, y)", $"System.Action<int, int> func = ({fixDelimiter}int x,{delimiter} int y) => Bar(x, y)", 41 };
+            yield return new object[] { $"System.Action<int, int> func = delegate(int x,{delimiter} int y) {{ Bar(x, y); }}", $"System.Action<int, int> func = delegate({fixDelimiter}int x,{delimiter} int y) {{ Bar(x, y); }}", 49 };
+            yield return new object[] { $"new string('a',{delimiter} 2)", $"new string({fixDelimiter}'a',{delimiter} 2)", 20 };
+            yield return new object[] { $"var arr = new string[2,{delimiter} 2];", $"var arr = new string[{fixDelimiter}2,{delimiter} 2];", 30 };
+            yield return new object[] { $"char cc = (new char[3, 3])[2,{delimiter} 2];", $"char cc = (new char[3, 3])[{fixDelimiter}2,{delimiter} 2];", 36 };
+            yield return new object[] { $"char? c = (new char[3, 3])?[2,{delimiter} 2];", $"char? c = (new char[3, 3])?[{fixDelimiter}2,{delimiter} 2];", 37 };
+            yield return new object[] { $"long ll = this[2,{delimiter} 2];", $"long ll = this[{fixDelimiter}2,{delimiter} 2];", 24 };
+            yield return new object[] { $"Buz(() =>{delimiter} {{{delimiter} }},{delimiter} () => {{ }})", $"Buz({fixDelimiter}() =>{delimiter} {{{delimiter} }},{delimiter} () => {{ }})", 13 };
+            yield return new object[] { $"new System.Lazy<int>(() =>{delimiter} {{{delimiter} return 1;{delimiter} }})", $"new System.Lazy<int>({fixDelimiter}() =>{delimiter} {{{delimiter} return 1;{delimiter} }})", 30 };
+        }
+
+        public static IEnumerable<object[]> ValidTestExpressions()
+        {
+            yield return new object[] { $"System.Action func = () => Bar(0, 3)", null, 0 };
+            yield return new object[] { $"System.Action<int> func = x => Bar(x, 3)", null, 0 };
+            yield return new object[] { $"System.Action func = delegate {{ Bar(0, 0); }}", null, 0 };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestDeclarations), "", "")]
+        public async Task TestValidDeclarationAsync(string declaration, string fixedDeclaration, int column)
+        {
+            // Not needed for this test
+            _ = fixedDeclaration;
+            _ = column;
+
+            var testCode = $@"
+class Foo
+{{
+    {declaration}
+}}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestDeclarations), "\r\n", "\r\n        ")]
+        public async Task TestInvalidDeclarationAsync(string declaration, string fixedDeclaration, int column)
+        {
+            var testCode = $@"
+class Foo
+{{
+    {declaration}
+}}";
+            var fixedCode = $@"
+class Foo
+{{
+    {fixedDeclaration}
+}}";
+            DiagnosticResult expected = Diagnostic().WithLocation(4, column);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestConstructorInitializers), "", "")]
+        public async Task TestValidConstructorInitializerAsync(string initializer, string fixedInitializer)
+        {
+            // Not needed for this test
+            _ = fixedInitializer;
+
+            var testCode = $@"
+class Base
+{{
+    public Base(int a, string s)
+    {{
+    }}
+
+    public Base(System.UriBuilder b)
+    {{
+    }}
+}}
+
+class Derived : Base
+{{
+    public Derived()
+        : {initializer}
+    {{
+    }}
+
+    public Derived(int i, string z)
+        : base(i, z)
+    {{
+    }}
+
+    public Derived(System.UriBuilder u)
+        : base(u)
+    {{
+    }}
+}}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestConstructorInitializers), "\r\n", "\r\n            ")]
+        public async Task TestInvalidConstructorInitializerAsync(string initializer, string fixedInitializer)
+        {
+            var testCode = $@"
+class Base
+{{
+    public Base(int a, string s)
+    {{
+    }}
+
+    public Base(System.UriBuilder b)
+    {{
+    }}
+}}
+
+class Derived : Base
+{{
+    public Derived()
+        : {initializer}
+    {{
+    }}
+
+    public Derived(int i, string z)
+        : base(i, z)
+    {{
+    }}
+
+    public Derived(System.UriBuilder u)
+        : base(u)
+    {{
+    }}
+}}";
+            var fixedCode = $@"
+class Base
+{{
+    public Base(int a, string s)
+    {{
+    }}
+
+    public Base(System.UriBuilder b)
+    {{
+    }}
+}}
+
+class Derived : Base
+{{
+    public Derived()
+        : {fixedInitializer}
+    {{
+    }}
+
+    public Derived(int i, string z)
+        : base(i, z)
+    {{
+    }}
+
+    public Derived(System.UriBuilder u)
+        : base(u)
+    {{
+    }}
+}}";
+
+            DiagnosticResult expected = Diagnostic().WithLocation(16, 16);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestExpressions), "", "")]
+        [MemberData(nameof(ValidTestExpressions))]
+        public async Task TestValidExpressionAsync(string expression, string fixedExpression, int column)
+        {
+            // Not needed for this test
+            _ = fixedExpression;
+            _ = column;
+
+            var testCode = $@"
+class Foo
+{{
+    public void Bar(int i, int z)
+    {{
+    }}
+
+    public void Buz(System.Action x, System.Action y)
+    {{
+    }}
+
+    public void Baz()
+    {{
+        {expression};
+    }}
+
+    public long this[int a, int s] => a + s;
+}}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestExpressions), "\r\n", "\r\n            ")]
+        public async Task TestInvalidExpressionAsync(string expression, string fixedExpression, int column)
+        {
+            var testCode = $@"
+class Foo
+{{
+    public void Bar(int i, int z)
+    {{
+    }}
+
+    public void Buz(System.Action x, System.Action y)
+    {{
+    }}
+
+    public void Baz()
+    {{
+        {expression};
+    }}
+
+    public long this[int a, int s] => a + s;
+}}";
+            var fixedCode = $@"
+class Foo
+{{
+    public void Bar(int i, int z)
+    {{
+    }}
+
+    public void Buz(System.Action x, System.Action y)
+    {{
+    }}
+
+    public void Baz()
+    {{
+        {fixedExpression};
+    }}
+
+    public long this[int a, int s] => a + s;
+}}";
+
+            DiagnosticResult expected = Diagnostic().WithLocation(14, column);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestImplicitElementAccessAsync()
+        {
+            var testCode = @"
+class Foo
+{
+    private System.Collections.Generic.Dictionary<int, string> dict = new System.Collections.Generic.Dictionary<int, string>
+    {
+        [1] = ""foo""
+    };
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestValidAttributeAsync()
+        {
+            var testCode = @"
+[System.AttributeUsage(System.AttributeTargets.Class)]
+public class MyAttribute : System.Attribute
+{
+    public MyAttribute(int a, int b)
+    {
+    }
+}
+
+[MyAttribute(1, 2)]
+class Foo
+{
+}
+
+// This is a regression test for https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1211
+[System.Obsolete]
+class ObsoleteType
+{
+}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        public async Task TestInvalidAttributeAsync()
+        {
+            var testCode = @"
+[System.AttributeUsage(System.AttributeTargets.Class)]
+public class MyAttribute : System.Attribute
+{
+    public MyAttribute(int a, int b)
+    {
+    }
+}
+
+[MyAttribute(1,
+      2)]
+class Foo
+{
+}";
+            var fixedCode = @"
+[System.AttributeUsage(System.AttributeTargets.Class)]
+public class MyAttribute : System.Attribute
+{
+    public MyAttribute(int a, int b)
+    {
+    }
+}
+
+[MyAttribute(
+    1,
+      2)]
+class Foo
+{
+}";
+
+            DiagnosticResult expected = Diagnostic().WithLocation(10, 14);
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SX1117UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SX1117UnitTests.cs
@@ -1,0 +1,346 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#nullable disable
+
+namespace StyleCop.Analyzers.Test.ReadabilityRules
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.ReadabilityRules.SX1117ParametersMustBeOnSameLineOrSeparateLines>;
+
+    public class SX1117UnitTests
+    {
+        public static IEnumerable<object[]> GetTestDeclarations(string delimiter)
+        {
+            yield return new object[] { $"public Foo(int a, int b,{delimiter} {{|#0:string s|}}) {{ }}" };
+            yield return new object[] { $"public object Bar(int a, int b,{delimiter} {{|#0:string s|}}) => null;" };
+            yield return new object[] { $"public object this[int a, int b,{delimiter} {{|#0:string s|}}] => null;" };
+            yield return new object[] { $"public delegate void Bar(int a, int b,{delimiter} {{|#0:string s|}});" };
+        }
+
+        public static IEnumerable<object[]> GetMultilineTestDeclarations(string delimiter)
+        {
+            yield return new object[] { $"public Foo(int a,{delimiter} {{|#0:string\r\ns|}}) {{ }}" };
+            yield return new object[] { $"public object Bar(int a,{delimiter} {{|#0:string\r\ns|}}) => null;" };
+            yield return new object[] { $"public object this[int a,{delimiter} {{|#0:string\r\ns|}}] => null;" };
+            yield return new object[] { $"public delegate void Bar(int a,{delimiter} {{|#0:string\r\ns|}});" };
+        }
+
+        public static IEnumerable<object[]> GetTestConstructorInitializers(string delimiter)
+        {
+            yield return new object[] { $"this(42, 43, {delimiter} {{|#0:\"hello\"|}})" };
+            yield return new object[] { $"base(42, 43, {delimiter} {{|#0:\"hello\"|}})" };
+            yield return new object[] { $"this(42, 43, {delimiter} {{|#0:new System.UriBuilder() {{ Port = 5000 }}|}})" };
+            yield return new object[] { $"base(42, 43, {delimiter} {{|#0:new System.UriBuilder() {{ Port = 5000 }}|}})" };
+        }
+
+        public static IEnumerable<object[]> GetMultilineTestConstructorInitializers(string delimiter)
+        {
+            yield return new object[] { $"this(42\r\n+ 1, {delimiter} {{|#0:43|}}, {delimiter} \"hello\")" };
+            yield return new object[] { $"base(42\r\n+ 1, {delimiter} {{|#0:43|}}, {delimiter} \"hello\")" };
+            yield return new object[] { $"this(42, {delimiter} 43, {delimiter} {{|#0:new System.UriBuilder()\r\n{{\r\nPort = 5000\r\n}}|}})" };
+            yield return new object[] { $"base(42, {delimiter} 43, {delimiter} {{|#0:new System.UriBuilder()\r\n{{\r\nPort = 5000\r\n}}|}})" };
+        }
+
+        public static IEnumerable<object[]> GetTestExpressions(string delimiter)
+        {
+            yield return new object[] { $"Bar(1, 2, {delimiter} {{|#0:2|}})" };
+            yield return new object[] { $"System.Action<int, int, int> func = (int x, int y, {delimiter} {{|#0:int z|}}) => Bar(x, y, z)" };
+            yield return new object[] { $"System.Action<int, int, int> func = delegate(int x, int y, {delimiter} {{|#0:int z|}}) {{ Bar(x, y, z); }}" };
+            yield return new object[] { $"new System.DateTime(2015, 9, {delimiter} {{|#0:14|}})" };
+            yield return new object[] { $"var arr = new string[2, 2, {delimiter} {{|#0:2|}}];" };
+            yield return new object[] { $"char cc = (new char[3, 3, 3])[2, 2,{delimiter} {{|#0:2|}}];" };
+            yield return new object[] { $"char? c = (new char[3, 3, 3])?[2, 2,{delimiter} {{|#0:2|}}];" };
+            yield return new object[] { $"long ll = this[2, 2,{delimiter} {{|#0:2|}}];" };
+            yield return new object[] { $"Buz(() => {{ }}, 2,{delimiter} {{|#0:() => {{ }}|}});" };
+        }
+
+        public static IEnumerable<object[]> GetTrailingMultilineTestExpressions(string delimiter)
+        {
+            yield return new object[] { $"System.Action<int, int, int> func = (int x, {delimiter} int y, {delimiter} {{|#0:int\r\nz|}}) => Bar(x, y, z)" };
+            yield return new object[] { $"System.Action<int, int, int> func = delegate(int x, {delimiter} int y, {delimiter} {{|#0:int\r\nz|}}) {{ Bar(x, y, z); }}" };
+            yield return new object[] { $"var arr = new string[2, {delimiter} {{|#0:2\r\n+ 2|}}];" };
+            yield return new object[] { $"char cc = (new char[3, 3])[2, {delimiter} {{|#0:2\r\n+ 2|}}];" };
+            yield return new object[] { $"char? c = (new char[3, 3])?[2, {delimiter} {{|#0:2\r\n+ 2|}}];" };
+            yield return new object[] { $"long ll = this[2,{delimiter} 2,{delimiter} {{|#0:2\r\n+ 1|}}];" };
+            yield return new object[] { $"var str = string.Join(\r\n\"def\",{delimiter}{{|#0:\"abc\"\r\n + \"cba\"|}});" };
+            yield return new object[] { $"Buz(() => {{ }},{delimiter} 3,\r\n {{|#0:() =>\r\n{{\r\n}}|}});" };
+        }
+
+        public static IEnumerable<object[]> GetLeadingMultilineTestExpressions(string delimiter)
+        {
+            yield return new object[] { $"var str = string.Join(\r\n\"abc\"\r\n + \"cba\",{delimiter}{{|#0:\"def\"|}});" };
+            yield return new object[] { $"Bar(\r\n1\r\n + 2,{delimiter}{{|#0:3|}},\r\n 4);" };
+            yield return new object[] { $"Buz(\r\n() =>\r\n{{\r\n}},{delimiter}{{|#0:3|}},\r\n () => {{ }});" };
+            yield return new object[] { $"new System.Lazy<int>(\r\n() =>\r\n{{\r\nreturn 1;\r\n}},{delimiter} {{|#0:true|}})" };
+        }
+
+        public static IEnumerable<object[]> GetTestAttributes(string delimiter)
+        {
+            yield return new object[] { $"[MyAttribute(1, {delimiter}2, {{|#0:3|}})]" };
+        }
+
+        public static IEnumerable<object[]> GetMultilineTestAttributes(string delimiter)
+        {
+            yield return new object[] { $"[MyAttribute(1, {delimiter}2, {delimiter}{{|#0:3\r\n+ 5|}})]" };
+        }
+
+        public static IEnumerable<object[]> ValidTestExpressions()
+        {
+            yield return new object[] { $"System.Action func = () => Bar(0, 2, 3)" };
+            yield return new object[] { $"System.Action<int> func = x => Bar(x, 2, 3)" };
+            yield return new object[] { $"System.Action func = delegate {{ Bar(0, 0, 0); }}" };
+            yield return new object[] { "var weird = new int[10][,,,];" };
+            yield return new object[] { $"new System.Lazy<int>(() => {{ return 1; }}, true)" };
+        }
+
+        public static IEnumerable<object[]> ValidTestDeclarations()
+        {
+            yield return new object[]
+            {
+                $@"public Foo(
+    int a, int b, string s) {{ }}",
+            };
+            yield return new object[]
+            {
+                $@"public Foo(
+    int a,
+    int b,
+    string s) {{ }}",
+            };
+        }
+
+        public static IEnumerable<object[]> ValidTestAttribute()
+        {
+            // This is a regression test for https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1211
+            yield return new object[] { @"[System.Obsolete]" };
+            yield return new object[]
+            {
+                @"[MyAttribute(
+    1, 2, 3)]",
+            };
+            yield return new object[]
+            {
+                @"[MyAttribute(
+    1,
+    2,
+    3)]",
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestDeclarations), "")]
+        [MemberData(nameof(GetMultilineTestDeclarations), "\r\n")]
+        [MemberData(nameof(ValidTestDeclarations))]
+        public async Task TestValidDeclarationAsync(string declaration)
+        {
+            var testCode = $@"
+class Foo
+{{
+    {declaration}
+}}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestDeclarations), "\r\n")]
+        [MemberData(nameof(GetMultilineTestDeclarations), "")]
+        public async Task TestInvalidDeclarationAsync(string declaration)
+        {
+            var testCode = $@"
+class Foo
+{{
+    {declaration}
+}}";
+
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestConstructorInitializers), "")]
+        [MemberData(nameof(GetMultilineTestConstructorInitializers), "\r\n")]
+        public async Task TestValidConstructorInitializerAsync(string initializer)
+        {
+            var testCode = $@"
+class Base
+{{
+    public Base(int a, int b, string s)
+    {{
+    }}
+
+    public Base(int a, int b, System.UriBuilder s)
+    {{
+    }}
+}}
+
+class Derived : Base
+{{
+    public Derived()
+        : {initializer}
+    {{
+    }}
+
+    public Derived(int i, int j, string z)
+        : base(i, j, z)
+    {{
+    }}
+
+    public Derived(int i, int j, System.UriBuilder z)
+        : base(i, j, z)
+    {{
+    }}
+}}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestConstructorInitializers), "\r\n")]
+        [MemberData(nameof(GetMultilineTestConstructorInitializers), "")]
+        public async Task TestInvalidConstructorInitializerAsync(string initializer)
+        {
+            var testCode = $@"
+class Base
+{{
+    public Base(int a, int b, string s)
+    {{
+    }}
+
+    public Base(int a, int b, System.UriBuilder s)
+    {{
+    }}
+}}
+
+class Derived : Base
+{{
+    public Derived()
+        : {initializer}
+    {{
+    }}
+
+    public Derived(int i, int j, string z)
+        : base(i, j, z)
+    {{
+    }}
+
+    public Derived(int i, int j, System.UriBuilder z)
+        : base(i, j, z)
+    {{
+    }}
+}}";
+
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestExpressions), "")]
+        [MemberData(nameof(GetLeadingMultilineTestExpressions), "\r\n")]
+        [MemberData(nameof(GetTrailingMultilineTestExpressions), "\r\n")]
+        [MemberData(nameof(ValidTestExpressions))]
+        public async Task TestValidExpressionAsync(string expression)
+        {
+            var testCode = $@"
+class Foo
+{{
+    public void Bar(int i, int j, int k)
+    {{
+    }}
+
+    public void Buz(System.Action i, int j, System.Action k)
+    {{
+    }}
+
+    public void Baz()
+    {{
+        {expression};
+    }}
+
+    public long this[int a, int b, int s] => a + b + s;
+}}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestExpressions), "\r\n")]
+        [MemberData(nameof(GetLeadingMultilineTestExpressions), "")]
+        [MemberData(nameof(GetTrailingMultilineTestExpressions), "")]
+        public async Task TestInvalidExpressionAsync(string expression)
+        {
+            var testCode = $@"
+class Foo
+{{
+    public void Bar(int i, int j, int k)
+    {{
+    }}
+
+    public void Buz(System.Action i, int j, System.Action k)
+    {{
+    }}
+
+    public void Baz()
+    {{
+        {expression};
+    }}
+
+    public long this[int a, int b, int s] => a + b + s;
+}}";
+
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestAttributes), "")]
+        [MemberData(nameof(GetMultilineTestAttributes), "\r\n")]
+        [MemberData(nameof(ValidTestAttribute))]
+        public async Task TestValidAttributeAsync(string attribute)
+        {
+            var testCode = $@"
+[System.AttributeUsage(System.AttributeTargets.Class)]
+public class MyAttribute : System.Attribute
+{{
+    public MyAttribute(int a, int b, int c)
+    {{
+    }}
+}}
+
+{attribute}
+class Foo
+{{
+}}";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetTestAttributes), "\r\n")]
+        [MemberData(nameof(GetMultilineTestAttributes), "")]
+        public async Task TestInvalidAttributeAsync(string attribute)
+        {
+            var testCode = $@"
+[System.AttributeUsage(System.AttributeTargets.Class)]
+public class MyAttribute : System.Attribute
+{{
+    public MyAttribute(int a, int b, int c)
+    {{
+    }}
+}}
+
+{attribute}
+class Foo
+{{
+}}";
+
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerReleases.Unshipped.md
@@ -10,6 +10,7 @@ SA1142 | StyleCop.CSharp.ReadabilityRules | Warning | SA1142ReferToTupleElements
 SA1316 | StyleCop.CSharp.NamingRules | Warning | SA1316TupleElementNamesShouldUseCorrectCasing, [Documentation](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1316.md)
 SA1414 | StyleCop.CSharp.ReadabilityRules | Warning | SA1414TupleTypesInSignaturesShouldHaveElementNames, [Documentation](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1414.md)
 SA1518 | StyleCop.CSharp.LayoutRules | Warning | SA1518UseLineEndingsCorrectlyAtEndOfFile, [Documentation](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1518.md)
+SX1116 | StyleCop.CSharp.ReadabilityRules | Warning | SX1116SplitParametersMustStartOnLineAfterDeclaration, [Documentation](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1116.md)
 
 ### Changed Rules
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/AnalyzerReleases.Unshipped.md
@@ -11,6 +11,7 @@ SA1316 | StyleCop.CSharp.NamingRules | Warning | SA1316TupleElementNamesShouldUs
 SA1414 | StyleCop.CSharp.ReadabilityRules | Warning | SA1414TupleTypesInSignaturesShouldHaveElementNames, [Documentation](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1414.md)
 SA1518 | StyleCop.CSharp.LayoutRules | Warning | SA1518UseLineEndingsCorrectlyAtEndOfFile, [Documentation](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1518.md)
 SX1116 | StyleCop.CSharp.ReadabilityRules | Warning | SX1116SplitParametersMustStartOnLineAfterDeclaration, [Documentation](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1116.md)
+SX1117 | StyleCop.CSharp.ReadabilityRules | Warning | SX1117ParametersMustBeOnSameLineOrSeparateLines, [Documentation](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1117.md)
 
 ### Changed Rules
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp/Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp.CSharpResxGenerator/ReadabilityResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp/Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp.CSharpResxGenerator/ReadabilityResources.Designer.cs
@@ -322,7 +322,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
         public static string @SX1116CodeFix => GetResourceString("SX1116CodeFix")!;
         /// <summary>The parameters to a C# method or indexer call or declaration span across multiple lines, but the first parameter does not start on the line after the opening bracket.</summary>
         public static string @SX1116Description => GetResourceString("SX1116Description")!;
-        /// <summary>The parameters should begin on the line after the declaration, whenever the parameter span across multiple lines</summary>
+        /// <summary>The parameters should begin on the line after the declaration, whenever the parameters span across multiple lines</summary>
         public static string @SX1116MessageFormat => GetResourceString("SX1116MessageFormat")!;
         /// <summary>Split parameters should start on line after declaration</summary>
         public static string @SX1116Title => GetResourceString("SX1116Title")!;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp/Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp.CSharpResxGenerator/ReadabilityResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp/Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp.CSharpResxGenerator/ReadabilityResources.Designer.cs
@@ -318,6 +318,14 @@ namespace StyleCop.Analyzers.ReadabilityRules
         public static string @SX1101MessageFormat => GetResourceString("SX1101MessageFormat")!;
         /// <summary>Do not prefix local calls with 'this.'</summary>
         public static string @SX1101Title => GetResourceString("SX1101Title")!;
+        /// <summary>Move first argument to next line</summary>
+        public static string @SX1116CodeFix => GetResourceString("SX1116CodeFix")!;
+        /// <summary>The parameters to a C# method or indexer call or declaration span across multiple lines, but the first parameter does not start on the line after the opening bracket.</summary>
+        public static string @SX1116Description => GetResourceString("SX1116Description")!;
+        /// <summary>The parameters should begin on the line after the declaration, whenever the parameter span across multiple lines</summary>
+        public static string @SX1116MessageFormat => GetResourceString("SX1116MessageFormat")!;
+        /// <summary>Split parameters should start on line after declaration</summary>
+        public static string @SX1116Title => GetResourceString("SX1116Title")!;
 
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp/Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp.CSharpResxGenerator/ReadabilityResources.Designer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/.generated/Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp/Microsoft.CodeAnalysis.ResxSourceGenerator.CSharp.CSharpResxGenerator/ReadabilityResources.Designer.cs
@@ -326,6 +326,12 @@ namespace StyleCop.Analyzers.ReadabilityRules
         public static string @SX1116MessageFormat => GetResourceString("SX1116MessageFormat")!;
         /// <summary>Split parameters should start on line after declaration</summary>
         public static string @SX1116Title => GetResourceString("SX1116Title")!;
+        /// <summary>The parameters to a C# method or indexer call or declaration are not all on the same line or each on a separate line.</summary>
+        public static string @SX1117Description => GetResourceString("SX1117Description")!;
+        /// <summary>The parameters should all be placed on the same line or each parameter should be placed on its own line</summary>
+        public static string @SX1117MessageFormat => GetResourceString("SX1117MessageFormat")!;
+        /// <summary>Parameters should be on same line or separate lines</summary>
+        public static string @SX1117Title => GetResourceString("SX1117Title")!;
 
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.resx
@@ -585,4 +585,13 @@
   <data name="SX1116Title" xml:space="preserve">
     <value>Split parameters should start on line after declaration</value>
   </data>
+  <data name="SX1117Description" xml:space="preserve">
+    <value>The parameters to a C# method or indexer call or declaration are not all on the same line or each on a separate line.</value>
+  </data>
+  <data name="SX1117MessageFormat" xml:space="preserve">
+    <value>The parameters should all be placed on the same line or each parameter should be placed on its own line</value>
+  </data>
+  <data name="SX1117Title" xml:space="preserve">
+    <value>Parameters should be on same line or separate lines</value>
+  </data>
 </root>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.resx
@@ -573,4 +573,16 @@
   <data name="SX1101Title" xml:space="preserve">
     <value>Do not prefix local calls with 'this.'</value>
   </data>
+  <data name="SX1116CodeFix" xml:space="preserve">
+    <value>Move first argument to next line</value>
+  </data>
+  <data name="SX1116Description" xml:space="preserve">
+    <value>The parameters to a C# method or indexer call or declaration span across multiple lines, but the first parameter does not start on the line after the opening bracket.</value>
+  </data>
+  <data name="SX1116MessageFormat" xml:space="preserve">
+    <value>The parameters should begin on the line after the declaration, whenever the parameter span across multiple lines</value>
+  </data>
+  <data name="SX1116Title" xml:space="preserve">
+    <value>Split parameters should start on line after declaration</value>
+  </data>
 </root>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.resx
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/ReadabilityResources.resx
@@ -580,7 +580,7 @@
     <value>The parameters to a C# method or indexer call or declaration span across multiple lines, but the first parameter does not start on the line after the opening bracket.</value>
   </data>
   <data name="SX1116MessageFormat" xml:space="preserve">
-    <value>The parameters should begin on the line after the declaration, whenever the parameter span across multiple lines</value>
+    <value>The parameters should begin on the line after the declaration, whenever the parameters span across multiple lines</value>
   </data>
   <data name="SX1116Title" xml:space="preserve">
     <value>Split parameters should start on line after declaration</value>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SX1116SplitParametersMustStartOnLineAfterDeclaration.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SX1116SplitParametersMustStartOnLineAfterDeclaration.cs
@@ -1,0 +1,249 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#nullable disable
+
+namespace StyleCop.Analyzers.ReadabilityRules
+{
+    using System;
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
+    using StyleCop.Analyzers.Lightup;
+
+    /// <summary>
+    /// The parameters to a C# method or indexer call or declaration span across multiple lines, but the first parameter
+    /// does not start on the line after the opening bracket.
+    /// </summary>
+    /// <remarks>
+    /// <para>A violation of this rule occurs when the parameters to a method or indexer span across multiple lines, but
+    /// the first parameter does not start on the line after the opening bracket. For example:</para>
+    /// <code language="csharp">
+    /// public string JoinName(string first,
+    ///     string last)
+    /// {
+    /// }
+    /// </code>
+    /// <para>The parameters should begin on the line after the declaration, whenever the parameter span across multiple
+    /// lines:</para>
+    /// <code language="csharp">
+    /// public string JoinName(
+    ///     string first,
+    ///     string last)
+    /// {
+    /// }
+    /// </code>
+    /// </remarks>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal class SX1116SplitParametersMustStartOnLineAfterDeclaration : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// The ID for diagnostics produced by the <see cref="SX1116SplitParametersMustStartOnLineAfterDeclaration"/>
+        /// analyzer.
+        /// </summary>
+        public const string DiagnosticId = "SX1116";
+        private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1116.md";
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(ReadabilityResources.SX1116Title), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(ReadabilityResources.SX1116MessageFormat), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(ReadabilityResources.SX1116Description), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
+
+        private static readonly DiagnosticDescriptor Descriptor =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.ReadabilityRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledAlternative, Description, HelpLink);
+
+        private static readonly ImmutableArray<SyntaxKind> BaseMethodDeclarationKinds =
+            ImmutableArray.Create(SyntaxKind.ConstructorDeclaration, SyntaxKind.MethodDeclaration, SyntaxKind.OperatorDeclaration);
+
+        private static readonly Action<SyntaxNodeAnalysisContext> BaseMethodDeclarationAction = HandleBaseMethodDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext> LocalFunctionStatementAction = HandleLocalFunctionStatement;
+        private static readonly Action<SyntaxNodeAnalysisContext> ConstructorInitializerAction = HandleConstructorInitializer;
+        private static readonly Action<SyntaxNodeAnalysisContext> DelegateDeclarationAction = HandleDelegateDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext> IndexerDeclarationAction = HandleIndexerDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext> InvocationExpressionAction = HandleInvocationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> ObjectCreationExpressionAction = HandleObjectCreationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> ImplicitObjectCreationExpressionAction = HandleImplicitObjectCreationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> ElementAccessExpressionAction = HandleElementAccessExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> ElementBindingExpressionAction = HandleElementBindingExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> ImplicitElementAccessAction = HandleImplicitElementAccess;
+        private static readonly Action<SyntaxNodeAnalysisContext> ArrayCreationExpressionAction = HandleArrayCreationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> AttributeAction = HandleAttribute;
+        private static readonly Action<SyntaxNodeAnalysisContext> AnonymousMethodExpressionAction = HandleAnonymousMethodExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> ParenthesizedLambdaExpressionAction = HandleParenthesizedLambdaExpression;
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+            ImmutableArray.Create(Descriptor);
+
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterSyntaxNodeAction(BaseMethodDeclarationAction, BaseMethodDeclarationKinds);
+            context.RegisterSyntaxNodeAction(LocalFunctionStatementAction, SyntaxKindEx.LocalFunctionStatement);
+            context.RegisterSyntaxNodeAction(ConstructorInitializerAction, SyntaxKinds.ConstructorInitializer);
+            context.RegisterSyntaxNodeAction(DelegateDeclarationAction, SyntaxKind.DelegateDeclaration);
+            context.RegisterSyntaxNodeAction(IndexerDeclarationAction, SyntaxKind.IndexerDeclaration);
+            context.RegisterSyntaxNodeAction(InvocationExpressionAction, SyntaxKind.InvocationExpression);
+            context.RegisterSyntaxNodeAction(ObjectCreationExpressionAction, SyntaxKind.ObjectCreationExpression);
+            context.RegisterSyntaxNodeAction(ImplicitObjectCreationExpressionAction, SyntaxKindEx.ImplicitObjectCreationExpression);
+            context.RegisterSyntaxNodeAction(ElementAccessExpressionAction, SyntaxKind.ElementAccessExpression);
+            context.RegisterSyntaxNodeAction(ElementBindingExpressionAction, SyntaxKind.ElementBindingExpression);
+            context.RegisterSyntaxNodeAction(ImplicitElementAccessAction, SyntaxKind.ImplicitElementAccess);
+            context.RegisterSyntaxNodeAction(ArrayCreationExpressionAction, SyntaxKind.ArrayCreationExpression);
+            context.RegisterSyntaxNodeAction(AttributeAction, SyntaxKind.Attribute);
+            context.RegisterSyntaxNodeAction(AnonymousMethodExpressionAction, SyntaxKind.AnonymousMethodExpression);
+            context.RegisterSyntaxNodeAction(ParenthesizedLambdaExpressionAction, SyntaxKind.ParenthesizedLambdaExpression);
+        }
+
+        private static void HandleBaseMethodDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var declaration = (BaseMethodDeclarationSyntax)context.Node;
+            HandleParameterListSyntax(context, declaration.ParameterList);
+        }
+
+        private static void HandleLocalFunctionStatement(SyntaxNodeAnalysisContext context)
+        {
+            var statement = (LocalFunctionStatementSyntaxWrapper)context.Node;
+            HandleParameterListSyntax(context, statement.ParameterList);
+        }
+
+        private static void HandleInvocationExpression(SyntaxNodeAnalysisContext context)
+        {
+            var invocation = (InvocationExpressionSyntax)context.Node;
+            HandleArgumentListSyntax(context, invocation.ArgumentList);
+        }
+
+        private static void HandleObjectCreationExpression(SyntaxNodeAnalysisContext context)
+        {
+            var objectCreation = (ObjectCreationExpressionSyntax)context.Node;
+            HandleArgumentListSyntax(context, objectCreation.ArgumentList);
+        }
+
+        private static void HandleImplicitObjectCreationExpression(SyntaxNodeAnalysisContext context)
+        {
+            var implicitObjectCreation = (ImplicitObjectCreationExpressionSyntaxWrapper)context.Node;
+            HandleArgumentListSyntax(context, implicitObjectCreation.ArgumentList);
+        }
+
+        private static void HandleIndexerDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var indexerDeclaration = (IndexerDeclarationSyntax)context.Node;
+            BracketedParameterListSyntax argumentListSyntax = indexerDeclaration.ParameterList;
+            SeparatedSyntaxList<ParameterSyntax> arguments = argumentListSyntax.Parameters;
+            Analyze(context, argumentListSyntax.OpenBracketToken, arguments);
+        }
+
+        private static void HandleElementAccessExpression(SyntaxNodeAnalysisContext context)
+        {
+            var elementAccess = (ElementAccessExpressionSyntax)context.Node;
+            HandleBracketedArgumentListSyntax(context, elementAccess.ArgumentList);
+        }
+
+        private static void HandleArrayCreationExpression(SyntaxNodeAnalysisContext context)
+        {
+            var arrayCreation = (ArrayCreationExpressionSyntax)context.Node;
+            foreach (var rankSpecifier in arrayCreation.Type.RankSpecifiers)
+            {
+                SeparatedSyntaxList<ExpressionSyntax> sizes = rankSpecifier.Sizes;
+                Analyze(context, rankSpecifier.OpenBracketToken, sizes);
+            }
+        }
+
+        private static void HandleAttribute(SyntaxNodeAnalysisContext context)
+        {
+            var attribute = (AttributeSyntax)context.Node;
+            AttributeArgumentListSyntax argumentListSyntax = attribute.ArgumentList;
+            if (argumentListSyntax == null)
+            {
+                return;
+            }
+
+            SeparatedSyntaxList<AttributeArgumentSyntax> arguments = argumentListSyntax.Arguments;
+            Analyze(context, argumentListSyntax.OpenParenToken, arguments);
+        }
+
+        private static void HandleAnonymousMethodExpression(SyntaxNodeAnalysisContext context)
+        {
+            var anonymousMethod = (AnonymousMethodExpressionSyntax)context.Node;
+            HandleParameterListSyntax(context, anonymousMethod.ParameterList);
+        }
+
+        private static void HandleParenthesizedLambdaExpression(SyntaxNodeAnalysisContext context)
+        {
+            var parenthesizedLambda = (ParenthesizedLambdaExpressionSyntax)context.Node;
+            HandleParameterListSyntax(context, parenthesizedLambda.ParameterList);
+        }
+
+        private static void HandleDelegateDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var delegateDeclaration = (DelegateDeclarationSyntax)context.Node;
+            HandleParameterListSyntax(context, delegateDeclaration.ParameterList);
+        }
+
+        private static void HandleConstructorInitializer(SyntaxNodeAnalysisContext context)
+        {
+            var constructorInitializer = (ConstructorInitializerSyntax)context.Node;
+            HandleArgumentListSyntax(context, constructorInitializer.ArgumentList);
+        }
+
+        private static void HandleElementBindingExpression(SyntaxNodeAnalysisContext context)
+        {
+            var elementBinding = (ElementBindingExpressionSyntax)context.Node;
+            HandleBracketedArgumentListSyntax(context, elementBinding.ArgumentList);
+        }
+
+        private static void HandleImplicitElementAccess(SyntaxNodeAnalysisContext context)
+        {
+            var implicitElementAccess = (ImplicitElementAccessSyntax)context.Node;
+            HandleBracketedArgumentListSyntax(context, implicitElementAccess.ArgumentList);
+        }
+
+        private static void HandleArgumentListSyntax(SyntaxNodeAnalysisContext context, ArgumentListSyntax argumentList)
+        {
+            if (argumentList == null)
+            {
+                return;
+            }
+
+            SeparatedSyntaxList<ArgumentSyntax> parameters = argumentList.Arguments;
+            Analyze(context, argumentList.OpenParenToken, parameters);
+        }
+
+        private static void HandleParameterListSyntax(SyntaxNodeAnalysisContext context, ParameterListSyntax parameterList)
+        {
+            if (parameterList == null)
+            {
+                return;
+            }
+
+            SeparatedSyntaxList<ParameterSyntax> parameters = parameterList.Parameters;
+            Analyze(context, parameterList.OpenParenToken, parameters);
+        }
+
+        private static void HandleBracketedArgumentListSyntax(SyntaxNodeAnalysisContext context, BracketedArgumentListSyntax bracketedArgumentList)
+        {
+            SeparatedSyntaxList<ArgumentSyntax> parameters = bracketedArgumentList.Arguments;
+            Analyze(context, bracketedArgumentList.OpenBracketToken, parameters);
+        }
+
+        private static void Analyze<T>(SyntaxNodeAnalysisContext context, SyntaxToken openParenOrBracketToken, SeparatedSyntaxList<T> arguments)
+            where T : SyntaxNode
+        {
+            if (arguments.Count < 1)
+            {
+                return;
+            }
+
+            SyntaxNode firstParameter = arguments.First();
+            int firstParameterLine = firstParameter.GetLine();
+            if (firstParameterLine == openParenOrBracketToken.GetLine() && firstParameterLine != arguments.Last().GetEndLine())
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptor, firstParameter.GetLocation()));
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SX1117ParametersMustBeOnSameLineOrSeparateLines.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/ReadabilityRules/SX1117ParametersMustBeOnSameLineOrSeparateLines.cs
@@ -1,0 +1,267 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#nullable disable
+
+namespace StyleCop.Analyzers.ReadabilityRules
+{
+    using System;
+    using System.Collections.Immutable;
+    using Microsoft.CodeAnalysis;
+    using Microsoft.CodeAnalysis.CSharp;
+    using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Diagnostics;
+    using StyleCop.Analyzers.Helpers;
+    using StyleCop.Analyzers.Lightup;
+
+    /// <summary>
+    /// The parameters to a C# method or indexer call or declaration are not all on the same line or each on a separate
+    /// line.
+    /// </summary>
+    /// <remarks>
+    /// <para>A violation of this rule occurs when the parameters to a method or indexer are not all on the same line or
+    /// each on its own line. For example:</para>
+    /// <code language="csharp">
+    /// public string JoinName(string first, string middle,
+    ///     string last)
+    /// {
+    /// }
+    /// </code>
+    /// <para>The parameters can all be placed on the same line:</para>
+    /// <code language="csharp">
+    /// public string JoinName(string first, string middle, string last)
+    /// {
+    /// }
+    ///
+    /// public string JoinName(
+    ///     string first, string middle, string last)
+    /// {
+    /// }
+    /// </code>
+    /// <para>Alternatively, each parameter can be placed on its own line:</para>
+    /// <code language="csharp">
+    /// public string JoinName(
+    ///     string first,
+    ///     string middle,
+    ///     string last)
+    /// {
+    /// }
+    /// </code>
+    /// </remarks>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    internal class SX1117ParametersMustBeOnSameLineOrSeparateLines : DiagnosticAnalyzer
+    {
+        /// <summary>
+        /// The ID for diagnostics produced by the <see cref="SX1117ParametersMustBeOnSameLineOrSeparateLines"/>
+        /// analyzer.
+        /// </summary>
+        public const string DiagnosticId = "SX1117";
+        private const string HelpLink = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SX1117.md";
+        private static readonly LocalizableString Title = new LocalizableResourceString(nameof(ReadabilityResources.SX1117Title), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
+        private static readonly LocalizableString MessageFormat = new LocalizableResourceString(nameof(ReadabilityResources.SX1117MessageFormat), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
+        private static readonly LocalizableString Description = new LocalizableResourceString(nameof(ReadabilityResources.SX1117Description), ReadabilityResources.ResourceManager, typeof(ReadabilityResources));
+
+        private static readonly DiagnosticDescriptor Descriptor =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, AnalyzerCategory.ReadabilityRules, DiagnosticSeverity.Warning, AnalyzerConstants.DisabledAlternative, Description, HelpLink);
+
+        private static readonly ImmutableArray<SyntaxKind> BaseMethodDeclarationKinds =
+            ImmutableArray.Create(SyntaxKind.ConstructorDeclaration, SyntaxKind.MethodDeclaration);
+
+        private static readonly Action<SyntaxNodeAnalysisContext> BaseMethodDeclarationAction = HandleBaseMethodDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext> LocalFunctionStatementAction = HandleLocalFunctionStatement;
+        private static readonly Action<SyntaxNodeAnalysisContext> ConstructorInitializerAction = HandleConstructorInitializer;
+        private static readonly Action<SyntaxNodeAnalysisContext> DelegateDeclarationAction = HandleDelegateDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext> IndexerDeclarationAction = HandleIndexerDeclaration;
+        private static readonly Action<SyntaxNodeAnalysisContext> InvocationExpressionAction = HandleInvocationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> ObjectCreationExpressionAction = HandleObjectCreationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> ImplicitObjectCreationExpressionAction = HandleImplicitObjectCreationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> ElementAccessExpressionAction = HandleElementAccessExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> ElementBindingExpressionAction = HandleElementBindingExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> ArrayCreationExpressionAction = HandleArrayCreationExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> AttributeAction = HandleAttribute;
+        private static readonly Action<SyntaxNodeAnalysisContext> AnonymousMethodExpressionAction = HandleAnonymousMethodExpression;
+        private static readonly Action<SyntaxNodeAnalysisContext> ParenthesizedLambdaExpressionAction = HandleParenthesizedLambdaExpression;
+
+        /// <inheritdoc/>
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
+            = ImmutableArray.Create(Descriptor);
+
+        /// <inheritdoc/>
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterSyntaxNodeAction(BaseMethodDeclarationAction, BaseMethodDeclarationKinds);
+            context.RegisterSyntaxNodeAction(LocalFunctionStatementAction, SyntaxKindEx.LocalFunctionStatement);
+            context.RegisterSyntaxNodeAction(ConstructorInitializerAction, SyntaxKinds.ConstructorInitializer);
+            context.RegisterSyntaxNodeAction(DelegateDeclarationAction, SyntaxKind.DelegateDeclaration);
+            context.RegisterSyntaxNodeAction(IndexerDeclarationAction, SyntaxKind.IndexerDeclaration);
+            context.RegisterSyntaxNodeAction(InvocationExpressionAction, SyntaxKind.InvocationExpression);
+            context.RegisterSyntaxNodeAction(ObjectCreationExpressionAction, SyntaxKind.ObjectCreationExpression);
+            context.RegisterSyntaxNodeAction(ImplicitObjectCreationExpressionAction, SyntaxKindEx.ImplicitObjectCreationExpression);
+            context.RegisterSyntaxNodeAction(ElementAccessExpressionAction, SyntaxKind.ElementAccessExpression);
+            context.RegisterSyntaxNodeAction(ElementBindingExpressionAction, SyntaxKind.ElementBindingExpression);
+            context.RegisterSyntaxNodeAction(ArrayCreationExpressionAction, SyntaxKind.ArrayCreationExpression);
+            context.RegisterSyntaxNodeAction(AttributeAction, SyntaxKind.Attribute);
+            context.RegisterSyntaxNodeAction(AnonymousMethodExpressionAction, SyntaxKind.AnonymousMethodExpression);
+            context.RegisterSyntaxNodeAction(ParenthesizedLambdaExpressionAction, SyntaxKind.ParenthesizedLambdaExpression);
+        }
+
+        private static void HandleBaseMethodDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var declaration = (BaseMethodDeclarationSyntax)context.Node;
+            HandleParameterListSyntax(context, declaration.ParameterList);
+        }
+
+        private static void HandleLocalFunctionStatement(SyntaxNodeAnalysisContext context)
+        {
+            var statement = (LocalFunctionStatementSyntaxWrapper)context.Node;
+            HandleParameterListSyntax(context, statement.ParameterList);
+        }
+
+        private static void HandleInvocationExpression(SyntaxNodeAnalysisContext context)
+        {
+            var invocation = (InvocationExpressionSyntax)context.Node;
+            HandleArgumentListSyntax(context, invocation.ArgumentList);
+        }
+
+        private static void HandleObjectCreationExpression(SyntaxNodeAnalysisContext context)
+        {
+            var objectCreation = (ObjectCreationExpressionSyntax)context.Node;
+            HandleArgumentListSyntax(context, objectCreation.ArgumentList);
+        }
+
+        private static void HandleImplicitObjectCreationExpression(SyntaxNodeAnalysisContext context)
+        {
+            var implicitObjectCreation = (ImplicitObjectCreationExpressionSyntaxWrapper)context.Node;
+            HandleArgumentListSyntax(context, implicitObjectCreation.ArgumentList);
+        }
+
+        private static void HandleIndexerDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var indexerDeclaration = (IndexerDeclarationSyntax)context.Node;
+            BracketedParameterListSyntax argumentListSyntax = indexerDeclaration.ParameterList;
+            SeparatedSyntaxList<ParameterSyntax> arguments = argumentListSyntax.Parameters;
+
+            Analyze(context, arguments);
+        }
+
+        private static void HandleElementAccessExpression(SyntaxNodeAnalysisContext context)
+        {
+            var elementAccess = (ElementAccessExpressionSyntax)context.Node;
+            HandleBracketedArgumentListSyntax(context, elementAccess.ArgumentList);
+        }
+
+        private static void HandleArrayCreationExpression(SyntaxNodeAnalysisContext context)
+        {
+            var arrayCreation = (ArrayCreationExpressionSyntax)context.Node;
+
+            foreach (var rankSpecifier in arrayCreation.Type.RankSpecifiers)
+            {
+                SeparatedSyntaxList<ExpressionSyntax> sizes = rankSpecifier.Sizes;
+                Analyze(context, sizes);
+            }
+        }
+
+        private static void HandleAttribute(SyntaxNodeAnalysisContext context)
+        {
+            var attribute = (AttributeSyntax)context.Node;
+            AttributeArgumentListSyntax argumentListSyntax = attribute.ArgumentList;
+            if (argumentListSyntax == null)
+            {
+                return;
+            }
+
+            SeparatedSyntaxList<AttributeArgumentSyntax> arguments = argumentListSyntax.Arguments;
+            Analyze(context, arguments);
+        }
+
+        private static void HandleAnonymousMethodExpression(SyntaxNodeAnalysisContext context)
+        {
+            var anonymousMethod = (AnonymousMethodExpressionSyntax)context.Node;
+            HandleParameterListSyntax(context, anonymousMethod.ParameterList);
+        }
+
+        private static void HandleParenthesizedLambdaExpression(SyntaxNodeAnalysisContext context)
+        {
+            var parenthesizedLambda = (ParenthesizedLambdaExpressionSyntax)context.Node;
+            HandleParameterListSyntax(context, parenthesizedLambda.ParameterList);
+        }
+
+        private static void HandleDelegateDeclaration(SyntaxNodeAnalysisContext context)
+        {
+            var delegateDeclaration = (DelegateDeclarationSyntax)context.Node;
+            HandleParameterListSyntax(context, delegateDeclaration.ParameterList);
+        }
+
+        private static void HandleConstructorInitializer(SyntaxNodeAnalysisContext context)
+        {
+            var constructorInitializer = (ConstructorInitializerSyntax)context.Node;
+            HandleArgumentListSyntax(context, constructorInitializer.ArgumentList);
+        }
+
+        private static void HandleElementBindingExpression(SyntaxNodeAnalysisContext context)
+        {
+            var elementBinding = (ElementBindingExpressionSyntax)context.Node;
+            HandleBracketedArgumentListSyntax(context, elementBinding.ArgumentList);
+        }
+
+        private static void HandleArgumentListSyntax(SyntaxNodeAnalysisContext context, ArgumentListSyntax argumentList)
+        {
+            if (argumentList == null)
+            {
+                return;
+            }
+
+            SeparatedSyntaxList<ArgumentSyntax> arguments = argumentList.Arguments;
+            Analyze(context, arguments);
+        }
+
+        private static void HandleParameterListSyntax(SyntaxNodeAnalysisContext context, ParameterListSyntax parameterList)
+        {
+            if (parameterList == null)
+            {
+                return;
+            }
+
+            SeparatedSyntaxList<ParameterSyntax> parameters = parameterList.Parameters;
+            Analyze(context, parameters);
+        }
+
+        private static void HandleBracketedArgumentListSyntax(SyntaxNodeAnalysisContext context, BracketedArgumentListSyntax bracketedArgumentList)
+        {
+            SeparatedSyntaxList<ArgumentSyntax> arguments = bracketedArgumentList.Arguments;
+            Analyze(context, arguments);
+        }
+
+        private static void Analyze<T>(SyntaxNodeAnalysisContext context, SeparatedSyntaxList<T> arguments)
+            where T : SyntaxNode
+        {
+            if (arguments.Count < 2)
+            {
+                return;
+            }
+
+            SyntaxNode firstParameter = arguments[0];
+            SyntaxNode secondParameter = arguments[1];
+
+            Func<SyntaxNode, SyntaxNode, bool> lineCondition = firstParameter.GetLine() == secondParameter.GetEndLine()
+                ? (param1, param2) => param1.GetLine() == param2.GetEndLine() // Arguments should be on same line.
+                : (param1, param2) => param1.GetEndLine() != param2.GetLine(); // Each argument should be on its own line.
+
+            SyntaxNode previousParameter = firstParameter;
+            for (int i = 1; i < arguments.Count; ++i)
+            {
+                SyntaxNode currentParameter = arguments[i];
+                if (!lineCondition(previousParameter, currentParameter))
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptor, currentParameter.GetLocation()));
+                    return;
+                }
+
+                previousParameter = currentParameter;
+            }
+        }
+    }
+}

--- a/StyleCopAnalyzers.sln
+++ b/StyleCopAnalyzers.sln
@@ -243,6 +243,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentat
 		documentation\SpecialRules.md = documentation\SpecialRules.md
 		documentation\SX1101.md = documentation\SX1101.md
 		documentation\SX1116.md = documentation\SX1116.md
+		documentation\SX1117.md = documentation\SX1117.md
 		documentation\SX1309.md = documentation\SX1309.md
 		documentation\SX1309S.md = documentation\SX1309S.md
 	EndProjectSection

--- a/StyleCopAnalyzers.sln
+++ b/StyleCopAnalyzers.sln
@@ -242,6 +242,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "documentation", "documentat
 		documentation\SpacingRules.md = documentation\SpacingRules.md
 		documentation\SpecialRules.md = documentation\SpecialRules.md
 		documentation\SX1101.md = documentation\SX1101.md
+		documentation\SX1116.md = documentation\SX1116.md
 		documentation\SX1309.md = documentation\SX1309.md
 		documentation\SX1309S.md = documentation\SX1309S.md
 	EndProjectSection

--- a/documentation/AlternativeRules.md
+++ b/documentation/AlternativeRules.md
@@ -1,8 +1,11 @@
 ### Alternative Rules (SX0000-)
+
 Rules which are non-standard extensions to the default StyleCop behavior, and represent an alternative style which is adopted by some projects. Alternative rules are known to directly conflict with standard StyleCop rules.
 
 Identifier | Name | Description
 -----------|------|------------
-[SX1101](SX1101.md) | DoNotPrefixLocalMembersWithThis | A call to an instance member of the local class or a base class is prefixed with 'this.', within a C# code file. 
+[SX1101](SX1101.md) | DoNotPrefixLocalMembersWithThis | A call to an instance member of the local class or a base class is prefixed with 'this.', within a C# code file.
+[SX1116](SX1116.md) | SplitParametersMustStartOnLineAfterDeclaration | The parameters to a C# method or indexer call or declaration span across multiple lines, but the first parameter does not start on the line after the opening bracket.
+[SX1117](SX1117.md) | ParametersMustBeOnSameLineOrSeparateLines | The parameters to a C# method or indexer call or declaration are not all on the same line or each on a separate line.
 [SX1309](SX1309.md) | FieldNamesMustBeginWithUnderscore | A field name does not begin with an underscore.
 [SX1309S](SX1309S.md) | StaticFieldNamesMustBeginWithUnderscore | A static field name does not begin with an underscore.

--- a/documentation/SX1116.md
+++ b/documentation/SX1116.md
@@ -15,6 +15,10 @@
 </tr>
 </table>
 
+## Alternative rule
+
+This rule is a non-standard extension to the default StyleCop behavior, and represents an alternative style which is adopted by some projects. Alternative rules are known to directly conflict with standard StyleCop rules.
+
 ## Cause
 
 The parameters to a C# method or indexer call or declaration span across multiple lines, but the first parameter does not start on the line after the opening bracket.
@@ -24,21 +28,29 @@ The parameters to a C# method or indexer call or declaration span across multipl
 A violation of this rule occurs when the parameters to a method or indexer span across multiple lines, but the first parameter does not start on the line after the opening bracket. For example:
 
 ```csharp
-public string JoinName(string first, 
-    string last)
+var lazyLargeObject = new Lazy<LargeObject>(() =>
 {
-}
+    return new LargeObject(Thread.CurrentThread.ManagedThreadId);
+});
 ```
 
 The parameters should begin on the line after the declaration, whenever the parameter span across multiple lines:
 
 ```csharp
-public string JoinName(
-    string first, 
-    string last)
-{
-}
+var lazyLargeObject = new Lazy<LargeObject>(
+    () =>
+    {
+        return new LargeObject(Thread.CurrentThread.ManagedThreadId);
+    });
 ```
+
+Alternatively, the parameters can all be on the same line if the parameters are not too long.
+
+```csharp
+var lazyLargeObject = new Lazy<LargeObject>(() => new LargeObject(Thread.CurrentThread.ManagedThreadId));
+```
+
+This rule is disabled by default. When enabling this rule, the [SA1116](SA1116.md) rule should be disabled.
 
 ## How to fix violations
 

--- a/documentation/SX1116.md
+++ b/documentation/SX1116.md
@@ -1,0 +1,56 @@
+﻿## SX1116
+
+<table>
+<tr>
+  <td>TypeName</td>
+  <td>SX1116SplitParametersMustStartOnLineAfterDeclaration</td>
+</tr>
+<tr>
+  <td>CheckId</td>
+  <td>SX1116</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Readability Rules</td>
+</tr>
+</table>
+
+## Cause
+
+The parameters to a C# method or indexer call or declaration span across multiple lines, but the first parameter does not start on the line after the opening bracket.
+
+## Rule description
+
+A violation of this rule occurs when the parameters to a method or indexer span across multiple lines, but the first parameter does not start on the line after the opening bracket. For example:
+
+```csharp
+public string JoinName(string first, 
+    string last)
+{
+}
+```
+
+The parameters should begin on the line after the declaration, whenever the parameter span across multiple lines:
+
+```csharp
+public string JoinName(
+    string first, 
+    string last)
+{
+}
+```
+
+## How to fix violations
+
+To fix a violation of this rule, ensure that the first parameter starts on the line after the opening bracket, or place all parameters on the same line if the parameters are not too long.
+
+## How to suppress violations
+
+```csharp
+[SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SX1116:SplitParametersMustStartOnLineAfterDeclaration", Justification = "Reviewed.")]
+```
+
+```csharp
+#pragma warning disable SX1116 // SplitParametersMustStartOnLineAfterDeclaration
+#pragma warning restore SX1116 // SplitParametersMustStartOnLineAfterDeclaration
+```

--- a/documentation/SX1117.md
+++ b/documentation/SX1117.md
@@ -1,0 +1,70 @@
+﻿## SX1117
+
+<table>
+<tr>
+  <td>TypeName</td>
+  <td>SX1117ParametersMustBeOnSameLineOrSeparateLines</td>
+</tr>
+<tr>
+  <td>CheckId</td>
+  <td>SX1117</td>
+</tr>
+<tr>
+  <td>Category</td>
+  <td>Readability Rules</td>
+</tr>
+</table>
+
+## Cause
+
+The parameters to a C# method or indexer call or declaration are not all on the same line or each on a separate line.
+
+## Rule description
+
+A violation of this rule occurs when the parameters to a method or indexer are not all on the same line or each on its own line. For example:
+
+```csharp
+public string JoinName(string first, string middle,
+    string last)
+{
+}
+```
+
+The parameters can all be placed on the same line:
+
+```csharp
+public string JoinName(string first, string middle, string last)
+{
+}
+
+public string JoinName(
+    string first, string middle, string last)
+{
+}
+```
+
+Alternatively, each parameter can be placed on its own line:
+
+```csharp
+public string JoinName(
+    string first, 
+    string middle, 
+    string last)
+{
+}
+```
+
+## How to fix violations
+
+To fix a violation of this rule, place all parameters on the same line, or place each parameter on its own line.
+
+## How to suppress violations
+
+```csharp
+[SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SX1117:ParametersMustBeOnSameLineOrSeparateLines", Justification = "Reviewed.")]
+```
+
+```csharp
+#pragma warning disable SX1117 // ParametersMustBeOnSameLineOrSeparateLines
+#pragma warning restore SX1117 // ParametersMustBeOnSameLineOrSeparateLines
+```

--- a/documentation/SX1117.md
+++ b/documentation/SX1117.md
@@ -15,6 +15,10 @@
 </tr>
 </table>
 
+## Alternative rule
+
+This rule is a non-standard extension to the default StyleCop behavior, and represents an alternative style which is adopted by some projects. Alternative rules are known to directly conflict with standard StyleCop rules.
+
 ## Cause
 
 The parameters to a C# method or indexer call or declaration are not all on the same line or each on a separate line.
@@ -24,35 +28,33 @@ The parameters to a C# method or indexer call or declaration are not all on the 
 A violation of this rule occurs when the parameters to a method or indexer are not all on the same line or each on its own line. For example:
 
 ```csharp
-public string JoinName(string first, string middle,
-    string last)
+builder.Services.Configure<HttpClientFactoryOptions>(builder.Name, options =>
 {
-}
+    options.HttpClientActions.Add(configureClient);
+});
 ```
 
 The parameters can all be placed on the same line:
 
 ```csharp
-public string JoinName(string first, string middle, string last)
-{
-}
+builder.Services.Configure<HttpClientFactoryOptions>(builder.Name, options => options.HttpClientActions.Add(configureClient));
 
-public string JoinName(
-    string first, string middle, string last)
-{
-}
+builder.Services.Configure<HttpClientFactoryOptions>(
+    builder.Name, options => options.HttpClientActions.Add(configureClient));
 ```
 
 Alternatively, each parameter can be placed on its own line:
 
 ```csharp
-public string JoinName(
-    string first, 
-    string middle, 
-    string last)
-{
-}
+builder.Services.Configure<HttpClientFactoryOptions>(
+    builder.Name,
+    options =>
+    {
+        options.HttpClientActions.Add(configureClient);
+    });
 ```
+
+This rule is disabled by default. When enabling this rule, the [SA1117](SA1117.md) rule should be disabled.
 
 ## How to fix violations
 


### PR DESCRIPTION
Fixes #3183 by adding alternative rules that can be used in place of SA1116 and SA1117 to use stricter handling of multiline parameters.

This is an alternative approach to #3869.