### PR TITLE
Update SA1623 and SA1624 to not trigger if the summary contains an inheritdoc element

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1623UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1623UnitTests.cs
@@ -345,5 +345,25 @@ public class TestClass
 
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
+
+        [Theory]
+        [InlineData("<inheritdoc/>")]
+        [InlineData("XYZ <inheritdoc/>")]
+        [InlineData("<inheritdoc/> XYZ")]
+        [WorkItem(3465, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3465")]
+        public async Task VerifyInheritdocInSummaryTagIsAllowedAsync(string summary)
+        {
+            var testCode = $@"
+public class TestClass
+{{
+    /// <summary>
+    /// {summary}
+    /// </summary>
+    public int TestProperty {{ get; set; }}
+}}
+";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1624UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1624UnitTests.cs
@@ -156,5 +156,25 @@ public class TestClass
 
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
+
+        [Theory]
+        [InlineData("<inheritdoc/>")]
+        [InlineData("XYZ <inheritdoc/>")]
+        [InlineData("<inheritdoc/> XYZ")]
+        [WorkItem(3465, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3465")]
+        public async Task VerifyInheritdocInSummaryTagIsAllowedAsync(string summary)
+        {
+            var testCode = $@"
+public class TestClass
+{{
+    /// <summary>
+    /// {summary}
+    /// </summary>
+    public int TestProperty {{ get; private set; }}
+}}
+";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
@@ -67,6 +67,12 @@ namespace StyleCop.Analyzers.DocumentationRules
                 return;
             }
 
+            if (summaryElement.Content.GetFirstXmlElement(XmlCommentHelper.InheritdocXmlTag) != null)
+            {
+                // Ignore nodes with an <inheritdoc/> tag.
+                return;
+            }
+
             var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
             var propertyType = context.SemanticModel.GetTypeInfo(propertyDeclaration.Type.StripRefFromType());
             var culture = settings.DocumentationRules.DocumentationCultureInfo;

--- a/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/DocumentationRules/PropertySummaryDocumentationAnalyzer.cs
@@ -61,6 +61,12 @@ namespace StyleCop.Analyzers.DocumentationRules
         /// <inheritdoc/>
         protected override void HandleXmlElement(SyntaxNodeAnalysisContext context, StyleCopSettings settings, bool needsComment, XmlNodeSyntax syntax, XElement completeDocumentation, Location diagnosticLocation)
         {
+            if (!(syntax is XmlElementSyntax summaryElement))
+            {
+                // This is reported by SA1604 or SA1606.
+                return;
+            }
+
             var propertyDeclaration = (PropertyDeclarationSyntax)context.Node;
             var propertyType = context.SemanticModel.GetTypeInfo(propertyDeclaration.Type.StripRefFromType());
             var culture = settings.DocumentationRules.DocumentationCultureInfo;
@@ -70,7 +76,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             {
                 AnalyzeSummaryElement(
                     context,
-                    syntax,
+                    summaryElement,
                     diagnosticLocation,
                     propertyDeclaration,
                     resourceManager.GetString(nameof(DocumentationResources.StartingTextGetsWhether), culture),
@@ -82,7 +88,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             {
                 AnalyzeSummaryElement(
                     context,
-                    syntax,
+                    summaryElement,
                     diagnosticLocation,
                     propertyDeclaration,
                     resourceManager.GetString(nameof(DocumentationResources.StartingTextGets), culture),
@@ -92,7 +98,7 @@ namespace StyleCop.Analyzers.DocumentationRules
             }
         }
 
-        private static void AnalyzeSummaryElement(SyntaxNodeAnalysisContext context, XmlNodeSyntax syntax, Location diagnosticLocation, PropertyDeclarationSyntax propertyDeclaration, string startingTextGets, string startingTextSets, string startingTextGetsOrSets, string startingTextReturns)
+        private static void AnalyzeSummaryElement(SyntaxNodeAnalysisContext context, XmlElementSyntax summaryElement, Location diagnosticLocation, PropertyDeclarationSyntax propertyDeclaration, string startingTextGets, string startingTextSets, string startingTextGetsOrSets, string startingTextReturns)
         {
             var diagnosticProperties = ImmutableDictionary.CreateBuilder<string, string>();
             ArrowExpressionClauseSyntax expressionBody = propertyDeclaration.ExpressionBody;
@@ -114,12 +120,6 @@ namespace StyleCop.Analyzers.DocumentationRules
                         break;
                     }
                 }
-            }
-
-            if (!(syntax is XmlElementSyntax summaryElement))
-            {
-                // This is reported by SA1604 or SA1606.
-                return;
             }
 
             // Add a no code fix tag when the summary element is empty.


### PR DESCRIPTION
Fixes #3465