### PR TITLE
SA1313: Adding features and tests.

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/NamingRules/SA1313CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/NamingRules/SA1313CSharp9UnitTests.cs
@@ -41,5 +41,31 @@ public record R(int A)
 
             await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
+
+        [Fact]
+        [WorkItem(2974, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2974")]
+        public async Task TestLambdaParameterWithAllUnderscoresAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        System.Action<int> action1 = _ => { };
+        System.Action<int, int> action2 = (_, _) => { };
+        System.Action<int, int, int> action3 = (_, _, _) => { };
+        System.Action<int, int, int, int> action4 = (_, _, _, _) => { };
+        System.Action<int> action5 = delegate(int _) { };
+        System.Action<int, int> action6 = delegate(int _, int _) { };
+        System.Action<int, int, int> action7 = delegate(int _, int _, int _) { };
+        System.Action<int, int, int, int> action8 = delegate(int _, int _, int _, int _) { };
+
+        System.Action<int, int> action9 = (_, a) => { };
+        System.Action<int, int> action10 = (a, _) => { };
+        System.Action<int, int, int> action11 = (_, a, _) => { };
+        System.Action<int, int, int> action12 = (a, _, _) => { };
+    }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/HelperTests/SyntaxTreeHelpersTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/HelperTests/SyntaxTreeHelpersTests.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#nullable disable
+
+namespace StyleCop.Analyzers.Test.HelperTests
+{
+    using Microsoft.CodeAnalysis;
+    using StyleCop.Analyzers.Helpers;
+    using Xunit;
+
+    public class SyntaxTreeHelpersTests
+    {
+        [Fact]
+        public void TestContainsUsingAliasArgumentIsNull()
+        {
+            SyntaxTree tree = null;
+            Assert.False(tree.ContainsUsingAlias(null));
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
@@ -594,12 +594,49 @@ public class Test : Testbase
         {
             var testCode = @"public class TypeName
 {
-    public void MethodName(int __)
+    public void MethodName(int __, int _)
     {
     }
 }";
 
-            DiagnosticResult expected = Diagnostic().WithArguments("__").WithLocation(3, 32);
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithArguments("__").WithLocation(3, 32),
+                Diagnostic().WithArguments("_").WithLocation(3, 40),
+            };
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(2974, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2974")]
+        public async Task TestMethodParameterNamedIncrementUnderscoreAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName(int _, int __, int ___)
+    {
+    }
+}";
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(2974, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2974")]
+        public async Task TestMethodParameterNamedIrregularUnderscoreAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName1(int __, int _) { }
+    public void MethodName2(int _, int ___, int __) { }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithArguments("__").WithLocation(3, 33),
+                Diagnostic().WithArguments("_").WithLocation(3, 41),
+                Diagnostic().WithArguments("___").WithLocation(4, 40),
+                Diagnostic().WithArguments("__").WithLocation(4, 49),
+            };
             await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
@@ -436,6 +436,7 @@ public class Test : Testbase
 
         [Fact]
         [WorkItem(1606, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1606")]
+        [WorkItem(2974, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2974")]
         public async Task TestLambdaParameterNamedDoubleUnderscoreAsync()
         {
             var testCode = @"public class TypeName
@@ -448,7 +449,13 @@ public class Test : Testbase
     }
 }";
 
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithArguments("__").WithLocation(5, 38),
+                Diagnostic().WithArguments("__").WithLocation(6, 39),
+                Diagnostic().WithArguments("__").WithLocation(7, 51),
+            };
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -457,6 +464,7 @@ public class Test : Testbase
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         [Fact]
         [WorkItem(1606, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1606")]
+        [WorkItem(2974, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2974")]
         public async Task TestLambdaParameterNamedDoubleUnderscoreUsageAsync()
         {
             var testCode = @"public class TypeName
@@ -469,7 +477,13 @@ public class Test : Testbase
     }
 }";
 
-            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithArguments("__").WithLocation(5, 43),
+                Diagnostic().WithArguments("__").WithLocation(6, 44),
+                Diagnostic().WithArguments("__").WithLocation(7, 56),
+            };
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
@@ -492,21 +506,85 @@ public class Test : Testbase
                 Diagnostic().WithArguments("___").WithLocation(6, 39),
                 Diagnostic().WithArguments("___").WithLocation(7, 51),
             };
-            await VerifyCSharpFixAsync(testCode, expected, testCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(2974, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2974")]
+        public async Task TestLambdaParameterWithIncreasingNumberOfUnderscoresAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName()
+    {
+        System.Action<int> action1 = _ => { };
+        System.Action<int, int> action2 = (_, __) => { };
+        System.Action<int, int, int> action3 = (_, __, ___) => { };
+        System.Action<int, int, int, int> action4 = (_, __, ___, ____) => { };
+        System.Action<int> action5 = delegate(int _) { };
+        System.Action<int, int> action6 = delegate(int _, int __) { };
+        System.Action<int, int, int> action7 = delegate(int _, int __, int ___) { };
+        System.Action<int, int, int, int> action8 = delegate(int _, int __, int ___, int ____) { };
+
+        System.Action<int, int> action9 = (a, _) => { };
+        System.Action<int, int> action10 = (a, __) => { };
+        System.Action<int, int, int> action11 = (_, a, __) => { };
+        System.Action<int, int, int> action12 = (_, __, a) => { };
+        System.Action<int, int, int> action13 = (_, a, ___) => { };
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithArguments("__").WithLocation(15, 48),
+                Diagnostic().WithArguments("___").WithLocation(18, 56),
+            };
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]
         [WorkItem(1343, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1343")]
+        [WorkItem(2974, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2974")]
         public async Task TestMethodParameterNamedUnderscoreAsync()
         {
             var testCode = @"public class TypeName
 {
     public void MethodName(int _)
     {
+        ++_;
     }
 }";
 
             DiagnosticResult expected = Diagnostic().WithArguments("_").WithLocation(3, 32);
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(2974, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2974")]
+        public async Task TestMethodParameterNamedUnderscoresUsedAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public void MethodName1(int _1, short _2)
+    {
+        ++_1;
+        ++_2;
+    }
+
+    public void MethodName2(int _, short __)
+    {
+        ++_;
+        ++__;
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithArguments("_1").WithLocation(3, 33),
+                Diagnostic().WithArguments("_2").WithLocation(3, 43),
+                Diagnostic().WithArguments("_").WithLocation(9, 33),
+                Diagnostic().WithArguments("__").WithLocation(9, 42),
+            };
             await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
@@ -586,6 +664,28 @@ public class TestClass
 
             var expected = Diagnostic().WithLocation(4, 29).WithArguments("_text");
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(2974, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2974")]
+        public async Task TestMethodParameterNamedUnusedAsync()
+        {
+            var testCode = @"public class TypeName
+{
+    public int MethodName(int _used, int _unused, int _, int _1, int _2, int ___, int __)
+    {
+        return _used + _2;
+    }
+}";
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithArguments("_used").WithLocation(3, 31),
+                Diagnostic().WithArguments("_2").WithLocation(3, 70),
+                Diagnostic().WithArguments("___").WithLocation(3, 78),
+                Diagnostic().WithArguments("__").WithLocation(3, 87),
+            };
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/SyntaxTreeHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/SyntaxTreeHelpers.cs
@@ -7,6 +7,7 @@ namespace StyleCop.Analyzers.Helpers
 {
     using System;
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
     using Microsoft.CodeAnalysis;
@@ -70,6 +71,70 @@ namespace StyleCop.Analyzers.Helpers
 
             return firstToken.IsKind(SyntaxKind.EndOfFileToken)
                 && TriviaHelper.IndexOfFirstNonWhitespaceTrivia(firstToken.LeadingTrivia) == -1;
+        }
+
+        /// <summary>
+        /// Recursively descends through the tree structure, enumerating all Statement nodes encountered during the traversal.
+        /// </summary>
+        /// <param name="syntaxNode">The syntax node to recursively.</param>
+        /// <returns>Enumerated StatementSyntax.</returns>
+        public static IEnumerable<StatementSyntax> StatementDescendRecursively(this SyntaxNode syntaxNode)
+        {
+            foreach (var statement in syntaxNode.ChildNodes().OfType<StatementSyntax>())
+            {
+                yield return statement;
+
+                foreach (var innerItem in StatementDescendRecursively(statement))
+                {
+                    yield return innerItem;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Recursively descends through the tree structure, enumerating all Expression nodes encountered during the traversal.
+        /// </summary>
+        /// <param name="syntaxNode">The syntax node to recursively.</param>
+        /// <returns>Enumerated ExpressionSyntax.</returns>
+        public static IEnumerable<ExpressionSyntax> ExpressionDescendRecursively(this SyntaxNode syntaxNode)
+        {
+            foreach (var node in syntaxNode.ChildNodes())
+            {
+                if (node is StatementSyntax statementSyntax)
+                {
+                    foreach (var expression in ExpressionDescendRecursively(statementSyntax))
+                    {
+                        yield return expression;
+                    }
+                }
+                else if (node is ExpressionSyntax expressionSyntax)
+                {
+                    yield return expressionSyntax;
+
+                    foreach (var expression in ExpressionDescendRecursively(expressionSyntax))
+                    {
+                        yield return expression;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Recursively descends through the tree structure, enumerating all Expression nodes encountered during the traversal.
+        /// </summary>
+        /// <param name="expressionSyntax">The expression syntax to recursively.</param>
+        /// <returns>Enumerated ExpressionSyntax.</returns>
+        public static IEnumerable<ExpressionSyntax> ExpressionDescendRecursively(this ExpressionSyntax expressionSyntax)
+        {
+            foreach (var inner in expressionSyntax.ChildNodes().OfType<ExpressionSyntax>())
+            {
+                yield return inner;
+
+                foreach (var innerItem in ExpressionDescendRecursively(inner))
+                {
+                    yield return innerItem;
+                }
+            }
         }
 
         internal static bool ContainsUsingAlias(this SyntaxTree tree, ConcurrentDictionary<SyntaxTree, bool> cache)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/SyntaxTreeHelpers.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/SyntaxTreeHelpers.cs
@@ -74,24 +74,6 @@ namespace StyleCop.Analyzers.Helpers
         }
 
         /// <summary>
-        /// Recursively descends through the tree structure, enumerating all Statement nodes encountered during the traversal.
-        /// </summary>
-        /// <param name="syntaxNode">The syntax node to recursively.</param>
-        /// <returns>Enumerated StatementSyntax.</returns>
-        public static IEnumerable<StatementSyntax> StatementDescendRecursively(this SyntaxNode syntaxNode)
-        {
-            foreach (var statement in syntaxNode.ChildNodes().OfType<StatementSyntax>())
-            {
-                yield return statement;
-
-                foreach (var innerItem in StatementDescendRecursively(statement))
-                {
-                    yield return innerItem;
-                }
-            }
-        }
-
-        /// <summary>
         /// Recursively descends through the tree structure, enumerating all Expression nodes encountered during the traversal.
         /// </summary>
         /// <param name="syntaxNode">The syntax node to recursively.</param>

--- a/documentation/SA1313.md
+++ b/documentation/SA1313.md
@@ -25,8 +25,12 @@ The name of a parameter in C# does not begin with a lower-case letter.
 
 A violation of this rule occurs when the name of a parameter does not begin with a lower-case letter.
 
-An exception to this rule is made for lambda parameters named `_` and `__`. These parameters are often used to designate a
-placeholder parameter which is not actually used in the body of the lambda expression.
+### Exceptions
+
+1. An exception to this rule is made for lambda parameters that have names consisting only of '_', such as '_', '__', or '___'.
+   These parameters are often used to designate a placeholder parameter which is not actually used in the body of the lambda expression.
+2. An exception to this rule is made for method parameters whose names start with '_'.
+   These parameters are often used to indicate parameters that are not actually used in the body of the method.
 
 If the parameter name is intended to match the name of an item associated with Win32 or COM, and thus needs to begin
 with an upper-case letter, place the parameter within a special `NativeMethods` class. A `NativeMethods` class is any


### PR DESCRIPTION
# #2974  SA1313: Parameter '__' must begin with lower-case letter. 

## Support for parameter names containing only '_'

The issue with lambda expression parameter names can be resolved by apply the following three options:
* Allow
  1. All _
    ```
    System.Action<int, int, int> action = (_, _, _) => { };
    ```
  2. Increasing from _ by one character
    ```
    System.Action<int, int, int> action = (_, __, ___) => { };
    ```
* Not allow
  1. Single __ is not allowed
    ```
    System.Action<int> action = __ => { };
    ```

## A compromise between IDE0060 and SA1313
Although it was decided not to fix it in #2599, since there is an exception rule for _ in SA1313, we think that it can be resolved by allowing parameters starting with _ as an exception when they are unused, in response to IDE0060 in SA1313.

- Exception rule:
  * Since _ in method parameter names can be used as variables, the naming convention prioritizes unused intent and allows unused parameter names starting with _.  
    However, to prioritize simple code, explicit discarding is not allowed.
  * In the case where parameter names start with _ and increase by one character at a time.
- Examples
  * Allowed
    ``` csharp
    void Handler(object sender, EventArgs e) { _ = sender; _ = e; } // Explicit discards
    ```
  * Allow
    ``` csharp
    void Handler(object _, EventArg __) { }
    void MethodName(int _, int a, int __) { }
    ```
  * Not allow
    ``` csharp
    void Handler(object _1, EventArg _2) { _ = _1; _ = _2; } // Explicit discards
    void MethodName(ref int _) { ++_; }
    ```
