### PR TITLE
SA1137 is not raised

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/ReadabilityRules/SA1137CSharp12UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/ReadabilityRules/SA1137CSharp12UnitTests.cs
@@ -3,9 +3,61 @@
 
 namespace StyleCop.Analyzers.Test.CSharp12.ReadabilityRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp11.ReadabilityRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<
+        StyleCop.Analyzers.ReadabilityRules.SA1137ElementsShouldHaveTheSameIndentation>;
 
     public partial class SA1137CSharp12UnitTests : SA1137CSharp11UnitTests
     {
+        [Fact]
+        [WorkItem(3904, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3904")]
+        public async Task TestCollectionInitializationAsync()
+        {
+            var csharp = new CSharpTest()
+            {
+                TestSources =
+                {
+                    @"
+                    class FirstCase
+                    {
+                        private readonly System.Collections.Generic.List<string> example1 = 
+                        [
+                            ""a"",
+                    ""b"",
+                                    ""c"",
+                        ];
+                    }",
+                    @"
+                    class SecondCase
+                    {
+                        private readonly System.Collections.Generic.List<int> example2 = 
+                        [
+                            1,
+                            2,
+                    3,
+                    4,
+                        ];
+                    }",
+                    @"
+                    class ThirdCase
+                    {
+                        private readonly System.Collections.Generic.List<int> example3 = [1, 2, 3, 4];
+                    }",
+                },
+                ExpectedDiagnostics =
+                {
+                    DiagnosticResult.CompilerWarning("SA1137").WithLocation("/0/Test0.cs", 7, 1),
+                    DiagnosticResult.CompilerWarning("SA1137").WithLocation("/0/Test0.cs", 8, 1),
+                    DiagnosticResult.CompilerWarning("SA1137").WithLocation("/0/Test1.cs", 8, 1),
+                    DiagnosticResult.CompilerWarning("SA1137").WithLocation("/0/Test1.cs", 9, 1),
+                },
+            };
+
+            await csharp.RunAsync(CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }


### PR DESCRIPTION
Issue URL: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3904

Collectionexpressions are detected as variable declarations and not as InitializerExpression. 

Previously they where checked based on the declaration itself (so we only have 1 Item e.g. `var myVariable = [1,2,3])` . Now, for collection initializations we get the SyntaxNode from the variable and then validate each item of the collection on its own. 

Since this is my first open source contribution feedback is very welcome. 

I also found 2 points where I'm not sure how to proceed with: 
- `Microsoft.CodeAnalysis.CSharp` is installed with V.1.2.1 @Stylecop.Analyzers. V.4.7.0 introduced  the `CollectionExpressionSyntax` that would simply my `IsCollectionExpression()` to just a type check basiclly. Also the "workaround" with that id could be removed so imo it would be way cleaner, due to beeing 3 Major Versions behind i didnt wanted to update, since i basiclly dont know the project and also what could be affected by that upgrade. 
-  locally StyleCop.Analyzers.Test.CSharp8.SpacingRules.SA1009CSharp8UnitTests.TestMissingTokenAsync failed due to having a different Windows language. A possible solution could be https://stackoverflow.com/questions/5793000/is-this-a-good-approach-for-temporarily-changing-the-current-threads-culture 