### PR TITLE
Update SA1008OpeningParenthesisMustBeSpacedCorrectly to disallow a leading space before a lambda in a collection expression

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/SpacingRules/SA1008CSharp12UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp12/SpacingRules/SA1008CSharp12UnitTests.cs
@@ -5,6 +5,7 @@ namespace StyleCop.Analyzers.Test.CSharp12.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp11.SpacingRules;
     using Xunit;
 
@@ -27,6 +28,27 @@ using TestAlias = (string X, bool Y);";
 
             var expected = Diagnostic(DescriptorPreceded).WithLocation(0);
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3931, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3931")]
+        public async Task TestParenthesizedLambdaInCollectionExpressionAsync()
+        {
+            var testCode = @"
+class TestClass
+{
+    private System.Action[] actions = [ [|(|]) => {}];
+}
+";
+
+            var fixedCode = @"
+class TestClass
+{
+    private System.Action[] actions = [() => {}];
+}
+";
+
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/SpacingRules/SA1008OpeningParenthesisMustBeSpacedCorrectly.cs
@@ -248,7 +248,8 @@ namespace StyleCop.Analyzers.SpacingRules
 
             case SyntaxKind.ParameterList:
                 var partOfLambdaExpression = token.Parent.Parent.IsKind(SyntaxKind.ParenthesizedLambdaExpression);
-                haveLeadingSpace = partOfLambdaExpression;
+                var startOfCollectionExpression = prevToken.IsKind(SyntaxKind.OpenBracketToken) && prevToken.Parent.IsKind(SyntaxKindEx.CollectionExpression);
+                haveLeadingSpace = partOfLambdaExpression && !startOfCollectionExpression;
                 break;
 
             case SyntaxKindEx.TupleType:


### PR DESCRIPTION
Fixes #3931