### PR TITLE
Use existing constant SyntaxKind.GlobalKeyword

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/UsingAliasCache.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/UsingAliasCache.cs
@@ -71,7 +71,7 @@ namespace StyleCop.Analyzers.Helpers
         {
             // Check for "global" using aliases in one specific syntax tree
             var nodes = ((CompilationUnitSyntax)tree.GetRoot()).Usings;
-            return nodes.Any(x => x.GlobalKeyword().IsKind(SyntaxKindEx.GlobalKeyword) && x.Alias != null);
+            return nodes.Any(x => x.GlobalKeyword().IsKind(SyntaxKind.GlobalKeyword) && x.Alias != null);
         }
 
         private bool ContainsGlobalUsingAlias(SemanticModel semanticModel, CancellationToken cancellationToken)

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/SyntaxKindEx.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Lightup/SyntaxKindEx.cs
@@ -9,7 +9,6 @@ namespace StyleCop.Analyzers.Lightup
     {
         public const SyntaxKind DotDotToken = (SyntaxKind)8222;
         public const SyntaxKind QuestionQuestionEqualsToken = (SyntaxKind)8284;
-        public const SyntaxKind GlobalKeyword = (SyntaxKind)8408;
         public const SyntaxKind OrKeyword = (SyntaxKind)8438;
         public const SyntaxKind AndKeyword = (SyntaxKind)8439;
         public const SyntaxKind NotKeyword = (SyntaxKind)8440;


### PR DESCRIPTION
`SyntaxKindEx.GlobalKeyword` was added unnecessarily in 77ee83d; use the existing constant `SyntaxKind.GlobalKeyword` instead.