### PR TITLE
Updates for covariant return types in C# 9

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/DocumentationRules/SA1615CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/DocumentationRules/SA1615CSharp9UnitTests.cs
@@ -3,9 +3,73 @@
 
 namespace StyleCop.Analyzers.Test.CSharp9.DocumentationRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp8.DocumentationRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1615ElementReturnValueMustBeDocumented>;
 
     public partial class SA1615CSharp9UnitTests : SA1615CSharp8UnitTests
     {
+        [Fact]
+        [WorkItem(3975, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3975")]
+        public async Task TestCovariantOverrideMissingReturnsDocumentationAsync()
+        {
+            var testCode = @"
+public class BaseType
+{
+}
+
+public class DerivedType : BaseType
+{
+}
+
+public class BaseClass
+{
+    /// <summary>Creates a base instance.</summary>
+    /// <returns>A <see cref=""BaseType""/> instance.</returns>
+    public virtual BaseType Create() => new BaseType();
+}
+
+public class DerivedClass : BaseClass
+{
+    /// <summary>Creates a derived instance.</summary>
+    public override [|DerivedType|] Create() => new DerivedType();
+}
+";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3975, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3975")]
+        public async Task TestCovariantOverrideInheritsReturnsDocumentationAsync()
+        {
+            var testCode = @"
+public class BaseType
+{
+}
+
+public class DerivedType : BaseType
+{
+}
+
+public class BaseClass
+{
+    /// <summary>Creates a base instance.</summary>
+    /// <returns>A <see cref=""BaseType""/> instance.</returns>
+    public virtual BaseType Create() => new BaseType();
+}
+
+public class DerivedClass : BaseClass
+{
+    /// <inheritdoc/>
+    public override DerivedType Create() => new DerivedType();
+}
+";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/OrderingRules/SA1206CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/OrderingRules/SA1206CSharp9UnitTests.cs
@@ -3,9 +3,62 @@
 
 namespace StyleCop.Analyzers.Test.CSharp9.OrderingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp8.OrderingRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.OrderingRules.SA1206DeclarationKeywordsMustFollowOrder,
+        StyleCop.Analyzers.OrderingRules.SA1206CodeFixProvider>;
 
     public partial class SA1206CSharp9UnitTests : SA1206CSharp8UnitTests
     {
+        [Fact]
+        [WorkItem(3975, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3975")]
+        public async Task TestCovariantOverrideKeywordsOutOfOrderAsync()
+        {
+            var testCode = @"
+public class BaseType
+{
+}
+
+public class DerivedType : BaseType
+{
+}
+
+public class BaseClass
+{
+    public virtual BaseType Create() => new BaseType();
+}
+
+public class DerivedClass : BaseClass
+{
+    override [|public|] DerivedType Create() => new DerivedType();
+}
+";
+
+            var fixedCode = @"
+public class BaseType
+{
+}
+
+public class DerivedType : BaseType
+{
+}
+
+public class BaseClass
+{
+    public virtual BaseType Create() => new BaseType();
+}
+
+public class DerivedClass : BaseClass
+{
+    public override DerivedType Create() => new DerivedType();
+}
+";
+
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/ReadabilityRules/SA1100CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/ReadabilityRules/SA1100CSharp9UnitTests.cs
@@ -3,9 +3,110 @@
 
 namespace StyleCop.Analyzers.Test.CSharp9.ReadabilityRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp8.ReadabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.ReadabilityRules.SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists,
+        StyleCop.Analyzers.ReadabilityRules.SA1100CodeFixProvider>;
 
     public partial class SA1100CSharp9UnitTests : SA1100CSharp8UnitTests
     {
+        [Fact]
+        [WorkItem(3975, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3975")]
+        public async Task TestCovariantOverrideAllowsBaseCallWhenOverrideExistsAsync()
+        {
+            var testCode = @"
+public class BaseType
+{
+}
+
+public class DerivedType : BaseType
+{
+}
+
+public class BaseClass
+{
+    protected virtual BaseType Create() => new BaseType();
+}
+
+public class DerivedClass : BaseClass
+{
+    protected override DerivedType Create()
+    {
+        var value = base.Create();
+        return new DerivedType();
+    }
+}
+";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3975, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3975")]
+        public async Task TestBaseCallFlaggedWhenOverrideOnlyInIntermediateTypeAsync()
+        {
+            var testCode = @"
+public class BaseType
+{
+}
+
+public class DerivedType : BaseType
+{
+}
+
+public class BaseClass
+{
+    protected virtual BaseType Create() => new BaseType();
+}
+
+public class IntermediateClass : BaseClass
+{
+    protected override DerivedType Create() => new DerivedType();
+}
+
+public class DerivedClass : IntermediateClass
+{
+    public BaseType CreateThroughBase()
+    {
+        return [|base|].Create();
+    }
+}
+";
+
+            var fixedCode = @"
+public class BaseType
+{
+}
+
+public class DerivedType : BaseType
+{
+}
+
+public class BaseClass
+{
+    protected virtual BaseType Create() => new BaseType();
+}
+
+public class IntermediateClass : BaseClass
+{
+    protected override DerivedType Create() => new DerivedType();
+}
+
+public class DerivedClass : IntermediateClass
+{
+    public BaseType CreateThroughBase()
+    {
+        return this.Create();
+    }
+}
+";
+
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/documentation/SA1100.md
+++ b/documentation/SA1100.md
@@ -44,9 +44,13 @@ public override string JoinName(string first, string last)
 }
 ```
 
-At this point, the local call to `base.JoinName(...)` most likely introduces a bug into the code. This call will always call the base class method and will cause the local override to be ignored. 
+At this point, the local call to `base.JoinName(...)` most likely introduces a bug into the code. This call will always call the base class method and will cause the local override to be ignored.
 
 For this reason, calls to members from a base class should not begin with `base.`, unless a local override is implemented, and the developer wants to specifically call the base class member. When there is no local override of the base class member, the call should be prefixed with `this.` rather than `base.`.
+
+### Covariant return types
+
+Starting in C# 9, overrides can return a more derived type than the base member. A `base.` call still bypasses the most-derived override, even when an intermediate class provides a covariant implementation. SA1100 continues to report `base.` calls from a class that does not declare its own override, and the suggested fix remains to call the member through `this.` instead.
 
 ## How to fix violations
 

--- a/documentation/SA1600.md
+++ b/documentation/SA1600.md
@@ -83,6 +83,31 @@ class Car : Vehicle
 }
 ```
 
+Starting with C# 9, overrides can declare covariant return types. Documentation can still be inherited directly from the base member using `<inheritdoc/>`:
+
+```csharp
+/// <summary>
+/// Base factory.
+/// </summary>
+class WidgetFactory
+{
+  /// <summary>
+  /// Creates a widget.
+  /// </summary>
+  /// <returns>The newly created <see cref="Widget"/>.</returns>
+  public virtual Widget Create() => new Widget();
+}
+
+/// <summary>
+/// Specialized factory.
+/// </summary>
+class FancyWidgetFactory : WidgetFactory
+{
+  /// <inheritdoc/>
+  public override FancyWidget Create() => new FancyWidget();
+}
+```
+
 ## How to suppress violations
 
 ```csharp


### PR DESCRIPTION
Only changes tests and documentation.

Closes #3975