### PR TITLE
Update for partial methods in C# 9

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/DocumentationRules/SA1611CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/DocumentationRules/SA1611CSharp9UnitTests.cs
@@ -9,9 +9,33 @@ namespace StyleCop.Analyzers.Test.CSharp9.DocumentationRules
     using StyleCop.Analyzers.Test.CSharp8.DocumentationRules;
     using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1611ElementParametersMustBeDocumented>;
 
     public partial class SA1611CSharp9UnitTests : SA1611CSharp8UnitTests
     {
+        [Fact]
+        [WorkItem(3971, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3971")]
+        public async Task TestPartialMethodDeclarationMissingParameterDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Tests a partial method.
+/// </summary>
+public partial class TestClass
+{
+    /// <summary>Declaration.</summary>
+    public partial void TestMethod(int {|#0:value|});
+
+    public partial void TestMethod(int value)
+    {
+    }
+}";
+
+            var expected = Diagnostic().WithLocation(0).WithArguments("value");
+
+            await VerifyCSharpDiagnosticAsync(testCode, new[] { expected }, CancellationToken.None).ConfigureAwait(false);
+        }
+
         [Theory]
         [MemberData(nameof(CommonMemberData.RecordTypeDeclarationKeywords), MemberType = typeof(CommonMemberData))]
         [WorkItem(3770, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3770")]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/DocumentationRules/SA1612CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/DocumentationRules/SA1612CSharp9UnitTests.cs
@@ -3,9 +3,36 @@
 
 namespace StyleCop.Analyzers.Test.CSharp9.DocumentationRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using StyleCop.Analyzers.Test.CSharp8.DocumentationRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1612ElementParameterDocumentationMustMatchElementParameters>;
 
     public partial class SA1612CSharp9UnitTests : SA1612CSharp8UnitTests
     {
+        [Fact]
+        [WorkItem(3971, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3971")]
+        public async Task TestPartialMethodDeclarationWithMismatchedParameterDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Tests a partial method.
+/// </summary>
+public partial class TestClass
+{
+    /// <summary>Declaration.</summary>
+    /// <param name=""{|#0:value|}"">Value.</param>
+    public partial void TestMethod(int other);
+
+    public partial void TestMethod(int other)
+    {
+    }
+}";
+
+            var expected = Diagnostic().WithLocation(0).WithArguments("value");
+
+            await VerifyCSharpDiagnosticAsync(testCode, new[] { expected }, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/DocumentationRules/SA1615CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/DocumentationRules/SA1615CSharp9UnitTests.cs
@@ -3,9 +3,33 @@
 
 namespace StyleCop.Analyzers.Test.CSharp9.DocumentationRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using StyleCop.Analyzers.Test.CSharp8.DocumentationRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1615ElementReturnValueMustBeDocumented>;
 
     public partial class SA1615CSharp9UnitTests : SA1615CSharp8UnitTests
     {
+        [Fact]
+        [WorkItem(3971, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3971")]
+        public async Task TestPartialMethodDeclarationMissingReturnsDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Tests a partial method.
+/// </summary>
+public partial class TestClass
+{
+    /// <summary>Declaration.</summary>
+    public partial {|#0:int|} TestMethod(int value);
+
+    public partial int TestMethod(int value) => value;
+}";
+
+            var expected = Diagnostic().WithLocation(0);
+
+            await VerifyCSharpDiagnosticAsync(testCode, new[] { expected }, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/DocumentationRules/SA1618CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/DocumentationRules/SA1618CSharp9UnitTests.cs
@@ -3,9 +3,35 @@
 
 namespace StyleCop.Analyzers.Test.CSharp9.DocumentationRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
     using StyleCop.Analyzers.Test.CSharp8.DocumentationRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1618GenericTypeParametersMustBeDocumented>;
 
     public partial class SA1618CSharp9UnitTests : SA1618CSharp8UnitTests
     {
+        [Fact]
+        [WorkItem(3971, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3971")]
+        public async Task TestPartialMethodDeclarationMissingTypeParameterDocumentationAsync()
+        {
+            var testCode = @"
+/// <summary>
+/// Tests a partial method.
+/// </summary>
+public partial class TestClass
+{
+    /// <summary>Declaration.</summary>
+    public partial void TestMethod<{|#0:T|}>();
+
+    public partial void TestMethod<T>()
+    {
+    }
+}";
+
+            var expected = Diagnostic().WithLocation(0).WithArguments("T");
+
+            await VerifyCSharpDiagnosticAsync(testCode, new[] { expected }, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/OrderingRules/SA1202CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/OrderingRules/SA1202CSharp9UnitTests.cs
@@ -3,9 +3,65 @@
 
 namespace StyleCop.Analyzers.Test.CSharp9.OrderingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp8.OrderingRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.OrderingRules.SA1202ElementsMustBeOrderedByAccess,
+        StyleCop.Analyzers.OrderingRules.ElementOrderCodeFixProvider>;
 
     public partial class SA1202CSharp9UnitTests : SA1202CSharp8UnitTests
     {
+        [Fact]
+        [WorkItem(3971, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3971")]
+        public async Task TestPartialMethodExplicitAccessibilityDeclarationOrderingAsync()
+        {
+            var testCode = @"
+public partial class TestClass
+{
+    private void Helper() { }
+
+    public partial void {|#0:TestMethod|}();
+}
+
+public partial class TestClass
+{
+    public partial void TestMethod()
+    {
+    }
+}
+";
+
+            var expected = Diagnostic().WithLocation(0).WithArguments("public", "private");
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3971, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3971")]
+        public async Task TestPartialMethodExplicitAccessibilityImplementationOrderingAsync()
+        {
+            var testCode = @"
+public partial class TestClass
+{
+    public partial void TestMethod();
+}
+
+public partial class TestClass
+{
+    private void Helper() { }
+
+    public partial void {|#0:TestMethod|}()
+    {
+    }
+}
+";
+
+            var expected = Diagnostic().WithLocation(0).WithArguments("public", "private");
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/OrderingRules/SA1205CSharp9UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp9/OrderingRules/SA1205CSharp9UnitTests.cs
@@ -3,9 +3,80 @@
 
 namespace StyleCop.Analyzers.Test.CSharp9.OrderingRules
 {
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Test.CSharp8.OrderingRules;
+    using Xunit;
+    using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
+        StyleCop.Analyzers.OrderingRules.SA1205PartialElementsMustDeclareAccess,
+        StyleCop.Analyzers.OrderingRules.SA1205CodeFixProvider>;
 
     public partial class SA1205CSharp9UnitTests : SA1205CSharp8UnitTests
     {
+        [Fact]
+        [WorkItem(3971, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3971")]
+        public async Task TestPartialMethodWithPublicAccessModifierAsync()
+        {
+            var testCode = @"
+public partial class TestClass
+{
+    public partial int TestMethod();
+}
+
+public partial class TestClass
+{
+    public partial int TestMethod()
+    {
+        return 0;
+    }
+}
+";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3971, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3971")]
+        public async Task TestPartialMethodWithoutAccessModifierAsync()
+        {
+            var testCode = @"
+public partial class TestClass
+{
+    partial void {|#0:TestMethod|}();
+}
+
+public partial class TestClass
+{
+    public partial void {|CS8799:TestMethod|}()
+    {
+    }
+}
+";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Fact]
+        [WorkItem(3971, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3971")]
+        public async Task TestPartialMethodWithoutAccessModifierNonVoidAsync()
+        {
+            var testCode = @"
+public partial class TestClass
+{
+    partial int {|CS8796:TestMethod|}();
+}
+
+public partial class TestClass
+{
+    public partial int {|CS8799:TestMethod|}()
+    {
+        return 0;
+    }
+}
+";
+
+            await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1612UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1612UnitTests.cs
@@ -562,8 +562,6 @@ public class ClassName
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        // Syntax node actions for type declarations with a primary constructor were called twice
-        // before support for c# 11 was added.
         protected static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken)
             => VerifyCSharpDiagnosticAsync(source, testSettings: null, expected, ignoreCompilerDiagnostics: false, cancellationToken);
 
@@ -682,6 +680,8 @@ public class ClassName
             return GetExpectedDiagnostics(new[] { normallyExpected }, declaration);
         }
 
+        // Syntax node actions for type declarations with a primary constructor were called twice
+        // before support for c# 11 was added.
         private static DiagnosticResult[] GetExpectedDiagnostics(DiagnosticResult[] normallyExpected, string declaration)
         {
             var isPrimaryConstructor = declaration.Contains("record") || declaration.Contains("class") || declaration.Contains("struct");

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1612UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1612UnitTests.cs
@@ -562,35 +562,15 @@ public class ClassName
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        private static DiagnosticResult[] GetExpectedDiagnostics(DiagnosticResult normallyExpected, string declaration)
-        {
-            return GetExpectedDiagnostics(new[] { normallyExpected }, declaration);
-        }
-
         // Syntax node actions for type declarations with a primary constructor were called twice
         // before support for c# 11 was added.
-        private static DiagnosticResult[] GetExpectedDiagnostics(DiagnosticResult[] normallyExpected, string declaration)
-        {
-            var isPrimaryConstructor = declaration.Contains("record") || declaration.Contains("class") || declaration.Contains("struct");
-
-            if (isPrimaryConstructor && !LightupHelpers.SupportsCSharp11)
-            {
-                // Diagnostic issued twice because of https://github.com/dotnet/roslyn/issues/53136 and https://github.com/dotnet/roslyn/issues/70488
-                return normallyExpected.Concat(normallyExpected).ToArray();
-            }
-            else
-            {
-                return normallyExpected;
-            }
-        }
-
-        private static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken)
+        protected static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken)
             => VerifyCSharpDiagnosticAsync(source, testSettings: null, expected, ignoreCompilerDiagnostics: false, cancellationToken);
 
-        private static Task VerifyCSharpDiagnosticAsync(string source, string testSettings, DiagnosticResult[] expected, CancellationToken cancellationToken)
+        protected static Task VerifyCSharpDiagnosticAsync(string source, string testSettings, DiagnosticResult[] expected, CancellationToken cancellationToken)
             => VerifyCSharpDiagnosticAsync(source, testSettings, expected, ignoreCompilerDiagnostics: false, cancellationToken);
 
-        private static Task VerifyCSharpDiagnosticAsync(string source, string testSettings, DiagnosticResult[] expected, bool ignoreCompilerDiagnostics, CancellationToken cancellationToken)
+        protected static Task VerifyCSharpDiagnosticAsync(string source, string testSettings, DiagnosticResult[] expected, bool ignoreCompilerDiagnostics, CancellationToken cancellationToken)
         {
             string contentWithoutParamDocumentation = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
 <ClassName>
@@ -695,6 +675,24 @@ public class ClassName
 
             test.ExpectedDiagnostics.AddRange(expected);
             return test.RunAsync(cancellationToken);
+        }
+
+        private static DiagnosticResult[] GetExpectedDiagnostics(DiagnosticResult normallyExpected, string declaration)
+        {
+            return GetExpectedDiagnostics(new[] { normallyExpected }, declaration);
+        }
+
+        private static DiagnosticResult[] GetExpectedDiagnostics(DiagnosticResult[] normallyExpected, string declaration)
+        {
+            var isPrimaryConstructor = declaration.Contains("record") || declaration.Contains("class") || declaration.Contains("struct");
+
+            if (isPrimaryConstructor && !LightupHelpers.SupportsCSharp11)
+            {
+                // Diagnostic issued twice because of https://github.com/dotnet/roslyn/issues/53136 and https://github.com/dotnet/roslyn/issues/70488
+                return normallyExpected.Concat(normallyExpected).ToArray();
+            }
+
+            return normallyExpected;
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1615UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1615UnitTests.cs
@@ -340,10 +340,10 @@ internal class ClassName
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        private static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken)
+        protected static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken)
             => VerifyCSharpFixAsync(source, new[] { expected }, fixedSource: null, cancellationToken);
 
-        private static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken)
+        protected static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken)
             => VerifyCSharpFixAsync(source, expected, fixedSource: null, cancellationToken);
 
         private static Task VerifyCSharpFixAsync(string source, DiagnosticResult expected, string fixedSource, CancellationToken cancellationToken)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1618UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1618UnitTests.cs
@@ -427,10 +427,10 @@ internal class ClassName
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        private static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken)
+        protected static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult expected, CancellationToken cancellationToken)
             => VerifyCSharpDiagnosticAsync(source, new[] { expected }, cancellationToken);
 
-        private static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken)
+        protected static Task VerifyCSharpDiagnosticAsync(string source, DiagnosticResult[] expected, CancellationToken cancellationToken)
         {
             string contentClassWithTypeparamDoc = @"<?xml version=""1.0"" encoding=""utf-8"" ?>
 <TestClass>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
@@ -989,5 +989,23 @@ public class TestClass : TestInterface
 
             await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
+
+        [Fact]
+        [WorkItem(3971, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3971")]
+        public async Task TestPartialMethodImplicitPrivateOrderingAsync()
+        {
+            var testCode = @"
+public partial class TestClass
+{
+    partial void TestMethod();
+
+    public void {|#0:PublicMethod|}() { }
+}
+";
+
+            var expected = Diagnostic().WithLocation(0).WithArguments("public", "private");
+
+            await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
+        }
     }
 }

--- a/documentation/SA1205.md
+++ b/documentation/SA1205.md
@@ -23,6 +23,13 @@ The partial element does not have an access modifier defined.
 
 A violation of this rule occurs when the partial elements does not have an access modifier defined.
 
+### Partial methods in C# 9
+
+C# 9 allows partial methods to have access modifiers and non-`void` return types. For compatibility across versions,
+SA1205 does not require these access modifiers to be included. In addition, the compiler enforces the presence of access
+modifiers when using the new features, so SA1205 will not apply duplicate diagnostics in cases where required modifiers
+are omitted.
+
 ## How to fix violations
 
 To fix an instance of this violation, specify an access modifier for the partial element.


### PR DESCRIPTION
Only changes tests and documentation.

Closes #3971