### PR TITLE
Fix line ending handling

### DIFF
--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/FormattingHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/Helpers/FormattingHelper.cs
@@ -6,14 +6,87 @@
 namespace StyleCop.Analyzers.Helpers
 {
     using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CodeActions;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
     using Microsoft.CodeAnalysis.Formatting;
+    using Microsoft.CodeAnalysis.Options;
+    using Microsoft.CodeAnalysis.Text;
 
     internal static class FormattingHelper
     {
+        /// <summary>
+        /// Retrieves the appropriate end-of-line trivia for use in code fixes at the specified token location.
+        /// </summary>
+        /// <remarks><para>This method attempts to preserve the existing line ending style near the specified
+        /// token. If no suitable end-of-line trivia is found, a default carriage return and line feed (CRLF) is
+        /// returned.</para></remarks>
+        /// <param name="token">The syntax token for which to determine the end-of-line trivia.</param>
+        /// <param name="options">The options to use for formatting. This value is only used if the document does not already contain line endings.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+        /// <returns>A <see cref="SyntaxTrivia"/> representing the end-of-line trivia suitable for code fixes at the given token
+        /// position.</returns>
+        public static async Task<SyntaxTrivia> GetEndOfLineForCodeFixAsync(SyntaxToken token, OptionSet options, CancellationToken cancellationToken)
+        {
+            if (TryGetPrecedingEndOfLineTrivia(token, out var precedingEndOfLine))
+            {
+                return precedingEndOfLine;
+            }
+
+            var text = await token.SyntaxTree.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            return GetEndOfLineForCodeFix(token, text, options);
+        }
+
+        /// <summary>
+        /// Retrieves the appropriate end-of-line trivia for use in code fixes, based on the position of the specified
+        /// syntax token and the provided source text.
+        /// </summary>
+        /// <remarks><para>This method examines the token's position and surrounding lines to select the most
+        /// contextually appropriate end-of-line trivia, ensuring consistency with the existing file
+        /// formatting.</para></remarks>
+        /// <param name="token">The syntax token for which to determine the end-of-line trivia.</param>
+        /// <param name="text">The source text containing the token. Used to identify line boundaries and end-of-line characters.</param>
+        /// <param name="options">The options to use for formatting. This value is only used if the document does not already contain line endings.</param>
+        /// <returns>A <see cref="SyntaxTrivia"/> representing the end-of-line trivia suitable for code fixes. If no specific
+        /// trivia is found, returns a default carriage return and line feed trivia.</returns>
+        public static SyntaxTrivia GetEndOfLineForCodeFix(SyntaxToken token, SourceText text, OptionSet options)
+        {
+            if (TryGetPrecedingEndOfLineTrivia(token, out var precedingEndOfLine))
+            {
+                return precedingEndOfLine;
+            }
+
+            var lineNumber = token.GetLine();
+            if (lineNumber >= 0 && lineNumber < text.Lines.Count && GetEndOfLineTriviaForLine(text.Lines[lineNumber]) is { } followingTrivia)
+            {
+                return followingTrivia;
+            }
+
+            if (lineNumber > 0 && GetEndOfLineTriviaForLine(text.Lines[lineNumber - 1]) is { } precedingTrivia)
+            {
+                return precedingTrivia;
+            }
+
+            return SyntaxFactory.SyntaxTrivia(SyntaxKind.EndOfLineTrivia, options.GetOption(FormattingOptions.NewLine, LanguageNames.CSharp));
+
+            static SyntaxTrivia? GetEndOfLineTriviaForLine(TextLine textLine)
+            {
+                return (textLine.EndIncludingLineBreak - textLine.End) switch
+                {
+                    2 => SyntaxFactory.CarriageReturnLineFeed,
+                    1 => textLine.Text[textLine.End] switch
+                    {
+                        '\n' => SyntaxFactory.LineFeed,
+                        char c => SyntaxFactory.EndOfLine(c.ToString()),
+                    },
+                    _ => null,
+                };
+            }
+        }
+
         public static SyntaxTrivia GetNewLineTrivia(Document document)
         {
             return SyntaxFactory.SyntaxTrivia(SyntaxKind.EndOfLineTrivia, document.Project.Solution.Workspace.Options.GetOption(FormattingOptions.NewLine, LanguageNames.CSharp));
@@ -151,6 +224,40 @@ namespace StyleCop.Analyzers.Helpers
         private static SyntaxTrivia WithoutFormattingImpl(SyntaxTrivia trivia)
         {
             return trivia.WithoutAnnotations(Formatter.Annotation, SyntaxAnnotation.ElasticAnnotation);
+        }
+
+        /// <summary>
+        /// Returns the closest end of line trivia preceding the <paramref name="token"/>.
+        /// This currently only looks immediately before the specified token.
+        /// </summary>
+        /// <param name="token">The token to process.</param>
+        /// <param name="trivia">When this method returns, contains the closest preceding end of line trivia, if found; otherwise, the default value.</param>
+        /// <returns><see langword="true"/> if an end of line trivia was found; otherwise, <see langword="false"/>.</returns>
+        private static bool TryGetPrecedingEndOfLineTrivia(this SyntaxToken token, out SyntaxTrivia trivia)
+        {
+            var leadingTrivia = token.LeadingTrivia;
+            for (var i = leadingTrivia.Count - 1; i >= 0; i--)
+            {
+                if (leadingTrivia[i].IsKind(SyntaxKind.EndOfLineTrivia))
+                {
+                    trivia = leadingTrivia[i];
+                    return true;
+                }
+            }
+
+            var prevToken = token.GetPreviousToken();
+            var prevTrailingTrivia = prevToken.TrailingTrivia;
+            for (var i = prevTrailingTrivia.Count - 1; i >= 0; i--)
+            {
+                if (prevTrailingTrivia[i].IsKind(SyntaxKind.EndOfLineTrivia))
+                {
+                    trivia = prevTrailingTrivia[i];
+                    return true;
+                }
+            }
+
+            trivia = default;
+            return false;
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1501CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1501CodeFixProvider.cs
@@ -133,7 +133,7 @@ namespace StyleCop.Analyzers.LayoutRules
             }
             else
             {
-                parentIndentationLevel = IndentationHelper.GetIndentationSteps(indentationSettings, GetFirstOnLineParent(parent));
+                parentIndentationLevel = IndentationHelper.GetIndentationSteps(indentationSettings, parent.GetFirstOnLineAncestorOrSelf());
             }
 
             return parentIndentationLevel;
@@ -273,18 +273,6 @@ namespace StyleCop.Analyzers.LayoutRules
             }
 
             return statementSyntax;
-        }
-
-        private static SyntaxNode GetFirstOnLineParent(SyntaxNode parent)
-        {
-            // if the parent is not the first on a line, find the parent that is.
-            // This mainly happens for 'else if' statements.
-            while (!parent.GetFirstToken().IsFirstInLine())
-            {
-                parent = parent.Parent;
-            }
-
-            return parent;
         }
 
         private class FixAll : DocumentBasedFixAllProvider

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1513CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/LayoutRules/SA1513CodeFixProvider.cs
@@ -61,11 +61,13 @@ namespace StyleCop.Analyzers.LayoutRules
         private static async Task<SyntaxNode> GetTransformedDocumentAsync(Document document, ImmutableArray<Diagnostic> diagnostics, CancellationToken cancellationToken)
         {
             var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var text = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var options = document.Project.Solution.Workspace.Options;
             return root.ReplaceTokens(
                 diagnostics.Select(diagnostic => root.FindToken(diagnostic.Location.SourceSpan.End)),
                 (originalToken, rewrittenToken) =>
                 {
-                    var endOfLineTrivia = rewrittenToken.GetPrecedingEndOfLineTrivia();
+                    var endOfLineTrivia = FormattingHelper.GetEndOfLineForCodeFix(rewrittenToken, text, options);
                     var newTrivia = rewrittenToken.LeadingTrivia.Insert(0, endOfLineTrivia);
                     return rewrittenToken.WithLeadingTrivia(newTrivia);
                 });

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/NamingRules/RenameToUpperCaseCodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/NamingRules/RenameToUpperCaseCodeFixProvider.cs
@@ -76,7 +76,7 @@ namespace StyleCop.Analyzers.NamingRules
                     {
                         IdentifierNameSyntax identifierSyntax = (IdentifierNameSyntax)token.Parent;
 
-                        var newIdentifierSyntax = identifierSyntax.WithIdentifier(SyntaxFactory.Identifier(newName));
+                        var newIdentifierSyntax = identifierSyntax.WithIdentifier(SyntaxFactory.Identifier(newName)).WithTriviaFrom(identifierSyntax);
 
                         var newRoot = root.ReplaceNode(identifierSyntax, newIdentifierSyntax);
                         return Task.FromResult(context.Document.WithSyntaxRoot(newRoot));

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/SA1212SA1213CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/SA1212SA1213CodeFixProvider.cs
@@ -53,6 +53,8 @@ namespace StyleCop.Analyzers.OrderingRules
         private static async Task<Document> GetTransformedDocumentAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
         {
             var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var options = document.Project.Solution.Workspace.Options;
 
             var accessorToken = syntaxRoot.FindToken(diagnostic.Location.SourceSpan.Start);
             var accessorList = (AccessorListSyntax)accessorToken.Parent.Parent;
@@ -67,8 +69,9 @@ namespace StyleCop.Analyzers.OrderingRules
 
             if (HasLeadingBlankLines(secondAccessor))
             {
+                var endOfLine = FormattingHelper.GetEndOfLineForCodeFix(firstAccesor.Keyword, sourceText, options);
                 trackedFirstAccessor = syntaxRoot.GetCurrentNode(firstAccesor);
-                var newFirstAccessor = trackedFirstAccessor.WithLeadingTrivia(new[] { SyntaxFactory.CarriageReturnLineFeed }.Concat(firstAccesor.GetFirstToken().WithoutLeadingBlankLines().LeadingTrivia));
+                var newFirstAccessor = trackedFirstAccessor.WithLeadingTrivia(new[] { endOfLine }.Concat(firstAccesor.GetFirstToken().WithoutLeadingBlankLines().LeadingTrivia));
                 syntaxRoot = syntaxRoot.ReplaceNode(trackedFirstAccessor, newFirstAccessor);
             }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/UsingCodeFixProvider.UsingsSorter.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/OrderingRules/UsingCodeFixProvider.UsingsSorter.cs
@@ -13,6 +13,7 @@ namespace StyleCop.Analyzers.OrderingRules
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.CSharp.Syntax;
+    using Microsoft.CodeAnalysis.Text;
     using StyleCop.Analyzers.Helpers;
     using StyleCop.Analyzers.Lightup;
     using StyleCop.Analyzers.Settings.ObjectModel;
@@ -92,7 +93,7 @@ namespace StyleCop.Analyzers.OrderingRules
                 return result;
             }
 
-            public SyntaxList<UsingDirectiveSyntax> GenerateGroupedUsings(TreeTextSpan directiveSpan, string indentation, bool withLeadingBlankLine, bool withTrailingBlankLine, bool qualifyNames, bool includeGlobal, bool includeLocal)
+            public SyntaxList<UsingDirectiveSyntax> GenerateGroupedUsings(TreeTextSpan directiveSpan, string indentation, SyntaxTrivia endOfLine, bool withLeadingBlankLine, bool withTrailingBlankLine, bool qualifyNames, bool includeGlobal, bool includeLocal)
             {
                 var usingList = new List<UsingDirectiveSyntax>();
                 List<SyntaxTrivia> triviaToMove = new List<SyntaxTrivia>();
@@ -100,21 +101,21 @@ namespace StyleCop.Analyzers.OrderingRules
 
                 if (includeGlobal)
                 {
-                    usingList.AddRange(this.GenerateUsings(this.systemUsings, directiveSpan, indentation, triviaToMove, qualifyNames, isGlobal: true));
-                    usingList.AddRange(this.GenerateUsings(this.namespaceUsings, directiveSpan, indentation, triviaToMove, qualifyNames, isGlobal: true));
-                    usingList.AddRange(this.GenerateUsings(this.systemStaticImports, directiveSpan, indentation, triviaToMove, qualifyNames, isGlobal: true));
-                    usingList.AddRange(this.GenerateUsings(this.staticImports, directiveSpan, indentation, triviaToMove, qualifyNames, isGlobal: true));
-                    usingList.AddRange(this.GenerateUsings(this.aliases, directiveSpan, indentation, triviaToMove, qualifyNames, isGlobal: true));
+                    usingList.AddRange(this.GenerateUsings(this.systemUsings, directiveSpan, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: true));
+                    usingList.AddRange(this.GenerateUsings(this.namespaceUsings, directiveSpan, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: true));
+                    usingList.AddRange(this.GenerateUsings(this.systemStaticImports, directiveSpan, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: true));
+                    usingList.AddRange(this.GenerateUsings(this.staticImports, directiveSpan, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: true));
+                    usingList.AddRange(this.GenerateUsings(this.aliases, directiveSpan, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: true));
                     lastGlobalDirective = usingList.Count - 1;
                 }
 
                 if (includeLocal)
                 {
-                    usingList.AddRange(this.GenerateUsings(this.systemUsings, directiveSpan, indentation, triviaToMove, qualifyNames, isGlobal: false));
-                    usingList.AddRange(this.GenerateUsings(this.namespaceUsings, directiveSpan, indentation, triviaToMove, qualifyNames, isGlobal: false));
-                    usingList.AddRange(this.GenerateUsings(this.systemStaticImports, directiveSpan, indentation, triviaToMove, qualifyNames, isGlobal: false));
-                    usingList.AddRange(this.GenerateUsings(this.staticImports, directiveSpan, indentation, triviaToMove, qualifyNames, isGlobal: false));
-                    usingList.AddRange(this.GenerateUsings(this.aliases, directiveSpan, indentation, triviaToMove, qualifyNames, isGlobal: false));
+                    usingList.AddRange(this.GenerateUsings(this.systemUsings, directiveSpan, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: false));
+                    usingList.AddRange(this.GenerateUsings(this.namespaceUsings, directiveSpan, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: false));
+                    usingList.AddRange(this.GenerateUsings(this.systemStaticImports, directiveSpan, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: false));
+                    usingList.AddRange(this.GenerateUsings(this.staticImports, directiveSpan, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: false));
+                    usingList.AddRange(this.GenerateUsings(this.aliases, directiveSpan, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: false));
                 }
 
                 if (!this.insertBlankLinesBetweenGroups && lastGlobalDirective >= 0 && lastGlobalDirective < usingList.Count - 1)
@@ -123,7 +124,7 @@ namespace StyleCop.Analyzers.OrderingRules
                     // usings
                     var last = usingList[lastGlobalDirective];
 
-                    usingList[lastGlobalDirective] = last.WithTrailingTrivia(last.GetTrailingTrivia().Add(SyntaxFactory.CarriageReturnLineFeed));
+                    usingList[lastGlobalDirective] = last.WithTrailingTrivia(last.GetTrailingTrivia().Add(endOfLine));
                 }
 
                 if (triviaToMove.Count > 0)
@@ -135,35 +136,35 @@ namespace StyleCop.Analyzers.OrderingRules
                 if (withLeadingBlankLine && usingList.Count > 0)
                 {
                     var firstUsing = usingList[0];
-                    usingList[0] = firstUsing.WithLeadingTrivia(firstUsing.GetLeadingTrivia().Insert(0, SyntaxFactory.CarriageReturnLineFeed));
+                    usingList[0] = firstUsing.WithLeadingTrivia(firstUsing.GetLeadingTrivia().Insert(0, endOfLine));
                 }
 
                 if (withTrailingBlankLine && (usingList.Count > 0))
                 {
                     var lastUsing = usingList[usingList.Count - 1];
-                    usingList[usingList.Count - 1] = lastUsing.WithTrailingTrivia(lastUsing.GetTrailingTrivia().Add(SyntaxFactory.CarriageReturnLineFeed));
+                    usingList[usingList.Count - 1] = lastUsing.WithTrailingTrivia(lastUsing.GetTrailingTrivia().Add(endOfLine));
                 }
 
                 return SyntaxFactory.List(usingList);
             }
 
-            public SyntaxList<UsingDirectiveSyntax> GenerateGroupedUsings(List<UsingDirectiveSyntax> usingsList, string indentation, bool withLeadingBlankLine, bool withTrailingBlankLine, bool qualifyNames)
+            public SyntaxList<UsingDirectiveSyntax> GenerateGroupedUsings(List<UsingDirectiveSyntax> usingsList, string indentation, SyntaxTrivia endOfLine, bool withLeadingBlankLine, bool withTrailingBlankLine, bool qualifyNames)
             {
                 var usingList = new List<UsingDirectiveSyntax>();
                 List<SyntaxTrivia> triviaToMove = new List<SyntaxTrivia>();
 
-                usingList.AddRange(this.GenerateUsings(this.systemUsings, usingsList, indentation, triviaToMove, qualifyNames, isGlobal: true));
-                usingList.AddRange(this.GenerateUsings(this.namespaceUsings, usingsList, indentation, triviaToMove, qualifyNames, isGlobal: true));
-                usingList.AddRange(this.GenerateUsings(this.systemStaticImports, usingsList, indentation, triviaToMove, qualifyNames, isGlobal: true));
-                usingList.AddRange(this.GenerateUsings(this.staticImports, usingsList, indentation, triviaToMove, qualifyNames, isGlobal: true));
-                usingList.AddRange(this.GenerateUsings(this.aliases, usingsList, indentation, triviaToMove, qualifyNames, isGlobal: true));
+                usingList.AddRange(this.GenerateUsings(this.systemUsings, usingsList, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: true));
+                usingList.AddRange(this.GenerateUsings(this.namespaceUsings, usingsList, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: true));
+                usingList.AddRange(this.GenerateUsings(this.systemStaticImports, usingsList, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: true));
+                usingList.AddRange(this.GenerateUsings(this.staticImports, usingsList, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: true));
+                usingList.AddRange(this.GenerateUsings(this.aliases, usingsList, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: true));
                 int lastGlobalDirective = usingList.Count - 1;
 
-                usingList.AddRange(this.GenerateUsings(this.systemUsings, usingsList, indentation, triviaToMove, qualifyNames, isGlobal: false));
-                usingList.AddRange(this.GenerateUsings(this.namespaceUsings, usingsList, indentation, triviaToMove, qualifyNames, isGlobal: false));
-                usingList.AddRange(this.GenerateUsings(this.systemStaticImports, usingsList, indentation, triviaToMove, qualifyNames, isGlobal: false));
-                usingList.AddRange(this.GenerateUsings(this.staticImports, usingsList, indentation, triviaToMove, qualifyNames, isGlobal: false));
-                usingList.AddRange(this.GenerateUsings(this.aliases, usingsList, indentation, triviaToMove, qualifyNames, isGlobal: false));
+                usingList.AddRange(this.GenerateUsings(this.systemUsings, usingsList, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: false));
+                usingList.AddRange(this.GenerateUsings(this.namespaceUsings, usingsList, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: false));
+                usingList.AddRange(this.GenerateUsings(this.systemStaticImports, usingsList, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: false));
+                usingList.AddRange(this.GenerateUsings(this.staticImports, usingsList, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: false));
+                usingList.AddRange(this.GenerateUsings(this.aliases, usingsList, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal: false));
 
                 if (!this.insertBlankLinesBetweenGroups && lastGlobalDirective >= 0 && lastGlobalDirective < usingList.Count - 1)
                 {
@@ -171,7 +172,7 @@ namespace StyleCop.Analyzers.OrderingRules
                     // usings
                     var last = usingList[lastGlobalDirective];
 
-                    usingList[lastGlobalDirective] = last.WithTrailingTrivia(last.GetTrailingTrivia().Add(SyntaxFactory.CarriageReturnLineFeed));
+                    usingList[lastGlobalDirective] = last.WithTrailingTrivia(last.GetTrailingTrivia().Add(endOfLine));
                 }
 
                 if (triviaToMove.Count > 0)
@@ -183,19 +184,19 @@ namespace StyleCop.Analyzers.OrderingRules
                 if (withLeadingBlankLine && usingList.Count > 0)
                 {
                     var firstUsing = usingList[0];
-                    usingList[0] = firstUsing.WithLeadingTrivia(firstUsing.GetLeadingTrivia().Insert(0, SyntaxFactory.CarriageReturnLineFeed));
+                    usingList[0] = firstUsing.WithLeadingTrivia(firstUsing.GetLeadingTrivia().Insert(0, endOfLine));
                 }
 
                 if (withTrailingBlankLine && (usingList.Count > 0))
                 {
                     var lastUsing = usingList[usingList.Count - 1];
-                    usingList[usingList.Count - 1] = lastUsing.WithTrailingTrivia(lastUsing.GetTrailingTrivia().Add(SyntaxFactory.CarriageReturnLineFeed));
+                    usingList[usingList.Count - 1] = lastUsing.WithTrailingTrivia(lastUsing.GetTrailingTrivia().Add(endOfLine));
                 }
 
                 return SyntaxFactory.List(usingList);
             }
 
-            private List<UsingDirectiveSyntax> GenerateUsings(Dictionary<TreeTextSpan, List<UsingDirectiveSyntax>> usingsGroup, TreeTextSpan directiveSpan, string indentation, List<SyntaxTrivia> triviaToMove, bool qualifyNames, bool isGlobal)
+            private List<UsingDirectiveSyntax> GenerateUsings(Dictionary<TreeTextSpan, List<UsingDirectiveSyntax>> usingsGroup, TreeTextSpan directiveSpan, string indentation, SyntaxTrivia endOfLine, List<SyntaxTrivia> triviaToMove, bool qualifyNames, bool isGlobal)
             {
                 List<UsingDirectiveSyntax> result = new List<UsingDirectiveSyntax>();
                 List<UsingDirectiveSyntax> usingsList;
@@ -205,10 +206,10 @@ namespace StyleCop.Analyzers.OrderingRules
                     return result;
                 }
 
-                return this.GenerateUsings(usingsList, indentation, triviaToMove, qualifyNames, isGlobal);
+                return this.GenerateUsings(usingsList, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal);
             }
 
-            private List<UsingDirectiveSyntax> GenerateUsings(List<UsingDirectiveSyntax> usingsList, string indentation, List<SyntaxTrivia> triviaToMove, bool qualifyNames, bool isGlobal)
+            private List<UsingDirectiveSyntax> GenerateUsings(List<UsingDirectiveSyntax> usingsList, string indentation, SyntaxTrivia endOfLine, List<SyntaxTrivia> triviaToMove, bool qualifyNames, bool isGlobal)
             {
                 List<UsingDirectiveSyntax> result = new List<UsingDirectiveSyntax>();
 
@@ -365,7 +366,7 @@ namespace StyleCop.Analyzers.OrderingRules
                     var newTrailingTrivia = currentTrailingTrivia;
                     if (!currentTrailingTrivia.Any() || !currentTrailingTrivia.Last().IsKind(SyntaxKind.EndOfLineTrivia))
                     {
-                        newTrailingTrivia = newTrailingTrivia.Add(SyntaxFactory.CarriageReturnLineFeed);
+                        newTrailingTrivia = newTrailingTrivia.Add(endOfLine);
                     }
 
                     var processedUsing = (qualifyNames ? this.QualifyUsingDirective(currentUsing) : currentUsing)
@@ -382,7 +383,7 @@ namespace StyleCop.Analyzers.OrderingRules
                 {
                     var last = result[result.Count - 1];
 
-                    result[result.Count - 1] = last.WithTrailingTrivia(last.GetTrailingTrivia().Add(SyntaxFactory.CarriageReturnLineFeed));
+                    result[result.Count - 1] = last.WithTrailingTrivia(last.GetTrailingTrivia().Add(endOfLine));
                 }
 
                 return result;
@@ -576,11 +577,11 @@ namespace StyleCop.Analyzers.OrderingRules
                 usingList.Add(usingDirective);
             }
 
-            private List<UsingDirectiveSyntax> GenerateUsings(Dictionary<TreeTextSpan, List<UsingDirectiveSyntax>> usingsGroup, List<UsingDirectiveSyntax> usingsList, string indentation, List<SyntaxTrivia> triviaToMove, bool qualifyNames, bool isGlobal)
+            private List<UsingDirectiveSyntax> GenerateUsings(Dictionary<TreeTextSpan, List<UsingDirectiveSyntax>> usingsGroup, List<UsingDirectiveSyntax> usingsList, string indentation, SyntaxTrivia endOfLine, List<SyntaxTrivia> triviaToMove, bool qualifyNames, bool isGlobal)
             {
                 var filteredUsingsList = this.FilterRelevantUsings(usingsGroup, usingsList);
 
-                return this.GenerateUsings(filteredUsingsList, indentation, triviaToMove, qualifyNames, isGlobal);
+                return this.GenerateUsings(filteredUsingsList, indentation, endOfLine, triviaToMove, qualifyNames, isGlobal);
             }
 
             private List<UsingDirectiveSyntax> FilterRelevantUsings(Dictionary<TreeTextSpan, List<UsingDirectiveSyntax>> usingsGroup, List<UsingDirectiveSyntax> usingsList)

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1106CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1106CodeFixProvider.cs
@@ -85,20 +85,50 @@ namespace StyleCop.Analyzers.ReadabilityRules
                 var options = document.Project.Solution.Workspace.Options;
                 var endOfLine = FormattingHelper.GetEndOfLineForCodeFix(node.SemicolonToken, text, options);
                 var settings = SettingsHelper.GetStyleCopSettingsInCodeFix(document.Project.AnalyzerOptions, root.SyntaxTree, cancellationToken);
-                var indentSteps = IndentationHelper.GetIndentationSteps(settings.Indentation, node.Parent.GetFirstOnLineAncestorOrSelf());
-                var indentTrivia = IndentationHelper.GenerateWhitespaceTrivia(settings.Indentation, indentSteps);
-                var block = SyntaxFactory.Block(
-                    SyntaxFactory.Token(
-                        node.GetLeadingTrivia().WithoutTrailingWhitespace().Add(indentTrivia),
-                        SyntaxKind.OpenBraceToken,
-                        SyntaxFactory.TriviaList(endOfLine)),
-                    SyntaxFactory.List<StatementSyntax>(),
-                    SyntaxFactory.Token(
-                        SyntaxFactory.TriviaList(indentTrivia),
-                        SyntaxKind.CloseBraceToken,
-                        node.GetTrailingTrivia()));
-                newRoot = root.ReplaceNode(node, block);
-                return document.WithSyntaxRoot(newRoot);
+
+                if (node.SemicolonToken.IsFirstInLine())
+                {
+                    var indentSteps = IndentationHelper.GetIndentationSteps(settings.Indentation, node.Parent.GetFirstOnLineAncestorOrSelf());
+                    var indentTrivia = IndentationHelper.GenerateWhitespaceTrivia(settings.Indentation, indentSteps);
+                    var block = SyntaxFactory.Block(
+                        SyntaxFactory.Token(
+                            node.GetLeadingTrivia().WithoutTrailingWhitespace().Add(indentTrivia),
+                            SyntaxKind.OpenBraceToken,
+                            SyntaxFactory.TriviaList(endOfLine)),
+                        SyntaxFactory.List<StatementSyntax>(),
+                        SyntaxFactory.Token(
+                            SyntaxFactory.TriviaList(indentTrivia),
+                            SyntaxKind.CloseBraceToken,
+                            node.GetTrailingTrivia()));
+                    newRoot = root.ReplaceNode(node, block);
+                    return document.WithSyntaxRoot(newRoot);
+                }
+                else
+                {
+                    var firstTokenOnLine = IndentationHelper.GetFirstTokenOnTextLine(node.SemicolonToken);
+                    var previousToken = node.SemicolonToken.GetPreviousToken(includeZeroWidth: true);
+                    var replacementPreviousToken = previousToken.WithTrailingTrivia(previousToken.TrailingTrivia.WithoutTrailingWhitespace().Add(endOfLine));
+                    var indentSteps = IndentationHelper.GetIndentationSteps(settings.Indentation, firstTokenOnLine);
+                    var indentTrivia = IndentationHelper.GenerateWhitespaceTrivia(settings.Indentation, indentSteps);
+                    var block = SyntaxFactory.Block(
+                        SyntaxFactory.Token(
+                            node.GetLeadingTrivia().WithoutTrailingWhitespace().Add(indentTrivia),
+                            SyntaxKind.OpenBraceToken,
+                            SyntaxFactory.TriviaList(endOfLine)),
+                        SyntaxFactory.List<StatementSyntax>(),
+                        SyntaxFactory.Token(
+                            SyntaxFactory.TriviaList(indentTrivia),
+                            SyntaxKind.CloseBraceToken,
+                            node.GetTrailingTrivia()));
+                    newRoot = root.ReplaceSyntax(
+                        new[] { node },
+                        (originalNode, rewrittenNode) => block,
+                        new[] { previousToken },
+                        (originalToken, rewrittenToken) => replacementPreviousToken,
+                        new SyntaxTrivia[0],
+                        (originalToken, rewrittenToken) => rewrittenToken);
+                    return document.WithSyntaxRoot(newRoot);
+                }
 
             case SyntaxKind.LabeledStatement:
                 // handle this case as a text manipulation for simplicity

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1116CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1116CodeFixProvider.cs
@@ -72,10 +72,12 @@ namespace StyleCop.Analyzers.ReadabilityRules
                 }
             }
 
+            var options = document.Project.Solution.Workspace.Options;
+            var endOfLineTrivia = FormattingHelper.GetEndOfLineForCodeFix(originalToken, sourceText, options);
             var settings = SettingsHelper.GetStyleCopSettingsInCodeFix(document.Project.AnalyzerOptions, tree, cancellationToken);
             SyntaxTriviaList newTrivia =
                 SyntaxFactory.TriviaList(
-                    SyntaxFactory.CarriageReturnLineFeed,
+                    endOfLineTrivia,
                     SyntaxFactory.Whitespace(lineText.Substring(0, indentLength) + IndentationHelper.GenerateIndentationString(settings.Indentation, 1)));
 
             SyntaxToken updatedToken = originalToken.WithLeadingTrivia(originalToken.LeadingTrivia.AddRange(newTrivia));

--- a/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1136CodeFixProvider.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.CodeFixes/ReadabilityRules/SA1136CodeFixProvider.cs
@@ -53,6 +53,8 @@ namespace StyleCop.Analyzers.ReadabilityRules
         private static async Task<Document> GetTransformedDocumentAsync(Document document, Diagnostic diagnostic, CancellationToken cancellationToken)
         {
             var syntaxRoot = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+            var sourceText = await document.GetTextAsync(cancellationToken).ConfigureAwait(false);
+            var options = document.Project.Solution.Workspace.Options;
             var settings = SettingsHelper.GetStyleCopSettingsInCodeFix(document.Project.AnalyzerOptions, syntaxRoot.SyntaxTree, cancellationToken);
 
             var enumMemberDeclaration = (EnumMemberDeclarationSyntax)syntaxRoot.FindNode(diagnostic.Location.SourceSpan);
@@ -71,7 +73,7 @@ namespace StyleCop.Analyzers.ReadabilityRules
 
             var newTrailingTrivia = SyntaxFactory.TriviaList(sharedTrivia)
                 .WithoutTrailingWhitespace()
-                .Add(SyntaxFactory.CarriageReturnLineFeed);
+                .Add(FormattingHelper.GetEndOfLineForCodeFix(precedingSeparatorToken, sourceText, options));
 
             // replace the trivia for the tokens
             var replacements = new Dictionary<SyntaxToken, SyntaxToken>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1142CSharp7UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test.CSharp7/ReadabilityRules/SA1142CSharp7UnitTests.cs
@@ -7,6 +7,7 @@ namespace StyleCop.Analyzers.Test.CSharp7.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using StyleCop.Analyzers.Test.ReadabilityRules;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
@@ -43,9 +44,12 @@ public class TestClass
         /// <summary>
         /// Verify that tuple names referenced by their metadata name will produce the expected diagnostics.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use for the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task ValidateMetadataNameReferencesAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task ValidateMetadataNameReferencesAsync(string lineEnding)
         {
             var testCode = @"
 public class TestClass
@@ -60,7 +64,7 @@ public class TestClass
         return p1.[|Item1|] + p1.nameB.[|Item1|] + p1.[|Item2|].[|Item2|];
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedCode = @"
 public class TestClass
@@ -75,7 +79,7 @@ public class TestClass
         return p1.nameA + p1.nameB.subNameA + p1.nameB.subNameB;
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1623UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1623UnitTests.cs
@@ -7,6 +7,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.DocumentationRules.PropertySummaryDocumentationAnalyzer,
@@ -201,14 +202,16 @@ public class TestClass
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
         [WorkItem(1934, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/1934")]
-        public async Task SummaryInParagraphCanBeFixedAsync()
+        public async Task SummaryInParagraphCanBeFixedAsync(string lineEnding)
         {
             var testCode = @"public class ClassName
 {
     /// <summary><para>Gets the first test value.</para></summary>
-    public int Property1
+    public int {|#0:Property1|}
     {
         set { }
     }
@@ -216,7 +219,7 @@ public class TestClass
     /// <summary>
     /// <para>Gets the second test value.</para>
     /// </summary>
-    public int Property2
+    public int {|#1:Property2|}
     {
         set { }
     }
@@ -226,11 +229,11 @@ public class TestClass
     /// Gets the third test value.
     /// </para>
     /// </summary>
-    public int Property3
+    public int {|#2:Property3|}
     {
         set { }
     }
-}";
+}".ReplaceLineEndings(lineEnding);
             var fixedTestCode = @"public class ClassName
 {
     /// <summary><para>Sets the first test value.</para></summary>
@@ -256,13 +259,13 @@ public class TestClass
     {
         set { }
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic(PropertySummaryDocumentationAnalyzer.SA1623Descriptor).WithLocation(4, 16).WithArguments("Sets"),
-                Diagnostic(PropertySummaryDocumentationAnalyzer.SA1623Descriptor).WithLocation(12, 16).WithArguments("Sets"),
-                Diagnostic(PropertySummaryDocumentationAnalyzer.SA1623Descriptor).WithLocation(22, 16).WithArguments("Sets"),
+                Diagnostic(PropertySummaryDocumentationAnalyzer.SA1623Descriptor).WithLocation(0).WithArguments("Sets"),
+                Diagnostic(PropertySummaryDocumentationAnalyzer.SA1623Descriptor).WithLocation(1).WithArguments("Sets"),
+                Diagnostic(PropertySummaryDocumentationAnalyzer.SA1623Descriptor).WithLocation(2).WithArguments("Sets"),
             };
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1626UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1626UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.DocumentationRules.SA1626SingleLineCommentsMustNotUseDocumentationStyleSlashes,
@@ -45,17 +44,19 @@ public class TypeName
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestMethodWithOneLineThreeSlashCommentAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestMethodWithOneLineThreeSlashCommentAsync(string lineEnding)
         {
             var testCode = @"public class TypeName
 {
     public void Bar()
     {
-        /// This is a comment
+        {|#0:///|} This is a comment
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
             var fixedCode = @"public class TypeName
 {
     public void Bar()
@@ -63,9 +64,9 @@ public class TypeName
         // This is a comment
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(5, 9);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1633UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1633UnitTests.cs
@@ -7,6 +7,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
 
     /// <summary>
@@ -184,16 +185,19 @@ namespace Bar
         /// <summary>
         /// Verifies that a file without a header, but with leading trivia will produce the correct diagnostic message.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestMissingFileHeaderWithLeadingTriviaAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestMissingFileHeaderWithLeadingTriviaAsync(string lineEnding)
         {
-            var testCode = @"#define MYDEFINE
+            var testCode = @"{|#0:|}#define MYDEFINE
 
 namespace Foo
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
             var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
 // Copyright (c) FooCorp. All rights reserved.
 // </copyright>
@@ -203,9 +207,9 @@ namespace Foo
 namespace Foo
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
-            var expectedDiagnostic = Diagnostic(FileHeaderAnalyzers.SA1633DescriptorMissing).WithLocation(1, 1);
+            var expectedDiagnostic = Diagnostic(FileHeaderAnalyzers.SA1633DescriptorMissing).WithLocation(0);
             await this.VerifyCSharpFixAsync(testCode, expectedDiagnostic, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1634UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1634UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
 
     /// <summary>
@@ -16,16 +15,19 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     /// </summary>
     public class SA1634UnitTests : FileHeaderTestBase
     {
-        private string multiLineSettings;
+        private string? multiLineSettings;
 
         /// <summary>
         /// Verifies that a file header without a copyright element will produce the expected diagnostic (none for the default case).
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestFileHeaderWithMissingCopyrightTagAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestFileHeaderWithMissingCopyrightTagAsync(string lineEnding)
         {
-            var testCode = @"// <author>
+            var testCode = @"{|#0://|} <author>
 //   John Doe
 // </author>
 // <summary>This is a test file.</summary>
@@ -33,7 +35,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
 namespace Bar
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
             var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
 // Copyright (c) FooCorp. All rights reserved.
 // </copyright>
@@ -45,9 +47,9 @@ namespace Bar
 namespace Bar
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
-            var expectedDiagnostic = Diagnostic(FileHeaderAnalyzers.SA1634Descriptor).WithLocation(1, 1);
+            var expectedDiagnostic = Diagnostic(FileHeaderAnalyzers.SA1634Descriptor).WithLocation(0);
             await this.VerifyCSharpFixAsync(testCode, expectedDiagnostic, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1635UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1635UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using StyleCop.Analyzers.DocumentationRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
 
     /// <summary>
@@ -18,16 +17,19 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         /// <summary>
         /// Verifies that a file header with a copyright element in short hand notation will produce the expected diagnostic message.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestFileHeaderWithShorthandCopyrightAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestFileHeaderWithShorthandCopyrightAsync(string lineEnding)
         {
-            var testCode = @"// <copyright file=""Test0.cs"" company=""FooCorp""/>
+            var testCode = @"// {|#0:<copyright|} file=""Test0.cs"" company=""FooCorp""/>
 
 namespace Bar
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
             var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
 // Copyright (c) FooCorp. All rights reserved.
 // </copyright>
@@ -35,9 +37,9 @@ namespace Bar
 namespace Bar
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
-            var expectedDiagnostic = Diagnostic(FileHeaderAnalyzers.SA1635Descriptor).WithLocation(1, 4);
+            var expectedDiagnostic = Diagnostic(FileHeaderAnalyzers.SA1635Descriptor).WithLocation(0);
             await this.VerifyCSharpFixAsync(testCode, expectedDiagnostic, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1636UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1636UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
 
     /// <summary>
@@ -45,18 +44,21 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         /// <summary>
         /// Verifies that a file header with a copyright message that is different than in the settings will produce the expected diagnostic message.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestFileHeaderWithDifferentCopyrightMessageAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestFileHeaderWithDifferentCopyrightMessageAsync(string lineEnding)
         {
-            var testCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
+            var testCode = @"// {|#0:<copyright|} file=""Test0.cs"" company=""FooCorp"">
 //   My custom copyright message.
 // </copyright>
 
 namespace Bar
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
             var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
 // Copyright (c) FooCorp. All rights reserved.
 // </copyright>
@@ -64,9 +66,9 @@ namespace Bar
 namespace Bar
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
-            var expectedDiagnostic = Diagnostic(FileHeaderAnalyzers.SA1636Descriptor).WithLocation(1, 4);
+            var expectedDiagnostic = Diagnostic(FileHeaderAnalyzers.SA1636Descriptor).WithLocation(0);
             await this.VerifyCSharpFixAsync(testCode, expectedDiagnostic, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1637UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1637UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using StyleCop.Analyzers.DocumentationRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
 
     /// <summary>
@@ -18,18 +17,21 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         /// <summary>
         /// Verifies that a file header without a file attribute in the copyright element will produce the expected diagnostic message.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestCopyrightElementWithoutFileAttributeAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestCopyrightElementWithoutFileAttributeAsync(string lineEnding)
         {
-            var testCode = @"// <copyright company=""FooCorp"">
+            var testCode = @"// {|#0:<copyright|} company=""FooCorp"">
 //   Copyright (c) FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
             var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
 // Copyright (c) FooCorp. All rights reserved.
 // </copyright>
@@ -37,9 +39,9 @@ namespace Bar
 namespace Bar
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
-            var expectedDiagnostic = Diagnostic(FileHeaderAnalyzers.SA1637Descriptor).WithLocation(1, 4);
+            var expectedDiagnostic = Diagnostic(FileHeaderAnalyzers.SA1637Descriptor).WithLocation(0);
             await this.VerifyCSharpFixAsync(testCode, expectedDiagnostic, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1638UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1638UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using StyleCop.Analyzers.DocumentationRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
 
     /// <summary>
@@ -32,18 +31,21 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         /// <summary>
         /// Verifies that a file header with a mismatching file attribute in the copyright element will produce the expected diagnostic message.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestCopyrightElementWithMismatchingFileAttributeAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestCopyrightElementWithMismatchingFileAttributeAsync(string lineEnding)
         {
-            var testCode = @"// <copyright file=""wrongfile.cs"" company=""FooCorp"">
+            var testCode = @"// {|#0:<copyright|} file=""wrongfile.cs"" company=""FooCorp"">
 //   Copyright (c) FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
             var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
 // Copyright (c) FooCorp. All rights reserved.
 // </copyright>
@@ -51,9 +53,9 @@ namespace Bar
 namespace Bar
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
-            var expectedDiagnostic = Diagnostic(FileHeaderAnalyzers.SA1638Descriptor).WithLocation(1, 4);
+            var expectedDiagnostic = Diagnostic(FileHeaderAnalyzers.SA1638Descriptor).WithLocation(0);
             await this.VerifyCSharpFixAsync(testCode, expectedDiagnostic, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1640UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1640UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using StyleCop.Analyzers.DocumentationRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
 
     /// <summary>
@@ -18,18 +17,21 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         /// <summary>
         /// Verifies that a file header without a company attribute in the copyright element will produce the expected diagnostic message.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestCopyrightElementWithoutCompanyAttributeAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestCopyrightElementWithoutCompanyAttributeAsync(string lineEnding)
         {
-            var testCode = @"// <copyright file=""Test0.cs"">
+            var testCode = @"// {|#0:<copyright|} file=""Test0.cs"">
 //   Copyright (c) FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
             var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
 // Copyright (c) FooCorp. All rights reserved.
 // </copyright>
@@ -37,9 +39,9 @@ namespace Bar
 namespace Bar
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
-            var expectedDiagnostic = Diagnostic(FileHeaderAnalyzers.SA1640Descriptor).WithLocation(1, 4);
+            var expectedDiagnostic = Diagnostic(FileHeaderAnalyzers.SA1640Descriptor).WithLocation(0);
             await this.VerifyCSharpFixAsync(testCode, expectedDiagnostic, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1641UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1641UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.DocumentationRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using StyleCop.Analyzers.DocumentationRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
 
     /// <summary>
@@ -18,18 +17,21 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
         /// <summary>
         /// Verifies that a file header with a company attribute in the copyright element that does not match the settings will produce the expected diagnostic message.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestCopyrightElementWithWrongCompanyAttributeAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestCopyrightElementWithWrongCompanyAttributeAsync(string lineEnding)
         {
-            var testCode = @"// <copyright file=""Test0.cs"" company=""WrongCompany"">
+            var testCode = @"// {|#0:<copyright|} file=""Test0.cs"" company=""WrongCompany"">
 //   Copyright (c) FooCorp. All rights reserved.
 // </copyright>
 
 namespace Bar
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
             var fixedCode = @"// <copyright file=""Test0.cs"" company=""FooCorp"">
 // Copyright (c) FooCorp. All rights reserved.
 // </copyright>
@@ -37,9 +39,9 @@ namespace Bar
 namespace Bar
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
-            var expectedDiagnostic = Diagnostic(FileHeaderAnalyzers.SA1641Descriptor).WithLocation(1, 4);
+            var expectedDiagnostic = Diagnostic(FileHeaderAnalyzers.SA1641Descriptor).WithLocation(0);
             await this.VerifyCSharpFixAsync(testCode, expectedDiagnostic, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1651UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/DocumentationRules/SA1651UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.DocumentationRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.DocumentationRules.SA1651DoNotUsePlaceholderElements>;
@@ -50,18 +51,20 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestTopLevelPlaceholderAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestTopLevelPlaceholderAsync(string lineEnding)
         {
             var testCode = @"namespace FooNamespace
 {
-    /// <placeholder><summary>
+    /// {|#0:<placeholder><summary>
     /// Content.
-    /// </summary></placeholder>
+    /// </summary></placeholder>|}
     public class ClassName
     {
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             var fixedCode = @"namespace FooNamespace
 {
@@ -71,9 +74,9 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     public class ClassName
     {
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(3, 9);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
@@ -95,18 +98,20 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestEmbeddedPlaceholderAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestEmbeddedPlaceholderAsync(string lineEnding)
         {
             var testCode = @"namespace FooNamespace
 {
     /// <summary>
-    /// <placeholder>Content.</placeholder>
+    /// {|#0:<placeholder>Content.</placeholder>|}
     /// </summary>
     public class ClassName
     {
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             var fixedCode = @"namespace FooNamespace
 {
@@ -116,9 +121,9 @@ namespace StyleCop.Analyzers.Test.DocumentationRules
     public class ClassName
     {
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(4, 9);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/CommonData.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/Helpers/CommonData.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+namespace StyleCop.Analyzers.Test.Helpers
+{
+    using Xunit;
+
+    internal static class CommonData
+    {
+        public static TheoryData<string> EndOfLineSequences
+        {
+            get
+            {
+                var result = new TheoryData<string>();
+                result.Add("\n");
+                result.Add("\r\n");
+                return result;
+            }
+        }
+    }
+}

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1119UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1119UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.MaintainabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.MaintainabilityRules.SA1119StatementMustNotUseUnnecessaryParenthesis,
@@ -32,22 +33,24 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestLiteralParenthesisAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestLiteralParenthesisAsync(string lineEnding)
         {
             var testCode = @"public class Foo
 {
     public void Bar()
     {
-        int x = (1);
+        int x = {|#0:{|#1:(|}1{|#2:)|}|};
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
                 {
-                    Diagnostic(DiagnosticId).WithSpan(5, 17, 5, 20),
-                    Diagnostic(ParenthesesDiagnosticId).WithLocation(5, 17),
-                    Diagnostic(ParenthesesDiagnosticId).WithLocation(5, 19),
+                    Diagnostic(DiagnosticId).WithLocation(0),
+                    Diagnostic(ParenthesesDiagnosticId).WithLocation(1),
+                    Diagnostic(ParenthesesDiagnosticId).WithLocation(2),
                 };
 
             var fixedCode = @"public class Foo
@@ -56,7 +59,8 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     {
         int x = 1;
     }
-}";
+}".ReplaceLineEndings(lineEnding);
+
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1400UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1400UnitTests.cs
@@ -183,6 +183,33 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
             await this.TestNestedDeclarationAsync("private", "MemberName", "void MemberName", "  ( int\n parameter\n ) { }").ConfigureAwait(false);
         }
 
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestMethodDeclarationWithLineEndingAsync(string lineEnding)
+        {
+            const string keywordLine = "void {|#0:MemberName|}";
+            const string linesAfter = "  ( int\n parameter\n ) { }";
+
+            var testCode = @$"using System;
+internal class OuterTypeName
+{{
+ {Tab} {keywordLine}
+{linesAfter}
+}}".ReplaceLineEndings(lineEnding);
+
+            DiagnosticResult expected = Diagnostic().WithArguments("MemberName").WithLocation(0);
+
+            var fixedTestCode = @$"using System;
+internal class OuterTypeName
+{{
+ {Tab} private {keywordLine}
+{linesAfter}
+}}".ReplaceLineEndings(lineEnding);
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
         [Fact]
         public async Task TestMethodDeclarationWithAttributesAsync()
         {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402ForBlockDeclarationUnitTestsBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1402ForBlockDeclarationUnitTestsBase.cs
@@ -12,6 +12,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using Microsoft.CodeAnalysis.Diagnostics;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.MaintainabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
 
     public abstract class SA1402ForBlockDeclarationUnitTestsBase : FileMayOnlyContainTestBase
@@ -28,31 +29,33 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
 
         protected abstract bool IsConfiguredAsTopLevelTypeByDefault { get; }
 
-        [Fact]
-        public async Task TestTwoGenericElementsAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestTwoGenericElementsAsync(string lineEnding)
         {
             var testCode = @"%1 Foo<T1>
 {
 }
-%1 Bar<T2, T3>
+%1 {|#0:Bar|}<T2, T3>
 {
-}";
+}".ReplaceLineEndings(lineEnding);
 
             var fixedCode = new[]
             {
                 ("/0/Test0.cs", @"%1 Foo<T1>
 {
 }
-"),
+".ReplaceLineEndings(lineEnding)),
                 ("Bar{T2,T3}.cs", @"%1 Bar<T2, T3>
 {
-}"),
+}".ReplaceLineEndings(lineEnding)),
             };
 
             testCode = testCode.Replace("%1", this.Keyword);
             fixedCode = fixedCode.Select(c => (c.Item1, c.Item2.Replace("%1", this.Keyword))).ToArray();
 
-            DiagnosticResult expected = this.Diagnostic().WithLocation(4, this.Keyword.Length + 2);
+            DiagnosticResult expected = this.Diagnostic().WithLocation(0);
             await this.VerifyCSharpFixAsync(testCode, this.GetSettings(), expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1404UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1404UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.MaintainabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.MaintainabilityRules.SA1404CodeAnalysisSuppressionMustHaveJustification,
@@ -66,38 +67,40 @@ public class Foo
             await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestSuppressionWithNoJustificationAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestSuppressionWithNoJustificationAsync(string lineEnding)
         {
             var testCode = @"public class Foo
 {
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(null, null)]
+    [{|#0:System.Diagnostics.CodeAnalysis.SuppressMessage(null, null)|}]
     public void Bar()
     {
 
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            var fixedCode = @"public class Foo
-{
-    [System.Diagnostics.CodeAnalysis.SuppressMessage(null, null, Justification = """ + SA1404CodeAnalysisSuppressionMustHaveJustification.JustificationPlaceholder + @""")]
+            var fixedCode = $@"public class Foo
+{{
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(null, null, {{|#0:Justification = ""{SA1404CodeAnalysisSuppressionMustHaveJustification.JustificationPlaceholder}""|}})]
     public void Bar()
-    {
+    {{
 
-    }
-}";
+    }}
+}}".ReplaceLineEndings(lineEnding);
 
             await new CSharpTest
             {
                 TestCode = testCode,
                 ExpectedDiagnostics =
                 {
-                    Diagnostic().WithLocation(3, 6),
+                    Diagnostic().WithLocation(0),
                 },
                 FixedCode = fixedCode,
                 RemainingDiagnostics =
                 {
-                    Diagnostic().WithLocation(3, 66),
+                    Diagnostic().WithLocation(0),
                 },
                 NumberOfIncrementalIterations = 2,
                 NumberOfFixAllIterations = 2,

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1407UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1407UnitTests.cs
@@ -8,6 +8,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.MaintainabilityRules.SA1407ArithmeticExpressionsMustDeclarePrecedence,
@@ -54,17 +55,19 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestAdditionMultiplicationAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestAdditionMultiplicationAsync(string lineEnding)
         {
             var testCode = @"public class Foo
 {
     public void Bar()
     {
-        int x = 1 + 1 * 1;
+        int x = 1 + {|#0:1 * 1|};
     }
-}";
-            DiagnosticResult expected = Diagnostic().WithLocation(5, 21);
+}".ReplaceLineEndings(lineEnding);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             var fixedCode = @"public class Foo
 {
@@ -72,7 +75,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     {
         int x = 1 + (1 * 1);
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1408UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1408UnitTests.cs
@@ -8,6 +8,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.MaintainabilityRules.SA1408ConditionalExpressionsMustDeclarePrecedence,
@@ -41,17 +42,19 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestOrAndAndAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestOrAndAndAsync(string lineEnding)
         {
             var testCode = @"public class Foo
 {
     public void Bar()
     {
-        bool x = true || false && true;
+        bool x = true || {|#0:false && true|};
     }
-}";
-            DiagnosticResult expected = Diagnostic().WithLocation(5, 26);
+}".ReplaceLineEndings(lineEnding);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             var fixedCode = @"public class Foo
 {
@@ -59,7 +62,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     {
         bool x = true || (false && true);
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1410UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1410UnitTests.cs
@@ -8,6 +8,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.MaintainabilityRules.SA1410RemoveDelegateParenthesisWhenPossible,
@@ -56,16 +57,18 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
             await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestCodeFixAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestCodeFixAsync(string lineEnding)
         {
             var oldSource = @"public class Foo
 {
     public void Bar()
     {
-        System.Func<int> getRandomNumber = delegate() { return 3; };
+        System.Func<int> getRandomNumber = delegate{|#0:()|} { return 3; };
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             var newSource = @"public class Foo
 {
@@ -73,9 +76,9 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     {
         System.Func<int> getRandomNumber = delegate { return 3; };
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            var expected = Diagnostic().WithLocation(5, 52);
+            var expected = Diagnostic().WithLocation(0);
             await VerifyCSharpFixAsync(oldSource, expected, newSource, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1411UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1411UnitTests.cs
@@ -8,6 +8,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.MaintainabilityRules.SA1411AttributeConstructorMustNotUseUnnecessaryParenthesis,
@@ -90,16 +91,18 @@ public class Foo
             await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestCodeFixAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestCodeFixAsync(string lineEnding)
         {
             var oldSource = @"public class Foo
 {
-    [System.Obsolete()]
+    [System.Obsolete{|#0:()|}]
     public void Bar()
     {
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             var newSource = @"public class Foo
 {
@@ -107,9 +110,9 @@ public class Foo
     public void Bar()
     {
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            var expected = Diagnostic().WithLocation(3, 21);
+            var expected = Diagnostic().WithLocation(0);
             await VerifyCSharpFixAsync(oldSource, expected, newSource, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1412UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1412UnitTests.cs
@@ -12,6 +12,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Testing;
     using Microsoft.CodeAnalysis.Text;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.MaintainabilityRules.SA1412StoreFilesAsUtf8,
@@ -65,11 +66,14 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
             await test.RunAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestFileWithUtf8EncodingWithoutBOMAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestFileWithUtf8EncodingWithoutBOMAsync(string lineEnding)
         {
-            var testCode = SourceText.From("class TypeName { }", new UTF8Encoding(false));
-            var fixedCode = SourceText.From(testCode.ToString(), Encoding.UTF8);
+            var source = "class TypeName\n{\n}\n".ReplaceLineEndings(lineEnding);
+            var testCode = SourceText.From(source, new UTF8Encoding(false));
+            var fixedCode = SourceText.From(source, Encoding.UTF8);
 
             var expected = Diagnostic().WithLocation(1, 1);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1413UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/MaintainabilityRules/SA1413UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.MaintainabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.MaintainabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.MaintainabilityRules.SA1413UseTrailingCommasInMultiLineInitializers,
@@ -79,9 +80,12 @@ namespace TestNamespace
         /// <summary>
         /// Verifies that an object initializer without a trailing comma produces a diagnostic.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task VerifyObjectInitializerAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task VerifyObjectInitializerAsync(string lineEnding)
         {
             var testCode = @"
 namespace TestNamespace
@@ -101,12 +105,12 @@ namespace TestNamespace
             {
                 Age = 100,
                 Height = 0.2M,
-                Weight = 0.88M
+                {|#0:Weight = 0.88M|}
             };
         }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"
 namespace TestNamespace
@@ -131,11 +135,11 @@ namespace TestNamespace
         }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(19, 17),
+                Diagnostic().WithLocation(0),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1300UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.NamingRules
 {
     using System.Threading;
@@ -28,20 +26,22 @@ namespace StyleCop.Analyzers.Test.NamingRules
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestLowerCaseNamespaceAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestLowerCaseNamespaceAsync(string lineEnding)
         {
-            var testCode = @"namespace test
+            var testCode = @"namespace {|#0:test|}
 { 
 
-}";
+}".ReplaceLineEndings(lineEnding);
 
             var fixedCode = @"namespace Test
 { 
 
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithArguments("test").WithLocation(1, 11);
+            DiagnosticResult expected = Diagnostic().WithArguments("test").WithLocation(0);
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1302UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1302UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.NamingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.NamingRules.SA1302InterfaceNamesMustBeginWithI,
@@ -15,20 +14,22 @@ namespace StyleCop.Analyzers.Test.NamingRules
 
     public class SA1302UnitTests
     {
-        [Fact]
-        public async Task TestInterfaceDeclarationDoesNotStartWithIAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInterfaceDeclarationDoesNotStartWithIAsync(string lineEnding)
         {
             var testCode = @"
-public interface Foo
+public interface {|#0:Foo|}
 {
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(2, 18);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             var fixedCode = @"
 public interface IFoo
 {
-}";
+}".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1303UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1303UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.NamingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.NamingRules.SA1303ConstFieldNamesMustBeginWithUpperCaseLetter,
@@ -15,19 +14,21 @@ namespace StyleCop.Analyzers.Test.NamingRules
 
     public class SA1303UnitTests
     {
-        [Fact]
-        public async Task TestConstFieldStartingWithLowerCaseAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestConstFieldStartingWithLowerCaseAsync(string lineEnding)
         {
             var testCode = @"public class Foo
 {
-    public const string bar = ""baz"";
-}";
+    public const string {|#0:bar|} = ""baz"";
+}".ReplaceLineEndings(lineEnding);
             var fixedCode = @"public class Foo
 {
     public const string Bar = ""baz"";
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(3, 25);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1304UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1304UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.NamingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.NamingRules.SA1304NonPrivateReadonlyFieldsMustBeginWithUpperCaseLetter,
@@ -72,20 +71,22 @@ namespace StyleCop.Analyzers.Test.NamingRules
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestInternalReadonlyFieldStartingWithLowerCaseAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInternalReadonlyFieldStartingWithLowerCaseAsync(string lineEnding)
         {
             var testCode = @"public class Foo
 {
-    internal readonly string bar = ""baz"";
-}";
+    internal readonly string {|#0:bar|} = ""baz"";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(3, 30);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             var fixedCode = @"public class Foo
 {
     internal readonly string Bar = ""baz"";
-}";
+}".ReplaceLineEndings(lineEnding);
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1306UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1306UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.NamingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.NamingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.NamingRules.SA1306FieldNamesMustBeginWithLowerCaseLetter,
@@ -259,22 +258,24 @@ string bar, car, dar;
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestFieldWithCodefixRenameConflictAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestFieldWithCodefixRenameConflictAsync(string lineEnding)
         {
             var testCode = @"public class Foo
 {
     private string _test = ""test1"";
-    private string _Test = ""test2"";
-}";
+    private string {|#0:_Test|} = ""test2"";
+}".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"public class Foo
 {
     private string _test = ""test1"";
     private string _test1 = ""test2"";
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            var expected = Diagnostic().WithArguments("_Test").WithLocation(4, 20);
+            var expected = Diagnostic().WithArguments("_Test").WithLocation(0);
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1307UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1307UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.NamingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.NamingRules.SA1307AccessibleFieldsMustBeginWithUpperCaseLetter,
@@ -151,20 +150,22 @@ string CarValueValue, Car, CarValue;
             await test.RunAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestFieldStartingWithVerbatimIdentifierAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestFieldStartingWithVerbatimIdentifierAsync(string lineEnding)
         {
             var testCode = @"public class Foo
 {
-    public string @bar = ""baz"";
-}";
+    public string {|#0:@bar|} = ""baz"";
+}".ReplaceLineEndings(lineEnding);
 
             var fixedCode = @"public class Foo
 {
     public string Bar = ""baz"";
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            var expected = Diagnostic().WithArguments("bar").WithLocation(3, 19);
+            var expected = Diagnostic().WithArguments("bar").WithLocation(0);
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1308UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1308UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.NamingRules
 {
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.NamingRules.SA1308VariableNamesMustNotBePrefixed,
@@ -50,14 +49,16 @@ namespace StyleCop.Analyzers.Test.NamingRules
             }
         }
 
-        [Fact]
-        public async Task TestMUnderscoreOnlyAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestMUnderscoreOnlyAsync(string lineEnding)
         {
             var originalCode = @"public class Foo
 {
-private string m_ = ""baz"";
-}";
-            DiagnosticResult expected = Diagnostic().WithArguments("m_", "m_").WithLocation(3, 16);
+private string {|#0:m_|} = ""baz"";
+}".ReplaceLineEndings(lineEnding);
+            DiagnosticResult expected = Diagnostic().WithArguments("m_", "m_").WithLocation(0);
 
             // When the variable name is simply the disallowed prefix, we will not offer a code fix, as we cannot infer the correct variable name.
             await VerifyCSharpFixAsync(originalCode, expected, originalCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1309UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1309UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.NamingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.NamingRules.SA1309FieldNamesMustNotBeginWithUnderscore,
@@ -15,20 +14,22 @@ namespace StyleCop.Analyzers.Test.NamingRules
 
     public class SA1309UnitTests
     {
-        [Fact]
-        public async Task TestFieldStartingWithAnUnderscoreAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestFieldStartingWithAnUnderscoreAsync(string lineEnding)
         {
             var testCode = @"public class Foo
 {
-    public string _bar = ""baz"";
-}";
+    public string {|#0:_bar|} = ""baz"";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithArguments("_bar").WithLocation(3, 19);
+            DiagnosticResult expected = Diagnostic().WithArguments("_bar").WithLocation(0);
 
             var fixedCode = @"public class Foo
 {
     public string bar = ""baz"";
-}";
+}".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1310UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1310UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.NamingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.NamingRules.SA1310FieldNamesMustNotContainUnderscore,
@@ -15,20 +14,22 @@ namespace StyleCop.Analyzers.Test.NamingRules
 
     public class SA1310UnitTests
     {
-        [Fact]
-        public async Task TestFieldWithUnderscoreAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestFieldWithUnderscoreAsync(string lineEnding)
         {
             var testCode = @"public class ClassName
 {
-    public string name_bar = ""baz"";
-}";
+    public string {|#0:name_bar|} = ""baz"";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithArguments("name_bar").WithLocation(3, 19);
+            DiagnosticResult expected = Diagnostic().WithArguments("name_bar").WithLocation(0);
 
             var fixedCode = @"public class ClassName
 {
     public string nameBar = ""baz"";
-}";
+}".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1311UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1311UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.NamingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.NamingRules.SA1311StaticReadonlyFieldsMustBeginWithUpperCaseLetter,
@@ -15,20 +14,22 @@ namespace StyleCop.Analyzers.Test.NamingRules
 
     public class SA1311UnitTests
     {
-        [Fact]
-        public async Task TestStaticReadonlyFieldStartingWithLowerCaseAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestStaticReadonlyFieldStartingWithLowerCaseAsync(string lineEnding)
         {
             var testCode = @"public class Foo
 {
-    public static readonly string bar = ""baz"";
-}";
+    public static readonly string {|#0:bar|} = ""baz"";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(3, 35);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             var fixedCode = @"public class Foo
 {
     public static readonly string Bar = ""baz"";
-}";
+}".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1312UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1312UnitTests.cs
@@ -73,23 +73,25 @@ public class TypeName
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestThatDiagnosticIsReported_SingleVariableAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestThatDiagnosticIsReported_SingleVariableAsync(string lineEnding)
         {
             var testCode = @"public class TypeName
 {
     public void MethodName()
     {
-        string Bar;
+        string {|#0:Bar|};
         string car;
-        string Par;
+        string {|#1:Par|};
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithArguments("Bar").WithLocation(5, 16),
-                Diagnostic().WithArguments("Par").WithLocation(7, 16),
+                Diagnostic().WithArguments("Bar").WithLocation(0),
+                Diagnostic().WithArguments("Par").WithLocation(1),
             };
 
             var fixedCode = @"public class TypeName
@@ -100,7 +102,7 @@ public class TypeName
         string car;
         string par;
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1313UnitTests.cs
@@ -63,24 +63,26 @@ public class TypeName
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestThatDiagnosticIsReported_SingleParameterAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestThatDiagnosticIsReported_SingleParameterAsync(string lineEnding)
         {
             var testCode = @"public class TypeName
 {
-    public void MethodName(string Bar)
+    public void MethodName(string {|#0:Bar|})
     {
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithArguments("Bar").WithLocation(3, 35);
+            DiagnosticResult expected = Diagnostic().WithArguments("Bar").WithLocation(0);
 
             var fixedCode = @"public class TypeName
 {
     public void MethodName(string bar)
     {
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1314UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SA1314UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.NamingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.NamingRules.SA1314TypeParameterNamesMustBeginWithT,
@@ -15,20 +14,22 @@ namespace StyleCop.Analyzers.Test.NamingRules
 
     public class SA1314UnitTests
     {
-        [Fact]
-        public async Task TestTypeParameterDoesNotStartWithTAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestTypeParameterDoesNotStartWithTAsync(string lineEnding)
         {
             var testCode = @"
-public interface IFoo<Key>
+public interface IFoo<{|#0:Key|}>
 {
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(2, 23);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             var fixedCode = @"
 public interface IFoo<TKey>
 {
-}";
+}".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SX1309SUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SX1309SUnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.NamingRules.SX1309SStaticFieldNamesMustBeginWithUnderscore,
@@ -75,6 +76,26 @@ namespace StyleCop.Analyzers.Test.NamingRules
 {{
     {modifiers} string _bar = ""bar"";
 }}";
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestCheckedFieldNotStartingWithAnUnderscoreWithLineEndingsAsync(string lineEnding)
+        {
+            var testCode = @"public class ClassName
+{
+    private static string {|#0:bar|} = ""bar"";
+}".ReplaceLineEndings(lineEnding);
+
+            DiagnosticResult expected = Diagnostic().WithArguments("bar").WithLocation(0);
+
+            var fixedCode = @"public class ClassName
+{
+    private static string _bar = ""bar"";
+}".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SX1309UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/NamingRules/SX1309UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.NamingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.NamingRules.SX1309FieldNamesMustBeginWithUnderscore,
@@ -75,6 +76,26 @@ namespace StyleCop.Analyzers.Test.NamingRules
 {{
     {modifiers} string _bar = ""bar"";
 }}";
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestCheckedFieldNotStartingWithAnUnderscoreWithLineEndingsAsync(string lineEnding)
+        {
+            var testCode = @"public class ClassName
+{
+    private string {|#0:bar|} = ""bar"";
+}".ReplaceLineEndings(lineEnding);
+
+            DiagnosticResult expected = Diagnostic().WithArguments("bar").WithLocation(0);
+
+            var fixedCode = @"public class ClassName
+{
+    private string _bar = ""bar"";
+}".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1200OutsideNamespaceUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1200OutsideNamespaceUnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.OrderingRules
 {
     using System.Threading;
@@ -11,6 +9,7 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
     using StyleCop.Analyzers.Settings.ObjectModel;
+    using StyleCop.Analyzers.Test.Helpers;
     using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
 
@@ -55,28 +54,31 @@ namespace StyleCop.Analyzers.Test.OrderingRules
         /// <summary>
         /// Verifies that using statements in a namespace produces the expected diagnostics.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestInvalidUsingStatementsInNamespaceAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidUsingStatementsInNamespaceAsync(string lineEnding)
         {
             var testCode = @"namespace TestNamespace
 {
-    using System;
-    using System.Threading;
+    {|#0:using System;|}
+    {|#1:using System.Threading;|}
 }
-";
+".ReplaceLineEndings(lineEnding);
             var fixedTestCode = @"using System;
 using System.Threading;
 
 namespace TestNamespace
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expectedResults =
             {
-                Diagnostic(SA1200UsingDirectivesMustBePlacedCorrectly.DescriptorOutside).WithLocation(3, 5),
-                Diagnostic(SA1200UsingDirectivesMustBePlacedCorrectly.DescriptorOutside).WithLocation(4, 5),
+                Diagnostic(SA1200UsingDirectivesMustBePlacedCorrectly.DescriptorOutside).WithLocation(0),
+                Diagnostic(SA1200UsingDirectivesMustBePlacedCorrectly.DescriptorOutside).WithLocation(1),
             };
 
             await VerifyCSharpFixAsync(testCode, expectedResults, fixedTestCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1200UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1200UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.OrderingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.OrderingRules.SA1200UsingDirectivesMustBePlacedCorrectly,
@@ -100,29 +99,32 @@ namespace TestNamespace
         /// <summary>
         /// Verifies that having using statements in the compilation unit will produce the expected diagnostics.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestInvalidUsingStatementsInCompilationUnitAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidUsingStatementsInCompilationUnitAsync(string lineEnding)
         {
-            var testCode = @"using System;
-using System.Threading;
+            var testCode = @"{|#0:using System;|}
+{|#1:using System.Threading;|}
 
 namespace TestNamespace
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"namespace TestNamespace
 {
     using System;
     using System.Threading;
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expectedResults =
             {
-                Diagnostic(SA1200UsingDirectivesMustBePlacedCorrectly.DescriptorInside).WithLocation(1, 1),
-                Diagnostic(SA1200UsingDirectivesMustBePlacedCorrectly.DescriptorInside).WithLocation(2, 1),
+                Diagnostic(SA1200UsingDirectivesMustBePlacedCorrectly.DescriptorInside).WithLocation(0),
+                Diagnostic(SA1200UsingDirectivesMustBePlacedCorrectly.DescriptorInside).WithLocation(1),
             };
 
             await VerifyCSharpFixAsync(testCode, expectedResults, fixedTestCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1201UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1201UnitTests.cs
@@ -281,22 +281,24 @@ public {classKeyword} FooClass {{ }}
             await test.RunAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestTypeMemberOrderWrongOrderInterfaceAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestTypeMemberOrderWrongOrderInterfaceAsync(string lineEnding)
         {
             string testCode = @"public interface OuterType
 {
     string TestProperty { get; set; }
-    event System.Action TestEvent;
+    {|#0:event System.Action TestEvent;|}
     void TestMethod ();
-    string this[string arg] { get; set; }
+    string {|#1:this|}[string arg] { get; set; }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(4, 5).WithArguments("event", "property"),
-                Diagnostic().WithLocation(6, 12).WithArguments("indexer", "method"),
+                Diagnostic().WithLocation(0).WithArguments("event", "property"),
+                Diagnostic().WithLocation(1).WithArguments("indexer", "method"),
             };
 
             string fixedCode = @"public interface OuterType
@@ -306,7 +308,7 @@ public {classKeyword} FooClass {{ }}
     string this[string arg] { get; set; }
     void TestMethod ();
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1202UnitTests.cs
@@ -125,6 +125,24 @@ internal {keyword} TestClass1 {{ }}
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestTypeOrderingWithLineEndingsAsync(string lineEnding)
+        {
+            var testCode = @"internal class TestClass1 { }
+public class {|#0:TestClass2|} { }
+".ReplaceLineEndings(lineEnding);
+
+            var expected = Diagnostic().WithLocation(0).WithArguments("public", "internal");
+
+            var fixedCode = @"public class TestClass2 { }
+internal class TestClass1 { }
+".ReplaceLineEndings(lineEnding);
+
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Verifies that the analyzer will properly handle interfaces before classes.
         /// </summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1203UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1203UnitTests.cs
@@ -8,6 +8,7 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.OrderingRules.SA1203ConstantsMustAppearBeforeFields,
@@ -91,23 +92,25 @@ public class TestClass2
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestClassViolationAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestClassViolationAsync(string lineEnding)
         {
             var testCode = @"
 public class Foo
 {
     private int Baz = 1;
-    private const int Bar = 2;
-}";
-            var firstDiagnostic = Diagnostic().WithLocation(5, 23);
+    private const int {|#0:Bar|} = 2;
+}".ReplaceLineEndings(lineEnding);
+            var firstDiagnostic = Diagnostic().WithLocation(0);
 
             var fixedTestCode = @"
 public class Foo
 {
     private const int Bar = 2;
     private int Baz = 1;
-}";
+}".ReplaceLineEndings(lineEnding);
             await VerifyCSharpFixAsync(testCode, firstDiagnostic, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1204UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1204UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.OrderingRules.SA1204StaticElementsMustAppearBeforeInstanceElements,
@@ -107,22 +108,25 @@ public class TestClass2
         /// <summary>
         /// Verifies that the analyzer will properly handle non-static classes before static.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestNonStaticClassBeforeStaticAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestNonStaticClassBeforeStaticAsync(string lineEnding)
         {
             var testCode = @"public class TestClass1 { }
-public static class TestClass2 { }
-";
+public static class {|#0:TestClass2|} { }
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(2, 21),
+                Diagnostic().WithLocation(0),
             };
 
             var fixedCode = @"public static class TestClass2 { }
 public class TestClass1 { }
-";
+".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1205UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1205UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.OrderingRules
 {
     using System.Collections.Generic;
@@ -12,6 +10,7 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Lightup;
     using StyleCop.Analyzers.OrderingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.OrderingRules.SA1205PartialElementsMustDeclareAccess,
@@ -187,20 +186,23 @@ namespace StyleCop.Analyzers.Test.OrderingRules
         /// <summary>
         /// Verifies that the code fix will properly copy over the access modifier defined in another fragment of the partial element.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestProperAccessModifierPropagationAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestProperAccessModifierPropagationAsync(string lineEnding)
         {
             var testCode = @"public partial class Foo
 {
     private int field1;
 }
 
-partial class Foo
+partial class {|#0:Foo|}
 {
     private int field2;
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"public partial class Foo
 {
@@ -211,9 +213,9 @@ public partial class Foo
 {
     private int field2;
 }
-";
+".ReplaceLineEndings(lineEnding);
 
-            await VerifyCSharpFixAsync(testCode, Diagnostic().WithLocation(6, 15), fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, Diagnostic().WithLocation(0), fixedTestCode, CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1206CodeFixProviderUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1206CodeFixProviderUnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.OrderingRules.SA1206DeclarationKeywordsMustFollowOrder,
@@ -30,6 +31,26 @@ namespace StyleCop.Analyzers.Test.OrderingRules
             var fixedTestCode = @"public abstract class FooBar {}";
 
             var expected = Diagnostic().WithLocation(1, 10).WithArguments("public", "abstract");
+            await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task VerifyKeywordReorderingInClassDeclarationWithLineEndingsAsync(string lineEnding)
+        {
+            var testCode = @"abstract
+{|#0:public|}
+class FooBar
+{
+}".ReplaceLineEndings(lineEnding);
+            var fixedTestCode = @"public
+abstract
+class FooBar
+{
+}".ReplaceLineEndings(lineEnding);
+
+            var expected = Diagnostic().WithLocation(0).WithArguments("public", "abstract");
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1207UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1207UnitTests.cs
@@ -12,6 +12,7 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.OrderingRules.SA1207ProtectedMustComeBeforeInternal,
@@ -132,6 +133,29 @@ public class Foo
             var fixedTestCode = TestCodeTemplate.Replace("$$", fixedDeclaration);
 
             DiagnosticResult expected = Diagnostic().WithArguments("protected", "internal").WithLocation(4, 4 + diagnosticColumn);
+            await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidDeclarationWithLineEndingsAsync(string lineEnding)
+        {
+            var invalidDeclaration = @"internal
+static
+{|#0:protected|}
+int
+Bar;";
+            var fixedDeclaration = @"protected
+static
+internal
+int
+Bar;";
+
+            var testCode = TestCodeTemplate.Replace("$$", invalidDeclaration).ReplaceLineEndings(lineEnding);
+            var fixedTestCode = TestCodeTemplate.Replace("$$", fixedDeclaration).ReplaceLineEndings(lineEnding);
+
+            DiagnosticResult expected = Diagnostic().WithArguments("protected", "internal").WithLocation(0);
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1208UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1208UnitTests.cs
@@ -8,6 +8,7 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.OrderingRules.SA1208SystemUsingDirectivesMustBePlacedBeforeOtherUsingDirectives,
@@ -306,8 +307,10 @@ namespace Test
             }.RunAsync(CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestPreprocessorDirectivesAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestPreprocessorDirectivesAsync(string lineEnding)
         {
             var testCode = @"using System;
 using Microsoft.Win32;
@@ -316,8 +319,8 @@ using Microsoft.CodeAnalysis;
 
 #if true
 using Microsoft.CodeAnalysis.CSharp;
-using System.Threading;
-using System.Collections;
+{|#0:using System.Threading;|}
+{|#1:using System.Collections;|}
 #if true
 using System.Collections.Generic;
 #endif
@@ -325,7 +328,7 @@ using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp;
 using System.Threading;
 using System.Collections;
-#endif";
+#endif".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"using System;
 using Microsoft.CodeAnalysis;
@@ -343,13 +346,13 @@ using System.Collections.Generic;
 using Microsoft.CodeAnalysis.CSharp;
 using System.Threading;
 using System.Collections;
-#endif";
+#endif".ReplaceLineEndings(lineEnding);
 
             // else block is skipped
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(8, 1).WithArguments("System.Threading", "Microsoft.CodeAnalysis.CSharp"),
-                Diagnostic().WithLocation(9, 1).WithArguments("System.Collections", "Microsoft.CodeAnalysis.CSharp"),
+                Diagnostic().WithLocation(0).WithArguments("System.Threading", "Microsoft.CodeAnalysis.CSharp"),
+                Diagnostic().WithLocation(1).WithArguments("System.Collections", "Microsoft.CodeAnalysis.CSharp"),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1209UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1209UnitTests.cs
@@ -8,6 +8,7 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.OrderingRules.SA1209UsingAliasDirectivesMustBePlacedAfterOtherUsingDirectives,
@@ -44,10 +45,12 @@ class A
             await VerifyCSharpDiagnosticAsync(usingsInNamespaceDeclaration, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestWhenUsingAliasDirectivesAreNotPlacedCorrectlyInCompilationAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestWhenUsingAliasDirectivesAreNotPlacedCorrectlyInCompilationAsync(string lineEnding)
         {
-            var testCodeCompilationUnit = @"using TasksNamespace = System.Threading.Tasks;
+            var testCodeCompilationUnit = @"{|#0:using TasksNamespace = System.Threading.Tasks;|}
 using System.Net;
 using System;
 using System.IO;
@@ -55,7 +58,7 @@ using System.Linq;
 
 class A
 {
-}";
+}".ReplaceLineEndings(lineEnding);
             var fixedTestCodeCompilationUnit = @"using System;
 using System.IO;
 using System.Linq;
@@ -64,9 +67,9 @@ using TasksNamespace = System.Threading.Tasks;
 
 class A
 {
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expectedForCompilationUnit = Diagnostic().WithLocation(1, 1);
+            DiagnosticResult expectedForCompilationUnit = Diagnostic().WithLocation(0);
 
             await VerifyCSharpFixAsync(testCodeCompilationUnit, expectedForCompilationUnit, fixedTestCodeCompilationUnit, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210CombinedSystemDirectivesUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210CombinedSystemDirectivesUnitTests.cs
@@ -10,6 +10,7 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
     using StyleCop.Analyzers.Settings.ObjectModel;
+    using StyleCop.Analyzers.Test.Helpers;
     using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.CustomDiagnosticVerifier<StyleCop.Analyzers.OrderingRules.SA1210UsingDirectivesMustBeOrderedAlphabeticallyByNamespace>;
@@ -49,22 +50,24 @@ namespace Bar
             await VerifyCSharpDiagnosticAsync(namespaceDeclaration, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestInvalidOrderedUsingDirectivesInNamespaceDeclarationAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidOrderedUsingDirectivesInNamespaceDeclarationAsync(string lineEnding)
         {
             var testCode = @"namespace Food
 {
-    using System.Threading;
+    {|#0:using System.Threading;|}
     using System;
 }
 
 namespace Bar
 {
-    using Food;
+    {|#1:using Food;|}
     using Bar;
-    using System.Threading;
+    {|#2:using System.Threading;|}
     using System;
-}";
+}".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"namespace Food
 {
@@ -78,13 +81,13 @@ namespace Bar
     using Food;
     using System;
     using System.Threading;
-}";
+}".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(3, 5),
-                Diagnostic().WithLocation(9, 5),
-                Diagnostic().WithLocation(11, 5),
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
+                Diagnostic().WithLocation(2),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1210UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.OrderingRules.SA1210UsingDirectivesMustBeOrderedAlphabeticallyByNamespace,
@@ -48,24 +49,26 @@ namespace Bar
             await VerifyCSharpDiagnosticAsync(namespaceDeclaration, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestInvalidOrderedUsingDirectivesInCompilationUnitAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidOrderedUsingDirectivesInCompilationUnitAsync(string lineEnding)
         {
-            var testCode = @"using System.Threading;
-using System.IO;
+            var testCode = @"{|#0:using System.Threading;|}
+{|#1:using System.IO;|}
 using System;
-using System.Linq;";
+using System.Linq;".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"using System;
 using System.IO;
 using System.Linq;
 using System.Threading;
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(1, 1),
-                Diagnostic().WithLocation(2, 1),
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1212UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1212UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.OrderingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.OrderingRules.SA1212PropertyAccessorsMustFollowOrder,
@@ -15,8 +14,10 @@ namespace StyleCop.Analyzers.Test.OrderingRules
 
     public class SA1212UnitTests
     {
-        [Fact]
-        public async Task TestPropertyWithDocumentationAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestPropertyWithDocumentationAsync(string lineEnding)
         {
             var testCode = @"
 public class Foo
@@ -28,10 +29,10 @@ public class Foo
         /// <summary>
         /// The setter documentation
         /// </summary>
-        set
+        {|#0:set
         {
             i = value;
-        }
+        }|}
 
         /// <summary>
         /// The getter documentation
@@ -41,9 +42,9 @@ public class Foo
             return i;
         }
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(11, 9);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             var fixedCode = @"
 public class Foo
@@ -68,7 +69,7 @@ public class Foo
             i = value;
         }
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1213UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1213UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.OrderingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.OrderingRules.SA1213EventAccessorsMustFollowOrder,
@@ -15,8 +14,10 @@ namespace StyleCop.Analyzers.Test.OrderingRules
 
     public class SA1213UnitTests
     {
-        [Fact]
-        public async Task TestAddAccessorAfterRemoveAccessorAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestAddAccessorAfterRemoveAccessorAsync(string lineEnding)
         {
             var testCode = @"
 using System;
@@ -26,7 +27,7 @@ public class Foo
 
     public event EventHandler NameChanged
     {
-        remove
+        {|#0:remove|}
         {
             this.nameChanged -= value;
         }
@@ -35,9 +36,9 @@ public class Foo
             this.nameChanged += value;
         }
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(9, 9);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             var fixedCode = @"
 using System;
@@ -56,7 +57,7 @@ public class Foo
             this.nameChanged -= value;
         }
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1214UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1214UnitTests.cs
@@ -8,6 +8,7 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.OrderingRules.SA1214ReadonlyElementsMustAppearBeforeNonReadonlyElements,
@@ -84,19 +85,21 @@ public class TestClass2
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestTwoFieldsInClassStaticReadonlyFieldPlacedAfterStaticNonReadonlyAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestTwoFieldsInClassStaticReadonlyFieldPlacedAfterStaticNonReadonlyAsync(string lineEnding)
         {
             var testCode = @"
 public class Foo
 {
     private static int i = 0;
-    private static readonly int j = 0;
-}";
+    private static readonly int {|#0:j|} = 0;
+}".ReplaceLineEndings(lineEnding);
 
             var expected = new[]
             {
-                Diagnostic().WithLocation(5, 33),
+                Diagnostic().WithLocation(0),
             };
 
             var fixTestCode = @"
@@ -104,7 +107,7 @@ public class Foo
 {
     private static readonly int j = 0;
     private static int i = 0;
-}";
+}".ReplaceLineEndings(lineEnding);
             await VerifyCSharpFixAsync(testCode, expected, fixTestCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1215UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1215UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.OrderingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.OrderingRules.SA1214ReadonlyElementsMustAppearBeforeNonReadonlyElements,
@@ -111,25 +112,28 @@ namespace StyleCop.Analyzers.Test.OrderingRules
         /// <summary>
         /// Verifies that the analyzer will properly handle readonly fields in classes.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestReadonlyOrderingInClassAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestReadonlyOrderingInClassAsync(string lineEnding)
         {
             var testCode = @"public class TestClass
 {
     public int TestField1;
-    public readonly int TestField2 = 1;
+    public readonly int {|#0:TestField2|} = 1;
 }
-";
+".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(4, 25);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             var fixTestCode = @"public class TestClass
 {
     public readonly int TestField2 = 1;
     public int TestField1;
 }
-";
+".ReplaceLineEndings(lineEnding);
             await VerifyCSharpFixAsync(testCode, expected, fixTestCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1216UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1216UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.OrderingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.OrderingRules.SA1216UsingStaticDirectivesMustBePlacedAtTheCorrectLocation,
@@ -86,13 +85,16 @@ public class Foo
         /// <summary>
         /// Verifies that the analyzer will produce the proper diagnostics when the using directives are ordered wrong.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestInvalidUsingDirectivesOrderingAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidUsingDirectivesOrderingAsync(string lineEnding)
         {
             var testCode = @"namespace Foo
 {
-    using static System.Math;
+    {|#0:using static System.Math;|}
     using Execute = System.Action;
     using System;
 }
@@ -100,11 +102,11 @@ public class Foo
 namespace Bar
 {
     using Execute = System.Action;
-    using static System.Array;
+    {|#1:using static System.Array;|}
     using static System.Math;
     using System;
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"namespace Foo
 {
@@ -120,12 +122,12 @@ namespace Bar
     using static System.Math;
     using Execute = System.Action;
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expectedDiagnostics =
             {
-                Diagnostic().WithLocation(3, 5),
-                Diagnostic().WithLocation(11, 5),
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
             };
 
             await VerifyCSharpFixAsync(testCode, expectedDiagnostics, fixedTestCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1217UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/OrderingRules/SA1217UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.OrderingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.OrderingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
 
@@ -108,26 +107,29 @@ public class Foo
         /// <summary>
         /// Verifies that the analyzer will produce the proper diagnostics when the using directives are ordered wrong.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestInvalidUsingDirectivesOrderingAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidUsingDirectivesOrderingAsync(string lineEnding)
         {
             var testCode = @"namespace Foo
 {
     using System;
     using Execute = System.Action;
-    using static System.Math;
+    {|#0:using static System.Math;|}
     using static System.Array;
 }
 
 namespace Bar
 {
-    using static System.Math;
+    {|#1:using static System.Math;|}
     using Execute = System.Action;
     using static System.Array;
     using System;
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"namespace Foo
 {
@@ -144,12 +146,12 @@ namespace Bar
     using static System.Math;
     using Execute = System.Action;
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expectedDiagnostics =
             {
-                Diagnostic().WithLocation(5, 5).WithArguments("System.Math", "System.Array"),
-                Diagnostic().WithLocation(11, 5).WithArguments("System.Math", "System.Array"),
+                Diagnostic().WithLocation(0).WithArguments("System.Math", "System.Array"),
+                Diagnostic().WithLocation(1).WithArguments("System.Math", "System.Array"),
             };
 
             await this.VerifyCSharpFixAsync(testCode, expectedDiagnostics, fixedTestCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1100UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1100UnitTests.cs
@@ -8,6 +8,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1100DoNotPrefixCallsWithBaseUnlessLocalImplementationExists,
@@ -15,8 +16,10 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 
     public class SA1100UnitTests
     {
-        [Fact]
-        public async Task TestChildClassUsesBaseButNoOverrideAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestChildClassUsesBaseButNoOverrideAsync(string lineEnding)
         {
             var testCode = @"
 public class Foo
@@ -31,11 +34,11 @@ public class FooChild : Foo
 {
     protected void Baz()
     {
-        base.Bar();
+        {|#0:base|}.Bar();
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(14, 9);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             var fixedTest = @"
 public class Foo
@@ -52,7 +55,7 @@ public class FooChild : Foo
     {
         this.Bar();
     }
-}";
+}".ReplaceLineEndings(lineEnding);
             await VerifyCSharpFixAsync(testCode, expected, fixedTest, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1101UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1101UnitTests.cs
@@ -6,6 +6,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1101PrefixLocalCallsWithThis,
@@ -262,20 +263,22 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestPrefixLocalCallsWithThisWithGenericArgumentsAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestPrefixLocalCallsWithThisWithGenericArgumentsAsync(string lineEnding)
         {
             string testCode = @"public class Test_SA1101
 {
     public void Foo()
     {
-        ConvertAll(42); // SA1101
+        {|#0:ConvertAll|}(42); // SA1101
         this.ConvertAll(42); // no SA1101
-        ConvertAll<int>(42); // SA1101
+        {|#1:ConvertAll<int>|}(42); // SA1101
         this.ConvertAll<int>(42); // no SA1101
     }
     public void ConvertAll<T>(T value) { }
-}";
+}".ReplaceLineEndings(lineEnding);
             string fixedCode = @"public class Test_SA1101
 {
     public void Foo()
@@ -286,12 +289,12 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
         this.ConvertAll<int>(42); // no SA1101
     }
     public void ConvertAll<T>(T value) { }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             var expected = new[]
             {
-                Diagnostic().WithLocation(5, 9),
-                Diagnostic().WithLocation(7, 9),
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1102UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1102UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA110xQueryClauses,
@@ -16,8 +17,10 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 
     public class SA1102UnitTests
     {
-        [Fact]
-        public async Task TestSelectOnSeparateLineWithAdditionalEmptyLineAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestSelectOnSeparateLineWithAdditionalEmptyLineAsync(string lineEnding)
         {
             var testCode = @"
 using System.Linq;
@@ -31,9 +34,9 @@ public class Foo4
             from m in source
             where m > 0
 
-            select m;
+            {|#0:select|} m;
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"
 using System.Linq;
@@ -48,9 +51,9 @@ public class Foo4
             where m > 0
             select m;
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic(SA110xQueryClauses.SA1102Descriptor).WithLocation(13, 13);
+            DiagnosticResult expected = Diagnostic(SA110xQueryClauses.SA1102Descriptor).WithLocation(0);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1103UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1103UnitTests.cs
@@ -10,6 +10,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA110xQueryClauses,
@@ -23,9 +24,12 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
         /// <summary>
         /// Verifies that a select query expression produces the expected results.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestSelectQueryExpressionAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestSelectQueryExpressionAsync(string lineEnding)
         {
             var testCode = @"namespace TestNamespace
 {
@@ -37,12 +41,12 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 
         public void TestMethod()
         {
-            var x = from element in testArray where (element > 1)
+            var x = {|#0:from|} element in testArray where (element > 1)
                 select element;
         }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"namespace TestNamespace
 {
@@ -58,11 +62,11 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
         }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expectedDiagnostics =
             {
-                Diagnostic(SA110xQueryClauses.SA1103Descriptor).WithLocation(11, 21),
+                Diagnostic(SA110xQueryClauses.SA1103Descriptor).WithLocation(0),
             };
 
             await VerifyCSharpFixAsync(testCode, expectedDiagnostics, fixedTestCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1104UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1104UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA110xQueryClauses,
@@ -22,9 +23,12 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
         /// <summary>
         /// Verifies that a select query expression produces the expected results.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestSelectQueryExpressionAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestSelectQueryExpressionAsync(string lineEnding)
         {
             var testCode = @"namespace TestNamespace
 {
@@ -43,11 +47,11 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
                 from element in TestMethod1
                 (
                     12
-                ) select element;
+                ) {|#0:select|} element;
         }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"namespace TestNamespace
 {
@@ -71,11 +75,11 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
         }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expectedDiagnostics =
             {
-                Diagnostic(SA110xQueryClauses.SA1104Descriptor).WithLocation(18, 19),
+                Diagnostic(SA110xQueryClauses.SA1104Descriptor).WithLocation(0),
             };
 
             await VerifyCSharpFixAsync(testCode, expectedDiagnostics, fixedTestCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1105UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1105UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA110xQueryClauses,
@@ -22,9 +23,12 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
         /// <summary>
         /// Verifies that a select query expression produces the expected results.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestSelectQueryExpressionAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestSelectQueryExpressionAsync(string lineEnding)
         {
             var testCode = @"namespace TestNamespace
 {
@@ -40,14 +44,14 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
         public void TestMethod2()
         {
             var x =
-                from element in new[] { 1, 2, 3 } select TestMethod1
+                from element in new[] { 1, 2, 3 } {|#0:select|} TestMethod1
                 (
                     element
                 );
         }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"namespace TestNamespace
 {
@@ -71,11 +75,11 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
         }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expectedDiagnostics =
             {
-                Diagnostic(SA110xQueryClauses.SA1105Descriptor).WithLocation(15, 51),
+                Diagnostic(SA110xQueryClauses.SA1105Descriptor).WithLocation(0),
             };
 
             await VerifyCSharpFixAsync(testCode, expectedDiagnostics, fixedTestCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1106UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1106UnitTests.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.ReadabilityRules
 {
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
@@ -16,13 +15,28 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 
     public class SA1106UnitTests
     {
+        public static TheoryData<string, string> StatementAsBlock
+        {
+            get
+            {
+                var result = new TheoryData<string, string>();
+                foreach (var lineEndingData in CommonData.EndOfLineSequences)
+                {
+                    var lineEnding = (string)lineEndingData.Single();
+                    result.Add("if (true)", lineEnding);
+                    result.Add("if (true) { } else", lineEnding);
+                    result.Add("for (int i = 0; i < 10; i++)", lineEnding);
+                    result.Add("foreach (int i in new int[] { 0 })", lineEnding);
+                    result.Add("while (true)", lineEnding);
+                }
+
+                return result;
+            }
+        }
+
         [Theory]
-        [InlineData("if (true)")]
-        [InlineData("if (true) { } else")]
-        [InlineData("for (int i = 0; i < 10; i++)")]
-        [InlineData("foreach (int i in new int[] { 0 })")]
-        [InlineData("while (true)")]
-        public async Task TestEmptyStatementAsBlockAsync(string controlFlowConstruct)
+        [MemberData(nameof(StatementAsBlock))]
+        public async Task TestEmptyStatementAsBlockAsync(string controlFlowConstruct, string lineEnding)
         {
             var testCode = $@"
 class TestClass
@@ -30,9 +44,9 @@ class TestClass
     public void TestMethod()
     {{
         {controlFlowConstruct}
-            ;
+            {{|#0:;|}}
     }}
-}}";
+}}".ReplaceLineEndings(lineEnding);
             var fixedCode = $@"
 class TestClass
 {{
@@ -42,15 +56,17 @@ class TestClass
         {{
         }}
     }}
-}}";
+}}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(7, 13);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestEmptyStatementAsBlockInDoWhileAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestEmptyStatementAsBlockInDoWhileAsync(string lineEnding)
         {
             var testCode = @"
 class TestClass
@@ -58,10 +74,10 @@ class TestClass
     public void TestMethod()
     {
         do
-            ;
+            {|#0:;|}
         while (false);
     }
-}";
+}".ReplaceLineEndings(lineEnding);
             var fixedCode = @"
 class TestClass
 {
@@ -72,9 +88,9 @@ class TestClass
         }
         while (false);
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(7, 13);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
@@ -128,26 +144,28 @@ class TestClass
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestEmptyStatementAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestEmptyStatementAsync(string lineEnding)
         {
             var testCode = @"
 class TestClass
 {
     public void TestMethod()
     {
-        ;
+        {|#0:;|}
     }
-}";
+}".ReplaceLineEndings(lineEnding);
             var fixedCode = @"
 class TestClass
 {
     public void TestMethod()
     {
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(6, 9);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1107UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1107UnitTests.cs
@@ -49,7 +49,7 @@ class ClassName
         }
 
         [Theory]
-        [InlineData("\n", Skip = "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/3656")]
+        [InlineData("\n")]
         [InlineData("\r\n")]
         public async Task TestWrongCodeAsync(string lineEnding)
         {
@@ -88,7 +88,7 @@ class ClassName
     {
         int i = 5;
         int j = 6, k = 3;
-        if (true)
+        if(true)
         {
             i++;
         }
@@ -96,11 +96,10 @@ class ClassName
         {
             j++;
         }
-
         Foo(""a"", ""b"");
 
         Func<int, int, int> g = (c, d) => { c++;
-            return c + d; };
+        return c + d; };
     }
 }
 ".ReplaceLineEndings(lineEnding);
@@ -158,16 +157,19 @@ class Program
     }
 }
 ";
+            string fixedCode = @"
+class Program
+{
+    static void Main(string[] args)
+    {
+        {
+        }
+        ;
+    }
+}
+";
 
-            await new CSharpTest
-            {
-                TestCode = testCode,
-                FixedCode = testCode,
-
-                // A code fix is offered even though no changes are applied by it
-                NumberOfIncrementalIterations = 1,
-                NumberOfFixAllIterations = 1,
-            }.RunAsync(CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1110UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1110UnitTests.cs
@@ -8,6 +8,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1110OpeningParenthesisMustBeOnDeclarationLine,
@@ -15,18 +16,20 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 
     public class SA1110UnitTests
     {
-        [Fact]
-        public async Task TestMethodDeclarationOpeningParenthesisInTheNextLineAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestMethodDeclarationOpeningParenthesisInTheNextLineAsync(string lineEnding)
         {
             var testCode = @"
 class Foo
 {
     public void Bar
-                    ()
+                    {|#0:(|})
     {
 
     }
-}";
+}".ReplaceLineEndings(lineEnding);
             var fixedCode = @"
 class Foo
 {
@@ -34,9 +37,9 @@ class Foo
     {
 
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(5, 21);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1111UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1111UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.ReadabilityRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1111ClosingParenthesisMustBeOnLineOfLastParameter,
@@ -15,18 +14,20 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 
     public class SA1111UnitTests
     {
-        [Fact]
-        public async Task TestMethodDeclarationWithOneParameterClosingParanthesisOnTheNextLineAsTheLastParameterAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestMethodDeclarationWithOneParameterClosingParanthesisOnTheNextLineAsTheLastParameterAsync(string lineEnding)
         {
             var testCode = @"
 class Foo
 {
     public void Bar(string s
-)
+{|#0:)|}
     {
 
     }
-}";
+}".ReplaceLineEndings(lineEnding);
             var fixedCode = @"
 class Foo
 {
@@ -34,9 +35,9 @@ class Foo
     {
 
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(5, 1);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1112UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1112UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.ReadabilityRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1112ClosingParenthesisMustBeOnLineOfOpeningParenthesis,
@@ -15,18 +14,20 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 
     public class SA1112UnitTests
     {
-        [Fact]
-        public async Task TestMethodWithNoParametersClosingParanthesisOnTheNextLineAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestMethodWithNoParametersClosingParanthesisOnTheNextLineAsync(string lineEnding)
         {
             var testCode = @"
 class Foo
 {
     public void Bar(
-)
+{|#0:)|}
     {
 
     }
-}";
+}".ReplaceLineEndings(lineEnding);
             var fixedCode = @"
 class Foo
 {
@@ -34,9 +35,9 @@ class Foo
     {
 
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(5, 1);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1113UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1113UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.ReadabilityRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1113CommaMustBeOnSameLineAsPreviousParameter,
@@ -15,25 +14,27 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 
     public class SA1113UnitTests
     {
-        [Fact]
-        public async Task TestMethodDeclarationWithTwoParametersCommaPlacedAtTheSameLineAsTheSecondParameterAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestMethodDeclarationWithTwoParametersCommaPlacedAtTheSameLineAsTheSecondParameterAsync(string lineEnding)
         {
             var testCode = @"public class Foo
 {
     public void Bar(string s
-                    , int i)
+                    {|#0:,|} int i)
     {
     }
-}";
+}".ReplaceLineEndings(lineEnding);
             var fixedCode = @"public class Foo
 {
     public void Bar(string s,
                     int i)
     {
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(4, 21);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1116UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1116UnitTests.cs
@@ -13,6 +13,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1116SplitParametersMustStartOnLineAfterDeclaration,
@@ -273,8 +274,10 @@ class ObsoleteType
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestInvalidAttributeAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidAttributeAsync(string lineEnding)
         {
             var testCode = @"
 [System.AttributeUsage(System.AttributeTargets.Class)]
@@ -285,11 +288,11 @@ public class MyAttribute : System.Attribute
     }
 }
 
-[MyAttribute(1,
+[MyAttribute({|#0:1|},
       2)]
 class Foo
 {
-}";
+}".ReplaceLineEndings(lineEnding);
             var fixedCode = @"
 [System.AttributeUsage(System.AttributeTargets.Class)]
 public class MyAttribute : System.Attribute
@@ -304,9 +307,9 @@ public class MyAttribute : System.Attribute
       2)]
 class Foo
 {
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(10, 14);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
     }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1120UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1120UnitTests.cs
@@ -8,6 +8,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1120CommentsMustContainText,
@@ -15,19 +16,21 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 
     public class SA1120UnitTests
     {
-        [Fact]
-        public async Task TestViolationWithSingleLineCommentAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestViolationWithSingleLineCommentAsync(string lineEnding)
         {
             var testCode = @"
 class Foo
 {
     public void Bar()
     {
-        //
+        {|#0://|}
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(6, 9);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             var expectedFixedCode = @"
 class Foo
@@ -35,7 +38,7 @@ class Foo
     public void Bar()
     {
     }
-}";
+}".ReplaceLineEndings(lineEnding);
             await VerifyCSharpFixAsync(testCode, expected, expectedFixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1121UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1121UnitTests.cs
@@ -16,6 +16,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1121UseBuiltInTypeAlias,
@@ -511,18 +512,21 @@ public class Foo
             await VerifyCSharpFixAsync(string.Format(testSource, fullName), expected, string.Format(testSource, predefined), CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestMissleadingUsingAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestMissleadingUsingAsync(string lineEnding)
         {
             string oldSource = @"namespace Foo
 {
   using Int32 = System.UInt32;
   class Bar
   {
-    Int32 value = 3;
+    {|#0:Int32|} value = 3;
   }
 }
-";
+".ReplaceLineEndings(lineEnding);
+
             string newSource = @"namespace Foo
 {
   using Int32 = System.UInt32;
@@ -531,12 +535,12 @@ public class Foo
     uint value = 3;
   }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             await new CSharpTest
             {
                 TestCode = oldSource,
-                ExpectedDiagnostics = { Diagnostic().WithLocation(6, 5) },
+                ExpectedDiagnostics = { Diagnostic().WithLocation(0) },
                 FixedCode = newSource,
             }.RunAsync(CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1122UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1122UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1122UseStringEmptyForEmptyStrings,
@@ -48,8 +49,10 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestCodeFixMultipleNodesAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestCodeFixMultipleNodesAsync(string lineEnding)
         {
             // Tests if the code fix works if the SourceSpan of the diagnostic has more then one SyntaxNode associated with it
             // In this case it is a InterpolatedStringInsert and the StringLiteralExpression
@@ -57,18 +60,18 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 {
     public void Bar()
     {
-        string test = $""{""""}"";
+        string test = $""{{|#0:""""|}}"";
     }
-}";
+}".ReplaceLineEndings(lineEnding);
             string newSource = @"public class Foo
 {
     public void Bar()
     {
         string test = $""{string.Empty}"";
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            var expected = Diagnostic().WithLocation(5, 26);
+            var expected = Diagnostic().WithLocation(0);
             await VerifyCSharpFixAsync(oldSource, expected, newSource, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1123UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1123UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1123DoNotPlaceRegionsWithinElements,
@@ -20,20 +21,22 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     /// </summary>
     public class SA1123UnitTests
     {
-        [Fact]
-        public async Task TestRegionInMethodAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestRegionInMethodAsync(string lineEnding)
         {
             var testCode = @"public class Foo
 {
     public void Bar()
     {
-#region Foo
+{|#0:#region Foo|}
         string test = """";
 #endregion
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(5, 1);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             string fixedCode = @"public class Foo
 {
@@ -41,7 +44,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     {
         string test = """";
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1124UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1124UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1124DoNotUseRegions,
@@ -56,20 +57,22 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
             await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestRegionPartialyInMethod2Async()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestRegionPartialyInMethod2Async(string lineEnding)
         {
             var testCode = @"public class Foo
 {
     public void Bar()
-#region Foo
+{|#0:#region Foo|}
     {
         string test = """";
     }
 #endregion
-}";
+}".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = Diagnostic().WithLocation(4, 1);
+            DiagnosticResult expected = Diagnostic().WithLocation(0);
 
             string fixedCode = @"public class Foo
 {
@@ -77,7 +80,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     {
         string test = """";
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1127UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1127UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1127GenericTypeConstraintsMustBeOnOwnLine,
@@ -49,22 +50,24 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestViolationWithMethodDeclarationAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestViolationWithMethodDeclarationAsync(string lineEnding)
         {
             var testCode = $@"
 class Foo
 {{
-    private void Method<T>() where T : class {{ }}
-}}";
+    private void Method<T>() {{|#0:where T : class|}} {{ }}
+}}".ReplaceLineEndings(lineEnding);
             var fixedCode = $@"
 class Foo
 {{
     private void Method<T>()
         where T : class
     {{ }}
-}}";
-            var expected = Diagnostic().WithLocation(4, 30);
+}}".ReplaceLineEndings(lineEnding);
+            var expected = Diagnostic().WithLocation(0);
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1128UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1128UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1128ConstructorInitializerMustBeOnOwnLine,
@@ -30,16 +31,18 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
             await VerifyCSharpDiagnosticAsync(declaration, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestViolationWithBaseInitializerOnSameLineAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestViolationWithBaseInitializerOnSameLineAsync(string lineEnding)
         {
             var testCode = @"
 public class TypeName
 {
-    public TypeName() : base()
+    public TypeName() {|#0:: base()|}
     {
     }
-}";
+}".ReplaceLineEndings(lineEnding);
             var fixedCode = @"
 public class TypeName
 {
@@ -47,8 +50,8 @@ public class TypeName
         : base()
     {
     }
-}";
-            var expected = Diagnostic().WithLocation(4, 23);
+}".ReplaceLineEndings(lineEnding);
+            var expected = Diagnostic().WithLocation(0);
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1129UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1129UnitTests.cs
@@ -10,6 +10,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1129DoNotUseDefaultValueTypeConstructor,
@@ -84,9 +85,12 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
         /// <summary>
         /// Verifies that new expressions for value types without parameters will generate diagnostics.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task VerifyInvalidValueTypeCreationAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task VerifyInvalidValueTypeCreationAsync(string lineEnding)
         {
             var testCode = @"public class TestClass
 {
@@ -102,7 +106,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
         public int TestProperty { get; set; }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"public class TestClass
 {
@@ -118,7 +122,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
         public int TestProperty { get; set; }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1130UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1130UnitTests.cs
@@ -11,6 +11,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1130UseLambdaSyntax,
@@ -32,8 +33,10 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
         private static readonly DiagnosticDescriptor CS1669 =
                           new DiagnosticDescriptor(nameof(CS1669), "Title", "__arglist is not valid in this context", "Category", DiagnosticSeverity.Error, AnalyzerConstants.EnabledByDefault);
 
-        [Fact]
-        public async Task TestSimpleDelegateUseAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestSimpleDelegateUseAsync(string lineEnding)
         {
             var testCode = @"
 using System;
@@ -41,11 +44,11 @@ public class TypeName
 {
     public void Test()
     {
-        Action action1 = delegate { };
-        Action action2 = delegate() { };
-        Action<int> action3 = delegate(int i) { };
+        Action action1 = {|#0:delegate|} { };
+        Action action2 = {|#1:delegate|}() { };
+        Action<int> action3 = {|#2:delegate|}(int i) { };
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             string fixedCode = @"
 using System;
@@ -57,13 +60,13 @@ public class TypeName
         Action action2 = () => { };
         Action<int> action3 = i => { };
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             var expected = new[]
             {
-                Diagnostic().WithLocation(7, 26),
-                Diagnostic().WithLocation(8, 26),
-                Diagnostic().WithLocation(9, 31),
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
+                Diagnostic().WithLocation(2),
             };
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1131UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1131UnitTests.cs
@@ -8,6 +8,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1131UseReadableConditions,
@@ -50,6 +51,43 @@ public class TypeName
             DiagnosticResult[] expected =
             {
                 Diagnostic().WithLocation(9, 13),
+            };
+            await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestYodaComparismWithLineEndingsAsync(string lineEnding)
+        {
+            var testCode = @"
+using System;
+public class TypeName
+{
+    public void Test()
+    {
+        int i = 5;
+        const int j = 6;
+        if ({|#0:j == i|}) { }
+    }
+}
+".ReplaceLineEndings(lineEnding);
+            var fixedCode = @"
+using System;
+public class TypeName
+{
+    public void Test()
+    {
+        int i = 5;
+        const int j = 6;
+        if (i == j) { }
+    }
+}
+".ReplaceLineEndings(lineEnding);
+
+            DiagnosticResult[] expected =
+            {
+                Diagnostic().WithLocation(0),
             };
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1132UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1132UnitTests.cs
@@ -1,13 +1,12 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.ReadabilityRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1132DoNotCombineFields,
@@ -29,16 +28,18 @@ class Foo
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestInvalidDeclarationAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidDeclarationAsync(string lineEnding)
         {
-            const string testCode = @"
+            string testCode = @"
 class Foo
 {
-    private int a, b,/*foo*/c,d;
-    public event System.Action aa, bb;
-}";
-            const string fixedCode = @"
+    {|#0:private int a, b,/*foo*/c,d;|}
+    {|#1:public event System.Action aa, bb;|}
+}".ReplaceLineEndings(lineEnding);
+            string fixedCode = @"
 class Foo
 {
     private int a;
@@ -47,12 +48,12 @@ class Foo
     private int d;
     public event System.Action aa;
     public event System.Action bb;
-}";
+}".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(4, 5),
-                Diagnostic().WithLocation(5, 5),
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1133UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1133UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1133DoNotCombineAttributes,
@@ -56,24 +57,27 @@ public class TestClass
         /// <summary>
         /// Verifies that an attribute list will produce the required diagnostics.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task VerifyThatAttributeListProducesDiagnosticAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task VerifyThatAttributeListProducesDiagnosticAsync(string lineEnding)
         {
             var testCode = @"using System.ComponentModel;
 
-[EditorBrowsable(EditorBrowsableState.Never), DesignOnly(true)]
+[EditorBrowsable(EditorBrowsableState.Never), {|#0:DesignOnly|}(true)]
 public class TestClass
 {
     /// <summary>
     /// Test method.
     /// </summary>
-    [EditorBrowsable(EditorBrowsableState.Never), DesignOnly(true), DisplayName(""Test"")] // test comment
+    [EditorBrowsable(EditorBrowsableState.Never), {|#1:DesignOnly|}(true), DisplayName(""Test"")] // test comment
     public void TestMethod()
     {
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"using System.ComponentModel;
 
@@ -91,12 +95,12 @@ public class TestClass
     {
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(3, 47),
-                Diagnostic().WithLocation(9, 51),
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1135UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1135UnitTests.cs
@@ -10,6 +10,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1135UsingDirectivesMustBeQualified,
@@ -17,26 +18,28 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
 
     public class SA1135UnitTests
     {
-        [Fact]
-        public async Task TestUnqualifiedUsingsAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestUnqualifiedUsingsAsync(string lineEnding)
         {
-            const string testCode = @"
+            string testCode = @"
 namespace System.Threading
 {
-    using IO;
-    using Tasks;
-}";
-            const string fixedCode = @"
+    {|#0:using IO;|}
+    {|#1:using Tasks;|}
+}".ReplaceLineEndings(lineEnding);
+            string fixedCode = @"
 namespace System.Threading
 {
     using System.IO;
     using System.Threading.Tasks;
-}";
+}".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic(SA1135UsingDirectivesMustBeQualified.DescriptorNamespace).WithLocation(4, 5).WithArguments("System.IO"),
-                Diagnostic(SA1135UsingDirectivesMustBeQualified.DescriptorNamespace).WithLocation(5, 5).WithArguments("System.Threading.Tasks"),
+                Diagnostic(SA1135UsingDirectivesMustBeQualified.DescriptorNamespace).WithLocation(0).WithArguments("System.IO"),
+                Diagnostic(SA1135UsingDirectivesMustBeQualified.DescriptorNamespace).WithLocation(1).WithArguments("System.Threading.Tasks"),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1136UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1136UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.ReadabilityRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1136EnumValuesShouldBeOnSeparateLines,
@@ -23,16 +22,19 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
         /// Verifies that an enum declaration with all values on the same line will return the expected diagnostics.
         /// This also verifies that an enum declaration with all values on separate lines will not produce diagnostics.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestSingleLineEnumDeclarationAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestSingleLineEnumDeclarationAsync(string lineEnding)
         {
             var testCode = @"
 public enum TestEnum
 {
-    FirstValue, SecondValue, ThirdValue
+    FirstValue, {|#0:SecondValue|}, {|#1:ThirdValue|}
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"
 public enum TestEnum
@@ -41,12 +43,12 @@ public enum TestEnum
     SecondValue,
     ThirdValue
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(4, 17),
-                Diagnostic().WithLocation(4, 30),
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1137UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1137UnitTests.cs
@@ -1881,8 +1881,10 @@ class ClassName
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestAnonymousObjectCreationExpressionAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestAnonymousObjectCreationExpressionAsync(string lineEnding)
         {
             string testCode = @"
 class ClassName
@@ -1893,8 +1895,8 @@ class ClassName
             new
             {
                 X = 0,
-              Y = 0,
-Z = 0,
+{|#0:              |}Y = 0,
+{|#1:Z|} = 0,
             };
     }
 
@@ -1904,12 +1906,12 @@ Z = 0,
             new
             {
 X = 0,
-              Y = 0,
-                Z = 0,
+{|#2:              |}Y = 0,
+{|#3:                |}Z = 0,
             };
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
             string fixedCode = @"
 class ClassName
 {
@@ -1935,14 +1937,14 @@ Z = 0,
             };
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(10, 1),
-                Diagnostic().WithLocation(11, 1),
-                Diagnostic().WithLocation(21, 1),
-                Diagnostic().WithLocation(22, 1),
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
+                Diagnostic().WithLocation(2),
+                Diagnostic().WithLocation(3),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1139UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SA1139UnitTests.cs
@@ -9,6 +9,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.ReadabilityRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SA1139UseLiteralSuffixNotationInsteadOfCasting,
@@ -271,10 +272,13 @@ class ClassName
         /// <summary>
         /// Verifies that the codefix will not insert extraneous spaces.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
         [WorkItem(2901, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2901")]
-        public async Task TestCodeFixDoesNotAddExtraneousSpacesAsync()
+        public async Task TestCodeFixDoesNotAddExtraneousSpacesAsync(string lineEnding)
         {
             var testCode = @"
 public class TestClass
@@ -288,7 +292,7 @@ public class TestClass
             / (double)4; // divisor
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedCode = @"
 public class TestClass
@@ -302,7 +306,7 @@ public class TestClass
             / 4D; // divisor
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expectedDiagnosticResult =
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SX1101UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/ReadabilityRules/SX1101UnitTests.cs
@@ -8,6 +8,7 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.ReadabilityRules.SX1101DoNotPrefixLocalMembersWithThis,
@@ -18,9 +19,12 @@ namespace StyleCop.Analyzers.Test.ReadabilityRules
         /// <summary>
         /// Verifies that this prefixes are detected and removed.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task VerifyThisPrefixesAreDetectedAndRemovedAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task VerifyThisPrefixesAreDetectedAndRemovedAsync(string lineEnding)
         {
             var testCode = @"using System;
 
@@ -73,7 +77,7 @@ public class TestClass : BaseTestClass
 
     public int listeners;
 }
-";
+".ReplaceLineEndings(lineEnding);
             var fixedTestCode = @"using System;
 
 public class BaseTestClass
@@ -125,7 +129,7 @@ public class TestClass : BaseTestClass
 
     public int listeners;
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/NumberSignSpacingTestBase.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/NumberSignSpacingTestBase.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Collections.Generic;
@@ -12,6 +10,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using Microsoft.CodeAnalysis.CodeFixes;
     using Microsoft.CodeAnalysis.Diagnostics;
     using Microsoft.CodeAnalysis.Testing;
+    using StyleCop.Analyzers.Test.Helpers;
     using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
 
@@ -32,35 +31,37 @@ namespace StyleCop.Analyzers.Test.SpacingRules
             get;
         }
 
-        [Fact]
-        public async Task TestPrefixUnaryOperatorAtEndOfLineAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestPrefixUnaryOperatorAtEndOfLineAsync(string lineEnding)
         {
-            string testCode = @"namespace Namespace
-{
+            string testCode = $@"namespace Namespace
+{{
     class Type
-    {
+    {{
         void Foo()
-        {
-            int x = " + this.Sign + @"
+        {{
+            int x = {{|#0:{this.Sign}|}}
 3;
-        }
-    }
-}
-";
+        }}
+    }}
+}}
+".ReplaceLineEndings(lineEnding);
 
-            string fixedTest = @"namespace Namespace
-{
+            string fixedTest = $@"namespace Namespace
+{{
     class Type
-    {
+    {{
         void Foo()
-        {
-            int x = " + this.Sign + @"3;
-        }
-    }
-}
-";
+        {{
+            int x = {this.Sign}3;
+        }}
+    }}
+}}
+".ReplaceLineEndings(lineEnding);
 
-            DiagnosticResult expected = this.Diagnostic().WithArguments(" not", "followed").WithLocation(7, 21);
+            DiagnosticResult expected = this.Diagnostic().WithArguments(" not", "followed").WithLocation(0);
 
             await this.VerifyCSharpFixAsync(testCode, expected, fixedTest, CancellationToken.None).ConfigureAwait(false);
         }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1000UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1000UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
@@ -10,6 +8,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using Microsoft.CodeAnalysis.CSharp;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1000KeywordsMustBeSpacedCorrectly,
@@ -903,8 +902,10 @@ class ClassName
             await VerifyCSharpDiagnosticAsync(testCode, expected, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestTrailingCommentAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestTrailingCommentAsync(string lineEnding)
         {
             string testCode = @"
 class ClassName
@@ -916,7 +917,7 @@ class ClassName
         }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
             string fixedCode = @"
 class ClassName
 {
@@ -927,7 +928,7 @@ class ClassName
         }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var expected = Diagnostic().WithArguments("if", string.Empty, "followed").WithLocation(6, 9);
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1001UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System;
@@ -10,6 +8,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1001CommasMustBeSpacedCorrectly,
@@ -302,9 +301,11 @@ class ClassName
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
         [WorkItem(2468, "https://github.com/DotNetAnalyzers/StyleCopAnalyzers/issues/2468")]
-        public async Task TestCodeFixCommaPlacementAsync()
+        public async Task TestCodeFixCommaPlacementAsync(string lineEnding)
         {
             var testCode = @"using System;
 
@@ -315,12 +316,12 @@ public class TestClass
         var test = (new[]
         {
             new Tuple<int, int>(1, 2)
-           ,new Tuple<int, int>(3, 4)
-           ,new Tuple<int, int>(5, 6)
+           {|#0:,|}new Tuple<int, int>(3, 4)
+           {|#1:,|}new Tuple<int, int>(5, 6)
         }).ToString();
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedCode = @"using System;
 
@@ -336,14 +337,14 @@ public class TestClass
         }).ToString();
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithArguments(" not", "preceded").WithLocation(10, 12),
-                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(10, 12),
-                Diagnostic().WithArguments(" not", "preceded").WithLocation(11, 12),
-                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(11, 12),
+                Diagnostic().WithArguments(" not", "preceded").WithLocation(0),
+                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(0),
+                Diagnostic().WithArguments(" not", "preceded").WithLocation(1),
+                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(1),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1002UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1002UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1002SemicolonsMustBeSpacedCorrectly,
@@ -20,20 +19,22 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     /// </summary>
     public class SA1002UnitTests
     {
-        [Fact]
-        public async Task TestForLoopAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestForLoopAsync(string lineEnding)
         {
             string testCode = @"
 class ClassName
 {
     void MethodName()
     {
-        for (int x =0;x<10;x++)
+        for (int x =0{|#0:;|}x<10{|#1:;|}x++)
         {
         }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
             string fixedCode = @"
 class ClassName
 {
@@ -44,12 +45,12 @@ class ClassName
         }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(6, 22),
-                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(6, 27),
+                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(0),
+                Diagnostic().WithArguments(string.Empty, "followed").WithLocation(1),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1003UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1003UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
 
     using static StyleCop.Analyzers.SpacingRules.SA1003SymbolsMustBeSpacedCorrectly;
@@ -725,9 +724,12 @@ public class Foo : Exception
         /// <summary>
         /// Verifies that invalid auto property initializers produce the correct diagnostics and code fixes.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestInvalidAutoPropertyInitializersAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidAutoPropertyInitializersAsync(string lineEnding)
         {
             var testCode = @"public class Foo
 {
@@ -737,7 +739,7 @@ public class Foo : Exception
 
     public int Qux { get; }=3;
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"public class Foo
 {
@@ -747,7 +749,7 @@ public class Foo : Exception
 
     public int Qux { get; } = 3;
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1004UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1004UnitTests.cs
@@ -10,6 +10,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Lightup;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1004DocumentationLinesMustBeginWithSingleSpace,
@@ -54,8 +55,10 @@ public class TypeName
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestRuleExampleAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestRuleExampleAsync(string lineEnding)
         {
             string testCode = @"
 public class TypeName
@@ -69,7 +72,7 @@ public class TypeName
     {
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             string fixedCode = @"
 public class TypeName
@@ -83,7 +86,7 @@ public class TypeName
     {
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1005UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1005UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
@@ -10,6 +8,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using Microsoft.CodeAnalysis;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1005SingleLineCommentsMustBeginWithSingleSpace,
@@ -44,9 +43,12 @@ namespace StyleCop.Analyzers.Test.SpacingRules
         /// <summary>
         /// Verify that a single line comment without a leading space gets detected and fixed properly.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestNoLeadingSpaceAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestNoLeadingSpaceAsync(string lineEnding)
         {
             var testCode = @"public class Foo
 {
@@ -55,7 +57,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     {
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"public class Foo
 {
@@ -64,7 +66,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     {
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var expected = Diagnostic().WithLocation(3, 5);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1006UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1006UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1006PreprocessorKeywordsMustNotBePrecededBySpace,
@@ -20,8 +19,10 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     /// </summary>
     public class SA1006UnitTests
     {
-        [Fact]
-        public async Task TestRegionDirectivesAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestRegionDirectivesAsync(string lineEnding)
         {
             string testCode = @"
 class ClassName
@@ -32,7 +33,7 @@ class ClassName
     }
     #  endregion
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             string fixedCode = @"
 class ClassName
@@ -43,7 +44,7 @@ class ClassName
     }
     #endregion
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1007UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1007UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1007OperatorKeywordMustBeFollowedBySpace,
@@ -20,8 +19,10 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     /// </summary>
     public class SA1007UnitTests
     {
-        [Fact]
-        public async Task TestOperatorKeywordCasesAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestOperatorKeywordCasesAsync(string lineEnding)
         {
             string testCode = @"
 using System;
@@ -34,7 +35,7 @@ class ClassName
         int(ClassName x) { return 0; }
     public static explicit operator/*comment*/long(ClassName x) { return 0; }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             string fixedCode = @"
 using System;
@@ -47,7 +48,7 @@ class ClassName
         int(ClassName x) { return 0; }
     public static explicit operator /*comment*/long(ClassName x) { return 0; }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1008UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1008UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1008OpeningParenthesisMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
@@ -2025,9 +2024,12 @@ class TestClass
         /// <summary>
         /// Verifies that interpolations are handled properly.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestInterpolationWrongSpacingAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInterpolationWrongSpacingAsync(string lineEnding)
         {
             var testCode = @"namespace TestNamespace
 {
@@ -2042,7 +2044,7 @@ class TestClass
             var fileTitle = $""{fileName}{ (FileContainer.HasContentChanged ? ""*"" : String.Empty)}"";
         }
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"namespace TestNamespace
 {
@@ -2057,7 +2059,7 @@ class TestClass
             var fileTitle = $""{fileName}{(FileContainer.HasContentChanged ? ""*"" : String.Empty)}"";
         }
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expectedDiagnostics =
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1009UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1009UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1009ClosingParenthesisMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
@@ -35,25 +34,27 @@ public class Foo
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestMethodWithWhitespaceBeforeClosingParenthesisAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestMethodWithWhitespaceBeforeClosingParenthesisAsync(string lineEnding)
         {
-            const string testCode = @"using System;
+            string testCode = @"using System;
 
 public class Foo
 {
     public void Method( )
     {
     }
-}";
-            const string fixedCode = @"using System;
+}".ReplaceLineEndings(lineEnding);
+            string fixedCode = @"using System;
 
 public class Foo
 {
     public void Method()
     {
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult expected = Diagnostic(DescriptorNotPreceded).WithLocation(5, 25);
 
@@ -1028,7 +1029,7 @@ public class TestClass
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
         }
 
-        private async Task TestWhitespaceInStatementOrDeclAsync(string originalStatement, string fixedStatement, params DiagnosticResult[] expected)
+        private async Task TestWhitespaceInStatementOrDeclAsync(string originalStatement, string? fixedStatement, params DiagnosticResult[] expected)
         {
             string template = @"namespace Foo
 {{

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1010UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1010UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1010OpeningSquareBracketsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
@@ -45,10 +44,12 @@ public class Foo
             await VerifyCSharpDiagnosticAsync(ExpectedCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestOpenSquareBracketMustNotBePrecededBySpaceAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestOpenSquareBracketMustNotBePrecededBySpaceAsync(string lineEnding)
         {
-            const string testCode = @"using System;
+            string testCode = @"using System;
 
 public class Foo
 {
@@ -65,7 +66,7 @@ public class Foo
             return ints [0] [0];
         }
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
@@ -79,7 +80,7 @@ public class Foo
                 Diagnostic(DescriptorNotPreceded).WithLocation(15, 29),
             };
 
-            await VerifyCSharpFixAsync(testCode, expected, ExpectedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, expected, ExpectedCode.ReplaceLineEndings(lineEnding), CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1011UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1011UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1011ClosingSquareBracketsMustBeSpacedCorrectly,
@@ -51,11 +50,14 @@ public class Foo
         /// <summary>
         /// Verifies that the analyzer will properly handle spaces before a closing square bracket.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestClosingSquareBracketMustNotBePrecededBySpaceAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestClosingSquareBracketMustNotBePrecededBySpaceAsync(string lineEnding)
         {
-            const string testCode = @"using System;
+            string testCode = @"using System;
 
 public class Foo
 {
@@ -72,8 +74,8 @@ public class Foo
             return ints[0 ][0 ];
         }
     }
-}";
-            const string fixedCode = @"using System;
+}".ReplaceLineEndings(lineEnding);
+            string fixedCode = @"using System;
 
 public class Foo
 {
@@ -90,7 +92,7 @@ public class Foo
             return ints[0][0];
         }
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
@@ -366,7 +368,7 @@ class ClassName
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        private async Task TestWhitespaceInStatementOrDeclAsync(string originalStatement, string fixedStatement, params DiagnosticResult[] expected)
+        private async Task TestWhitespaceInStatementOrDeclAsync(string originalStatement, string? fixedStatement, params DiagnosticResult[] expected)
         {
             string template = @"namespace Foo
 {{

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1012UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1012UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1012OpeningBracesMustBeSpacedCorrectly,
@@ -59,9 +58,12 @@ namespace StyleCop.Analyzers.Test.SpacingRules
         /// <summary>
         /// Verifies that the analyzer will properly handle opening braces in string interpolation.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestStringInterpolationAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestStringInterpolationAsync(string lineEnding)
         {
             var testCode = @"namespace TestNamespace
 {
@@ -74,12 +76,12 @@ namespace StyleCop.Analyzers.Test.SpacingRules
             x = $"" {test}"";
             x = $""({test})"";
             x = $""( {test})"";
-            x = $""{ test}"";
-            x = $"" { test}"";
+            x = $""{|#0:{|} test}"";
+            x = $"" {|#1:{|} test}"";
         }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedCode = @"namespace TestNamespace
 {
@@ -97,12 +99,12 @@ namespace StyleCop.Analyzers.Test.SpacingRules
         }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(12, 19).WithArguments(" not", "followed"),
-                Diagnostic().WithLocation(13, 20).WithArguments(" not", "followed"),
+                Diagnostic().WithLocation(0).WithArguments(" not", "followed"),
+                Diagnostic().WithLocation(1).WithArguments(" not", "followed"),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1013UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1013UnitTests.cs
@@ -7,6 +7,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1013ClosingBracesMustBeSpacedCorrectly,
@@ -102,9 +103,12 @@ namespace StyleCop.Analyzers.Test.SpacingRules
         /// <summary>
         /// Verifies that the analyzer will properly handle closing braces in property declaration.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestPropertyDeclarationAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestPropertyDeclarationAsync(string lineEnding)
         {
             var testCode = @"namespace TestNamespace
 {
@@ -114,7 +118,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
         public int TestProperty2 { get; set;{|#0:}|}
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedCode = @"namespace TestNamespace
 {
@@ -124,7 +128,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
         public int TestProperty2 { get; set; }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1014UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1014UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1014OpeningGenericBracketsMustBeSpacedCorrectly,
@@ -46,24 +45,27 @@ public class TestClass<T> where T : IEnumerable<object>
         /// <summary>
         /// Verifies that the analyzer will properly handle invalid opening generic brackets in a class declaration.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestInvalidSpacingOfClassDeclarationAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidSpacingOfClassDeclarationAsync(string lineEnding)
         {
             var testCode = @"using System.Collections.Generic;
 
-public class TestClass1 <T> where T : IEnumerable< object>
+public class TestClass1 {|#0:<|}T> where T : IEnumerable{|#1:<|} object>
 {
 }
 
-public class TestClass2< T> where T : IEnumerable <object>
+public class TestClass2{|#2:<|} T> where T : IEnumerable {|#3:<|}object>
 {
 }
 
-public class TestClass3 < T> where T : IEnumerable < object>
+public class TestClass3 {|#4:<|} T> where T : IEnumerable {|#5:<|} object>
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedCode = @"using System.Collections.Generic;
 
@@ -78,18 +80,18 @@ public class TestClass2<T> where T : IEnumerable<object>
 public class TestClass3<T> where T : IEnumerable<object>
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(3, 25).WithArguments("preceded"),
-                Diagnostic().WithLocation(3, 50).WithArguments("followed"),
-                Diagnostic().WithLocation(7, 24).WithArguments("followed"),
-                Diagnostic().WithLocation(7, 51).WithArguments("preceded"),
-                Diagnostic().WithLocation(11, 25).WithArguments("preceded"),
-                Diagnostic().WithLocation(11, 25).WithArguments("followed"),
-                Diagnostic().WithLocation(11, 52).WithArguments("preceded"),
-                Diagnostic().WithLocation(11, 52).WithArguments("followed"),
+                Diagnostic().WithLocation(0).WithArguments("preceded"),
+                Diagnostic().WithLocation(1).WithArguments("followed"),
+                Diagnostic().WithLocation(2).WithArguments("followed"),
+                Diagnostic().WithLocation(3).WithArguments("preceded"),
+                Diagnostic().WithLocation(4).WithArguments("preceded"),
+                Diagnostic().WithLocation(4).WithArguments("followed"),
+                Diagnostic().WithLocation(5).WithArguments("preceded"),
+                Diagnostic().WithLocation(5).WithArguments("followed"),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1015UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1015UnitTests.cs
@@ -7,6 +7,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1015ClosingGenericBracketsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
@@ -47,9 +48,12 @@ public class TestClass<T> where T : IEnumerable<object>
         /// <summary>
         /// Verifies that the analyzer will properly handle invalid closing generic brackets in a class declaration.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestInvalidSpacingOfClassDeclarationAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidSpacingOfClassDeclarationAsync(string lineEnding)
         {
             var testCode = @"using System.Collections.Generic;
 
@@ -57,14 +61,14 @@ public class TestClass1<T> where T : IEnumerable<object>
 {
 }
 
-public class TestClass2<T > where T : IEnumerable<object >
+public class TestClass2<T {|#0:>|} where T : IEnumerable<object {|#1:>|}
 {
 }
 
-public class TestClass3<T>where T : IEnumerable<object>
+public class TestClass3<T{|#2:>|}where T : IEnumerable<object>
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedCode = @"using System.Collections.Generic;
 
@@ -79,13 +83,13 @@ public class TestClass2<T> where T : IEnumerable<object>
 public class TestClass3<T> where T : IEnumerable<object>
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic(DescriptorNotPreceded).WithLocation(7, 27),
-                Diagnostic(DescriptorNotPreceded).WithLocation(7, 58),
-                Diagnostic(DescriptorFollowed).WithLocation(11, 26),
+                Diagnostic(DescriptorNotPreceded).WithLocation(0),
+                Diagnostic(DescriptorNotPreceded).WithLocation(1),
+                Diagnostic(DescriptorFollowed).WithLocation(2),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1016UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1016UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1016OpeningAttributeBracketsMustBeSpacedCorrectly,
@@ -70,26 +69,29 @@ sealed class MyAttribute : System.Attribute { }
         /// <summary>
         /// Verifies that the analyzer will properly report invalid bracket placements.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestInvalidBracketsAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidBracketsAsync(string lineEnding)
         {
             var testCode = @"
-[ System.Obsolete]
+{|#0:[|} System.Obsolete]
 class ClassName
 {
 }
 
-[  System.Obsolete]
+{|#1:[|}  System.Obsolete]
 class ClassName2
 {
 }
 
-[ /*comment*/ System.Obsolete]
+{|#2:[|} /*comment*/ System.Obsolete]
 class ClassName3
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
             var fixedCode = @"
 [System.Obsolete]
 class ClassName
@@ -105,13 +107,13 @@ class ClassName2
 class ClassName3
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(2, 1),
-                Diagnostic().WithLocation(7, 1),
-                Diagnostic().WithLocation(12, 1),
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
+                Diagnostic().WithLocation(2),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1017UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1017UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1017ClosingAttributeBracketsMustBeSpacedCorrectly,
@@ -70,26 +69,29 @@ sealed class MyAttribute : System.Attribute { }
         /// <summary>
         /// Verifies that the analyzer will properly report invalid bracket placements.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestInvalidBracketsAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidBracketsAsync(string lineEnding)
         {
             var testCode = @"
-[System.Obsolete ]
+[System.Obsolete {|#0:]|}
 class ClassName
 {
 }
 
-[System.Obsolete  ]
+[System.Obsolete  {|#1:]|}
 class ClassName2
 {
 }
 
-[System.Obsolete /*comment*/ ]
+[System.Obsolete /*comment*/ {|#2:]|}
 class ClassNam3
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
             var fixedCode = @"
 [System.Obsolete]
 class ClassName
@@ -105,13 +107,13 @@ class ClassName2
 class ClassNam3
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
-                Diagnostic().WithLocation(2, 18),
-                Diagnostic().WithLocation(7, 19),
-                Diagnostic().WithLocation(12, 30),
+                Diagnostic().WithLocation(0),
+                Diagnostic().WithLocation(1),
+                Diagnostic().WithLocation(2),
             };
 
             await VerifyCSharpFixAsync(testCode, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1018UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1018UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1018NullableTypeSymbolsMustNotBePrecededBySpace,
@@ -22,9 +21,12 @@ namespace StyleCop.Analyzers.Test.SpacingRules
         /// <summary>
         /// Verifies that nullable types with different kinds of spacing will report.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestNullableTypeSpacingAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestNullableTypeSpacingAsync(string lineEnding)
         {
             var testCode = @"namespace TestNamespace
 {
@@ -52,7 +54,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
         }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedTestCode = @"namespace TestNamespace
 {
@@ -77,7 +79,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
         }
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             await new CSharpTest
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1019UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1019UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System;
@@ -12,6 +10,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1019MemberAccessSymbolsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
@@ -47,6 +46,20 @@ namespace StyleCop.Analyzers.Test.SpacingRules
         {
             string template = this.GetTemplate($" {op}");
             var fixedCode = this.GetTemplate($"{op}");
+
+            DiagnosticResult expected = Diagnostic(DescriptorNotPreceded).WithLocation(16, 27).WithArguments(op[0]);
+
+            await VerifyCSharpFixAsync(template, expected, fixedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestSpaceBeforeOperatorWithLineEndingsAsync(string lineEnding)
+        {
+            const string op = ".";
+            string template = this.GetTemplate($" {op}").ReplaceLineEndings(lineEnding);
+            var fixedCode = this.GetTemplate($"{op}").ReplaceLineEndings(lineEnding);
 
             DiagnosticResult expected = Diagnostic(DescriptorNotPreceded).WithLocation(16, 27).WithArguments(op[0]);
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1020UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1020UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1020IncrementDecrementSymbolsMustBeSpacedCorrectly,
@@ -52,11 +51,14 @@ class ClassName
         /// </summary>
         /// <param name="symbol">The operator to test.</param>
         /// <param name="symbolName">The name of the symbol, as it appears in diagnostics.</param>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory]
-        [InlineData("++", "Increment")]
-        [InlineData("--", "Decrement")]
-        public async Task TestInvalidSymbolSpacingAsync(string symbol, string symbolName)
+        [InlineData("++", "Increment", "\n")]
+        [InlineData("++", "Increment", "\r\n")]
+        [InlineData("--", "Decrement", "\n")]
+        [InlineData("--", "Decrement", "\r\n")]
+        public async Task TestInvalidSymbolSpacingAsync(string symbol, string symbolName, string lineEnding)
         {
             var testCode = $@"
 class ClassName
@@ -82,7 +84,7 @@ class ClassName
         }}
     }}
 }}
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedCode = $@"
 class ClassName
@@ -104,7 +106,7 @@ class ClassName
         }}
     }}
 }}
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1021UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1021UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using Microsoft.CodeAnalysis.CodeFixes;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1022UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1022UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using Microsoft.CodeAnalysis.CodeFixes;

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1023UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1023UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1023DereferenceAndAccessOfSymbolsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
@@ -82,9 +81,12 @@ public unsafe class TestClass
         /// <summary>
         /// Verifies that the analyzer will properly handle invalid dereference and access of symbols.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestInvalidSpacingAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidSpacingAsync(string lineEnding)
         {
             var testCode = @"public class TestClass
 {
@@ -110,7 +112,7 @@ x;
         a = * x** x;
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedCode = @"public class TestClass
 {
@@ -134,7 +136,7 @@ x;
         a = *x**x;
     }
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1024UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1024UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.SpacingRules.SA1024ColonsMustBeSpacedCorrectly;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
@@ -135,11 +134,14 @@ base()
         /// <summary>
         /// Verifies that the analyzer will produce the proper diagnostics when the colons not followed by space.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestInvalidSpacedColonsMustBeFollowedAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidSpacedColonsMustBeFollowedAsync(string lineEnding)
         {
-            const string testCode = @"using System;
+            string testCode = @"using System;
 
 public class Foo<T> :object where T :IFormattable
 {
@@ -166,7 +168,7 @@ public class Foo<T> :object where T :IFormattable
                 goto _label;
         }
     }
-}";
+}".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {
@@ -177,7 +179,7 @@ public class Foo<T> :object where T :IFormattable
                 Diagnostic(DescriptorFollowed).WithLocation(10, 30),
             };
 
-            await VerifyCSharpFixAsync(testCode, expected, ExpectedCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode, expected, ExpectedCode.ReplaceLineEndings(lineEnding), CancellationToken.None).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1025UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1025UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Text;
@@ -10,6 +8,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1025CodeMustNotContainMultipleWhitespaceInARow,
@@ -61,19 +60,22 @@ namespace StyleCop.Analyzers.Test.SpacingRules
         /// <summary>
         /// Verifies that the analyzer will produce the proper diagnostics with multiple whitespace characters in namespace declaration.
         /// </summary>
+        /// <param name="lineEnding">The line ending to use in the test code.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
-        [Fact]
-        public async Task TestMultipleWhitespaceInNamespaceDeclarationAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestMultipleWhitespaceInNamespaceDeclarationAsync(string lineEnding)
         {
             var testCode = @"namespace  TestNamespace
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             var fixedCode = @"namespace TestNamespace
 {
 }
-";
+".ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected = { Diagnostic().WithLocation(1, 10) };
 

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1026UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1026UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1026CodeMustNotContainSpaceAfterNewKeywordInImplicitlyTypedArrayAllocation,
@@ -49,6 +48,32 @@ namespace StyleCop.Analyzers.Test.SpacingRules
             DiagnosticResult expected = Diagnostic().WithArguments("new").WithLocation(1, 46);
 
             await VerifyCSharpFixAsync(testCode, expected, expectedCode, CancellationToken.None).ConfigureAwait(false);
+        }
+
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidSpacingOfImplicitlyTypedArrayWithLineEndingsAsync(string lineEnding)
+        {
+            const string testCode = @"public class Foo
+{
+    public Foo()
+    {
+        var ints = new [] { 1, 2, 3 };
+    }
+}";
+
+            const string expectedCode = @"public class Foo
+{
+    public Foo()
+    {
+        var ints = new[] { 1, 2, 3 };
+    }
+}";
+
+            DiagnosticResult expected = Diagnostic().WithArguments("new").WithLocation(5, 20);
+
+            await VerifyCSharpFixAsync(testCode.ReplaceLineEndings(lineEnding), expected, expectedCode.ReplaceLineEndings(lineEnding), CancellationToken.None).ConfigureAwait(false);
         }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1027AlternateIndentationUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1027AlternateIndentationUnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
@@ -10,6 +8,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Settings.ObjectModel;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
 
@@ -55,8 +54,10 @@ namespace StyleCop.Analyzers.Test.SpacingRules
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestInvalidSpacesAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidSpacesAsync(string lineEnding)
         {
             var testCode =
                 "using\tSystem.Diagnostics;\r\n" +
@@ -94,7 +95,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
                 Diagnostic().WithLocation(9, 1),
             };
 
-            await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode.ReplaceLineEndings(lineEnding), expected, fixedTestCode.ReplaceLineEndings(lineEnding), CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1027UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1027UnitTests.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1027UseTabsCorrectly,
@@ -55,8 +54,10 @@ namespace StyleCop.Analyzers.Test.SpacingRules
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestInvalidTabsAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidTabsAsync(string lineEnding)
         {
             var testCode =
                 "using\tSystem.Diagnostics;\r\n" +
@@ -94,7 +95,7 @@ public  class   Foo
                 Diagnostic().WithLocation(9, 1),
             };
 
-            await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode.ReplaceLineEndings(lineEnding), expected, fixedTestCode.ReplaceLineEndings(lineEnding), CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1027UseTabsUnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1027UseTabsUnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Threading;
@@ -10,6 +8,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.Settings.ObjectModel;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using StyleCop.Analyzers.Test.Verifiers;
     using Xunit;
 
@@ -55,8 +54,10 @@ namespace StyleCop.Analyzers.Test.SpacingRules
             await VerifyCSharpDiagnosticAsync(testCode, DiagnosticResult.EmptyDiagnosticResults, CancellationToken.None).ConfigureAwait(false);
         }
 
-        [Fact]
-        public async Task TestInvalidSpacesAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TestInvalidSpacesAsync(string lineEnding)
         {
             var testCode =
                 "using\tSystem.Diagnostics;\r\n" +
@@ -94,7 +95,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
                 Diagnostic().WithLocation(9, 1),
             };
 
-            await VerifyCSharpFixAsync(testCode, expected, fixedTestCode, CancellationToken.None).ConfigureAwait(false);
+            await VerifyCSharpFixAsync(testCode.ReplaceLineEndings(lineEnding), expected, fixedTestCode.ReplaceLineEndings(lineEnding), CancellationToken.None).ConfigureAwait(false);
         }
 
         [Fact]

--- a/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers.Test/SpacingRules/SA1028UnitTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Tunnel Vision Laboratories, LLC. All Rights Reserved.
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 
-#nullable disable
-
 namespace StyleCop.Analyzers.Test.SpacingRules
 {
     using System.Text;
@@ -10,6 +8,7 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     using System.Threading.Tasks;
     using Microsoft.CodeAnalysis.Testing;
     using StyleCop.Analyzers.SpacingRules;
+    using StyleCop.Analyzers.Test.Helpers;
     using Xunit;
     using static StyleCop.Analyzers.Test.Verifiers.StyleCopCodeFixVerifier<
         StyleCop.Analyzers.SpacingRules.SA1028CodeMustNotContainTrailingWhitespace,
@@ -21,8 +20,10 @@ namespace StyleCop.Analyzers.Test.SpacingRules
     /// </summary>
     public class SA1028UnitTests
     {
-        [Fact]
-        public async Task TrailingWhitespaceAfterStatementAsync()
+        [Theory]
+        [InlineData("\n")]
+        [InlineData("\r\n")]
+        public async Task TrailingWhitespaceAfterStatementAsync(string lineEnding)
         {
             string testCode = new StringBuilder()
                 .AppendLine("class ClassName")
@@ -32,7 +33,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
                 .AppendLine("        System.Console.WriteLine(); ")
                 .AppendLine("    }")
                 .AppendLine("}")
-                .ToString();
+                .ToString()
+                .ReplaceLineEndings(lineEnding);
 
             string fixedCode = new StringBuilder()
                 .AppendLine("class ClassName")
@@ -42,7 +44,8 @@ namespace StyleCop.Analyzers.Test.SpacingRules
                 .AppendLine("        System.Console.WriteLine();")
                 .AppendLine("    }")
                 .AppendLine("}")
-                .ToString();
+                .ToString()
+                .ReplaceLineEndings(lineEnding);
 
             DiagnosticResult[] expected =
             {

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/SyntaxNodeExtensions.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/SyntaxNodeExtensions.cs
@@ -86,5 +86,26 @@ namespace StyleCop.Analyzers.Helpers
             return node.IsKind(SyntaxKind.ParenthesizedLambdaExpression)
                 || node.IsKind(SyntaxKind.SimpleLambdaExpression);
         }
+
+        /// <summary>
+        /// Finds the nearest ancestor of the specified syntax node that is the first token on its line.
+        /// </summary>
+        /// <remarks><para>This method is useful for scenarios such as handling 'else if' statements, where the
+        /// initial node may not be the first on its line. The search ascends the syntax tree until a suitable ancestor
+        /// is found.</para></remarks>
+        /// <param name="parent">The syntax node from which to begin searching for an ancestor that starts a line.</param>
+        /// <returns>A syntax node that is the first token on its line. If the specified node is already the first on its line,
+        /// returns the node itself.</returns>
+        public static SyntaxNode GetFirstOnLineAncestorOrSelf(this SyntaxNode parent)
+        {
+            // if the parent is not the first on a line, find the parent that is.
+            // This mainly happens for 'else if' statements.
+            while (!parent.GetFirstToken().IsFirstInLine())
+            {
+                parent = parent.Parent;
+            }
+
+            return parent;
+        }
     }
 }

--- a/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TokenHelper.cs
+++ b/StyleCop.Analyzers/StyleCop.Analyzers/Helpers/TokenHelper.cs
@@ -175,35 +175,5 @@ namespace StyleCop.Analyzers.Helpers
             triviaList = token.GetNextToken().LeadingTrivia;
             return triviaList.Count > 0 && triviaList.First().IsKind(SyntaxKind.WhitespaceTrivia);
         }
-
-        /// <summary>
-        /// Returns the closest end of line trivia preceding the <paramref name="token"/>.
-        /// This currently only looks immediately before the specified token.
-        /// </summary>
-        /// <param name="token">The token to process.</param>
-        /// <returns>The closest preceding end of line trivia, or <see cref="SyntaxFactory.CarriageReturnLineFeed"/> if none is found.</returns>
-        internal static SyntaxTrivia GetPrecedingEndOfLineTrivia(this SyntaxToken token)
-        {
-            var leadingTrivia = token.LeadingTrivia;
-            for (var i = leadingTrivia.Count - 1; i >= 0; i--)
-            {
-                if (leadingTrivia[i].IsKind(SyntaxKind.EndOfLineTrivia))
-                {
-                    return leadingTrivia[i];
-                }
-            }
-
-            var prevToken = token.GetPreviousToken();
-            var prevTrailingTrivia = prevToken.TrailingTrivia;
-            for (var i = prevTrailingTrivia.Count - 1; i >= 0; i--)
-            {
-                if (prevTrailingTrivia[i].IsKind(SyntaxKind.EndOfLineTrivia))
-                {
-                    return prevTrailingTrivia[i];
-                }
-            }
-
-            return SyntaxFactory.CarriageReturnLineFeed;
-        }
     }
 }


### PR DESCRIPTION
Code fixes always prefer to preserve the current line endings, and fall back to options only in files without any line endings to reference.

~~This should update all rules except SA1107, for which a skipped test has been added.~~

SA1107 is now updated, but includes some minor behavior changes. See the tests in c71c1293ca06268a2050113b5a6d31cd50d9f586 for more information.

Fixes #3247 
Contributes to #3656