### PR TITLE
Clarify how SA1518 is influenced by editorconfig in docs

### DIFF
--- a/documentation/SA1518.md
+++ b/documentation/SA1518.md
@@ -31,7 +31,9 @@ The specific settings is one of the following:
 * Require: Files are required to end with a single newline character
 * Omit: Files may not end with a newline character
 
-If you have set `insert_final_newline` in an `.editorconfig` file, it will be used to set this analyzer rule to either Require (`insert_final_newline = true`) or Omit (`insert_final_newline = false`). 
+If you have set `insert_final_newline` in an `.editorconfig` file, it will be used to set this analyzer rule to either:
+* Require (`insert_final_newline = true`)
+* Omit (`insert_final_newline = false`). 
 
 ## How to fix violations
 

--- a/documentation/SA1518.md
+++ b/documentation/SA1518.md
@@ -31,6 +31,8 @@ The specific settings is one of the following:
 * Require: Files are required to end with a single newline character
 * Omit: Files may not end with a newline character
 
+If you have set `insert_final_newline` in an `.editorconfig` file, it will be used to set this analyzer rule to either Require (`insert_final_newline = true`) or Omit (`insert_final_newline = false`). 
+
 ## How to fix violations
 
 To fix a violation of this rule, update the line endings at the end of the file to match the settings for the current


### PR DESCRIPTION
To avoid confusion if using an .editorconfig and the default configuration of the analyzer configuration is not used. See in [code](https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/513ba0fefdf66e86c030c00a73812322585358ae/StyleCop.Analyzers/StyleCop.Analyzers/Settings/ObjectModel/LayoutSettings.cs#L71)